### PR TITLE
Small fixes to make editing packages safer & easier

### DIFF
--- a/quilt/data.py
+++ b/quilt/data.py
@@ -45,7 +45,7 @@ class Node(object):
         if name.startswith('_') or isinstance(value, Node):
             super(Node, self).__setattr__(name, value)
         else:
-            raise ValueError("{val} is not a valid package node".format(val=value))
+            raise AttributeError("{val} is not a valid package node".format(val=value))
 
 class DataNode(Node):
     """

--- a/quilt/data.py
+++ b/quilt/data.py
@@ -41,6 +41,12 @@ class Node(object):
     def __repr__(self):
         return self._class_repr()
 
+    def __setattr__(self, name, value):
+        if name.startswith('_') or isinstance(value, Node):
+            super(Node, self).__setattr__(name, value)
+        else:
+            raise ValueError("{val} is not a valid package node".format(val=value))
+
 class DataNode(Node):
     """
     Represents a dataframe or a file. Allows accessing the contents using `()`.
@@ -96,6 +102,10 @@ class GroupNode(DataNode):
         keys directly accessible on this object via getattr or .
         """
         return [name for name in self.__dict__ if not name.startswith('_')]
+
+    def _add_group(self, groupname):
+        child = GroupNode(self._package, core.GroupNode({}))
+        setattr(self, groupname, child)
 
 class PackageNode(GroupNode):
     """

--- a/quilt/test/test_import.py
+++ b/quilt/test/test_import.py
@@ -138,6 +138,10 @@ class ImportTest(QuiltTestCase):
         file_path = os.path.join(mydir, 'data/foo.csv')
         package1._set(['new', 'file'], file_path)
 
+        # Add a new group
+        package1._add_group("newgroup")
+        package1._set(['new', 'newgroup', 'df'], df)
+
         # Can't overwrite things
         with self.assertRaises(ValueError):
             package1._set(['new'], file_path)
@@ -160,3 +164,16 @@ class ImportTest(QuiltTestCase):
 
         new_file = package3.new.file._data()
         assert isinstance(new_file, string_types)
+
+    def test_set_non_node_attr(self):
+        mydir = os.path.dirname(__file__)
+        build_path = os.path.join(mydir, './build.yml')
+        command.build('foo/package1', build_path)
+
+        from quilt.data.foo import package1
+
+        # Assign a DataFrame as a node
+        # (should throw exception)
+        df = pd.DataFrame(dict(a=[1, 2, 3]))
+        with self.assertRaises(ValueError):
+            package1.newdf = df

--- a/quilt/test/test_import.py
+++ b/quilt/test/test_import.py
@@ -175,5 +175,5 @@ class ImportTest(QuiltTestCase):
         # Assign a DataFrame as a node
         # (should throw exception)
         df = pd.DataFrame(dict(a=[1, 2, 3]))
-        with self.assertRaises(ValueError):
+        with self.assertRaises(AttributeError):
             package1.newdf = df


### PR DESCRIPTION
Adding a method to add groups to child nodes and putting a test on
setattr to validate that a GroupNode’s children are valid package nodes.