### PR TITLE
Make tests pass on Windows

### DIFF
--- a/quilt/test/test_build.py
+++ b/quilt/test/test_build.py
@@ -108,8 +108,10 @@ class BuildTest(QuiltTestCase):
         build.generate_build_file(path)
         assert os.path.exists(buildfilepath)
 
-        docs = yaml.load_all(open(buildfilepath))
-        data = next(docs, None)
+        with open(buildfilepath) as fd:
+            docs = yaml.load_all(fd)
+            data = next(docs, None)
+
         contents = data['contents']
 
         assert contents == {

--- a/quilt/tools/command.py
+++ b/quilt/tools/command.py
@@ -8,6 +8,7 @@ from builtins import input
 from datetime import datetime
 import json
 import os
+from shutil import move
 import stat
 import time
 import webbrowser
@@ -624,7 +625,7 @@ def install(package, hash=None, version=None, tag=None, force=False):
             raise CommandException("Fragment hashes do not match: expected %s, got %s." %
                                    (download_hash, file_hash))
 
-        os.rename(temp_path, local_filename)
+        move(temp_path, local_filename)
 
     pkgobj.save_contents()
 

--- a/quilt/tools/const.py
+++ b/quilt/tools/const.py
@@ -10,8 +10,8 @@ class TargetType(Enum):
     PANDAS = 'pandas'
     FILE = 'file'
 
-DATEF = '%F'
-TIMEF = '%T'
+DATEF = '%Y-%m-%d'
+TIMEF = '%H:%M:%S'
 DTIMEF = '%s %s' % (DATEF, TIMEF)
 LATEST_TAG = 'latest'
 PACKAGE_DIR_NAME = 'quilt_packages'

--- a/quilt/tools/package.py
+++ b/quilt/tools/package.py
@@ -1,7 +1,7 @@
 from enum import Enum
 import json
 import os
-from shutil import copyfile, rmtree
+from shutil import copyfile, move, rmtree
 import tempfile
 import zlib
 
@@ -173,14 +173,14 @@ class Package(object):
             for obj in files:
                 path = os.path.join(storepath, obj)
                 objhash = digest_file(path)
-                os.rename(path, self._store.object_path(objhash))
+                move(path, self._store.object_path(objhash))
                 hashes.append(objhash)
             self._add_to_contents(buildfile, hashes, ext, path, target, format)
             rmtree(storepath)
         else:
             filehash = digest_file(storepath)
             self._add_to_contents(buildfile, [filehash], ext, path, target, format)
-            os.rename(storepath, self._store.object_path(filehash))
+            move(storepath, self._store.object_path(filehash))
 
     def save_file(self, srcfile, name, path):
         """

--- a/quilt/tools/store.py
+++ b/quilt/tools/store.py
@@ -29,7 +29,7 @@ class PackageStore(object):
     PACKAGE_FILE_EXT = '.json'
     BUILD_DIR = 'build'
     OBJ_DIR = 'objs'
-    TMP_OBJ_DIR = 'objs/tmp'
+    TMP_OBJ_DIR = os.path.join('objs', 'tmp')
 
     def __init__(self, store_dir=PACKAGE_DIR_NAME):
         assert os.path.basename(os.path.abspath(store_dir)) == PACKAGE_DIR_NAME, \


### PR DESCRIPTION
- Use `shutil.move` instead of `os.rename`: `os.rename` fails if the destination exists.
- Don't try to delete open files.
- Don't use `%F` and `%T` date formats: apparently, they don't work on Windows.