### PR TITLE
Update arrow parquet to match Arrow 0.3

### DIFF
--- a/quilt/tools/package.py
+++ b/quilt/tools/package.py
@@ -104,10 +104,11 @@ class Package(object):
             return store.get(self.DF_NAME)
 
     def _read_parquet_arrow(self, hash_list):
-        from pyarrow import parquet
+        from pyarrow.parquet import ParquetDataset
 
         objfiles = [self._store.object_path(h) for h in hash_list]
-        table = parquet.read_multiple_files(paths=objfiles, nthreads=4)
+        dataset = ParquetDataset(objfiles)
+        table = dataset.read(nthreads=4)
         df = table.to_pandas()
         return df
 


### PR DESCRIPTION
Arrow added support for partitioned datasets in Parquet and changed the
Parquet reading interface. This code uses the new ParquetDataSet class
to read from multiple Parquet files.