### PR TITLE
Switch from HDF5 format to Parquet.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,14 +16,14 @@ matrix:
       python: 3.6
     # HACK this covers python 2.7 by default
     # TODO be explict about OS X Python version
-    - os: osx
-      language: generic
+    # HACK(dima): Disable OSX builds for now, since they now require conda.
+    # - os: osx
+    #   language: generic
 
 # TODO: test multiple python versions on OSX https://github.com/travis-ci/travis-ci/issues/2312
 
 before_install:
   - pip install pytest
-  - pip install Cython  # Workaround for a failure in the pyarrow package
   # Install HDF5
   # travis_retry here because occasionally fails on high latency
   - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then travis_retry brew update; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -68,7 +68,7 @@ install:
   # pytest
   - pip install pytest
   # install quilt from setup.py
-  - travis_retry pip install --only-binary 'tables,pyarrow' .
+  - travis_retry pip install --only-binary 'tables' .
 
 script:
   - pytest

--- a/.travis.yml
+++ b/.travis.yml
@@ -23,6 +23,7 @@ matrix:
 
 before_install:
   - pip install pytest
+  - pip install Cython  # Workaround for a failure in the pyarrow package
   # Install HDF5
   # travis_retry here because occasionally fails on high latency
   - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then travis_retry brew update; fi

--- a/README.md
+++ b/README.md
@@ -17,12 +17,9 @@ A data package is an abstraction that encapsulates and automates data preparatio
 <img src="https://github.com/quiltdata/resources/blob/955656180ef6398a2729c7ebc28e5dc708f26bd3/img/big-picture.png" width="320"/>
 
 # Installation
-## Mac
-1. Install [Homebrew](https://brew.sh/)
-1. `brew update`
-1. `brew install homebrew/science/hdf5@1.8` (pytables doesn't work with hdf5@1.10)
-1. Determine your HDF5 directory: `brew --prefix homebrew/science/hdf5@1.8`
-1. `export HDF5_DIR=*YOUR_HDF5_DIRECTORY*` (add this line to your .bash_profile)
+## Mac / Windows
+1. Install [Conda](https://conda.io/docs/install/quick.html)
+1. `conda install -c conda-forge pyarrow=0.3`
 1. `pip install quilt`
 
 ## Linux

--- a/quilt/test/build_hdf5.yml
+++ b/quilt/test/build_hdf5.yml
@@ -1,5 +1,5 @@
 ---
-format: PARQUET
+format: HDF5
 contents:
   dataframes:
     csv: 

--- a/quilt/test/test_build.py
+++ b/quilt/test/test_build.py
@@ -5,12 +5,7 @@ Test the build process
 #the functions that cli calls
 import os
 
-try:
-    import pyarrow
-except ImportError:
-    pyarrow = None
-
-import pytest
+from six import assertRaisesRegex
 
 from ..tools.package import ParquetLib, Package
 from ..tools import build
@@ -20,47 +15,13 @@ from .utils import QuiltTestCase
 PACKAGE = 'groot'
 
 class BuildTest(QuiltTestCase):
-    def test_build_hdf5(self):
-        """
-        Test compilation
-        """
-        mydir = os.path.dirname(__file__)
-        path = os.path.join(mydir, './build.yml')
-        build.build_package('test_hdf5', PACKAGE, path)
-        # TODO load DFs based on contents of .yml file at PATH
-        # not hardcoded vals (this will require loading modules from variable
-        # names, probably using __module__)
-        from quilt.data.test_hdf5.groot import dataframes, README
-        csv = dataframes.csv()
-        tsv = dataframes.csv()
-        xls = dataframes.xls()
-        rows = len(csv.index)
-        assert rows == len(tsv.index) and rows == len(xls.index), \
-            'Expected dataframes to have same # rows'
-        assert os.path.exists(README())
-        cols = len(csv.columns)
-        print(csv.columns, xls.columns, tsv.columns)
-        assert cols == len(tsv.columns) and cols == len(xls.columns), \
-            'Expected dataframes to have same # columns'
-
-        path = os.path.join(mydir, './build_bad_transform.yml')
-        with self.assertRaises(build.BuildException):
-            build.build_package('test_hdf5_transform', PACKAGE, path)
-
-        path = os.path.join(mydir, './build_bad_file.yml')
-        with self.assertRaises(build.BuildException):
-            build.build_package('test_hdf5_file', PACKAGE, path)
-
-        # TODO add more integrity checks, incl. negative test cases
-
-    @pytest.mark.skipif("pyarrow is None")
     def test_build_parquet_default(self):
         """
         Test compilation to Parquet via the default library
         """
         Package.reset_parquet_lib()
         mydir = os.path.dirname(__file__)
-        path = os.path.join(mydir, './build_parquet.yml')
+        path = os.path.join(mydir, './build.yml')
         build.build_package('test_parquet', PACKAGE, path)
         # TODO load DFs based on contents of .yml file at PATH
         # not hardcoded vals (this will require loading modules from variable
@@ -79,7 +40,6 @@ class BuildTest(QuiltTestCase):
             'Expected dataframes to have same # columns'
         # TODO add more integrity checks, incl. negative test cases
 
-    @pytest.mark.skipif("pyarrow is None")
     def test_build_parquet_pyarrow(self):
         """
         Test compilation Parquet via pyarrow
@@ -87,7 +47,7 @@ class BuildTest(QuiltTestCase):
         os.environ["QUILT_PARQUET_LIBRARY"] = ParquetLib.ARROW.value
         Package.reset_parquet_lib()
         mydir = os.path.dirname(__file__)
-        path = os.path.join(mydir, './build_parquet.yml')
+        path = os.path.join(mydir, './build.yml')
         build.build_package('test_arrow', PACKAGE, path)
         # TODO load DFs based on contents of .yml file at path
         # not hardcoded vals (this will require loading modules from variable
@@ -108,6 +68,12 @@ class BuildTest(QuiltTestCase):
         assert Package.get_parquet_lib() is ParquetLib.ARROW
         del os.environ["QUILT_PARQUET_LIBRARY"]
 
+    def test_build_hdf5(self):
+        mydir = os.path.dirname(__file__)
+        path = os.path.join(mydir, './build_hdf5.yml')
+        with assertRaisesRegex(self, build.BuildException, "no longer supported"):
+            build.build_package('test_hdf5', PACKAGE, path)
+
     def test_generate_buildfile(self):
         """
         Test auto-generating a buildfile for compilation
@@ -118,9 +84,9 @@ class BuildTest(QuiltTestCase):
         assert not os.path.exists(buildfilepath), "%s already exists" % buildfilepath
         build.generate_build_file(path)
         assert os.path.exists(buildfilepath)
-        build.build_package('test_hdf5', 'generated', buildfilepath)
+        build.build_package('test_generated', 'generated', buildfilepath)
         os.remove(buildfilepath)
-        from quilt.data.test_hdf5.generated import bad, foo, nuts, README
+        from quilt.data.test_generated.generated import bad, foo, nuts, README
 
     def test_failover(self):
         """

--- a/quilt/tools/build.py
+++ b/quilt/tools/build.py
@@ -156,6 +156,10 @@ def build_package(username, package, yaml_path):
     except ValueError:
         raise BuildException("Unsupported format: %r" % pkgformat)
 
+    # HDF5 no longer supported.
+    if pkgformat is PackageFormat.HDF5:
+        raise BuildException("HDF5 format is no longer supported; please use PARQUET instead.")
+
     store = PackageStore()
     newpackage = store.create_package(username, package)
     _build_node(build_dir, newpackage, '', contents, pkgformat)

--- a/quilt/tools/core.py
+++ b/quilt/tools/core.py
@@ -8,7 +8,7 @@ from six import iteritems, string_types
 class PackageFormat(Enum):
     HDF5 = 'HDF5'
     PARQUET = 'PARQUET'
-    default = HDF5
+    default = PARQUET
 
 class Node(object):
     @property

--- a/setup.py
+++ b/setup.py
@@ -41,6 +41,7 @@ setup(
         'future>=0.16.0',
         'packaging>=16.8',
         'pandas>=0.19.2',
+        'pyarrow>=0.3.0',
         'pyOpenSSL>=16.2.0',
         'pyyaml>=3.12',
         'requests>=2.12.4',


### PR DESCRIPTION
Reading the legacy HDF5 format is supported, but new packages can only be created
in Parquet format.