### PR TITLE
Pretty print contents.json

### DIFF
--- a/quilt/tools/store.py
+++ b/quilt/tools/store.py
@@ -147,7 +147,7 @@ class PackageStore(object):
         Saves an updated version of the package's contents.
         """
         with open(self._path, 'w') as contents_file:
-            json.dump(contents, contents_file)
+            json.dump(contents, contents_file, indent=2, sort_keys=True)
 
     def get(self, path):
         """


### PR DESCRIPTION
Do we rely on the hash of this file at any point?
We could be fancy and pretty print this on unpack but that's a (harmful) micro-optimization.