### PR TITLE
Updating developer instructions and .gitignore for test coverage

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,6 @@ tmp_*
 quilt_packages
 metastore_db
 derby.log
+
+.coverage
+cov_html

--- a/README.md
+++ b/README.md
@@ -179,9 +179,11 @@ If you wish to make a package public, `quilt access add YOU/YOUR_PACKAGE public`
 * `quilt tag remove USER/PACKAGE TAG` to delete a tag
 
 # Developer
-- `pip install pylint pytest`
+- `pip install pylint pytest pytest-cov`
 - `pytest` will run any `test_*` files in any subdirectory
-- All new modules, files, and functions should have a corresponding test
+- All new modules, files, and functions should have a corresponding test 
+- Track test code coverage by running: `python -m pytest --cov=quilt/tools/ --cov-report html:cov_html quilt/test -v`
+- View coverage results by opening cov_html/index.html
 
 ## Local installation
 1. `git clone https://github.com/quiltdata/quilt.git`


### PR DESCRIPTION
Adding instructions to run pytest-cov to README and including .coverage
and cov_html (pytest-cov outputs) in .gitignore.