### PR TITLE
Avoid building data frames when accessing nodes

### DIFF
--- a/quilt/data.py
+++ b/quilt/data.py
@@ -37,7 +37,12 @@ class DataNode(object):
         if name.startswith('_'):
             raise AttributeError
         path = self._prefix + '/' + name
-        return self._get_package_obj(path)
+
+        node = self._get_node(path)
+        if isinstance(node, GroupNode):
+            return DataNode(self._package, path)
+        else:
+            return self._package.get_obj(node)
 
     def __repr__(self):
         cinfo = str(self.__class__)
@@ -59,19 +64,15 @@ class DataNode(object):
         """
         pref = self._prefix + '/'
         return [k for k in self._keys()
-                if not isinstance(self._get_package_obj(pref + k), DataNode)]
+                if not isinstance(self._get_node(pref + k), GroupNode)]
 
-    def _get_package_obj(self, path):
+    def _get_node(self, path):
         try:
-            obj = self._package.get(path)
+            node = self._package.get(path)
         except KeyError:
             # No such group or table
             raise AttributeError("No such table or group: %s" % path)
-
-        if isinstance(obj, GroupNode):
-            return DataNode(self._package, path)
-        else:
-            return obj
+        return node
 
     def _groups(self):
         """
@@ -79,7 +80,7 @@ class DataNode(object):
         """
         pref = self._prefix + '/'
         return [k for k in self._keys()
-                if isinstance(self._get_package_obj(pref + k), DataNode)]
+                if isinstance(self._get_node(pref + k), GroupNode)]
 
     def _keys(self):
         """

--- a/quilt/tools/command.py
+++ b/quilt/tools/command.py
@@ -515,7 +515,8 @@ def inspect(package):
             _print_children(children, child_prefix, path + name)
         elif isinstance(node, TableNode):
             fullname = "/".join([path, name])
-            df = pkgobj.get(fullname)
+            node = pkgobj.get(fullname)
+            df = pkgobj.get_obj(node)
             assert isinstance(df, pd.DataFrame)
             info = "shape %s, type \"%s\"" % (df.shape, df.dtypes)
             print(prefix + name_prefix + ": " + info)

--- a/quilt/tools/package.py
+++ b/quilt/tools/package.py
@@ -235,7 +235,8 @@ class Package(object):
 
     def get(self, path):
         """
-        Read a group or object from the store.
+        Traverse the package tree and return node corresponding to
+        the given path.
         """
         key = path.lstrip('/')
         ipath = key.split('/') if key else []
@@ -251,6 +252,16 @@ class Package(object):
                     owner=self._user,
                     pkg=self._package))
         node = ptr
+        return node
+
+    def get_obj(self, node):
+        """
+        Read an object from the package given a node from the
+        package tree.
+        """
+        # TODO: This adds yet another re-reading of the contents file
+        ptr = self.get_contents()
+        pkgformat = ptr.format
 
         if isinstance(node, GroupNode):
             return node


### PR DESCRIPTION
This fixes a major performance bug that caused Quilt to read all
dataframe children of a group node into memory when the node __repr__
method was invoked. Now, package.get is split into two phases: get,
returns just the node and get_obj(node) returns the actual object
(dataframe, file or group).