### PR TITLE
make integration tests safer, more general

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -4,4 +4,4 @@ Add --integration option to pytest
 import pytest
 
 def pytest_addoption(parser):
-    parser.addoption("--integration", action="store_true", help="include integration tests")
+    parser.addoption("--integration", action="store", help="run integration test against provided env URL")

--- a/quilt/test/test_integration.py
+++ b/quilt/test/test_integration.py
@@ -1,7 +1,7 @@
 """
 Integration test of installation from known public package(s)
 """
-from unittest.mock import patch
+from .utils import patch
 
 import pytest
 

--- a/quilt/test/test_integration.py
+++ b/quilt/test/test_integration.py
@@ -9,15 +9,15 @@ from ..tools import command
 from .utils import BasicQuiltTestCase
 from .integration import skip
 
+ENV = pytest.config.getoption("--integration")
+
 @skip
+@patch('quilt.tools.command.QUILT_PKG_URL', ENV)
 class IntegrationTest(BasicQuiltTestCase):
-    """only runs if --integration ENV_URL is provided to pytest"""
     def test_env_install(self):
-        env = pytest.config.getoption("--integration")
-        with patch('quilt.tools.command.QUILT_PKG_URL', env):
-            # public package
-            command.install('akarve/days') # package exists on both stage and prod
-            from quilt.data.akarve import days
-            df = days.names.data()
-            # check for expected datum
-            assert df.loc[3]['Day'] == 'Wednesday', 'unexpected value in days df at loc[3]'
+        # public package
+        command.install('akarve/days') # package exists on both stage and prod
+        from quilt.data.akarve import days
+        df = days.names.data()
+        # check for expected datum
+        assert df.loc[3]['Day'] == 'Wednesday', 'unexpected value in days df at loc[3]'

--- a/quilt/test/test_integration.py
+++ b/quilt/test/test_integration.py
@@ -3,17 +3,25 @@ Integration test of installation from known public package(s)
 """
 import pytest
 
-
 from ..tools import command
 from .utils import BasicQuiltTestCase
 from .integration import skip
 
 @skip
 class IntegrationTest(BasicQuiltTestCase):
+    """only runs if --integration ENV_URL is provided to pytest"""
     def test_prod_install(self):
+        # this is done in preference to os.environ.get since there is no
+        # guarantee that command.QUILT_PKG_URL == os.environ.get['QUILT_PKG_URL']
+        # WARNING: not thread safe
+        old_env = command.QUILT_PKG_URL
+        env = pytest.config.getoption("--integration")
+        command.QUILT_PKG_URL = env
         # public package
-        command.install('akarve/days')
+        command.install('akarve/days') # package exists on both stage and prod
         from quilt.data.akarve import days
         df = days.names.data()
         # check for expected datum
-        assert(df.loc[3]['Day'] == 'Wednesday')
+        assert df.loc[3]['Day'] == 'Wednesday', 'unexpected value in days df at loc[3]'
+        # restore env
+        command.QUILT_PKG_URL = old_env

--- a/quilt/test/test_integration.py
+++ b/quilt/test/test_integration.py
@@ -1,6 +1,8 @@
 """
 Integration test of installation from known public package(s)
 """
+from unittest.mock import patch
+
 import pytest
 
 from ..tools import command
@@ -10,18 +12,12 @@ from .integration import skip
 @skip
 class IntegrationTest(BasicQuiltTestCase):
     """only runs if --integration ENV_URL is provided to pytest"""
-    def test_prod_install(self):
-        # this is done in preference to os.environ.get since there is no
-        # guarantee that command.QUILT_PKG_URL == os.environ.get['QUILT_PKG_URL']
-        # WARNING: not thread safe
-        old_env = command.QUILT_PKG_URL
+    def test_env_install(self):
         env = pytest.config.getoption("--integration")
-        command.QUILT_PKG_URL = env
-        # public package
-        command.install('akarve/days') # package exists on both stage and prod
-        from quilt.data.akarve import days
-        df = days.names.data()
-        # check for expected datum
-        assert df.loc[3]['Day'] == 'Wednesday', 'unexpected value in days df at loc[3]'
-        # restore env
-        command.QUILT_PKG_URL = old_env
+        with patch('quilt.tools.command.QUILT_PKG_URL', env):
+            # public package
+            command.install('akarve/days') # package exists on both stage and prod
+            from quilt.data.akarve import days
+            df = days.names.data()
+            # check for expected datum
+            assert df.loc[3]['Day'] == 'Wednesday', 'unexpected value in days df at loc[3]'

--- a/setup.py
+++ b/setup.py
@@ -24,6 +24,8 @@ setup(
         'Operating System :: OS Independent',
         'Programming Language :: Python',
         'Programming Language :: Python :: 2.7',
+        'Programming Language :: Python :: 3.4',
+        'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',
     ],
     author='quiltdata',


### PR DESCRIPTION
Require developer to explicitly supply URL for integration tests. (Now, even if CI goes off the rails, the code doesn't have enough info to run the integration tests.) Allows integration testing against `stage` as well as `prod`.

example: `pytest --integration https://pkg-stage.quiltdata.com`