### PR TITLE
Fix tests for invalid builds

### DIFF
--- a/quilt/test/test_build.py
+++ b/quilt/test/test_build.py
@@ -49,18 +49,12 @@ class BuildTest(QuiltTestCase):
             'Expected dataframes to have same # columns'
 
         path = os.path.join(mydir, './build_bad_transform.yml')
-        try: 
+        with self.assertRaises(build.BuildException):
             build.build_package('test_hdf5_transform', PACKAGE, path)
-            assert true, 'Expected build_bad_transform.yml to fail'
-        except build.BuildException:
-            pass
 
         path = os.path.join(mydir, './build_bad_file.yml')
-        try: 
+        with self.assertRaises(build.BuildException):
             build.build_package('test_hdf5_file', PACKAGE, path)
-            assert true, 'Expected build_bad_file.yml to fail'
-        except build.BuildException:
-            pass
 
         # TODO add more integrity checks, incl. negative test cases
 


### PR DESCRIPTION
`assert true` is a creative way to fail a test, but let's not do that.