### PR TITLE
When installing a package, don't redownload existing objects.

### DIFF
--- a/quilt/test/test_install.py
+++ b/quilt/test/test_install.py
@@ -112,7 +112,7 @@ class InstallTest(QuiltTestCase):
         self._mock_package('foo/bar', contents_hash, contents, [obj_hash])
         self._mock_s3(obj_hash, tabledata)
 
-        with assertRaisesRegex(self, command.CommandException, "Mismatched hash"):
+        with assertRaisesRegex(self, command.CommandException, "hashes do not match"):
             command.install('foo/bar')
 
         assert not os.path.exists('quilt_packages/foo/bar.json')
@@ -151,7 +151,7 @@ class InstallTest(QuiltTestCase):
 
         self._mock_tag('foo/bar', 'latest', contents_hash)
         self._mock_package('foo/bar', contents_hash, contents, file_hash_list)
-        # Don't mock the first file, since it's not supposed to be downloaded.
+        # Don't mock file0, since it's not supposed to be downloaded.
         self._mock_s3(file_hash_list[1], file_data_list[1])
         self._mock_s3(file_hash_list[2], file_data_list[2])
 

--- a/quilt/tools/command.py
+++ b/quilt/tools/command.py
@@ -483,18 +483,27 @@ def install(package, hash=None, version=None, tag=None, force=False):
     pkgobj = store.install_package(owner, pkg, response_contents)
 
     total = len(response_urls)
-    for idx, (download_hash, url) in enumerate(iteritems(response_urls)):
+    for idx, (download_hash, url) in enumerate(sorted(iteritems(response_urls))):
         print("Downloading object %d/%d..." % (idx + 1, total))
+
+        local_filename = store.object_path(download_hash)
+        if os.path.exists(local_filename):
+            file_hash = digest_file(local_filename)
+            if file_hash == download_hash:
+                print("Object already exists; skipping.")
+                continue
+            else:
+                print("Object exists, but has the wrong hash. Redownloading.")
 
         response = requests.get(url, stream=True)
         if not response.ok:
             msg = "Download {hash} failed: error {code}"
             raise CommandException(msg.format(hash=download_hash, code=response.status_code))
 
-        local_filename = store.object_path(download_hash)
         length_remaining = response.raw.length_remaining
 
-        with open(local_filename, 'wb') as output_file:
+        temp_path = store.temporary_object_path(download_hash)
+        with open(temp_path, 'wb') as output_file:
             with tqdm(total=length_remaining, unit='B', unit_scale=True) as progress:
                 # `requests` will automatically un-gzip the content, as long as
                 # the 'Content-Encoding: gzip' header is set.
@@ -507,11 +516,13 @@ def install(package, hash=None, version=None, tag=None, force=False):
                         progress.update(length_remaining - response.raw.length_remaining)
                         length_remaining = response.raw.length_remaining
 
-        file_hash = digest_file(local_filename)
+        file_hash = digest_file(temp_path)
         if file_hash != download_hash:
-            os.remove(local_filename)
+            os.remove(temp_path)
             raise CommandException("Mismatched hash! Expected %s, got %s." %
                                    (download_hash, file_hash))
+
+        os.rename(temp_path, local_filename)
 
     pkgobj.save_contents()
 

--- a/quilt/tools/command.py
+++ b/quilt/tools/command.py
@@ -496,10 +496,11 @@ def install(package, hash=None, version=None, tag=None, force=False):
         if os.path.exists(local_filename):
             file_hash = digest_file(local_filename)
             if file_hash == download_hash:
-                print("Object already exists; skipping.")
+                print("Fragment already installed; skipping.")
                 continue
             else:
-                print("Object exists, but has the wrong hash (%s); re-downloading." % file_hash)
+                print("Fragment already installed, but has the wrong hash (%s); re-downloading." %
+                      file_hash)
 
         response = requests.get(url, stream=True)
         if not response.ok:
@@ -525,7 +526,7 @@ def install(package, hash=None, version=None, tag=None, force=False):
         file_hash = digest_file(temp_path)
         if file_hash != download_hash:
             os.remove(temp_path)
-            raise CommandException("Mismatched hash! Expected %s, got %s." %
+            raise CommandException("Fragment hashes do not match: expected %s, got %s." %
                                    (download_hash, file_hash))
 
         os.rename(temp_path, local_filename)

--- a/quilt/tools/command.py
+++ b/quilt/tools/command.py
@@ -280,7 +280,7 @@ def push(package):
     total = len(upload_urls)
     for idx, (objhash, url) in enumerate(iteritems(upload_urls)):
         # Create a temporary gzip'ed file.
-        print("Uploading object %d/%d..." % (idx + 1, total))
+        print("Uploading %s (%d/%d)..." % (objhash, idx + 1, total))
         with pkgobj.tempfile(objhash) as temp_file:
             with FileWithReadProgress(temp_file) as temp_file_with_progress:
                 response = requests.put(url, data=temp_file_with_progress, headers=headers)
@@ -484,7 +484,7 @@ def install(package, hash=None, version=None, tag=None, force=False):
 
     total = len(response_urls)
     for idx, (download_hash, url) in enumerate(sorted(iteritems(response_urls))):
-        print("Downloading object %d/%d..." % (idx + 1, total))
+        print("Downloading %s (%d/%d)..." % (download_hash, idx + 1, total))
 
         local_filename = store.object_path(download_hash)
         if os.path.exists(local_filename):
@@ -493,7 +493,7 @@ def install(package, hash=None, version=None, tag=None, force=False):
                 print("Object already exists; skipping.")
                 continue
             else:
-                print("Object exists, but has the wrong hash. Redownloading.")
+                print("Object exists, but has the wrong hash (%s); re-downloading." % file_hash)
 
         response = requests.get(url, stream=True)
         if not response.ok:


### PR DESCRIPTION
Verify that their hashes are correct, and skip the download.

Use a temporary file until the download is complete, so we don't end up with
partially downloaded objects.

Sort the objects when downloading: otherwise, without a consistent order,
it looks as if existing objects are being downloaded again.