### PR TITLE
Use `GroupNode` and `LeafNode` wrapper objects for both groups and leaf nodes

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ the registry at [quiltdata.com](https://quiltdata.com/).
 1. You've got data frames
 ```python
 from quilt.data.examples import wine
-wine.quality.red # this is a pandas.DataFrame
+wine.quality.red()  # this is a pandas.DataFrame
 ```
 
 # Tutorial
@@ -54,20 +54,18 @@ The import syntax is `from quilt.data.USER import PACKAGE`.
 Let's see what's in the `wine` package:
 ```python
 >>> wine
-<class 'quilt.data.DataNode'>
-File: /Users/kmoore/toa/github/quilt2/quilt_packages/examples/wine.json
-Path: /
-README/
-quality/
->>> wine.quality
-<class 'quilt.data.DataNode'>
-File: /Users/kmoore/toa/github/quilt2/quilt_packages/examples/wine.json
-Path: /quality/
-red/
-white/
->>> type(wine.quality.red)
-<class 'pandas.core.frame.DataFrame'>
+<GroupNode '/Users/kmoore/toa/github/quilt2/quilt_packages/examples/wine' ''>
+>>> wine._keys()
+['README', 'quality']
+>>> wine.quality._keys()
+['white', 'red']
+>>> wine.quality.red._keys()
+[]
 >>> wine.quality.red
+<LeafNode '/home/dima/quilt_packages/examples/wine' '/quality/red'>
+>>> type(wine.quality.red())
+<class 'pandas.core.frame.DataFrame'>
+>>> wine.quality.red()
       fixed acidity  volatile acidity  citric acid  residual sugar  chlorides  \
 0               7.4             0.700         0.00             1.9      0.076   
 1               7.8             0.880         0.00             2.6      0.098   
@@ -144,7 +142,7 @@ Packages can include data and other contents that are not representable as DataF
 Files can be accessed by using the normal Python `open` method.
 ```python
 from quilt.data.USER import PACKAGE
-with open(PACKAGE.a_file, 'r') as localfile:
+with open(PACKAGE.a_file(), 'r') as localfile:
   print(localfile.read())
 ```
 

--- a/quilt/data.py
+++ b/quilt/data.py
@@ -63,8 +63,8 @@ class DataNode(object):
         finfo = 'File: ' + self._package.get_path()
         pinfo = 'Path: ' + self._prefix + ('/' if self._is_group() else '')
         #TODO maybe show all descendant subpaths instead of just children
-        groups = sorted(k + '/' for k in self._groups())
-        dfs = sorted(self._dfs())
+        groups = sorted(k + '/' for k in self._group_keys())
+        dfs = sorted(self._df_keys())
         output = [cinfo, finfo, pinfo] + groups + dfs
         return '\n'.join(output)
 

--- a/quilt/data.py
+++ b/quilt/data.py
@@ -82,7 +82,7 @@ class DataNode(object):
         assert not isinstance(self._node, GroupNode)
         return self._package.get_obj(self._node)
 
-    def _dfs(self):
+    def _df_keys(self):
         """
         every child key referencing a dataframe
         """
@@ -90,7 +90,7 @@ class DataNode(object):
         return [k for k in self._keys()
                 if not isinstance(self._package.get(pref + k), GroupNode)]
 
-    def _groups(self):
+    def _group_keys(self):
         """
         every child key referencing a group that is not a dataframe
         """

--- a/quilt/test/test_build.py
+++ b/quilt/test/test_build.py
@@ -36,13 +36,13 @@ class BuildTest(QuiltTestCase):
         # not hardcoded vals (this will require loading modules from variable
         # names, probably using __module__)
         from quilt.data.test_hdf5.groot import dataframes, README
-        csv = dataframes.csv._df()
-        tsv = dataframes.csv._df()
-        xls = dataframes.xls._df()
+        csv = dataframes.csv()
+        tsv = dataframes.csv()
+        xls = dataframes.xls()
         rows = len(csv.index)
         assert rows == len(tsv.index) and rows == len(xls.index), \
             'Expected dataframes to have same # rows'
-        assert os.path.exists(README._df())
+        assert os.path.exists(README())
         cols = len(csv.columns)
         print(csv.columns, xls.columns, tsv.columns)
         assert cols == len(tsv.columns) and cols == len(xls.columns), \
@@ -71,13 +71,13 @@ class BuildTest(QuiltTestCase):
         # not hardcoded vals (this will require loading modules from variable
         # names, probably using __module__)
         from quilt.data.test_parquet.groot import dataframes, README
-        csv = dataframes.csv._df()
-        tsv = dataframes.csv._df()
-        xls = dataframes.xls._df()
+        csv = dataframes.csv()
+        tsv = dataframes.csv()
+        xls = dataframes.xls()
         rows = len(csv.index)
         assert rows == len(tsv.index) and rows == len(xls.index), \
             'Expected dataframes to have same # rows'
-        assert os.path.exists(README._df())
+        assert os.path.exists(README())
         cols = len(csv.columns)
         print(csv.columns, xls.columns, tsv.columns)
         assert cols == len(tsv.columns) and cols == len(xls.columns), \
@@ -98,14 +98,14 @@ class BuildTest(QuiltTestCase):
         # not hardcoded vals (this will require loading modules from variable
         # names, probably using __module__)
         from quilt.data.test_fastparquet.groot import dataframes, README
-        csv = dataframes.csv._df()
-        tsv = dataframes.csv._df()
-        xls = dataframes.xls._df()
+        csv = dataframes.csv()
+        tsv = dataframes.csv()
+        xls = dataframes.xls()
         rows = len(csv.index)
         rows = len(csv.index)
         assert rows == len(tsv.index) and rows == len(xls.index), \
             'Expected dataframes to have same # rows'
-        assert os.path.exists(README._df())
+        assert os.path.exists(README())
         cols = len(csv.columns)
         print(csv.columns, xls.columns, tsv.columns)
         assert cols == len(tsv.columns) and cols == len(xls.columns), \
@@ -128,9 +128,9 @@ class BuildTest(QuiltTestCase):
         # not hardcoded vals (this will require loading modules from variable
         # names, probably using __module__)
         from quilt.data.test_arrow.groot import dataframes, README
-        csv = dataframes.csv._df()
-        tsv = dataframes.csv._df()
-        xls = dataframes.xls._df()
+        csv = dataframes.csv()
+        tsv = dataframes.csv()
+        xls = dataframes.xls()
         rows = len(csv.index)
         assert rows == len(tsv.index) and rows == len(xls.index), \
             'Expected dataframes to have same # rows'
@@ -138,7 +138,7 @@ class BuildTest(QuiltTestCase):
         print(csv.columns, xls.columns, tsv.columns)
         assert cols == len(tsv.columns) and cols == len(xls.columns), \
             'Expected dataframes to have same # columns'
-        assert os.path.exists(README._df())
+        assert os.path.exists(README())
         # TODO add more integrity checks, incl. negative test cases
         assert Package.get_parquet_lib() is ParquetLib.ARROW
         del os.environ["QUILT_PARQUET_LIBRARY"]

--- a/quilt/test/test_build.py
+++ b/quilt/test/test_build.py
@@ -36,13 +36,13 @@ class BuildTest(QuiltTestCase):
         # not hardcoded vals (this will require loading modules from variable
         # names, probably using __module__)
         from quilt.data.test_hdf5.groot import dataframes, README
-        csv = dataframes.csv
-        tsv = dataframes.csv
-        xls = dataframes.xls
+        csv = dataframes.csv._df()
+        tsv = dataframes.csv._df()
+        xls = dataframes.xls._df()
         rows = len(csv.index)
         assert rows == len(tsv.index) and rows == len(xls.index), \
             'Expected dataframes to have same # rows'
-        assert os.path.exists(README)
+        assert os.path.exists(README._df())
         cols = len(csv.columns)
         print(csv.columns, xls.columns, tsv.columns)
         assert cols == len(tsv.columns) and cols == len(xls.columns), \
@@ -71,13 +71,13 @@ class BuildTest(QuiltTestCase):
         # not hardcoded vals (this will require loading modules from variable
         # names, probably using __module__)
         from quilt.data.test_parquet.groot import dataframes, README
-        csv = dataframes.csv
-        tsv = dataframes.csv
-        xls = dataframes.xls
+        csv = dataframes.csv._df()
+        tsv = dataframes.csv._df()
+        xls = dataframes.xls._df()
         rows = len(csv.index)
         assert rows == len(tsv.index) and rows == len(xls.index), \
             'Expected dataframes to have same # rows'
-        assert os.path.exists(README)
+        assert os.path.exists(README._df())
         cols = len(csv.columns)
         print(csv.columns, xls.columns, tsv.columns)
         assert cols == len(tsv.columns) and cols == len(xls.columns), \
@@ -98,14 +98,14 @@ class BuildTest(QuiltTestCase):
         # not hardcoded vals (this will require loading modules from variable
         # names, probably using __module__)
         from quilt.data.test_fastparquet.groot import dataframes, README
-        csv = dataframes.csv
-        tsv = dataframes.csv
-        xls = dataframes.xls
+        csv = dataframes.csv._df()
+        tsv = dataframes.csv._df()
+        xls = dataframes.xls._df()
         rows = len(csv.index)
         rows = len(csv.index)
         assert rows == len(tsv.index) and rows == len(xls.index), \
             'Expected dataframes to have same # rows'
-        assert os.path.exists(README)
+        assert os.path.exists(README._df())
         cols = len(csv.columns)
         print(csv.columns, xls.columns, tsv.columns)
         assert cols == len(tsv.columns) and cols == len(xls.columns), \
@@ -128,9 +128,9 @@ class BuildTest(QuiltTestCase):
         # not hardcoded vals (this will require loading modules from variable
         # names, probably using __module__)
         from quilt.data.test_arrow.groot import dataframes, README
-        csv = dataframes.csv
-        tsv = dataframes.csv
-        xls = dataframes.xls
+        csv = dataframes.csv._df()
+        tsv = dataframes.csv._df()
+        xls = dataframes.xls._df()
         rows = len(csv.index)
         assert rows == len(tsv.index) and rows == len(xls.index), \
             'Expected dataframes to have same # rows'
@@ -138,7 +138,7 @@ class BuildTest(QuiltTestCase):
         print(csv.columns, xls.columns, tsv.columns)
         assert cols == len(tsv.columns) and cols == len(xls.columns), \
             'Expected dataframes to have same # columns'
-        assert os.path.exists(README)
+        assert os.path.exists(README._df())
         # TODO add more integrity checks, incl. negative test cases
         assert Package.get_parquet_lib() is ParquetLib.ARROW
         del os.environ["QUILT_PARQUET_LIBRARY"]

--- a/quilt/test/test_import.py
+++ b/quilt/test/test_import.py
@@ -28,8 +28,18 @@ class ImportTest(QuiltTestCase):
 
         assert isinstance(package, DataNode)
         assert isinstance(dataframes, DataNode)
-        assert isinstance(dataframes.csv, DataFrame)
-        assert isinstance(README, string_types)
+        assert isinstance(dataframes.csv, DataNode)
+        assert isinstance(README, DataNode)
+
+        assert package._is_group()
+        assert dataframes._is_group()
+        assert dataframes.csv._is_df()
+        assert README._is_df()
+
+        assert not package._is_df()
+        assert not dataframes._is_df()
+        assert not dataframes.csv._is_group()
+        assert not README._is_group()
 
         assert package.dataframes == dataframes
         assert package.README == README
@@ -37,6 +47,9 @@ class ImportTest(QuiltTestCase):
         assert set(dataframes._keys()) == {'xls', 'csv', 'tsv'}
         assert set(dataframes._groups()) == set()
         assert set(dataframes._dfs()) == {'xls', 'csv', 'tsv'}
+
+        assert set(dataframes.csv._keys()) == set()
+        assert set(README._keys()) == set()
 
         # Bad attributes of imported packages
 

--- a/quilt/test/test_import.py
+++ b/quilt/test/test_import.py
@@ -7,7 +7,7 @@ import os
 from pandas.core.frame import DataFrame
 from six import string_types
 
-from quilt.data import DataNode
+from quilt.data import GroupNode, LeafNode
 from quilt.tools import command
 from quilt.tools.const import PACKAGE_DIR_NAME
 from .utils import QuiltTestCase
@@ -26,30 +26,22 @@ class ImportTest(QuiltTestCase):
 
         # Contents of the imports
 
-        assert isinstance(package, DataNode)
-        assert isinstance(dataframes, DataNode)
-        assert isinstance(dataframes.csv, DataNode)
-        assert isinstance(README, DataNode)
-
-        assert package._is_group()
-        assert dataframes._is_group()
-        assert dataframes.csv._is_df()
-        assert README._is_df()
-
-        assert not package._is_df()
-        assert not dataframes._is_df()
-        assert not dataframes.csv._is_group()
-        assert not README._is_group()
+        assert isinstance(package, GroupNode)
+        assert isinstance(dataframes, GroupNode)
+        assert isinstance(dataframes.csv, LeafNode)
+        assert isinstance(README, LeafNode)
 
         assert package.dataframes == dataframes
         assert package.README == README
 
         assert set(dataframes._keys()) == {'xls', 'csv', 'tsv'}
         assert set(dataframes._group_keys()) == set()
-        assert set(dataframes._df_keys()) == {'xls', 'csv', 'tsv'}
+        assert set(dataframes._leaf_keys()) == {'xls', 'csv', 'tsv'}
 
-        assert set(dataframes.csv._keys()) == set()
-        assert set(README._keys()) == set()
+        assert isinstance(README(), string_types)
+        assert isinstance(README.data(), string_types)
+        assert isinstance(dataframes.csv(), DataFrame)
+        assert isinstance(dataframes.csv.data(), DataFrame)
 
         str(package)
         str(dataframes)

--- a/quilt/test/test_import.py
+++ b/quilt/test/test_import.py
@@ -45,8 +45,8 @@ class ImportTest(QuiltTestCase):
         assert package.README == README
 
         assert set(dataframes._keys()) == {'xls', 'csv', 'tsv'}
-        assert set(dataframes._groups()) == set()
-        assert set(dataframes._dfs()) == {'xls', 'csv', 'tsv'}
+        assert set(dataframes._group_keys()) == set()
+        assert set(dataframes._df_keys()) == {'xls', 'csv', 'tsv'}
 
         assert set(dataframes.csv._keys()) == set()
         assert set(README._keys()) == set()

--- a/quilt/test/test_import.py
+++ b/quilt/test/test_import.py
@@ -51,6 +51,10 @@ class ImportTest(QuiltTestCase):
         assert set(dataframes.csv._keys()) == set()
         assert set(README._keys()) == set()
 
+        str(package)
+        str(dataframes)
+        str(README)
+
         # Bad attributes of imported packages
 
         with self.assertRaises(AttributeError):

--- a/quilt/tools/package.py
+++ b/quilt/tools/package.py
@@ -277,9 +277,7 @@ class Package(object):
         ptr = self.get_contents()
         pkgformat = ptr.format
 
-        if isinstance(node, GroupNode):
-            return node
-        elif isinstance(node, TableNode):
+        if isinstance(node, TableNode):
             return self._dataframe(node.hashes, pkgformat)
         elif isinstance(node, FileNode):
             return self.file(node.hashes)


### PR DESCRIPTION
Makes things more consistent, and allows accessing leaf nodes without
having to load the dataframe into memory.