### PR TITLE
Keep extension fo file nodes

### DIFF
--- a/quilt/test/test_build.py
+++ b/quilt/test/test_build.py
@@ -155,7 +155,7 @@ class BuildTest(QuiltTestCase):
         assert os.path.exists(buildfilepath)
         build.build_package('test_hdf5', 'generated', buildfilepath)
         os.remove(buildfilepath)
-        from quilt.data.test_hdf5.generated import bad, foo, nuts, README
+        from quilt.data.test_hdf5.generated import bad, foo, nuts, README_md
 
     def test_failover(self):
         """

--- a/quilt/test/test_command.py
+++ b/quilt/test/test_command.py
@@ -161,7 +161,7 @@ class CommandTest(QuiltTestCase):
         buildfilepath = os.path.join(path, 'build.yml')
         assert not os.path.exists(buildfilepath), "%s already exists" % buildfilepath
         try:
-            command.build('foo/bar', None, generate=path)
+            command.generate(path)
             assert os.path.exists(buildfilepath), "failed to create %s" % buildfilepath
         finally:
             os.remove(buildfilepath)

--- a/quilt/test/test_command.py
+++ b/quilt/test/test_command.py
@@ -4,10 +4,11 @@ Tests for commands.
 
 import json
 import os
+import time
+
 import pytest
 import requests
 import responses
-import time
 
 from six import assertRaisesRegex
 
@@ -153,3 +154,14 @@ class CommandTest(QuiltTestCase):
             author=owner)])
         print("MOCKING URL=%s" % logs_url)
         self.requests_mock.add(responses.GET, logs_url, json.dumps(resp))
+
+    def test_generate_buildfile_wo_building(self):
+        mydir = os.path.dirname(__file__)
+        path = os.path.join(mydir, 'data')
+        buildfilepath = os.path.join(path, 'build.yml')
+        assert not os.path.exists(buildfilepath), "%s already exists" % buildfilepath
+        try:
+            command.build('foo/bar', None, generate=path)
+            assert os.path.exists(buildfilepath), "failed to create %s" % buildfilepath
+        finally:
+            os.remove(buildfilepath)

--- a/quilt/tools/build.py
+++ b/quilt/tools/build.py
@@ -168,8 +168,14 @@ def splitext_no_dot(filename):
     without the '.' (e.g., csv instead of .csv)
     """
     name, ext = os.path.splitext(filename)
-    ext.strip('.')
+    ext = ext.lower()
     return name, ext.strip('.')
+
+def _nodename(name, target='pandas'):
+    nodename, ext = splitext_no_dot(name)
+    if ext not in TARGET[target]:
+        nodename = "{node}_{ext}".format(node=nodename, ext=ext)
+    return _pythonize_name(nodename)
 
 def generate_build_file(startpath, outfilename='build.yml'):
     """
@@ -184,20 +190,16 @@ def generate_build_file(startpath, outfilename='build.yml'):
                 continue
 
             path = os.path.join(dir_path, name)
-
             if os.path.isdir(path):
-                nodename = name
                 data = _generate_contents(path)
             elif os.path.isfile(path):
-                nodename, ext = splitext_no_dot(name)
-                ext = ext.lower()
                 rel_path = os.path.relpath(path, startpath)
                 data = dict(file=rel_path)
             else:
                 continue
 
             try:
-                safename = _pythonize_name(nodename)
+                safename = _nodename(name)
                 if safename in contents:
                     print("Warning: duplicate name %r in %s." % (safename, dir_path))
                     continue

--- a/quilt/tools/build.py
+++ b/quilt/tools/build.py
@@ -50,7 +50,8 @@ def _build_node(build_dir, package, name, node, target='pandas'):
         ID = 'id'
         if transform:
             if (transform not in TARGET[target]) and (transform != ID):
-                raise BuildException("Unknown transform '%s' for %s @ %s" % (transform, rel_path, target))
+                raise BuildException("Unknown transform '%s' for %s @ %s" %
+                                     (transform, rel_path, target))
         else: # guess transform if user doesn't provide one
             ignore, ext = splitext_no_dot(rel_path)
             ext = ext.lower()
@@ -179,7 +180,7 @@ def generate_build_file(startpath, outfilename='build.yml'):
         contents = {}
 
         for name in os.listdir(dir_path):
-            if name.startswith('.') or name == PACKAGE_DIR_NAME:
+            if name.startswith('.') or name == PACKAGE_DIR_NAME or name == outfilename:
                 continue
 
             path = os.path.join(dir_path, name)
@@ -207,10 +208,14 @@ def generate_build_file(startpath, outfilename='build.yml'):
 
         return contents
 
+    buildfilepath = os.path.join(startpath, outfilename)
+    if os.path.exists(buildfilepath):
+        raise BuildException("Build file %s already exists." % buildfilepath)
+
     contents = dict(
         contents=_generate_contents(startpath)
     )
-    buildfilepath = os.path.join(startpath, outfilename)
+
     with open(buildfilepath, 'w') as outfile:
         yaml.dump(contents, outfile, default_flow_style=False)
     return buildfilepath

--- a/quilt/tools/command.py
+++ b/quilt/tools/command.py
@@ -171,7 +171,19 @@ def logout():
     else:
         print("Already logged out.")
 
-def build(package, path, directory=None, generate=None):
+def generate(directory):
+    """
+    Generate a build-file for quilt build from a directory of
+    source files.
+    """
+    try:
+        buildfilepath = generate_build_file(directory)
+    except BuildException as builderror:
+        raise CommandException(str(builderror))
+
+    print("Generated build-file %s." % (buildfilepath))
+
+def build(package, path, directory=None):
     """
     Compile a Quilt data package
     """
@@ -179,9 +191,6 @@ def build(package, path, directory=None, generate=None):
     if directory:
         buildfilepath = generate_build_file(directory)
         buildpath = buildfilepath
-    elif generate:
-        generate_build_file(generate)
-        buildpath = None
     else:
         buildpath = path
 
@@ -583,11 +592,14 @@ def main():
     log_p.add_argument("package", type=str, help="Owner/Package Name")
     log_p.set_defaults(func=log)
 
+    generate_p = subparsers.add_parser("generate")
+    generate_p.add_argument("directory", help="Source file directory")
+    generate_p.set_defaults(func=generate, need_session=False)
+
     build_p = subparsers.add_parser("build")
     build_p.add_argument("package", type=str, help="Owner/Package Name")
     buildpath_group = build_p.add_mutually_exclusive_group(required=True)
-    buildpath_group.add_argument("-d", "--directory", type=str, help="Source file directory")
-    buildpath_group.add_argument("-g", "--generate", type=str, help="Source file directory")
+    buildpath_group.add_argument("-a", "--auto", type=str, help="Source file directory")
     buildpath_group.add_argument("path", type=str, nargs='?', help="Path to the Yaml build file")
     build_p.set_defaults(func=build, need_session=False)
 

--- a/quilt/tools/command.py
+++ b/quilt/tools/command.py
@@ -183,11 +183,12 @@ def generate(directory):
 
     print("Generated build-file %s." % (buildfilepath))
 
-def build(package, path, directory=None):
+def build(package, path, auto=None):
     """
     Compile a Quilt data package
     """
     owner, pkg = _parse_package(package)
+    directory = auto
     if directory:
         try:
             buildpath = generate_build_file(directory)

--- a/quilt/tools/command.py
+++ b/quilt/tools/command.py
@@ -171,7 +171,7 @@ def logout():
     else:
         print("Already logged out.")
 
-def build(package, path, directory=None):
+def build(package, path, directory=None, generate=None):
     """
     Compile a Quilt data package
     """
@@ -179,14 +179,20 @@ def build(package, path, directory=None):
     if directory:
         buildfilepath = generate_build_file(directory)
         buildpath = buildfilepath
+    elif generate:
+        generate_build_file(generate)
+        buildpath = None
     else:
         buildpath = path
 
-    try:
-        build_package(owner, pkg, buildpath)
-        print("Built %s/%s successfully." % (owner, pkg))
-    except BuildException as ex:
-        raise CommandException("Failed to build the package: %s" % ex)
+    if buildpath is not None:
+        try:
+            build_package(owner, pkg, buildpath)
+            print("Built %s/%s successfully." % (owner, pkg))
+        except BuildException as ex:
+            raise CommandException("Failed to build the package: %s" % ex)
+    else:
+        assert generate is not None
 
 def log(session, package):
     """
@@ -581,6 +587,7 @@ def main():
     build_p.add_argument("package", type=str, help="Owner/Package Name")
     buildpath_group = build_p.add_mutually_exclusive_group(required=True)
     buildpath_group.add_argument("-d", "--directory", type=str, help="Source file directory")
+    buildpath_group.add_argument("-g", "--generate", type=str, help="Source file directory")
     buildpath_group.add_argument("path", type=str, nargs='?', help="Path to the Yaml build file")
     build_p.set_defaults(func=build, need_session=False)
 

--- a/quilt/tools/command.py
+++ b/quilt/tools/command.py
@@ -189,19 +189,18 @@ def build(package, path, directory=None):
     """
     owner, pkg = _parse_package(package)
     if directory:
-        buildfilepath = generate_build_file(directory)
-        buildpath = buildfilepath
+        try:
+            buildpath = generate_build_file(directory)
+        except BuildException as builderror:
+            raise CommandException(str(builderror))
     else:
         buildpath = path
 
-    if buildpath is not None:
-        try:
-            build_package(owner, pkg, buildpath)
-            print("Built %s/%s successfully." % (owner, pkg))
-        except BuildException as ex:
-            raise CommandException("Failed to build the package: %s" % ex)
-    else:
-        assert generate is not None
+    try:
+        build_package(owner, pkg, buildpath)
+        print("Built %s/%s successfully." % (owner, pkg))
+    except BuildException as ex:
+        raise CommandException("Failed to build the package: %s" % ex)
 
 def log(session, package):
     """


### PR DESCRIPTION
Extensions are important for file nodes (e.g. to indicate how to parse the file). We also see packages with
files that have the same base name, but different extensions. Here, the
extension is appended to the node name. We should also consider adding
the original filename (including extension) to the node metadata.