### PR TITLE
Test for pyspark more explicitly

### DIFF
--- a/quilt/tools/build.py
+++ b/quilt/tools/build.py
@@ -70,8 +70,14 @@ def _build_node(build_dir, package, name, node, format, target='pandas'):
 
             print("Serializing %s..." % path)
             try:
-                df = _file_to_spark_data_frame(transform, path, target, user_kwargs)
+                import pyspark
+                have_pyspark = True
             except ImportError:
+                have_pyspark = False
+
+            if have_pyspark:
+                df = _file_to_spark_data_frame(transform, path, target, user_kwargs)
+            else:
                 df = _file_to_data_frame(transform, path, target, user_kwargs)
 
             # serialize DataFrame to file(s)


### PR DESCRIPTION
Otherwise, in Python3, any subsequent exceptions get blamed on the failed import, which is misleading.