### PR TITLE
Add a `login_with_token` function.

### DIFF
--- a/quilt/__init__.py
+++ b/quilt/__init__.py
@@ -11,6 +11,7 @@ from .tools.command import (
     install,
     log,
     login,
+    login_with_token,
     logout,
     ls,
     delete,

--- a/quilt/tools/command.py
+++ b/quilt/tools/command.py
@@ -180,6 +180,8 @@ def _open_url(url):
 def login():
     """
     Authenticate.
+
+    Launches a web browser and asks the user for a token.
     """
     login_url = "%s/login" % QUILT_PKG_URL
 
@@ -191,9 +193,13 @@ def login():
     print()
     refresh_token = input("Enter the code from the webpage: ")
 
-    # Get an access token (and a new refresh token).
-    # Technically, we could have the user enter both tokens - but it doesn't
-    # really matter, and this lets us verify that the token actually works.
+    login_with_token(refresh_token)
+
+def login_with_token(refresh_token):
+    """
+    Authenticate using an existing token.
+    """
+    # Get an access token and a new refresh token.
     auth = _update_auth(refresh_token)
 
     _save_auth(auth)


### PR DESCRIPTION
Makes it possible to login using a token acquired elsewhere, instead of opening a browser and prompting the user.