### PR TITLE
Implement some very basic package saving functionality

### DIFF
--- a/quilt/data.py
+++ b/quilt/data.py
@@ -20,56 +20,31 @@ import sys
 
 from six import iteritems
 
-from .tools.core import GroupNode as CoreGroupNode
+from .tools import core
 from .tools.store import PackageStore
 
 __path__ = []  # Required for submodules to work
 
-class PackageNode(object):
+class Node(object):
     """
     Abstract class that represents a group or a leaf node in a package.
     """
-    def __init__(self, package, prefix, node):
+    def __init__(self):
         # Can't instantiate it directly
-        assert self.__class__ != PackageNode.__class__
+        assert self.__class__ != Node.__class__
 
-        self._package = package
-        self._prefix = prefix
-        self._node = node
-
-    def __eq__(self, other):
-        if isinstance(other, self.__class__):
-            return self._package == other._package and self._prefix == other._prefix
-        return NotImplemented
-
-    def __ne__(self, other):
-        return not self == other
-
-    def __hash__(self):
-        return hash((self._package, self._prefix))
+    def _class_repr(self):
+        """Only exists to make it easier for subclasses to customize `__repr__`."""
+        return "<%s>" % self.__class__.__name__
 
     def __repr__(self):
-        finfo = self._package.get_path()[:-len(PackageStore.PACKAGE_FILE_EXT)]
-        pinfo = self._prefix
-        return "<%s %r:%r>" % (self.__class__.__name__, finfo, pinfo)
+        return self._class_repr()
 
 
-class GroupNode(PackageNode):
+class GroupNode(Node):
     """
     Represents a group in a package. Allows accessing child objects using the dot notation.
     """
-    def __init__(self, package, prefix, node):
-        super(GroupNode, self).__init__(package, prefix, node)
-
-        for name, child_node in iteritems(node.children):
-            assert not name.startswith('_')
-            child_prefix = prefix + '/' + name
-            if isinstance(child_node, CoreGroupNode):
-                child = GroupNode(package, child_prefix, child_node)
-            else:
-                child = DataNode(package, child_prefix, child_node)
-            setattr(self, name, child)
-
     def __repr__(self):
         pinfo = super(GroupNode, self).__repr__()
         kinfo = '\n'.join(self._keys())
@@ -79,27 +54,42 @@ class GroupNode(PackageNode):
         """
         every child key referencing a dataframe
         """
-        return [name for name, node in iteritems(self._node.children)
-                if not isinstance(node, CoreGroupNode)]
+        return [name for name, value in iteritems(self.__dict__)
+                if not name.startswith('_') and not isinstance(value, GroupNode)]
 
     def _group_keys(self):
         """
         every child key referencing a group that is not a dataframe
         """
-        return [name for name, node in iteritems(self._node.children)
-                if isinstance(node, CoreGroupNode)]
+        return [name for name, value in iteritems(self.__dict__)
+                if not name.startswith('_') and isinstance(value, GroupNode)]
 
     def _keys(self):
         """
         keys directly accessible on this object via getattr or .
         """
-        return list(self._node.children)
+        return [name for name in self.__dict__ if not name.startswith('_')]
 
 
-class DataNode(PackageNode):
+class PackageNode(GroupNode):
+    def __init__(self, package):
+        super(PackageNode, self).__init__()
+        self._package = package
+
+    def _class_repr(self):
+        finfo = self._package.get_path()[:-len(PackageStore.PACKAGE_FILE_EXT)]
+        return "<%s %r>" % (self.__class__.__name__, finfo)
+
+
+class DataNode(Node):
     """
     Represents a dataframe or a file. Allows accessing the contents using `()`.
     """
+    def __init__(self, package, node):
+        super(DataNode, self).__init__()
+        self._package = package
+        self._node = node
+
     def __call__(self):
         return self.data()
 
@@ -128,6 +118,25 @@ class FakeLoader(object):
         mod.__package__ = fullname
         return mod
 
+
+def _from_core_node(package, core_node):
+    if isinstance(core_node, core.TableNode) or isinstance(core_node, core.FileNode):
+        node = DataNode(package, core_node)
+    else:
+        if isinstance(core_node, core.RootNode):
+            node = PackageNode(package)
+        elif isinstance(core_node, core.GroupNode):
+            node = GroupNode()
+        else:
+            assert "Unexpected node: %r" % core_node
+
+        for name, core_child in iteritems(core_node.children):
+            child = _from_core_node(package, core_child)
+            setattr(node, name, child)
+
+    return node
+
+
 class PackageLoader(object):
     """
     Module loader for Quilt tables.
@@ -147,7 +156,7 @@ class PackageLoader(object):
         # We're creating an object rather than a module. It's a hack, but it's approved by Guido:
         # https://mail.python.org/pipermail/python-ideas/2012-May/014969.html
 
-        mod = GroupNode(self._package, '', self._package.get_contents())
+        mod = _from_core_node(self._package, self._package.get_contents())
         sys.modules[fullname] = mod
         return mod
 

--- a/quilt/tools/package.py
+++ b/quilt/tools/package.py
@@ -225,6 +225,12 @@ class Package(object):
         """
         return self._contents
 
+    def set_contents(self, contents):
+        """
+        Sets a new contents.
+        """
+        self._contents = contents
+
     def save_contents(self):
         """
         Saves the in-memory contents to the package file.


### PR DESCRIPTION
Nodes in `data.py` now have their own package hierarchy instead of wrapping core nodes. This is required if we're going to allow moving them around - possibly even moving/copying from one package to another. The downside here is, the node no longer knows which package or path it has (it could have none or multiple).

There's no user-friendly way to create new nodes; that will come later.
