### PR TITLE
Support multi-file packages

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,5 @@ dist
 tmp_*
 
 quilt_packages
+metastore_db
+derby.log

--- a/quilt/data.py
+++ b/quilt/data.py
@@ -31,15 +31,12 @@ class Node(object):
     def __init__(self, store, prefix=''):
         self._prefix = prefix
         self._store = store
-        print("NODE: %s %s" % (prefix, store))
 
     def __getattr__(self, name):
         # TODO clean if... up since VALID_NAME_RE no longer allows leading _
-        print("GETATTR NAME=%s" % name)
         if name.startswith('_'):
             raise AttributeError
         path = self._prefix + '/' + name
-        print("GETATTR PATH=%s" % path)
         return self._get_store_obj(path)
 
     def __repr__(self):
@@ -64,7 +61,6 @@ class Node(object):
         self._keys()
         try:
             obj = self._store.get(path)
-            print("OBJ=%s" % obj)
         except KeyError:
             # No such group or table
             raise AttributeError("No such table or group: %s" % path)
@@ -86,7 +82,6 @@ class Node(object):
         """
         keys directly accessible on this object via getattr or .
         """
-        print("KEYS=%s" % self._store.keys(self._prefix))
         return self._store.keys(self._prefix)
 
 class FakeLoader(object):
@@ -95,7 +90,6 @@ class FakeLoader(object):
     """
     def __init__(self, path):
         self._path = path
-        print("FAKELOADER, PATH=%s" % path)
 
     def load_module(self, fullname):
         """
@@ -115,13 +109,11 @@ class PackageLoader(object):
     def __init__(self, path, store):
         self._path = path
         self._store = store
-        print("PKGLOADER, PATH=%s" % path)
 
     def load_module(self, fullname):
         """
         Returns an object that lazily looks up tables and groups.
         """
-        print("LOADING MODULE, FULLNAME=%s" % fullname)
         mod = sys.modules.get(fullname)
         if mod is not None:
             return mod
@@ -131,7 +123,6 @@ class PackageLoader(object):
 
         mod = Node(self._store)
         sys.modules[fullname] = mod
-        print("MOD=%s" % mod)
         return mod
 
 class ModuleFinder(object):
@@ -143,17 +134,12 @@ class ModuleFinder(object):
         """
         Looks up the table based on the module path.
         """
-
-        print("FULLNAME=%s" % fullname)
-        print("PATH=%s" % path)
-        
         if not fullname.startswith(__name__ + '.'):
             # Not a quilt submodule.
             return None
 
         submodule = fullname[len(__name__) + 1:]
         parts = submodule.split('.')
-        print("PARTS=%s" % parts)
 
         if len(parts) == 1:
             for package_dir in PackageStore.find_package_dirs():

--- a/quilt/data.py
+++ b/quilt/data.py
@@ -58,7 +58,6 @@ class Node(object):
                 if not isinstance(self._get_store_obj(pref + k), Node)]
 
     def _get_store_obj(self, path):
-        self._keys()
         try:
             obj = self._store.get(path)
         except KeyError:

--- a/quilt/data.py
+++ b/quilt/data.py
@@ -31,12 +31,15 @@ class Node(object):
     def __init__(self, store, prefix=''):
         self._prefix = prefix
         self._store = store
+        print("NODE: %s %s" % (prefix, store))
 
     def __getattr__(self, name):
         # TODO clean if... up since VALID_NAME_RE no longer allows leading _
+        print("GETATTR NAME=%s" % name)
         if name.startswith('_'):
             raise AttributeError
         path = self._prefix + '/' + name
+        print("GETATTR PATH=%s" % path)
         return self._get_store_obj(path)
 
     def __repr__(self):
@@ -58,16 +61,18 @@ class Node(object):
                 if not isinstance(self._get_store_obj(pref + k), Node)]
 
     def _get_store_obj(self, path):
+        self._keys()
         try:
-            with self._store:
-                return self._store.get(path)
+            obj = self._store.get(path)
+            print("OBJ=%s" % obj)
         except KeyError:
             # No such group or table
             raise AttributeError("No such table or group: %s" % path)
-        except TypeError:
-            # This is awful, but that's what happens when the object being looked up
-            # is a group rather than a table.
+
+        if isinstance(obj, dict):
             return Node(self._store, path)
+        else:
+            return obj
 
     def _groups(self):
         """
@@ -81,6 +86,7 @@ class Node(object):
         """
         keys directly accessible on this object via getattr or .
         """
+        print("KEYS=%s" % self._store.keys(self._prefix))
         return self._store.keys(self._prefix)
 
 class FakeLoader(object):
@@ -89,6 +95,7 @@ class FakeLoader(object):
     """
     def __init__(self, path):
         self._path = path
+        print("FAKELOADER, PATH=%s" % path)
 
     def load_module(self, fullname):
         """
@@ -108,11 +115,13 @@ class PackageLoader(object):
     def __init__(self, path, store):
         self._path = path
         self._store = store
+        print("PKGLOADER, PATH=%s" % path)
 
     def load_module(self, fullname):
         """
         Returns an object that lazily looks up tables and groups.
         """
+        print("LOADING MODULE, FULLNAME=%s" % fullname)
         mod = sys.modules.get(fullname)
         if mod is not None:
             return mod
@@ -122,6 +131,7 @@ class PackageLoader(object):
 
         mod = Node(self._store)
         sys.modules[fullname] = mod
+        print("MOD=%s" % mod)
         return mod
 
 class ModuleFinder(object):
@@ -133,15 +143,21 @@ class ModuleFinder(object):
         """
         Looks up the table based on the module path.
         """
+
+        print("FULLNAME=%s" % fullname)
+        print("PATH=%s" % path)
+        
         if not fullname.startswith(__name__ + '.'):
             # Not a quilt submodule.
             return None
 
         submodule = fullname[len(__name__) + 1:]
         parts = submodule.split('.')
+        print("PARTS=%s" % parts)
 
         if len(parts) == 1:
             for package_dir in PackageStore.find_package_dirs():
+                # find contents
                 file_path = os.path.join(package_dir, parts[0])
                 if os.path.isdir(file_path):
                     return FakeLoader(file_path)

--- a/quilt/test/test_build.py
+++ b/quilt/test/test_build.py
@@ -26,7 +26,7 @@ class BuildTest(QuiltTestCase):
         """
         mydir = os.path.dirname(__file__)
         PATH = os.path.join(mydir, './build.yml')
-         build.build_package('test_hdf5', PACKAGE, PATH)
+        build.build_package('test_hdf5', PACKAGE, PATH)
         # TODO load DFs based on contents of .yml file at PATH
         # not hardcoded vals (this will require loading modules from variable
         # names, probably using __module__)

--- a/quilt/test/test_build.py
+++ b/quilt/test/test_build.py
@@ -4,17 +4,17 @@ Test the build process
 #TODO: we should really test the CLI interface itself, rather than
 #the functions that cli calls
 import os
-import sys
+
+try:
+    import fastparquet
+except ImportError:
+    fastparquet = None
 
 import pytest
 
 from quilt.tools import build
 from quilt.tools.const import FORMAT_PARQ
 
-try:
-    import fastparquet
-except ImportError:
-    fastparquet = None
 
 USER = 'test_121'
 PACKAGE = 'groot'
@@ -59,6 +59,6 @@ def test_build_parquet():
     print(csv.columns, xls.columns, tsv.columns)
     assert cols == len(tsv.columns) and cols == len(xls.columns), \
         'Expected dataframes to have same # columns'
-    del(os.environ["QUILT_PACKAGE_FORMAT"])
+    del os.environ["QUILT_PACKAGE_FORMAT"]
     # TODO add more integrity checks, incl. negative test cases
 

--- a/quilt/test/test_install.py
+++ b/quilt/test/test_install.py
@@ -12,6 +12,7 @@ import responses
 from quilt.tools import command
 from quilt.tools.const import HASH_TYPE, TYPE_KEY, NodeType
 from quilt.tools.hashing import hash_contents
+from quilt.tools.store import get_store
 
 from .utils import QuiltTestCase
 
@@ -47,7 +48,9 @@ class InstallTest(QuiltTestCase):
             file_contents = json.loads(fd.read())
             assert file_contents == contents
 
-        with open('quilt_packages/objs/{hash}{ext}'.format(hash=obj_hash, ext='.h5')) as fd:
+        store = get_store("foo", "bar")
+        with open('quilt_packages/objs/{hash}{ext}'.format(hash=obj_hash,
+                                                           ext=store.DATA_FILE_EXT)) as fd:
             file_contents = fd.read()
             assert file_contents == tabledata
 
@@ -61,7 +64,7 @@ class InstallTest(QuiltTestCase):
         obj_hash = h.hexdigest()
         contents = {'foo': {TYPE_KEY: NodeType.GROUP.value,
                             'bar' : {TYPE_KEY: NodeType.TABLE.value,
-                                      'hashes': [obj_hash]}
+                                     'hashes': [obj_hash]}
                            }
                    }
         contents_hash = 'e867010701edc0b1c8be177e02a93aa3cb1342bb1123046e1f6b40e428c6048e'

--- a/quilt/test/test_install.py
+++ b/quilt/test/test_install.py
@@ -16,18 +16,24 @@ from quilt.tools.hashing import hash_contents
 from .utils import QuiltTestCase
 
 class InstallTest(QuiltTestCase):
+    """
+    Unit tests for quilt install.
+    """
     # Note: we're using the deprecated `assertRaisesRegexp` method because
     # the new one, `assertRaisesRegex`, is not present in Python2.
 
     def test_install_latest(self):
+        """
+        Install the latest update of a package.
+        """
         tabledata = "table"*10
         h = hashlib.new(HASH_TYPE)
         h.update(tabledata.encode('utf-8'))
         obj_hash = h.hexdigest()
         contents = dict(foo={TYPE_KEY: NodeType.GROUP.value,
-                             'bar' : { TYPE_KEY : NodeType.TABLE.value,
-                                       'hashes': [obj_hash]}
-                             })
+                             'bar' : {TYPE_KEY : NodeType.TABLE.value,
+                                      'hashes': [obj_hash]}
+                            })
         contents_hash = hash_contents(contents)
 
         self._mock_tag('foo/bar', 'latest', contents_hash)
@@ -46,14 +52,17 @@ class InstallTest(QuiltTestCase):
             assert file_contents == tabledata
 
     def test_bad_hash(self):
+        """
+        Test that a package with a bad hash fails installation.
+        """
         tabledata = 'Bad package'
         h = hashlib.new(HASH_TYPE)
         h.update(tabledata.encode('utf-8'))
         obj_hash = h.hexdigest()
         contents = dict(foo={TYPE_KEY: NodeType.GROUP.value,
-                             'bar' : { TYPE_KEY : NodeType.TABLE.value,
-                                       'hashes': [obj_hash]}
-                             })
+                             'bar' : {TYPE_KEY: NodeType.TABLE.value,
+                                      'hashes': [obj_hash]}
+                            })
         contents_hash = 'e867010701edc0b1c8be177e02a93aa3cb1342bb1123046e1f6b40e428c6048e'
 
         self._mock_tag('foo/bar', 'latest', contents_hash)
@@ -77,7 +86,7 @@ class InstallTest(QuiltTestCase):
         pkg_url = '%s/api/package/foo/bar/%s' % (command.QUILT_PKG_URL, pkg_hash)
         self.requests_mock.add(responses.GET, pkg_url, json.dumps(dict(
             contents=contents,
-            urls={h: 'https://example.com/%s' % h for h in hashes}      
+            urls={h: 'https://example.com/%s' % h for h in hashes}
         )))
 
     def _mock_s3(self, pkg_hash, contents):

--- a/quilt/test/test_install.py
+++ b/quilt/test/test_install.py
@@ -2,6 +2,7 @@
 Tests for commands.
 """
 
+import hashlib
 import json
 import os
 
@@ -9,6 +10,9 @@ import requests
 import responses
 
 from quilt.tools import command
+from quilt.tools.const import HASH_TYPE, TYPE_KEY, NodeType
+from quilt.tools.hashing import hash_contents
+
 from .utils import QuiltTestCase
 
 class InstallTest(QuiltTestCase):
@@ -16,33 +20,51 @@ class InstallTest(QuiltTestCase):
     # the new one, `assertRaisesRegex`, is not present in Python2.
 
     def test_install_latest(self):
-        contents = 'HDF5 package'
-        contents_hash = 'e867010701edc0b1c8be177e02a93aa3cb1342bb1123046e1f6b40e428c6048e'
+        tabledata = "table"*10
+        h = hashlib.new(HASH_TYPE)
+        h.update(tabledata.encode('utf-8'))
+        obj_hash = h.hexdigest()
+        contents = dict(foo={TYPE_KEY: NodeType.GROUP.value,
+                             'bar' : { TYPE_KEY : NodeType.TABLE.value,
+                                       'hashes': [obj_hash]}
+                             })
+        contents_hash = hash_contents(contents)
 
         self._mock_tag('foo/bar', 'latest', contents_hash)
-        self._mock_package('foo/bar', contents_hash)
-        self._mock_s3(contents_hash, contents)
+        self._mock_package('foo/bar', contents_hash, contents, [obj_hash])
+        self._mock_s3(obj_hash, tabledata)
 
         session = requests.Session()
         command.install(session, 'foo/bar')
 
-        with open('quilt_packages/foo/bar.h5') as fd:
-            file_contents = fd.read()
+        with open('quilt_packages/foo/bar.json') as fd:
+            file_contents = json.loads(fd.read())
             assert file_contents == contents
 
+        with open('quilt_packages/objs/{hash}{ext}'.format(hash=obj_hash, ext='.h5')) as fd:
+            file_contents = fd.read()
+            assert file_contents == tabledata
+
     def test_bad_hash(self):
-        contents = 'Bad package'
+        tabledata = 'Bad package'
+        h = hashlib.new(HASH_TYPE)
+        h.update(tabledata.encode('utf-8'))
+        obj_hash = h.hexdigest()
+        contents = dict(foo={TYPE_KEY: NodeType.GROUP.value,
+                             'bar' : { TYPE_KEY : NodeType.TABLE.value,
+                                       'hashes': [obj_hash]}
+                             })
         contents_hash = 'e867010701edc0b1c8be177e02a93aa3cb1342bb1123046e1f6b40e428c6048e'
 
         self._mock_tag('foo/bar', 'latest', contents_hash)
-        self._mock_package('foo/bar', contents_hash)
-        self._mock_s3(contents_hash, contents)
+        self._mock_package('foo/bar', contents_hash, contents, [obj_hash])
+        self._mock_s3(obj_hash, tabledata)
 
         session = requests.Session()
         with self.assertRaisesRegexp(command.CommandException, "Mismatched hash"):
             command.install(session, 'foo/bar')
 
-        assert not os.path.exists('quilt_packages/foo/bar.h5')
+        assert not os.path.exists('quilt_packages/foo/bar.json')
 
     def _mock_tag(self, package, tag, pkg_hash):
         tag_url = '%s/api/tag/%s/%s' % (command.QUILT_PKG_URL, package, tag)
@@ -51,13 +73,11 @@ class InstallTest(QuiltTestCase):
             hash=pkg_hash
         )))
 
-    def _mock_package(self, package, pkg_hash):
+    def _mock_package(self, package, pkg_hash, contents, hashes):
         pkg_url = '%s/api/package/foo/bar/%s' % (command.QUILT_PKG_URL, pkg_hash)
-        s3_url = 'https://example.com/%s' % pkg_hash
-
         self.requests_mock.add(responses.GET, pkg_url, json.dumps(dict(
-            url=s3_url,
-            hash=pkg_hash
+            contents=contents,
+            urls={h: 'https://example.com/%s' % h for h in hashes}      
         )))
 
     def _mock_s3(self, pkg_hash, contents):

--- a/quilt/test/test_install.py
+++ b/quilt/test/test_install.py
@@ -45,7 +45,7 @@ class InstallTest(QuiltTestCase):
         command.install(session, 'foo/bar')
 
         with open('quilt_packages/foo/bar.json') as fd:
-            file_contents = json.loads(fd.read())
+            file_contents = json.load(fd)
             assert file_contents == contents
 
         store = get_store("foo", "bar")

--- a/quilt/tools/build.py
+++ b/quilt/tools/build.py
@@ -77,9 +77,7 @@ def build_package(username, package, yaml_path):
 
     Returns the name of the package.
     """
-    #try:
     build_dir = os.path.dirname(yaml_path)
-
     fd = open(yaml_path)
     docs = yaml.load_all(fd)
     data = next(docs, None) # leave other dicts in the generator

--- a/quilt/tools/build.py
+++ b/quilt/tools/build.py
@@ -77,21 +77,20 @@ def build_package(username, package, yaml_path):
 
     Returns the name of the package.
     """
-    try:
-        build_dir = os.path.dirname(yaml_path)
+    #try:
+    build_dir = os.path.dirname(yaml_path)
 
-        fd = open(yaml_path)
-        docs = yaml.load_all(fd)
-        data = next(docs, None) # leave other dicts in the generator
-        if not isinstance(data, dict):
-            raise BuildException("Unable to parse YAML: %s" % yaml_path)
+    fd = open(yaml_path)
+    docs = yaml.load_all(fd)
+    data = next(docs, None) # leave other dicts in the generator
+    if not isinstance(data, dict):
+        raise BuildException("Unable to parse YAML: %s" % yaml_path)
 
-        tables = data.get('tables')
-        format = data.get('format', None)
-        if not isinstance(tables, dict):
-            raise BuildException("'tables' must be a dictionary")
+    tables = data.get('tables')
+    format = data.get('format', None)
+    if not isinstance(tables, dict):
+        raise BuildException("'tables' must be a dictionary")
 
-        with get_store(username, package, format, 'w') as store:
-            _build_table(build_dir, store, '', tables)
-    except (IOError, StoreException) as ex:
-        raise BuildException(str(ex))
+    with get_store(username, package, format, 'w') as store:
+        _build_table(build_dir, store, '', tables)
+

--- a/quilt/tools/build.py
+++ b/quilt/tools/build.py
@@ -92,5 +92,6 @@ def build_package(username, package, yaml_path):
         raise BuildException("'tables' must be a dictionary")
 
     with get_store(username, package, format, 'w') as store:
+        store.clear_contents()
         _build_table(build_dir, store, '', tables)
 

--- a/quilt/tools/command.py
+++ b/quilt/tools/command.py
@@ -216,7 +216,6 @@ def push(session, package):
     )
 
     dataset = response.json()
-    print("RESPONSE DATASET=%s" % dataset)    
     upload_urls = dataset['upload_urls']
 
     headers = {
@@ -406,12 +405,10 @@ def install(session, package, hash=None, version=None, tag=None):
         )
     )
     dataset = response.json()
-    print("RESPONSE DATASET=%s" % dataset)
 
     try:
         response_urls = dataset['urls']
         response_contents = dataset['contents']
-        print("URLS=%s" % response_urls)
         store.install(response_contents, response_urls)
     except StoreException as ex:
         raise CommandException("Failed to install the package: %s" % ex)

--- a/quilt/tools/command.py
+++ b/quilt/tools/command.py
@@ -216,21 +216,20 @@ def push(session, package):
     )
 
     dataset = response.json()
-    print("RESPONSE DATASET=%s" % dataset)
-
-
-    upload_url = dataset['upload_url']
+    print("RESPONSE DATASET=%s" % dataset)    
+    upload_urls = dataset['upload_urls']
 
     headers = {
         'Content-Encoding': 'gzip'
     }
 
-    # Create a temporary gzip'ed file.
-    with store.tempfile() as temp_file:
-        response = requests.put(upload_url, data=temp_file, headers=headers)
+    for hash, url in upload_urls.items():
+        # Create a temporary gzip'ed file.
+        with store.tempfile(hash) as temp_file:
+            response = requests.put(url, data=temp_file, headers=headers)
 
-        if not response.ok:
-            raise CommandException("Upload failed: error %s" % response.status_code)
+            if not response.ok:
+                raise CommandException("Upload failed: error %s" % response.status_code)
 
     # Set the "latest" tag.
     response = session.put(

--- a/quilt/tools/command.py
+++ b/quilt/tools/command.py
@@ -244,6 +244,10 @@ def push(session, package):
         ))
     )
 
+    if not response.ok:
+        raise CommandException("Failed to update latest tag: error %s" % response.status_code)
+
+
 def version_list(session, package):
     """
     List the versions of a package.
@@ -405,7 +409,10 @@ def install(session, package, hash=None, version=None, tag=None):
     print("RESPONSE DATASET=%s" % dataset)
 
     try:
-        store.install(dataset['contents'], dataset['urls'])
+        response_urls = dataset['urls']
+        response_contents = dataset['contents']
+        print("URLS=%s" % response_urls)
+        store.install(response_contents, response_urls)
     except StoreException as ex:
         raise CommandException("Failed to install the package: %s" % ex)
 

--- a/quilt/tools/command.py
+++ b/quilt/tools/command.py
@@ -16,7 +16,7 @@ import requests
 from .build import build_package, BuildException
 from .const import LATEST_TAG
 from .store import PackageStore, StoreException, get_store, ls_packages
-from .util import BASE_DIR
+from .util import BASE_DIR, flatten_contents
 
 HEADERS = {"Content-Type": "application/json", "Accept": "application/json"}
 
@@ -174,7 +174,8 @@ def push(session, package):
             hash=pkghash
         ),
         data=json.dumps(dict(
-            description=""  # TODO
+        contents=flatten_contents(store.get_contents()),
+        description=""  # TODO
         ))
     )
 

--- a/quilt/tools/command.py
+++ b/quilt/tools/command.py
@@ -165,11 +165,11 @@ def build(package, path):
     Compile a Quilt data package
     """
     owner, pkg = _parse_package(package)
-    #try:
-    build_package(owner, pkg, path)
-    print("Built %s/%s successfully." % (owner, pkg))
-    #except BuildException as ex:
-    #    raise CommandException("Failed to build the package: %s" % ex)
+    try:
+        build_package(owner, pkg, path)
+        print("Built %s/%s successfully." % (owner, pkg))
+    except BuildException as ex:
+        raise CommandException("Failed to build the package: %s" % ex)
 
 def log(session, package):
     """
@@ -243,9 +243,7 @@ def push(session, package):
             hash=pkghash
         ))
     )
-
-    if not response.ok:
-        raise CommandException("Failed to update latest tag: error %s" % response.status_code)
+    assert response.ok # other responses handled by _handle_response
 
 
 def version_list(session, package):
@@ -406,8 +404,7 @@ def install(session, package, hash=None, version=None, tag=None):
             hash=pkghash
         )
     )
-    if not response.ok:
-        raise CommandException("Failed to install the package: %s" % response.json())
+    assert response.ok # other responses handled by _handle_response
 
     dataset = response.json()
     response_urls = dataset['urls']
@@ -420,6 +417,7 @@ def install(session, package, hash=None, version=None, tag=None):
     try:
         store.install(response_contents, response_urls)
     except StoreException as ex:
+        store.clear_contents()
         raise CommandException("Failed to install the package: %s" % ex)
 
 def access_list(session, package):

--- a/quilt/tools/command.py
+++ b/quilt/tools/command.py
@@ -210,7 +210,7 @@ def push(session, package):
             hash=pkghash
         ),
         data=json.dumps(dict(
-        contents=flatten_contents(store.get_contents()),
+        contents=store.get_contents(),
         description=""  # TODO
         ))
     )
@@ -383,9 +383,10 @@ def install(session, package):
         )
     )
     dataset = response.json()
+    print("RESPONSE DATASET=%s" % dataset)
 
     try:
-        store.install(dataset['url'], dataset['hash'])
+        store.install(dataset['contents'], dataset['urls'])
     except StoreException as ex:
         raise CommandException("Failed to install the package: %s" % ex)
 

--- a/quilt/tools/const.py
+++ b/quilt/tools/const.py
@@ -7,6 +7,7 @@ class NodeType(Enum):
     GROUP = 'GROUP'
     TABLE = 'TABLE'
 
+TYPE_KEY = "$type"
 DATEF = '%F'
 TIMEF = '%T'
 DTIMEF = '%s %s' % (DATEF, TIMEF)

--- a/quilt/tools/const.py
+++ b/quilt/tools/const.py
@@ -1,6 +1,12 @@
 """
 Constants
 """
+from enum import Enum
+
+class NodeType(Enum):
+    GROUP = 'GROUP'
+    TABLE = 'TABLE'
+
 DATEF = '%F'
 TIMEF = '%T'
 DTIMEF = '%s %s' % (DATEF, TIMEF)

--- a/quilt/tools/hashing.py
+++ b/quilt/tools/hashing.py
@@ -77,7 +77,7 @@ def hash_contents(contents):
                 hash_str(h)
         elif obj_type is NodeType.GROUP:
             hash_int(len(obj) - 1)  # Skip the "$type"
-            for key, child in sorted(iteritems(obj)):                
+            for key, child in sorted(iteritems(obj)):
                 assert isinstance(key, string_types), "key={key} type={type}".format(key=key, type=type(key))
                 if key != TYPE_KEY:
                     hash_str(key)

--- a/quilt/tools/hashing.py
+++ b/quilt/tools/hashing.py
@@ -88,4 +88,4 @@ def hash_contents(contents):
         assert isinstance(key, str)
         hash_object(obj)
 
-        return result.hexdigest()
+    return result.hexdigest()

--- a/quilt/tools/hashing.py
+++ b/quilt/tools/hashing.py
@@ -1,6 +1,6 @@
 import hashlib
 import struct
-from .const import HASH_TYPE
+from .const import HASH_TYPE, NodeType, TYPE_KEY
 
 def digest_file(fname):
     """
@@ -14,7 +14,7 @@ def digest_file(fname):
       * distinct output
     PERF takes about 20 seconds to hash 3.3GB file
     on an empty file and on build.py
-    INSPIRATION: http://stackoverflow.com/questions/3431825/generating-an-md5-checksum-of-a-file 
+    INSPIRATION: http://stackoverflow.com/questions/3431825/generating-an-md5-checksum-of-a-file
     WARNING: not clear if we need to pad file bytes for proper cryptographic
       hashing
     """
@@ -28,35 +28,64 @@ def digest_file(fname):
 
 def hash_contents(contents):
     """
-    Hashes a dictionary of object names and hash lists.
-    
+    Creates a hash of key names and hashes in a dictionary matching
+    the "contents" in `PACKAGE_SCHEMA` above. "metadata" fields are ignored.
+
     Expected format:
-    
+
     {
-        "object1": ["hash1", "hash2", ...],
-        "object2": [...],
+        "table1": {
+            "$type": "TABLE",
+            "metadata": {...},
+            "hashes": ["hash1", "hash2", ...]
+        }
+        "group1": {
+            "$type": "GROUP",
+            "table2": {
+                ...
+            },
+            "group2": {
+                ...
+            },
+            ...
+        },
         ...
     }
     """
-    assert isinstance(contents, dict), "WTF? %s %s" % (type(contents), contents)
+    assert isinstance(contents, dict)
 
     result = hashlib.sha256()
-    
-    def hash_len(obj):
-        result.update(struct.pack(">L", len(obj)))
+
+    def hash_int(value):
+        result.update(struct.pack(">L", value))
 
     def hash_str(string):
-        hash_len(string)
+        hash_int(len(string))
         result.update(string.encode())
 
-    hash_len(contents)
-    for key, hash_list in sorted(contents.items()):
-        assert isinstance(key, str)
-        assert isinstance(hash_list, list)
-        hash_str(key)
-        hash_len(hash_list)
-        for h in hash_list:
-            assert isinstance(h, str)
-            hash_str(h)
+    def hash_object(obj):
+        assert isinstance(obj, dict)
+        obj_type = NodeType(obj[TYPE_KEY])
+        hash_str(obj_type.value)
+        if obj_type is NodeType.TABLE:
+            hashes = obj["hashes"]
+            hash_int(len(hashes))
+            for h in hashes:
+                assert isinstance(h, str)
+                hash_str(h)
+        elif obj_type is NodeType.GROUP:
+            hash_int(len(obj) - 1)  # Skip the "$type"
+            for key, child in sorted(obj.items()):
+                assert isinstance(key, str)
+                if key != TYPE_KEY:
+                    hash_str(key)
+                    hash_object(child)
+        else:
+            assert False
 
-    return result.hexdigest()
+    hash_int(len(contents))
+    for key, obj in sorted(contents.items()):
+        assert isinstance(key, str)
+        hash_object(obj)
+
+        return result.hexdigest()

--- a/quilt/tools/hashing.py
+++ b/quilt/tools/hashing.py
@@ -1,5 +1,7 @@
 import hashlib
+from six import iteritems, string_types
 import struct
+
 from .const import HASH_TYPE, NodeType, TYPE_KEY
 
 def digest_file(fname):
@@ -71,12 +73,12 @@ def hash_contents(contents):
             hashes = obj["hashes"]
             hash_int(len(hashes))
             for h in hashes:
-                assert isinstance(h, str)
+                assert isinstance(h, string_types)
                 hash_str(h)
         elif obj_type is NodeType.GROUP:
             hash_int(len(obj) - 1)  # Skip the "$type"
-            for key, child in sorted(obj.items()):
-                assert isinstance(key, str)
+            for key, child in sorted(iteritems(obj)):                
+                assert isinstance(key, string_types), "key={key} type={type}".format(key=key, type=type(key))
                 if key != TYPE_KEY:
                     hash_str(key)
                     hash_object(child)
@@ -84,8 +86,8 @@ def hash_contents(contents):
             assert False
 
     hash_int(len(contents))
-    for key, obj in sorted(contents.items()):
-        assert isinstance(key, str)
+    for key, obj in sorted(iteritems(contents)):
+        assert isinstance(key, string_types), "key={key} type={type}".format(key=key, type=type(key))
         hash_object(obj)
 
     return result.hexdigest()

--- a/quilt/tools/store.py
+++ b/quilt/tools/store.py
@@ -215,6 +215,7 @@ class HDF5PackageStore(PackageStore):
         return open(objpath, 'rb')
 
     def get_hash(self):
+        print("HASHING CONTENTS=%s" % self.get_contents())
         flat_contents = flatten_contents(self.get_contents())
         print("FLAT: %s" % flat_contents)
         return hash_contents(flat_contents)
@@ -246,7 +247,7 @@ class HDF5PackageStore(PackageStore):
         """
         return self.UploadFile(self, hash)
 
-    def install(self, contents):
+    def install(self, contents, urls):
         """
         Download and install a package locally.
         """
@@ -259,9 +260,9 @@ class HDF5PackageStore(PackageStore):
         # in object dir. Verify individual file hashes.
         # Verify global hash?
 
-        def install_table(node):
+        def install_table(node, urls):
             download_hash = node['hash']
-            url = node['url']
+            url = urls[download_hash]
 
             # download and install
             print("INSTALL: %s" % download_hash)
@@ -285,15 +286,16 @@ class HDF5PackageStore(PackageStore):
                 raise StoreException("Mismatched hash! Expected %s, got %s." %
                                      (download_hash, file_hash))
         
-        def install_tables(contents):
+        def install_tables(contents, urls):
             for key in contents.keys():
                 node = contents.get(key)
+                print("NODE=%s" % node)
                 if NodeType(node.get('type')) is NodeType.GROUP:
-                    return install_tables(node)
+                    return install_tables(node, urls)
                 else:
                     install_table(node)
 
-        return install_tables(contents)
+        return install_tables(contents, urls)
         
     def keys(self, prefix):
         return self.get_contents().keys()

--- a/quilt/tools/store.py
+++ b/quilt/tools/store.py
@@ -160,6 +160,12 @@ class PackageStore(object):
         """
         return self._path
 
+    def exists(self):
+        """
+        Returns True if the package is already installed.
+        """
+        return not self._path is None
+
     def _object_path(self, objhash):
         """
         Returns the path to an object file based on its hash.
@@ -242,12 +248,6 @@ class HDF5PackageStore(PackageStore):
     def __init__(self, user, package, mode):
         super(HDF5PackageStore, self).__init__(user, package, mode)
         self.__store = None
-
-    def exists(self):
-        """
-        Returns True if the package is already installed.
-        """
-        return not self._path is None
 
     def dataframe(self, hash_list):
         """

--- a/quilt/tools/store.py
+++ b/quilt/tools/store.py
@@ -86,6 +86,13 @@ class PackageStore(object):
     def __exit__(self, type, value, traceback):
         pass
 
+    @property
+    def DATA_FILE_EXT(self):
+        """
+        Return the format-specific object file extension
+        """
+        raise NotImplementedError()
+
     def get_contents(self):
         """
         Returns a dictionary with the contents of the package.
@@ -118,7 +125,7 @@ class PackageStore(object):
         """
         Returns a list of package contents.
         """
-        raise StoreException("Not Implemented")
+        return self.get_contents().keys()
 
     def get(self, path):
         """
@@ -301,11 +308,17 @@ class HDF5PackageStore(PackageStore):
     HDF5 Implementation of PackageStore.
     """
     DF_NAME = 'df'
-    DATA_FILE_EXT = '.h5'
 
     def __init__(self, user, package, mode):
         super(HDF5PackageStore, self).__init__(user, package, mode)
         self.__store = None
+
+    @property
+    def DATA_FILE_EXT(self):
+        """
+        Return the format-specific object file extension
+        """
+        return '.h5'
 
     def dataframe(self, hash_list):
         """
@@ -346,12 +359,6 @@ class HDF5PackageStore(PackageStore):
         """
         return self.UploadFile(self, hash)
 
-    def keys(self, prefix):
-        """
-        Returns a list of package contents.
-        """
-        return self.get_contents().keys()
-
     def save_df(self, df, name, path, ext, target):
         """
         Save a DataFrame to the store.
@@ -384,13 +391,17 @@ class ParquetPackageStore(PackageStore):
     """
     Parquet Implementation of PackageStore.
     """
-
-    DATA_FILE_EXT = '.parq'
-
     def __init__(self, user, package, mode):
         if fastparquet is None:
             raise StoreException("Module fastparquet is required for ParquetPackageStore.")
         super(ParquetPackageStore, self).__init__(user, package, mode)
+
+    @property
+    def DATA_FILE_EXT(self):
+        """
+        Return the format-specific object file extension
+        """
+        return '.parq'
 
     def save_df(self, df, name, path, ext, target):
         """

--- a/quilt/tools/store.py
+++ b/quilt/tools/store.py
@@ -173,7 +173,7 @@ class PackageStore(object):
         self._find_path_write()
         local_filename = self.get_path()
         with open(local_filename, 'w') as contents_file:
-            contents_file.write(json.dumps(contents))
+            json.dump(contents, contents_file)
 
         # Download individual object files and store
         # in object dir. Verify individual file hashes.

--- a/quilt/tools/store.py
+++ b/quilt/tools/store.py
@@ -446,6 +446,8 @@ class SparkPackageStore(ParquetPackageStore):
         Creates a DataFrame from a set of objects (identified by hashes).
         """
         spark = SparkSession.builder.getOrCreate()
+        assert len(hash_list) == 1, "Multi-file DFs not supported yet."
+        filehash = hash_list[0]
         df = spark.read.parquet(self._object_path(filehash))
         return df
 

--- a/quilt/tools/store.py
+++ b/quilt/tools/store.py
@@ -93,6 +93,18 @@ class PackageStore(object):
         """
         raise NotImplementedError()
 
+    def dataframe(self, hash_list):
+        """
+        Creates a DataFrame from a set of objects (identified by hashes).
+        """
+        raise NotImplementedError()
+
+    def save_df(self, df, name, path, ext, target):
+        """
+        Save a DataFrame to the store.
+        """
+        raise NotImplementedError()
+
     def get_contents(self):
         """
         Returns a dictionary with the contents of the package.

--- a/quilt/tools/util.py
+++ b/quilt/tools/util.py
@@ -27,10 +27,12 @@ def flatten_contents(contents, prefix=[]):
     assert isinstance(contents, dict)
     elements = {}
     for key, node in contents.items():
+        if key == 'type':
+            continue
         print("Node is: {node}".format(node=node))
         assert isinstance(node, dict), "Node is: {node}".format(node=node)
         path = prefix + [key]
-        type = NodeType(node.pop('type'))
+        type = NodeType(node.get('type'))
         if type is NodeType.TABLE:
             fullname = ".".join(path)
             elements[fullname] = node['hash']

--- a/quilt/tools/util.py
+++ b/quilt/tools/util.py
@@ -4,8 +4,6 @@ Helper functions.
 
 from appdirs import user_data_dir
 
-from .const import NodeType
-
 APP_NAME = "QuiltCli"
 APP_AUTHOR = "QuiltData"
 BASE_DIR = user_data_dir(APP_NAME, APP_AUTHOR)

--- a/quilt/tools/util.py
+++ b/quilt/tools/util.py
@@ -29,7 +29,6 @@ def flatten_contents(contents, prefix=[]):
     for key, node in contents.items():
         if key == 'type':
             continue
-        print("Node is: {node}".format(node=node))
         assert isinstance(node, dict), "Node is: {node}".format(node=node)
         path = prefix + [key]
         type = NodeType(node.get('type'))

--- a/quilt/tools/util.py
+++ b/quilt/tools/util.py
@@ -6,6 +6,8 @@ import re
 
 from appdirs import user_data_dir
 
+from .const import NodeType
+
 APP_NAME = "QuiltCli"
 APP_AUTHOR = "QuiltData"
 BASE_DIR = user_data_dir(APP_NAME, APP_AUTHOR)
@@ -20,3 +22,21 @@ def file_to_str(fname):
     with open(fname, 'rU') as f:
         data = f.read()
     return data
+
+def flatten_contents(contents, prefix=[]):
+    assert isinstance(contents, dict)
+    elements = {}
+    for key, node in contents.items():
+        print("Node is: {node}".format(node=node))
+        assert isinstance(node, dict), "Node is: {node}".format(node=node)
+        path = prefix + [key]
+        type = NodeType(node.pop('type'))
+        if type is NodeType.TABLE:
+            fullname = ".".join(path)
+            elements[fullname] = node['hash']
+        elif type is NodeType.GROUP:
+            elements.update(flatten_contents(node, prefix + [key]))
+        else:
+            assert False, "Unknown NodeType? {type}".format(type=type.value)
+
+    return elements

--- a/quilt/tools/util.py
+++ b/quilt/tools/util.py
@@ -1,8 +1,6 @@
 """
 Helper functions.
 """
-import os.path
-import re
 
 from appdirs import user_data_dir
 
@@ -22,22 +20,3 @@ def file_to_str(fname):
     with open(fname, 'rU') as f:
         data = f.read()
     return data
-
-def flatten_contents(contents, prefix=[]):
-    assert isinstance(contents, dict)
-    elements = {}
-    for key, node in contents.items():
-        if key == 'type':
-            continue
-        assert isinstance(node, dict), "Node is: {node}".format(node=node)
-        path = prefix + [key]
-        type = NodeType(node.get('type'))
-        if type is NodeType.TABLE:
-            fullname = ".".join(path)
-            elements[fullname] = node['hash']
-        elif type is NodeType.GROUP:
-            elements.update(flatten_contents(node, prefix + [key]))
-        else:
-            assert False, "Unknown NodeType? {type}".format(type=type.value)
-
-    return elements


### PR DESCRIPTION
Supporting packages with multiple files allows greater flexibility in file formats and more. This change adds a contents file to packages that tracks a set of individual object files, which are identified by their hash.