### PR TITLE
Cast all object columns to strings before serializing

### DIFF
--- a/quilt/tools/build.py
+++ b/quilt/tools/build.py
@@ -131,12 +131,11 @@ def _file_to_data_frame(ext, path, target, user_kwargs):
         df = handler(path, **failover_args)
 
     # cast object columns to strings
-    safecols = {}
     for name, col in df.iteritems():
-        safecols[name] = col.astype(str) if col.dtype == 'object' else col
+        if col.dtype == 'object':
+            df[name] = col.astype(str)
 
-    safedf = pd.DataFrame(safecols)
-    return safedf
+    return df
 
 def build_package(username, package, yaml_path):
     """

--- a/quilt/tools/build.py
+++ b/quilt/tools/build.py
@@ -130,7 +130,13 @@ def _file_to_data_frame(ext, path, target, user_kwargs):
         failover_args.update(kwargs)
         df = handler(path, **failover_args)
 
-    return df
+    # cast object columns to strings
+    safecols = {}
+    for name, col in df.iteritems():
+        safecols[name] = col.astype(str) if col.dtype == 'object' else col
+
+    safedf = pd.DataFrame(safecols)
+    return safedf
 
 def build_package(username, package, yaml_path):
     """


### PR DESCRIPTION
Arrow Parquet can’t handle mixed-type columns. Until there’s a fix in
Arrow, to be safe, let’s cast object-type columns to strings before
serializing to Parquet.