### PR TITLE
Sort the keys when printing out group nodes

### DIFF
--- a/quilt/data.py
+++ b/quilt/data.py
@@ -49,7 +49,7 @@ class GroupNode(Node):
     """
     def __repr__(self):
         pinfo = super(GroupNode, self).__repr__()
-        kinfo = '\n'.join(self._keys())
+        kinfo = '\n'.join(sorted(self._keys()))
         return "%s\n%s" % (pinfo, kinfo)
 
     def _items(self):


### PR DESCRIPTION
Even `dir` sorts the keys, so no excuse not to.