### PR TITLE
Only upload the objects that the server doesn't have yet

### DIFF
--- a/quilt/test/test_push.py
+++ b/quilt/test/test_push.py
@@ -12,17 +12,6 @@ from quilt.tools.core import find_object_hashes
 
 from .utils import QuiltTestCase
 
-def upload_urls(contents):
-    all_hashes = set(find_object_hashes(contents))
-
-    urls = {}
-    for blob_hash in all_hashes:
-        template = "https://example.com/{owner}/{pkg}/{hash}"
-        urls[blob_hash] = template.format(owner='foo',
-                                          pkg='bar',
-                                          hash=blob_hash)
-    return urls
-
 
 class PushTest(QuiltTestCase):
     """
@@ -37,24 +26,37 @@ class PushTest(QuiltTestCase):
         pkg_hash = pkg_obj.get_hash()
         assert pkg_hash
         contents = pkg_obj.get_contents()
-        urls = upload_urls(contents)
-        for url in urls.values():
-            self._mock_s3(url)
 
-        self._mock_put_package('foo/bar', pkg_hash, contents)
+        all_hashes = set(find_object_hashes(contents))
+        for blob_hash in all_hashes:
+            head_url = "https://example.com/head/{owner}/{hash}".format(
+                owner='foo', hash=blob_hash)
+            put_url = "https://example.com/put/{owner}/{hash}".format(
+                owner='foo', hash=blob_hash)
+            self._mock_get_blob('foo', blob_hash, head_url, put_url)
+            self._mock_s3(head_url, put_url)
+
+        self._mock_put_package('foo/bar', pkg_hash)
         self._mock_put_tag('foo/bar', 'latest')
 
         command.push('foo/bar')
 
-    def _mock_put_package(self, package, pkg_hash, contents):
-        pkg_url = '%s/api/package/%s/%s' % (command.QUILT_PKG_URL, package, pkg_hash)
-        self.requests_mock.add(responses.PUT, pkg_url, json.dumps(dict(
-            upload_urls=upload_urls(contents)
+    def _mock_get_blob(self, user, blob_hash, s3_head, s3_put):
+        blob_url = '%s/api/blob/%s/%s' % (command.QUILT_PKG_URL, user, blob_hash)
+        self.requests_mock.add(responses.GET, blob_url, json.dumps(dict(
+            head=s3_head,
+            get='',
+            put=s3_put,
         )))
+
+    def _mock_put_package(self, package, pkg_hash):
+        pkg_url = '%s/api/package/%s/%s' % (command.QUILT_PKG_URL, package, pkg_hash)
+        self.requests_mock.add(responses.PUT, pkg_url, json.dumps(dict()))
 
     def _mock_put_tag(self, package, tag):
         tag_url = '%s/api/tag/%s/%s' % (command.QUILT_PKG_URL, package, tag)
         self.requests_mock.add(responses.PUT, tag_url, json.dumps(dict()))
 
-    def _mock_s3(self, s3_url):
-        self.requests_mock.add(responses.PUT, s3_url)
+    def _mock_s3(self, s3_head, s3_put):
+        self.requests_mock.add(responses.HEAD, s3_head)
+        self.requests_mock.add(responses.PUT, s3_put)

--- a/quilt/tools/command.py
+++ b/quilt/tools/command.py
@@ -21,7 +21,7 @@ from tqdm import tqdm
 
 from .build import build_package, generate_build_file, BuildException
 from .const import DEFAULT_BUILDFILE, LATEST_TAG
-from .core import (hash_contents, GroupNode, TableNode, FileNode, PackageFormat,
+from .core import (hash_contents, find_object_hashes, GroupNode, TableNode, FileNode, PackageFormat,
                    decode_node, encode_node)
 from .hashing import digest_file
 from .store import PackageStore
@@ -296,7 +296,7 @@ def log(package):
         nice = ugly.strftime("%Y-%m-%d %H:%M:%S")
         print(format_str % (entry['hash'], nice, entry['author']))
 
-def push(package):
+def push(package, reupload=False):
     """
     Push a Quilt data package to the server
     """
@@ -306,10 +306,44 @@ def push(package):
     pkgobj = PackageStore.find_package(owner, pkg)
     if pkgobj is None:
         raise CommandException("Package {owner}/{pkg} not found.".format(owner=owner, pkg=pkg))
+
+    obj_hashes = sorted(set(find_object_hashes(pkgobj.get_contents())))
+    total = len(obj_hashes)
+
+    headers = {
+        'Content-Encoding': 'gzip'
+    }
+
+    for idx, obj_hash in enumerate(obj_hashes):
+        print("Uploading %s (%d/%d)..." % (obj_hash, idx + 1, total))
+
+        response = session.get(
+            "{url}/api/blob/{owner}/{hash}".format(
+                url=QUILT_PKG_URL,
+                owner=owner,
+                hash=obj_hash
+            )
+        )
+        contents = response.json()
+
+        if not reupload:
+            s3_response = requests.head(contents['head'])
+            if s3_response.ok:
+                print("Fragment already uploaded; skipping.")
+                continue
+
+        # Create a temporary gzip'ed file.
+        with pkgobj.tempfile(obj_hash) as temp_file:
+            with FileWithReadProgress(temp_file) as temp_file_with_progress:
+                url = contents['put']
+                response = requests.put(url, data=temp_file_with_progress, headers=headers)
+                if not response.ok:
+                    raise CommandException("Upload failed: error %s" % response.status_code)
+
     pkghash = pkgobj.get_hash()
 
     print("Uploading package metadata...")
-    response = session.put(
+    session.put(
         "{url}/api/package/{owner}/{pkg}/{hash}".format(
             url=QUILT_PKG_URL,
             owner=owner,
@@ -322,26 +356,8 @@ def push(package):
         ), default=encode_node)
     )
 
-    dataset = response.json()
-    upload_urls = dataset['upload_urls']
-
-    headers = {
-        'Content-Encoding': 'gzip'
-    }
-
-    total = len(upload_urls)
-    for idx, (objhash, url) in enumerate(iteritems(upload_urls)):
-        # Create a temporary gzip'ed file.
-        print("Uploading %s (%d/%d)..." % (objhash, idx + 1, total))
-        with pkgobj.tempfile(objhash) as temp_file:
-            with FileWithReadProgress(temp_file) as temp_file_with_progress:
-                response = requests.put(url, data=temp_file_with_progress, headers=headers)
-                if not response.ok:
-                    raise CommandException("Upload failed: error %s" % response.status_code)
-
     print("Updating the 'latest' tag...")
-    # Set the "latest" tag.
-    response = session.put(
+    session.put(
         "{url}/api/tag/{owner}/{pkg}/{tag}".format(
             url=QUILT_PKG_URL,
             owner=owner,
@@ -352,7 +368,6 @@ def push(package):
             hash=pkghash
         ))
     )
-    assert response.ok # other responses handled by _handle_response
 
     url = "https://quiltdata.com/package/%s/%s" % (owner, pkg)
     print("Push complete. Your package is live:\n%s" % url)

--- a/quilt/tools/main.py
+++ b/quilt/tools/main.py
@@ -42,10 +42,8 @@ def main():
 
     push_p = subparsers.add_parser("push")
     push_p.add_argument("package", type=str, help="Owner/Package Name")
-    push_p.set_defaults(func=command.push)
-
-    push_p = subparsers.add_parser("push")
-    push_p.add_argument("package", type=str, help="Owner/Package Name")
+    push_p.add_argument("--reupload", action="store_true",
+                        help="Re-upload all fragments, even the ones the server already has")
     push_p.set_defaults(func=command.push)
 
     version_p = subparsers.add_parser("version")


### PR DESCRIPTION
Use the new API endpoint to upload the objects before
creating the package, and upload only what is necessary.