### PR TITLE
Fix a bunch of lint problems

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -4,3 +4,10 @@ extension-pkg-whitelist=numpy
 [TYPECHECK]
 generated-members=requests.codes.*,responses.*
 ignored-modules=quilt.data
+
+[BASIC]
+variable-rgx=[a-z_][a-z0-9_]{0,30}$
+variable-name-hint=[a-z_][a-z0-9_]{0,30}$
+
+[VARIABLES]
+redefining-builtins-modules=six.moves,builtins

--- a/quilt/test/test_build.py
+++ b/quilt/test/test_build.py
@@ -25,8 +25,8 @@ class BuildTest(QuiltTestCase):
         Test compilation
         """
         mydir = os.path.dirname(__file__)
-        PATH = os.path.join(mydir, './build.yml')
-        build.build_package('test_hdf5', PACKAGE, PATH)
+        path = os.path.join(mydir, './build.yml')
+        build.build_package('test_hdf5', PACKAGE, path)
         # TODO load DFs based on contents of .yml file at PATH
         # not hardcoded vals (this will require loading modules from variable
         # names, probably using __module__)
@@ -47,9 +47,9 @@ class BuildTest(QuiltTestCase):
         """
         os.environ["QUILT_PACKAGE_FORMAT"] = FORMAT_PARQ
         mydir = os.path.dirname(__file__)
-        PATH = os.path.join(mydir, './build.yml')
-        build.build_package('test_parquet', PACKAGE, PATH)
-        # TODO load DFs based on contents of .yml file at PATH
+        path = os.path.join(mydir, './build.yml')
+        build.build_package('test_parquet', PACKAGE, path)
+        # TODO load DFs based on contents of .yml file at path
         # not hardcoded vals (this will require loading modules from variable
         # names, probably using __module__)
         from quilt.data.test_parquet.groot import csv, tsv, xls
@@ -60,5 +60,5 @@ class BuildTest(QuiltTestCase):
         print(csv.columns, xls.columns, tsv.columns)
         assert cols == len(tsv.columns) and cols == len(xls.columns), \
             'Expected dataframes to have same # columns'
-        del(os.environ["QUILT_PACKAGE_FORMAT"])
+        del os.environ["QUILT_PACKAGE_FORMAT"]
         # TODO add more integrity checks, incl. negative test cases

--- a/quilt/test/test_command.py
+++ b/quilt/test/test_command.py
@@ -6,6 +6,8 @@ import pytest
 import requests
 import responses
 
+from six import assertRaisesRegex
+
 try:
     import h5py
 except ImportError:
@@ -15,41 +17,38 @@ from quilt.tools import command
 from .utils import QuiltTestCase, patch
 
 class CommandTest(QuiltTestCase):
-    # Note: we're using the deprecated `assertRaisesRegexp` method because
-    # the new one, `assertRaisesRegex`, is not present in Python2.
-
     def test_push_invalid_package(self):
         session = requests.Session()
 
-        with self.assertRaisesRegexp(command.CommandException, "owner/package_name"):
+        with assertRaisesRegex(self, command.CommandException, "owner/package_name"):
             command.push(session=session, package="no_user")
-        with self.assertRaisesRegexp(command.CommandException, "owner/package_name"):
+        with assertRaisesRegex(self, command.CommandException, "owner/package_name"):
             command.push(session=session, package="a/b/c")
 
     def test_install_invalid_package(self):
         session = requests.Session()
 
-        with self.assertRaisesRegexp(command.CommandException, "owner/package_name"):
+        with assertRaisesRegex(self, command.CommandException, "owner/package_name"):
             command.install(session=session, package="no_user")
-        with self.assertRaisesRegexp(command.CommandException, "owner/package_name"):
+        with assertRaisesRegex(self, command.CommandException, "owner/package_name"):
             command.install(session=session, package="a/b/c")
 
     @pytest.mark.skipif("h5py is None")
     def test_inspect_invalid_package(self):
-        with self.assertRaisesRegexp(command.CommandException, "owner/package_name"):
+        with assertRaisesRegex(self, command.CommandException, "owner/package_name"):
             command.inspect(package="no_user")
-        with self.assertRaisesRegexp(command.CommandException, "owner/package_name"):
+        with assertRaisesRegex(self, command.CommandException, "owner/package_name"):
             command.inspect(package="a/b/c")
 
     def test_push_missing_package(self):
         session = requests.Session()
 
-        with self.assertRaisesRegexp(command.CommandException, "not found"):
+        with assertRaisesRegex(self, command.CommandException, "not found"):
             command.push(session=session, package="owner/package")
 
     @pytest.mark.skipif("h5py is None")
     def test_inspect_missing_package(self):
-        with self.assertRaisesRegexp(command.CommandException, "not found"):
+        with assertRaisesRegex(self, command.CommandException, "not found"):
             command.inspect(package="owner/package")
 
     @patch('webbrowser.open')

--- a/quilt/test/test_install.py
+++ b/quilt/test/test_install.py
@@ -8,6 +8,7 @@ import os
 
 import requests
 import responses
+from six import assertRaisesRegex
 
 from quilt.tools import command
 from quilt.tools.const import HASH_TYPE, TYPE_KEY, NodeType
@@ -19,9 +20,6 @@ class InstallTest(QuiltTestCase):
     """
     Unit tests for quilt install.
     """
-    # Note: we're using the deprecated `assertRaisesRegexp` method because
-    # the new one, `assertRaisesRegex`, is not present in Python2.
-
     def test_install_latest(self):
         """
         Install the latest update of a package.
@@ -71,7 +69,7 @@ class InstallTest(QuiltTestCase):
         self._mock_s3(obj_hash, tabledata)
 
         session = requests.Session()
-        with self.assertRaisesRegexp(command.CommandException, "Mismatched hash"):
+        with assertRaisesRegex(self, command.CommandException, "Mismatched hash"):
             command.install(session, 'foo/bar')
 
         assert not os.path.exists('quilt_packages/foo/bar.json')
@@ -95,7 +93,7 @@ class InstallTest(QuiltTestCase):
         self._mock_s3(obj_hash, tabledata)
 
         session = requests.Session()
-        with self.assertRaisesRegexp(command.CommandException, "Mismatched hash"):
+        with assertRaisesRegex(self, command.CommandException, "Mismatched hash"):
             command.install(session, 'foo/bar')
 
         assert not os.path.exists('quilt_packages/foo/bar.json')
@@ -108,7 +106,7 @@ class InstallTest(QuiltTestCase):
         )))
 
     def _mock_package(self, package, pkg_hash, contents, hashes):
-        pkg_url = '%s/api/package/foo/bar/%s' % (command.QUILT_PKG_URL, pkg_hash)
+        pkg_url = '%s/api/package/%s/%s' % (command.QUILT_PKG_URL, package, pkg_hash)
         self.requests_mock.add(responses.GET, pkg_url, json.dumps(dict(
             contents=contents,
             urls={h: 'https://example.com/%s' % h for h in hashes}

--- a/quilt/tools/command.py
+++ b/quilt/tools/command.py
@@ -500,7 +500,7 @@ def inspect(package):
                 fullname = "/".join([path, name])
                 print(prefix + name_prefix + name)
             else:
-                assert False, "Unhandled NodeType {nt}".format(nt=node_type)                
+                assert False, "Unhandled NodeType {nt}".format(nt=node_type)
         else:
             assert False, "node=%s type=%s" % (node, type(node))
 


### PR DESCRIPTION
- Allow short variable names
- Use `six.assertRaisesRegex`
- Allow built-in overrides from `builtins`
- Fix a few actual errors