### PR TITLE
Improve sessions

### DIFF
--- a/quilt/tools/command.py
+++ b/quilt/tools/command.py
@@ -61,7 +61,7 @@ def _save_auth(auth):
 
 def _handle_response(resp, **kwargs):
     if resp.status_code == requests.codes.unauthorized:
-        raise CommandException("Failed to log in. Run `quilt login` again.")
+        raise CommandException("Authentication failed. Run `quilt login` again.")
 
 def _create_session():
     try:


### PR DESCRIPTION
- Add a session hook that handles authentication errors.
- Stop making API calls just to check the validity of the access token.
- Remove the `QUILT_AUTH_URL` constant.