### PR TITLE
Remove references to `h5py` cause it's not needed anymore

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,6 @@ the registry at [quiltdata.com](https://quiltdata.com/package/examples/wine).
 
 
 # Known Issues
-- `Python 3.6` - Install fails due to missing HDF5 dependencies. Try Python 3.5. For example if you're using Anaconda, create a 3.5 environment: `conda create -n ENV python=3.5`.
 -  `quilt/test/build.yml` relies on pickle and is therefore not compatible between Python 2 and Python 3.
 
 # Quick Start
@@ -189,16 +188,3 @@ If you wish to make a package public, `quilt access add YOU/YOUR_PACKAGE public`
 1. `git clone https://github.com/quiltdata/quilt.git`
 1. `cd quilt`
 1. From the repository root: `pip install -e .`
-
-## If you need h5py
-### The easy way with binaries
-Use conda to `conda install h5py`.
-
-### The hard way from source (YMMV; this is for Mac OS)
-1. Install HDF5: `brew install homebrew/science/hdf5@1.8`
-  - [See also this `h5py` doc](http://docs.h5py.org/en/latest/build.html#source-installation-on-linux-and-os-x)
-1. Expose compiler flags in `~/.bash_profile`. Follow the homebrew instructions, which should look something like this:
-```
-export LDFLAGS="-L/usr/local/opt/hdf5@1.8/lib"
-export CPPFLAGS="-I/usr/local/opt/hdf5@1.8/include"
-```

--- a/quilt/test/test_command.py
+++ b/quilt/test/test_command.py
@@ -11,11 +11,6 @@ import responses
 
 from six import assertRaisesRegex
 
-try:
-    import h5py
-except ImportError:
-    h5py = None
-
 from quilt.tools import command, store
 from .utils import QuiltTestCase, patch
 


### PR DESCRIPTION
Also remove Python 3.6 from known issues cause it now works.