### PR TITLE
Move session creation out of command functions.

### DIFF
--- a/quilt/test/test_command.py
+++ b/quilt/test/test_command.py
@@ -3,6 +3,7 @@ Tests for commands.
 """
 
 import pytest
+import requests
 import responses
 
 try:
@@ -18,16 +19,20 @@ class CommandTest(QuiltTestCase):
     # the new one, `assertRaisesRegex`, is not present in Python2.
 
     def test_push_invalid_package(self):
+        session = requests.Session()
+
         with self.assertRaisesRegexp(command.CommandException, "owner/package_name"):
-            command.push(package="no_user")
+            command.push(session=session, package="no_user")
         with self.assertRaisesRegexp(command.CommandException, "owner/package_name"):
-            command.push(package="a/b/c")
+            command.push(session=session, package="a/b/c")
 
     def test_install_invalid_package(self):
+        session = requests.Session()
+
         with self.assertRaisesRegexp(command.CommandException, "owner/package_name"):
-            command.install(package="no_user")
+            command.install(session=session, package="no_user")
         with self.assertRaisesRegexp(command.CommandException, "owner/package_name"):
-            command.install(package="a/b/c")
+            command.install(session=session, package="a/b/c")
 
     @pytest.mark.skipif("h5py is None")
     def test_inspect_invalid_package(self):
@@ -37,8 +42,10 @@ class CommandTest(QuiltTestCase):
             command.inspect(package="a/b/c")
 
     def test_push_missing_package(self):
+        session = requests.Session()
+
         with self.assertRaisesRegexp(command.CommandException, "not found"):
-            command.push(package="owner/package")
+            command.push(session=session, package="owner/package")
 
     @pytest.mark.skipif("h5py is None")
     def test_inspect_missing_package(self):

--- a/quilt/test/test_install.py
+++ b/quilt/test/test_install.py
@@ -5,6 +5,7 @@ Tests for commands.
 import json
 import os
 
+import requests
 import responses
 
 from quilt.tools import command
@@ -22,7 +23,8 @@ class InstallTest(QuiltTestCase):
         self._mock_package('foo/bar', contents_hash)
         self._mock_s3(contents_hash, contents)
 
-        command.install('foo/bar')
+        session = requests.Session()
+        command.install(session, 'foo/bar')
 
         with open('quilt_packages/foo/bar.h5') as fd:
             file_contents = fd.read()
@@ -36,8 +38,9 @@ class InstallTest(QuiltTestCase):
         self._mock_package('foo/bar', contents_hash)
         self._mock_s3(contents_hash, contents)
 
+        session = requests.Session()
         with self.assertRaisesRegexp(command.CommandException, "Mismatched hash"):
-            command.install('foo/bar')
+            command.install(session, 'foo/bar')
 
         assert not os.path.exists('quilt_packages/foo/bar.h5')
 

--- a/quilt/test/utils.py
+++ b/quilt/test/utils.py
@@ -14,7 +14,6 @@ except ImportError:
     # Python2 - external dependency.
     from mock import patch
 
-import requests
 import responses
 
 
@@ -29,17 +28,11 @@ class QuiltTestCase(unittest.TestCase):
         self._test_dir = tempfile.mkdtemp(prefix='quilt-test-')
         os.chdir(self._test_dir)
 
-        # Return a plain session object instead of doing auth.
-        self._session_patch = patch('quilt.tools.command._create_session', requests.Session)
-        self._session_patch.start()
-
         self.requests_mock = responses.RequestsMock(assert_all_requests_are_fired=False)
         self.requests_mock.start()
 
     def tearDown(self):
         self.requests_mock.stop()
-
-        self._session_patch.stop()
 
         os.chdir(self._old_dir)
         shutil.rmtree(self._test_dir)


### PR DESCRIPTION
If we're going to support calls to `install`, `push`, etc. directly from Python
(rather than the `quilt` script), then it doesn't make sense to create a new
session for each call.

Also, this makes unit testing easier - no need to patch the session function.