### PR TITLE
Simplify the `GroupNode` class

### DIFF
--- a/quilt/tools/command.py
+++ b/quilt/tools/command.py
@@ -543,14 +543,11 @@ def inspect(package):
             print(prefix + name_prefix + name)
             _print_children(children, child_prefix, path + name)
         elif isinstance(node, TableNode):
-            fullname = "/".join([path, name])
-            node = pkgobj.get(fullname)
             df = pkgobj.get_obj(node)
             assert isinstance(df, pd.DataFrame)
             info = "shape %s, type \"%s\"" % (df.shape, df.dtypes)
             print(prefix + name_prefix + ": " + info)
         elif isinstance(node, FileNode):
-            fullname = "/".join([path, name])
             print(prefix + name_prefix + name)
         else:
             assert False, "node=%s type=%s" % (node, type(node))

--- a/quilt/tools/package.py
+++ b/quilt/tools/package.py
@@ -232,31 +232,6 @@ class Package(object):
         with open(self._path, 'w') as contents_file:
             json.dump(self._contents, contents_file, default=encode_node, indent=2, sort_keys=True)
 
-    def get(self, path):
-        """
-        Traverse the package tree and return node corresponding to
-        the given path.
-        """
-        key = path.lstrip('/')
-        ipath = key.split('/') if key else []
-        ptr = self.get_contents()
-        path_so_far = []
-        for node_name in ipath:
-            if not isinstance(ptr, GroupNode):
-                raise PackageException("Key {path} in package {owner}/{pkg} is a leaf node".format(
-                    path="/".join(path_so_far),
-                    owner=self._user,
-                    pkg=self._package))
-
-            path_so_far += [node_name]
-            ptr = ptr.children.get(node_name)
-            if ptr is None:
-                raise PackageException("Key {path} not found in package {owner}/{pkg}".format(
-                    path="/".join(path_so_far),
-                    owner=self._user,
-                    pkg=self._package))
-        return ptr
-
     def get_obj(self, node):
         """
         Read an object from the package given a node from the


### PR DESCRIPTION
- Set all of the attributes in the constructor instead of looking them up dynamically. We already
  have the whole tree in JSON, so there's not much cost in doing that.
- Get rid of `Package.get`: not needed anymore.