### PR TITLE
Use file extension to avoid duplicates

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ Chat with us on  [quiltdata.com](https://quiltdata.com/).
 * `quilt -h` for a list of commands
 * `quilt CMD -h` for info about a command
 * `quilt login`
-* `quilt build USER/PACKAGE FILE.YML`
+* `quilt build USER/PACKAGE [SOURCE DIRECTORY or FILE.YML]`
 * `quilt push USER/PACKAGE` stores the package in the registry
 * `quilt install [-x HASH | -v VERSION | -t TAG] USER/PACKAGE` installs a package
 * `quilt access list USER/PACKAGE` to see who has access to a package

--- a/quilt/test/test_command.py
+++ b/quilt/test/test_command.py
@@ -161,7 +161,7 @@ class CommandTest(QuiltTestCase):
         buildfilepath = os.path.join(path, 'build.yml')
         assert not os.path.exists(buildfilepath), "%s already exists" % buildfilepath
         try:
-            command.build('foo/bar', None, generate=path)
+            command.generate(path)
             assert os.path.exists(buildfilepath), "failed to create %s" % buildfilepath
         finally:
             os.remove(buildfilepath)

--- a/quilt/test/test_command.py
+++ b/quilt/test/test_command.py
@@ -4,10 +4,11 @@ Tests for commands.
 
 import json
 import os
+import time
+
 import pytest
 import requests
 import responses
-import time
 
 from six import assertRaisesRegex
 
@@ -153,3 +154,14 @@ class CommandTest(QuiltTestCase):
             author=owner)])
         print("MOCKING URL=%s" % logs_url)
         self.requests_mock.add(responses.GET, logs_url, json.dumps(resp))
+
+    def test_generate_buildfile_wo_building(self):
+        mydir = os.path.dirname(__file__)
+        path = os.path.join(mydir, 'data')
+        buildfilepath = os.path.join(path, 'build.yml')
+        assert not os.path.exists(buildfilepath), "%s already exists" % buildfilepath
+        try:
+            command.build('foo/bar', None, generate=path)
+            assert os.path.exists(buildfilepath), "failed to create %s" % buildfilepath
+        finally:
+            os.remove(buildfilepath)

--- a/quilt/tools/build.py
+++ b/quilt/tools/build.py
@@ -50,7 +50,8 @@ def _build_node(build_dir, package, name, node, target='pandas'):
         ID = 'id'
         if transform:
             if (transform not in TARGET[target]) and (transform != ID):
-                raise BuildException("Unknown transform '%s' for %s @ %s" % (transform, rel_path, target))
+                raise BuildException("Unknown transform '%s' for %s @ %s" %
+                                     (transform, rel_path, target))
         else: # guess transform if user doesn't provide one
             ignore, ext = splitext_no_dot(rel_path)
             ext = ext.lower()
@@ -179,7 +180,7 @@ def generate_build_file(startpath, outfilename='build.yml'):
         contents = {}
 
         for name in os.listdir(dir_path):
-            if name.startswith('.') or name == PACKAGE_DIR_NAME:
+            if name.startswith('.') or name == PACKAGE_DIR_NAME or name == outfilename:
                 continue
 
             path = os.path.join(dir_path, name)
@@ -207,10 +208,14 @@ def generate_build_file(startpath, outfilename='build.yml'):
 
         return contents
 
+    buildfilepath = os.path.join(startpath, outfilename)
+    if os.path.exists(buildfilepath):
+        raise BuildException("Build file %s already exists." % buildfilepath)
+
     contents = dict(
         contents=_generate_contents(startpath)
     )
-    buildfilepath = os.path.join(startpath, outfilename)
+
     with open(buildfilepath, 'w') as outfile:
         yaml.dump(contents, outfile, default_flow_style=False)
     return buildfilepath

--- a/quilt/tools/build.py
+++ b/quilt/tools/build.py
@@ -8,7 +8,7 @@ import yaml
 import pandas as pd
 
 from .store import PackageStore, VALID_NAME_RE, StoreException
-from .const import PACKAGE_DIR_NAME, RESERVED, TARGET
+from .const import DEFAULT_BUILDFILE, PACKAGE_DIR_NAME, RESERVED, TARGET
 from .core import PackageFormat
 from .util import FileWithReadProgress
 
@@ -38,7 +38,7 @@ def _build_node(build_dir, package, name, node, target='pandas'):
     if _is_internal_node(node):
         for child_name, child_table in node.items():
             if not isinstance(child_name, str) or not VALID_NAME_RE.match(child_name):
-                raise StoreException("Invalid table name: %r" % child_name)
+                raise StoreException("Invalid node name: %r" % child_name)
             _build_node(build_dir, package, name + '/' + child_name, child_table)
     else: # leaf node
         rel_path = node.get(RESERVED['file'])
@@ -171,7 +171,7 @@ def splitext_no_dot(filename):
     ext.strip('.')
     return name, ext.strip('.')
 
-def generate_build_file(startpath, outfilename='build.yml'):
+def generate_build_file(startpath, outfilename=DEFAULT_BUILDFILE):
     """
     Generate a build file (yaml) based on the contents of a
     directory tree.
@@ -180,7 +180,10 @@ def generate_build_file(startpath, outfilename='build.yml'):
         contents = {}
 
         for name in os.listdir(dir_path):
-            if name.startswith('.') or name == PACKAGE_DIR_NAME or name == outfilename:
+            if name.startswith('.') or \
+               name == PACKAGE_DIR_NAME or \
+               name.endswith('~') or \
+               name == outfilename:
                 continue
 
             path = os.path.join(dir_path, name)

--- a/quilt/tools/command.py
+++ b/quilt/tools/command.py
@@ -171,7 +171,19 @@ def logout():
     else:
         print("Already logged out.")
 
-def build(package, path, directory=None, generate=None):
+def generate(directory):
+    """
+    Generate a build-file for quilt build from a directory of
+    source files.
+    """
+    try:
+        buildfilepath = generate_build_file(directory)
+    except BuildException as builderror:
+        raise CommandException(str(builderror))
+
+    print("Generated build-file %s." % (buildfilepath))
+
+def build(package, path, directory=None):
     """
     Compile a Quilt data package
     """
@@ -179,9 +191,6 @@ def build(package, path, directory=None, generate=None):
     if directory:
         buildfilepath = generate_build_file(directory)
         buildpath = buildfilepath
-    elif generate:
-        generate_build_file(generate)
-        buildpath = None
     else:
         buildpath = path
 
@@ -583,11 +592,14 @@ def main():
     log_p.add_argument("package", type=str, help="Owner/Package Name")
     log_p.set_defaults(func=log)
 
+    generate_p = subparsers.add_parser("generate")
+    generate_p.add_argument("directory", help="Source file directory")
+    generate_p.set_defaults(func=generate, need_session=False)
+
     build_p = subparsers.add_parser("build")
     build_p.add_argument("package", type=str, help="Owner/Package Name")
     buildpath_group = build_p.add_mutually_exclusive_group(required=True)
-    buildpath_group.add_argument("-d", "--directory", type=str, help="Source file directory")
-    buildpath_group.add_argument("-g", "--generate", type=str, help="Source file directory")
+    buildpath_group.add_argument("-a", "--auto", type=str, help="Source file directory")
     buildpath_group.add_argument("path", type=str, nargs='?', help="Path to the Yaml build file")
     build_p.set_defaults(func=build, need_session=False)
 

--- a/quilt/tools/command.py
+++ b/quilt/tools/command.py
@@ -19,7 +19,7 @@ from six import iteritems
 from tqdm import tqdm
 
 from .build import build_package, generate_build_file, BuildException
-from .const import LATEST_TAG
+from .const import DEFAULT_BUILDFILE, LATEST_TAG
 from .core import (hash_contents, GroupNode, TableNode, FileNode,
                    decode_node, encode_node)
 from .hashing import digest_file
@@ -193,17 +193,22 @@ def generate(directory):
 
     print("Generated build-file %s." % (buildfilepath))
 
-def build(package, path, auto=None):
+def build(package, path):
     """
     Compile a Quilt data package
     """
+    if not os.path.exists(path):
+        raise CommandException("%s does not exist." % path)
+
     owner, pkg = _parse_package(package)
-    directory = auto
-    if directory:
-        try:
-            buildpath = generate_build_file(directory)
-        except BuildException as builderror:
-            raise CommandException(str(builderror))
+    if os.path.isdir(path):
+        buildpath = os.path.join(path, DEFAULT_BUILDFILE)
+        if not os.path.exists(buildpath):
+            try:
+                generated_buildfile = generate_build_file(path)
+                assert generated_buildfile == buildpath
+            except BuildException as builderror:
+                raise CommandException(str(builderror))
     else:
         buildpath = path
 

--- a/quilt/tools/command.py
+++ b/quilt/tools/command.py
@@ -183,11 +183,12 @@ def generate(directory):
 
     print("Generated build-file %s." % (buildfilepath))
 
-def build(package, path, directory=None):
+def build(package, path, auto=None):
     """
     Compile a Quilt data package
     """
     owner, pkg = _parse_package(package)
+    directory = auto
     if directory:
         try:
             buildpath = generate_build_file(directory)

--- a/quilt/tools/command.py
+++ b/quilt/tools/command.py
@@ -171,7 +171,7 @@ def logout():
     else:
         print("Already logged out.")
 
-def build(package, path, directory=None):
+def build(package, path, directory=None, generate=None):
     """
     Compile a Quilt data package
     """
@@ -179,14 +179,20 @@ def build(package, path, directory=None):
     if directory:
         buildfilepath = generate_build_file(directory)
         buildpath = buildfilepath
+    elif generate:
+        generate_build_file(generate)
+        buildpath = None
     else:
         buildpath = path
 
-    try:
-        build_package(owner, pkg, buildpath)
-        print("Built %s/%s successfully." % (owner, pkg))
-    except BuildException as ex:
-        raise CommandException("Failed to build the package: %s" % ex)
+    if buildpath is not None:
+        try:
+            build_package(owner, pkg, buildpath)
+            print("Built %s/%s successfully." % (owner, pkg))
+        except BuildException as ex:
+            raise CommandException("Failed to build the package: %s" % ex)
+    else:
+        assert generate is not None
 
 def log(session, package):
     """
@@ -581,6 +587,7 @@ def main():
     build_p.add_argument("package", type=str, help="Owner/Package Name")
     buildpath_group = build_p.add_mutually_exclusive_group(required=True)
     buildpath_group.add_argument("-d", "--directory", type=str, help="Source file directory")
+    buildpath_group.add_argument("-g", "--generate", type=str, help="Source file directory")
     buildpath_group.add_argument("path", type=str, nargs='?', help="Path to the Yaml build file")
     build_p.set_defaults(func=build, need_session=False)
 

--- a/quilt/tools/command.py
+++ b/quilt/tools/command.py
@@ -189,19 +189,18 @@ def build(package, path, directory=None):
     """
     owner, pkg = _parse_package(package)
     if directory:
-        buildfilepath = generate_build_file(directory)
-        buildpath = buildfilepath
+        try:
+            buildpath = generate_build_file(directory)
+        except BuildException as builderror:
+            raise CommandException(str(builderror))
     else:
         buildpath = path
 
-    if buildpath is not None:
-        try:
-            build_package(owner, pkg, buildpath)
-            print("Built %s/%s successfully." % (owner, pkg))
-        except BuildException as ex:
-            raise CommandException("Failed to build the package: %s" % ex)
-    else:
-        assert generate is not None
+    try:
+        build_package(owner, pkg, buildpath)
+        print("Built %s/%s successfully." % (owner, pkg))
+    except BuildException as ex:
+        raise CommandException("Failed to build the package: %s" % ex)
 
 def log(session, package):
     """

--- a/quilt/tools/const.py
+++ b/quilt/tools/const.py
@@ -15,6 +15,7 @@ TIMEF = '%T'
 DTIMEF = '%s %s' % (DATEF, TIMEF)
 LATEST_TAG = 'latest'
 PACKAGE_DIR_NAME = 'quilt_packages'
+DEFAULT_BUILDFILE = 'build.yml'
 # reserved words in build.yml
 RESERVED = {
     'file': 'file',

--- a/quilt/tools/main.py
+++ b/quilt/tools/main.py
@@ -36,8 +36,8 @@ def main():
     build_p = subparsers.add_parser("build")
     build_p.add_argument("package", type=str, help="Owner/Package Name")
     buildpath_group = build_p.add_mutually_exclusive_group(required=True)
-    buildpath_group.add_argument("path", type=str, nargs='?', help="Path to \
-    source files (directory) or the Yaml build file")
+    buildpath_group.add_argument("path", type=str, nargs='?',
+                                 help="Path to source files (directory) or the Yaml build file")
     build_p.set_defaults(func=command.build)
 
     push_p = subparsers.add_parser("push")

--- a/quilt/tools/main.py
+++ b/quilt/tools/main.py
@@ -36,7 +36,8 @@ def main():
     build_p = subparsers.add_parser("build")
     build_p.add_argument("package", type=str, help="Owner/Package Name")
     buildpath_group = build_p.add_mutually_exclusive_group(required=True)
-    buildpath_group.add_argument("path", type=str, nargs='?', help="Path to the Yaml build file")
+    buildpath_group.add_argument("path", type=str, nargs='?', help="Path to \
+    source files (directory) or the Yaml build file")
     build_p.set_defaults(func=command.build)
 
     push_p = subparsers.add_parser("push")

--- a/quilt/tools/main.py
+++ b/quilt/tools/main.py
@@ -36,7 +36,6 @@ def main():
     build_p = subparsers.add_parser("build")
     build_p.add_argument("package", type=str, help="Owner/Package Name")
     buildpath_group = build_p.add_mutually_exclusive_group(required=True)
-    buildpath_group.add_argument("-a", "--auto", type=str, help="Source file directory")
     buildpath_group.add_argument("path", type=str, nargs='?', help="Path to the Yaml build file")
     build_p.set_defaults(func=command.build)
 


### PR DESCRIPTION
Appending the file extension to node names for file nodes if the base name appears more than once in the packages and would otherwise produce a name conflict.