### PR TITLE
Fix the conda install and disable Python 3.4 in conda

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,15 +11,10 @@ env:
     - USE_CONDA=true
   matrix:
     - QPYVER=2.7
-    - QPYVER=3.4
     - QPYVER=3.5
     - QPYVER=3.6
 
 matrix:
-  allow_failures:
-    # no wheel support, so pyarrow installation fails on OSX/PY34
-    - os: osx
-      env: QPYVER=3.4
   fast_finish: true
   include:
     - os: linux

--- a/.travis.yml
+++ b/.travis.yml
@@ -59,9 +59,9 @@ before_install:
 install:
   - |
     if [[ "$USE_CONDA" = true ]]; then
-      conda create --yes -n quilt_env python=$QPYVER pip;
-      conda install --yes -c conda-forge pyarrow=0.3;
-      source activate quilt_env;
+      conda create --yes -n quilt_env python=$QPYVER pip
+      source activate quilt_env
+      conda install --yes -c conda-forge pyarrow=0.3
     fi
   # debug support
   - echo $(python --version)


### PR DESCRIPTION
- Activate the environment first, then install pyarrow
- Drop Python 3.4 cause there are no binaries for it in conda
