### PR TITLE
Drop support for Python 3.3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,9 +7,6 @@ matrix:
       python: 2.7
     - os: linux
       sudo: required
-      python: 3.3
-    - os: linux
-      sudo: required
       python: 3.4
     - os: linux
       sudo: required

--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ Chat with us on  [quiltdata.com](https://quiltdata.com/).
 ## Supported Python versions
 * 2.7
 * ~~3.2~~
-* 3.3
+* ~~3.3~~
 * 3.4
 * 3.5
 * 3.6


### PR DESCRIPTION
Very low penetration per https://github.com/pypa/pip/issues/3796
We could theoretically support 3.3 until 9/17 but it really slows CI down