### PR TITLE
Don't create the package file until we're actually saving the contents

### DIFF
--- a/quilt/tools/build.py
+++ b/quilt/tools/build.py
@@ -114,9 +114,14 @@ def build_package(username, package, yaml_path):
     pkgformat = data.get('format', PackageFormat.default.value)
     if not isinstance(pkgformat, str):
         raise BuildException("'format' must be a string")
+    try:
+        pkgformat = PackageFormat(pkgformat)
+    except ValueError:
+        raise BuildException("Unsupported format: %r" % pkgformat)
 
     store = PackageStore()
-    newpackage = store.create_package(username, package, pkgformat)
+    newpackage = store.create_package(username, package)
+    newpackage.set_format(pkgformat)
     _build_node(build_dir, newpackage, '', contents)
 
 def splitext_no_dot(filename):

--- a/quilt/tools/command.py
+++ b/quilt/tools/command.py
@@ -436,11 +436,10 @@ def install(session, package, hash=None, version=None, tag=None):
     if pkghash != hash_contents(response_contents):
         raise CommandException("Mismatched hash. Try again.")
 
-    pkgobj = store.create_package(owner, pkg, PackageFormat.HDF5)
+    pkgobj = store.create_package(owner, pkg)
     try:
         pkgobj.install(response_contents, response_urls)
     except PackageException as ex:
-        pkgobj.clear_contents()
         raise CommandException("Failed to install the package: %s" % ex)
 
 def access_list(session, package):

--- a/quilt/tools/package.py
+++ b/quilt/tools/package.py
@@ -85,6 +85,11 @@ class Package(object):
         self._package = package
         self._pkg_dir = pkg_dir
         self._path = path
+        self._format = None
+
+    def set_format(self, pkgformat):
+        """Set the format. Only used when building a new package."""
+        self._format = pkgformat
 
     def file(self, hash_list):
         """
@@ -202,15 +207,10 @@ class Package(object):
                 if not isinstance(contents, RootNode):
                     contents = RootNode(contents.children, PackageFormat.default.value)
         except IOError:
-            contents = RootNode(dict(), PackageFormat.default)
+            assert self._format is not None
+            contents = RootNode(dict(), self._format.value)
 
         return contents
-
-    def clear_contents(self):
-        """
-        Removes the package's contents file.
-        """
-        os.remove(self._path)
 
     def save_contents(self, contents):
         """
@@ -218,12 +218,6 @@ class Package(object):
         """
         with open(self._path, 'w') as contents_file:
             json.dump(contents, contents_file, default=encode_node, indent=2, sort_keys=True)
-
-    def init_contents(self, pkgformat):
-        # Verify the format is recognized
-        enumformat = PackageFormat(pkgformat)
-        contents = RootNode(dict(), enumformat.value)
-        self.save_contents(contents)
 
     def get(self, path):
         """

--- a/quilt/tools/store.py
+++ b/quilt/tools/store.py
@@ -74,7 +74,7 @@ class PackageStore(object):
                                pkg_dir=package_dir)
         return None
 
-    def create_package(self, user, package, pkgformat=PackageFormat.default):
+    def create_package(self, user, package):
         """
         Creates a new package in the innermost `quilt_packages` directory
         (or in a new `quilt_packages` directory in the current directory)
@@ -93,12 +93,16 @@ class PackageStore(object):
 
         path = os.path.join(package_dir, user, package + self.PACKAGE_FILE_EXT)
 
-        pkgobj = Package(user=user,
-                         package=package,
-                         path=path,
-                         pkg_dir=package_dir)
-        pkgobj.init_contents(pkgformat)
-        return pkgobj
+        # Delete any existing data.
+        try:
+            os.remove(path)
+        except OSError:
+            pass
+
+        return Package(user=user,
+                       package=package,
+                       path=path,
+                       pkg_dir=package_dir)
 
     @classmethod
     def ls_packages(cls, pkg_dir):


### PR DESCRIPTION
This makes `init_contents` and `clear_contents` unnecessary.