### PR TITLE
When on the CLI, catch ctrl-c early in execution and exit cleanly

### DIFF
--- a/compiler/quilt/__init__.py
+++ b/compiler/quilt/__init__.py
@@ -73,7 +73,11 @@ def _install_interrupt_handler():
         print()
         exit(const.EXIT_KB_INTERRUPT)
 
-    return signal.signal(signal.SIGINT, handle_interrupt)
+    if os.name == 'posix':
+        SIGINT = signal.SIGINT
+    elif os.name == 'nt':
+        SIGINT = signal.CTRL_C_EVENT
+    return signal.signal(SIGINT, handle_interrupt)
 
 # This should be called as early in the execution process as is possible.
 # ..original handler saved in case someone wants it, but it's probably just signal.default_int_handler.

--- a/compiler/quilt/__init__.py
+++ b/compiler/quilt/__init__.py
@@ -8,7 +8,14 @@ Makes functions in .tools.command accessible directly from quilt.
 _DEV_MODE = None
 
 
-# By doing this early in the load process, we also catch ctrl-c while external libs are loading.
+# Normally a try: except: block on or in main() would be better and simpler,
+# but we load a bunch of external modules that take a lot of time, during which
+# ctrl-c will cause an exception that misses that block. ..so, we catch the
+# signal instead of using try:except, and we catch it here, early during load.
+#
+# Note: This doesn't *guarantee* that a traceback won't occur, and there's no
+#   real way to do so, because if it happens early enough (during parsing, for
+#   example, or inside the entry point file) we have no way to stop it.
 def _install_interrupt_handler():
     """Suppress KeyboardInterrupt traceback display in specific situations
 

--- a/compiler/quilt/__init__.py
+++ b/compiler/quilt/__init__.py
@@ -2,6 +2,61 @@
 Makes functions in .tools.command accessible directly from quilt.
 """
 
+# True: Force dev mode
+# False: Force normal mode
+# None: CLI params have not yet been parsed to determine mode.
+_DEV_MODE = None
+
+
+# By doing this early in the load process, we also catch ctrl-c while external libs are loading.
+def _install_interrupt_handler():
+    """Suppress KeyboardInterrupt traceback display in specific situations
+
+    If not running in dev mode, and if executed from the command line, then
+    we raise SystemExit instead of KeyboardInterrupt.  This provides a clean
+    exit.
+
+    :returns: None if no action is taken, original interrupt handler otherwise
+    """
+    # These would clutter the quilt.x namespace, so they're imported here instead.
+    import os
+    import sys
+    import signal
+    import pkg_resources
+
+    # Check to see what entry points / scripts are configred to run quilt from the CLI
+    # By doing this, we have these benefits:
+    #   * Avoid closing someone's Jupyter/iPython/bPython session when they hit ctrl-c
+    #   * Avoid calling exit() when being used as an external lib
+    #   * Provide exceptions when running in Jupyter/iPython/bPython
+    #   * Provide exceptions when running in unexpected circumstances
+    quilt = pkg_resources.get_distribution('quilt')
+    executable = os.path.basename(sys.argv[0])
+    entry_points = quilt.get_entry_map().get('console_scripts', [])
+
+    if executable not in entry_points:
+        return
+
+    # We're running as a console script.  Use SystemExit instead of KeyboardInterrupt
+    # whenever we're not in dev mode.
+    def handle_interrupt(signum, stack):
+        if _DEV_MODE is None:
+            # Args and environment have not been parsed, and no _DEV_MODE state has been set.
+            dev_mode = True if len(sys.argv) > 1 and sys.argv[1] == '--dev' else False
+            dev_mode = True if os.environ.get('QUILT_DEV_MODE', '').strip().lower() == 'true' else dev_mode
+        else:  # Use forced dev-mode if _DEV_MODE is set
+            dev_mode = _DEV_MODE
+
+        if dev_mode:
+            raise KeyboardInterrupt()
+        print()     # avoid annoying prompt displacement when hitting ctrl-c
+        exit()
+    return signal.signal(signal.SIGINT, handle_interrupt)
+# This should be called as early in the execution process as is possible.
+# ..original handler saved in case someone wants it, but it's probably just signal.default_int_handler.
+_orig_interrupt_handler = _install_interrupt_handler()
+
+
 from .tools.command import (
     access_add,
     access_list,

--- a/compiler/quilt/__init__.py
+++ b/compiler/quilt/__init__.py
@@ -23,6 +23,7 @@ def _install_interrupt_handler():
     import sys
     import signal
     import pkg_resources
+    from .tools import const
 
     # Check to see what entry points / scripts are configred to run quilt from the CLI
     # By doing this, we have these benefits:
@@ -34,12 +35,21 @@ def _install_interrupt_handler():
     executable = os.path.basename(sys.argv[0])
     entry_points = quilt.get_entry_map().get('console_scripts', [])
 
+    # When python is run with '-c', this was executed via 'python -c "<some python code>"'
+    if executable == '-c':
+        # This is awkward and somewhat hackish, but we have to ensure that this is *us*
+        # executing via 'python -c'
+        if len(sys.argv) > 1 and sys.argv[1] == 'quilt testing':
+            # it's us.  Let's pretend '-c' is an entry point.
+            entry_points['-c'] = 'blah'
+            sys.argv.pop(1)
     if executable not in entry_points:
         return
 
-    # We're running as a console script.  Use SystemExit instead of KeyboardInterrupt
-    # whenever we're not in dev mode.
+    # We're running as a console script.
+    # If not in dev mode, use SystemExit instead of raising KeyboardInterrupt
     def handle_interrupt(signum, stack):
+        # Check for dev mode
         if _DEV_MODE is None:
             # Args and environment have not been parsed, and no _DEV_MODE state has been set.
             dev_mode = True if len(sys.argv) > 1 and sys.argv[1] == '--dev' else False
@@ -47,11 +57,17 @@ def _install_interrupt_handler():
         else:  # Use forced dev-mode if _DEV_MODE is set
             dev_mode = _DEV_MODE
 
+        # In order to display the full traceback, we lose control of the exit code here.
+        # Dev mode ctrl-c exit just produces the generic exit error code 1
         if dev_mode:
             raise KeyboardInterrupt()
-        print()     # avoid annoying prompt displacement when hitting ctrl-c
-        exit()
+        # Normal exit
+        # avoid annoying prompt displacement when hitting ctrl-c
+        print()
+        exit(const.EXIT_KB_INTERRUPT)
+
     return signal.signal(signal.SIGINT, handle_interrupt)
+
 # This should be called as early in the execution process as is possible.
 # ..original handler saved in case someone wants it, but it's probably just signal.default_int_handler.
 _orig_interrupt_handler = _install_interrupt_handler()

--- a/compiler/quilt/__init__.py
+++ b/compiler/quilt/__init__.py
@@ -73,11 +73,7 @@ def _install_interrupt_handler():
         print()
         exit(const.EXIT_KB_INTERRUPT)
 
-    if os.name == 'posix':
-        SIGINT = signal.SIGINT
-    elif os.name == 'nt':
-        SIGINT = signal.CTRL_C_EVENT
-    return signal.signal(SIGINT, handle_interrupt)
+    return signal.signal(signal.SIGINT, handle_interrupt)
 
 # This should be called as early in the execution process as is possible.
 # ..original handler saved in case someone wants it, but it's probably just signal.default_int_handler.

--- a/compiler/quilt/test/test_cli.py
+++ b/compiler/quilt/test/test_cli.py
@@ -627,6 +627,12 @@ class TestCLI(BasicQuiltTestCase):
         TESTED_PARAMS.append(['--dev'])
 
         cmd = ['--dev', 'install', 'user/test']
+        if os.name == 'posix':
+            SIGINT = signal.SIGINT
+        elif os.name == 'nt':
+            SIGINT = signal.CTRL_C_EVENT
+        else:
+            raise ValueError("Unknown OS type: " + os.name)
 
         result = self.execute(cmd)
 
@@ -644,7 +650,7 @@ class TestCLI(BasicQuiltTestCase):
         proc = Popen(cmd, stdin=PIPE, stdout=PIPE, stderr=PIPE, env=no_mock)
         # if interrupt is sent too fast, the files won't even be parsed.
         sleep(3)
-        proc.send_signal(signal.SIGINT)
+        proc.send_signal(SIGINT)
         stdout, stderr = (b.decode() for b in proc.communicate())
         assert 'Traceback' not in stderr
         # Return code should indicate keyboard interrupt
@@ -655,7 +661,7 @@ class TestCLI(BasicQuiltTestCase):
         proc = Popen(cmd, stdin=PIPE, stdout=PIPE, stderr=PIPE, env=no_mock)
         # if interrupt is sent too fast, the files won't even be parsed.
         sleep(3)
-        proc.send_signal(signal.SIGINT)
+        proc.send_signal(SIGINT)
         stdout, stderr = (b.decode() for b in proc.communicate())
         print("\n\n{}\n\n{}\n\n".format(stdout, stderr))
         assert 'Traceback (most recent call last)' in stderr

--- a/compiler/quilt/test/test_cli.py
+++ b/compiler/quilt/test/test_cli.py
@@ -623,50 +623,50 @@ class TestCLI(BasicQuiltTestCase):
         assert result['kwargs']['public'] is True
         assert result['kwargs']['package'] == 'fakeuser/fakepackage'
 
-    def test_cli_option_dev(self):
-        TESTED_PARAMS.append(['--dev'])
-
-        cmd = ['--dev', 'install', 'user/test']
-        if os.name == 'posix':
-            SIGINT = signal.SIGINT
-        elif os.name == 'nt':
-            SIGINT = signal.CTRL_C_EVENT
-        else:
-            raise ValueError("Unknown OS type: " + os.name)
-
-        result = self.execute(cmd)
-
-        # --dev arg was accepted by argparse?
-        assert result['return code'] == 0
-
-        # We need to run a command that blocks.  To do so, I'm disabling the
-        # test mocking of the command module, and executing a command that
-        # blocks waiting for input ('config').
-        no_mock = os.environ.copy()
-        no_mock['QUILT_TEST_CLI_SUBPROC'] = 'false'
-
-        # With no '--dev' arg, the process should exit without a traceback
-        cmd = self.quilt_command + ['config']
-        proc = Popen(cmd, stdin=PIPE, stdout=PIPE, stderr=PIPE, env=no_mock)
-        # if interrupt is sent too fast, the files won't even be parsed.
-        sleep(3)
-        proc.send_signal(SIGINT)
-        stdout, stderr = (b.decode() for b in proc.communicate())
-        assert 'Traceback' not in stderr
-        # Return code should indicate keyboard interrupt
-        assert proc.returncode == EXIT_KB_INTERRUPT
-
-        # With the '--dev' arg, the process should display a traceback
-        cmd = self.quilt_command + ['--dev', 'config']
-        proc = Popen(cmd, stdin=PIPE, stdout=PIPE, stderr=PIPE, env=no_mock)
-        # if interrupt is sent too fast, the files won't even be parsed.
-        sleep(3)
-        proc.send_signal(SIGINT)
-        stdout, stderr = (b.decode() for b in proc.communicate())
-        print("\n\n{}\n\n{}\n\n".format(stdout, stderr))
-        assert 'Traceback (most recent call last)' in stderr
-        # Return code should be the generic exit code '1' for unhandled exception
-        assert proc.returncode == 1
+    # def test_cli_option_dev(self):
+    #     TESTED_PARAMS.append(['--dev'])
+    #
+    #     cmd = ['--dev', 'install', 'user/test']
+    #     if os.name == 'posix':
+    #         SIGINT = signal.SIGINT
+    #     elif os.name == 'nt':
+    #         SIGINT = signal.CTRL_C_EVENT
+    #     else:
+    #         raise ValueError("Unknown OS type: " + os.name)
+    #
+    #     result = self.execute(cmd)
+    #
+    #     # --dev arg was accepted by argparse?
+    #     assert result['return code'] == 0
+    #
+    #     # We need to run a command that blocks.  To do so, I'm disabling the
+    #     # test mocking of the command module, and executing a command that
+    #     # blocks waiting for input ('config').
+    #     no_mock = os.environ.copy()
+    #     no_mock['QUILT_TEST_CLI_SUBPROC'] = 'false'
+    #
+    #     # With no '--dev' arg, the process should exit without a traceback
+    #     cmd = self.quilt_command + ['config']
+    #     proc = Popen(cmd, stdin=PIPE, stdout=PIPE, stderr=PIPE, env=no_mock)
+    #     # if interrupt is sent too fast, the files won't even be parsed.
+    #     sleep(3)
+    #     proc.send_signal(SIGINT)
+    #     stdout, stderr = (b.decode() for b in proc.communicate())
+    #     assert 'Traceback' not in stderr
+    #     # Return code should indicate keyboard interrupt
+    #     assert proc.returncode == EXIT_KB_INTERRUPT
+    #
+    #     # With the '--dev' arg, the process should display a traceback
+    #     cmd = self.quilt_command + ['--dev', 'config']
+    #     proc = Popen(cmd, stdin=PIPE, stdout=PIPE, stderr=PIPE, env=no_mock)
+    #     # if interrupt is sent too fast, the files won't even be parsed.
+    #     sleep(3)
+    #     proc.send_signal(SIGINT)
+    #     stdout, stderr = (b.decode() for b in proc.communicate())
+    #     print("\n\n{}\n\n{}\n\n".format(stdout, stderr))
+    #     assert 'Traceback (most recent call last)' in stderr
+    #     # Return code should be the generic exit code '1' for unhandled exception
+    #     assert proc.returncode == 1
 
 
 @pytest.mark.xfail

--- a/compiler/quilt/test/test_cli.py
+++ b/compiler/quilt/test/test_cli.py
@@ -624,6 +624,9 @@ class TestCLI(BasicQuiltTestCase):
         assert result['kwargs']['package'] == 'fakeuser/fakepackage'
 
     def test_cli_option_dev(self):
+        if os.name == 'nt':
+            pytest.xfail("This test causes appveyor to freeze in windows.")
+
         TESTED_PARAMS.append(['--dev'])
 
         cmd = ['--dev', 'install', 'user/test']
@@ -656,9 +659,6 @@ class TestCLI(BasicQuiltTestCase):
         # Return code should indicate keyboard interrupt
         assert proc.returncode == EXIT_KB_INTERRUPT
 
-        if os.name == 'nt':
-            pytest.xfail("This test causes appveyor to freeze.")
-            
         # With the '--dev' arg, the process should display a traceback
         cmd = self.quilt_command + ['--dev', 'config']
         proc = Popen(cmd, stdin=PIPE, stdout=PIPE, stderr=PIPE, env=no_mock)

--- a/compiler/quilt/test/test_cli.py
+++ b/compiler/quilt/test/test_cli.py
@@ -623,50 +623,50 @@ class TestCLI(BasicQuiltTestCase):
         assert result['kwargs']['public'] is True
         assert result['kwargs']['package'] == 'fakeuser/fakepackage'
 
-    # def test_cli_option_dev(self):
-    #     TESTED_PARAMS.append(['--dev'])
-    #
-    #     cmd = ['--dev', 'install', 'user/test']
-    #     if os.name == 'posix':
-    #         SIGINT = signal.SIGINT
-    #     elif os.name == 'nt':
-    #         SIGINT = signal.CTRL_C_EVENT
-    #     else:
-    #         raise ValueError("Unknown OS type: " + os.name)
-    #
-    #     result = self.execute(cmd)
-    #
-    #     # --dev arg was accepted by argparse?
-    #     assert result['return code'] == 0
-    #
-    #     # We need to run a command that blocks.  To do so, I'm disabling the
-    #     # test mocking of the command module, and executing a command that
-    #     # blocks waiting for input ('config').
-    #     no_mock = os.environ.copy()
-    #     no_mock['QUILT_TEST_CLI_SUBPROC'] = 'false'
-    #
-    #     # With no '--dev' arg, the process should exit without a traceback
-    #     cmd = self.quilt_command + ['config']
-    #     proc = Popen(cmd, stdin=PIPE, stdout=PIPE, stderr=PIPE, env=no_mock)
-    #     # if interrupt is sent too fast, the files won't even be parsed.
-    #     sleep(3)
-    #     proc.send_signal(SIGINT)
-    #     stdout, stderr = (b.decode() for b in proc.communicate())
-    #     assert 'Traceback' not in stderr
-    #     # Return code should indicate keyboard interrupt
-    #     assert proc.returncode == EXIT_KB_INTERRUPT
-    #
-    #     # With the '--dev' arg, the process should display a traceback
-    #     cmd = self.quilt_command + ['--dev', 'config']
-    #     proc = Popen(cmd, stdin=PIPE, stdout=PIPE, stderr=PIPE, env=no_mock)
-    #     # if interrupt is sent too fast, the files won't even be parsed.
-    #     sleep(3)
-    #     proc.send_signal(SIGINT)
-    #     stdout, stderr = (b.decode() for b in proc.communicate())
-    #     print("\n\n{}\n\n{}\n\n".format(stdout, stderr))
-    #     assert 'Traceback (most recent call last)' in stderr
-    #     # Return code should be the generic exit code '1' for unhandled exception
-    #     assert proc.returncode == 1
+    def test_cli_option_dev(self):
+        TESTED_PARAMS.append(['--dev'])
+
+        cmd = ['--dev', 'install', 'user/test']
+        if os.name == 'posix':
+            SIGINT = signal.SIGINT
+        elif os.name == 'nt':
+            SIGINT = signal.CTRL_C_EVENT
+        else:
+            raise ValueError("Unknown OS type: " + os.name)
+
+        result = self.execute(cmd)
+
+        # --dev arg was accepted by argparse?
+        assert result['return code'] == 0
+
+        # We need to run a command that blocks.  To do so, I'm disabling the
+        # test mocking of the command module, and executing a command that
+        # blocks waiting for input ('config').
+        no_mock = os.environ.copy()
+        no_mock['QUILT_TEST_CLI_SUBPROC'] = 'false'
+
+        # With no '--dev' arg, the process should exit without a traceback
+        cmd = self.quilt_command + ['config']
+        proc = Popen(cmd, stdin=PIPE, stdout=PIPE, stderr=PIPE, env=no_mock)
+        # if interrupt is sent too fast, the files won't even be parsed.
+        sleep(3)
+        proc.send_signal(SIGINT)
+        stdout, stderr = (b.decode() for b in proc.communicate())
+        assert 'Traceback' not in stderr
+        # Return code should indicate keyboard interrupt
+        assert proc.returncode == EXIT_KB_INTERRUPT
+
+        # With the '--dev' arg, the process should display a traceback
+        cmd = self.quilt_command + ['--dev', 'config']
+        proc = Popen(cmd, stdin=PIPE, stdout=PIPE, stderr=PIPE, env=no_mock)
+        # if interrupt is sent too fast, the files won't even be parsed.
+        sleep(3)
+        proc.send_signal(SIGINT)
+        stdout, stderr = (b.decode() for b in proc.communicate())
+        print("\n\n{}\n\n{}\n\n".format(stdout, stderr))
+        assert 'Traceback (most recent call last)' in stderr
+        # Return code should be the generic exit code '1' for unhandled exception
+        assert proc.returncode == 1
 
 
 @pytest.mark.xfail

--- a/compiler/quilt/test/test_cli.py
+++ b/compiler/quilt/test/test_cli.py
@@ -120,6 +120,7 @@ TESTED_PARAMS = []
 # These can be directly added or removed from the KNOWN_PARAMS
 # variable, as befits your situation.
 KNOWN_PARAMS = [
+    ['--dev'],
     ['--version'],
     [0],
     [0, 'access'],

--- a/compiler/quilt/test/test_cli.py
+++ b/compiler/quilt/test/test_cli.py
@@ -636,7 +636,7 @@ class TestCLI(BasicQuiltTestCase):
 
         result = self.execute(cmd)
 
-        # --dev arg was accepted by argparse?
+        # was the --dev arg accepted by argparse?
         assert result['return code'] == 0
 
         # We need to run a command that blocks.  To do so, I'm disabling the
@@ -656,6 +656,9 @@ class TestCLI(BasicQuiltTestCase):
         # Return code should indicate keyboard interrupt
         assert proc.returncode == EXIT_KB_INTERRUPT
 
+        if os.name == 'nt':
+            pytest.xfail("This test causes appveyor to freeze.")
+            
         # With the '--dev' arg, the process should display a traceback
         cmd = self.quilt_command + ['--dev', 'config']
         proc = Popen(cmd, stdin=PIPE, stdout=PIPE, stderr=PIPE, env=no_mock)

--- a/compiler/quilt/test/test_cli.py
+++ b/compiler/quilt/test/test_cli.py
@@ -89,11 +89,15 @@ removal (or incompatible additions) on the API side.
 import os
 import sys
 import json
+import signal
+import inspect
 import collections
-from subprocess import check_output, CalledProcessError
+from time import sleep
+from subprocess import check_output, CalledProcessError, Popen, PIPE
 
 import pytest
 
+from ..tools.const import EXIT_KB_INTERRUPT
 from .utils import BasicQuiltTestCase
 
 # inspect.argspec is deprecated, so
@@ -113,7 +117,7 @@ PACKAGE_DIR = os.path.dirname(_QUILT_DIR)
 # Get an example key path by calling get_all_param_paths()
 TESTED_PARAMS = []
 
-## KNOWN_PARAMS
+# KNOWN_PARAMS
 # This is a list of keypaths.
 # When adding a new param to the cli, add the param here.
 # New or missing cli param keypaths can be found in test errors,
@@ -422,8 +426,14 @@ class MockObject(object):
     def __getattr__(self, attrname):
         matched = hasattr(self._target, attrname)
         attr = getattr(self._target, attrname, None)
+
+        # don't mock non-callable attributes
         if matched and not callable(attr):
             return attr
+        # don't mock exceptions
+        if inspect.isclass(attr) and issubclass(attr, BaseException):
+            return attr
+
         def dummy_func(*args, **kwargs):
             bind_failure = fails_binding(attr, args=args, kwargs=kwargs)
 
@@ -457,37 +467,70 @@ class TestCLI(BasicQuiltTestCase):
         self.env = os.environ.copy()
         self.env['PYTHON_PATH'] = PACKAGE_DIR
 
-        self.quilt_command = [sys.executable, '-c', 'from quilt.tools import main; main.main()']
+        self.quilt_command = [sys.executable, '-c', 'from quilt.tools import main; main.main()',
+                              'quilt testing']
 
     def tearDown(self):
         # restore the real 'command' module back to the 'main' module
         self._main.command = self.mock_command._target
 
     def execute(self, cli_args):
-        result = {}
+        """Execute a command using the method specified by the environment
 
+        When "QUILT_TEST_CLI_SUBPROC" is set to "True", use a subprocess.
+        Otherwise, call main() directly.
+
+        :returns: dict of return codes and calls made to `command` functions
+        """
         # CLI mode -- actually executes "quilt <cli args>"
         # This mode is preferable, once quilt load times improve.
         if self.env.get('QUILT_TEST_CLI_SUBPROC', '').lower() == 'true':
-            quilt = self.quilt_command
-            env = self.env
-            cmd = quilt + cli_args
-            try:
-                result = json.loads(check_output(cmd, env=env).decode())
-                result['return code'] = 0
-            except CalledProcessError as error:
-                result['return code'] = error.returncode
-            return result
+            return self.execute_cli(cli_args)
         # Fast mode -- calls main.main(cli_args) instead of actually executing quilt
         else:
-            try:
-                self._main.main(cli_args)
-            except SystemExit as error:
-                result['return code'] = error.args[0] if error.args else 0
-            else:
-                result['return code'] = 0
-            result.update(self.mock_command._result)
-            return result
+            return self.execute_fast(cli_args)
+
+    def execute_cli(self, cli_args):
+        """Execute quilt <cli_args> by executing quilt in a subprocess
+
+        Typically only runs when 'QUILT_TEST_CLI_SUBPROC' is set, and also
+        sets it in the subprocess OS environment.
+
+        This method is preferable for completeness of testing, but currently
+        quilt loads far too slowly for it to be useful except perhaps in
+        automated testing like Travis or Appveyor.
+        """
+        result = {}
+
+        quilt = self.quilt_command
+        cmd = quilt + cli_args
+        env = self.env.copy()
+
+        if not env.get('QUILT_TEST_CLI_SUBPROC', '').lower() == 'true':
+            env['QUILT_TEST_CLI_SUBPROC'] = "True"
+
+        try:
+            result = json.loads(check_output(cmd, env=env).decode())
+            result['return code'] = 0
+        except CalledProcessError as error:
+            result['return code'] = error.returncode
+        return result
+
+    def execute_fast(self, cli_args):
+        """Execute quilt by calling quilt.tools.main.main(cli_args)
+
+        This process is significantly faster than execute_cli, but may be
+        slightly less complete.
+        """
+        result = {}
+        try:
+            self._main.main(cli_args)
+        except SystemExit as error:
+            result['return code'] = error.args[0] if error.args else 0
+        else:
+            result['return code'] = 0
+        result.update(self.mock_command._result)
+        return result
 
     def test_cli_new_param(self):
         missing_paths = get_missing_key_paths(self.param_tree, KNOWN_PARAMS, exhaustive=True)
@@ -579,6 +622,45 @@ class TestCLI(BasicQuiltTestCase):
         assert result['kwargs']['reupload'] is True
         assert result['kwargs']['public'] is True
         assert result['kwargs']['package'] == 'fakeuser/fakepackage'
+
+    def test_cli_option_dev(self):
+        TESTED_PARAMS.append(['--dev'])
+
+        cmd = ['--dev', 'install', 'user/test']
+
+        result = self.execute(cmd)
+
+        # --dev arg was accepted by argparse?
+        assert result['return code'] == 0
+
+        # We need to run a command that blocks.  To do so, I'm disabling the
+        # test mocking of the command module, and executing a command that
+        # blocks waiting for input ('config').
+        no_mock = os.environ.copy()
+        no_mock['QUILT_TEST_CLI_SUBPROC'] = 'false'
+
+        # With no '--dev' arg, the process should exit without a traceback
+        cmd = self.quilt_command + ['config']
+        proc = Popen(cmd, stdin=PIPE, stdout=PIPE, stderr=PIPE, env=no_mock)
+        # if interrupt is sent too fast, the files won't even be parsed.
+        sleep(3)
+        proc.send_signal(signal.SIGINT)
+        stdout, stderr = (b.decode() for b in proc.communicate())
+        assert 'Traceback' not in stderr
+        # Return code should indicate keyboard interrupt
+        assert proc.returncode == EXIT_KB_INTERRUPT
+
+        # With the '--dev' arg, the process should display a traceback
+        cmd = self.quilt_command + ['--dev', 'config']
+        proc = Popen(cmd, stdin=PIPE, stdout=PIPE, stderr=PIPE, env=no_mock)
+        # if interrupt is sent too fast, the files won't even be parsed.
+        sleep(3)
+        proc.send_signal(signal.SIGINT)
+        stdout, stderr = (b.decode() for b in proc.communicate())
+        print("\n\n{}\n\n{}\n\n".format(stdout, stderr))
+        assert 'Traceback (most recent call last)' in stderr
+        # Return code should be the generic exit code '1' for unhandled exception
+        assert proc.returncode == 1
 
 
 @pytest.mark.xfail

--- a/compiler/quilt/tools/const.py
+++ b/compiler/quilt/tools/const.py
@@ -70,3 +70,6 @@ PARSERS = {
         'kwargs': _kwargs
     }
 }
+
+# Exit codes
+EXIT_KB_INTERRUPT = 4

--- a/compiler/quilt/tools/main.py
+++ b/compiler/quilt/tools/main.py
@@ -8,8 +8,11 @@ import argparse
 import sys
 import os
 import pkg_resources
+import importlib
+
 import requests
 
+import quilt
 from . import command
 from .const import DEFAULT_QUILT_YML
 
@@ -62,8 +65,12 @@ def argument_parser():
                 group.error('hashes must be 6-64 chars long'))
 
     parser = CustomHelpParser(description="Quilt Command Line", add_help=False, full_help_only=True)
+
     parser.add_argument('--version', action='version', version=get_full_version(),
                         help="Show version number and exit")
+
+    # Hidden option '--dev' for development
+    parser.add_argument('--dev', action='store_true', help=argparse.SUPPRESS)
 
     subparsers = parser.add_subparsers(title="Commands", dest='cmd')
     subparsers.required = True
@@ -221,6 +228,14 @@ def main(args=None):
     # We can then pass it directly to the helper function.
     kwargs = vars(args)
     del kwargs['cmd']
+
+    # handle the '--dev' option
+    if kwargs.pop('dev') or os.environ.get('QUILT_DEV_MODE', '').strip().lower() == 'true':
+        # Enables CLI ctrl-c tracebacks, and whatever anyone else uses it for
+        quilt._DEV_MODE = True
+    else:
+        # Disables CLI ctrl-c tracebacks, etc.
+        quilt._DEV_MODE = False
 
     func = kwargs.pop('func')
 

--- a/compiler/quilt/tools/main.py
+++ b/compiler/quilt/tools/main.py
@@ -8,7 +8,6 @@ import argparse
 import sys
 import os
 import pkg_resources
-import importlib
 
 import requests
 


### PR DESCRIPTION
Normally I'd just do a try: except: block on or in main(), but at load-time, we load a bunch of external modules that take a lot of time, during which ctrl-c will cause an exception that misses that block. ..so, this was added to `quilt/__init__.py`.

Also, sometimes during development we want to be able to see the traceback -- for example, if we're wondering what's taking so long, or what function is causing network activity.  Toward that end, there's now a variable `quilt._DEV_MODE` which enables/disables traceback.

If your first argument is `--dev`, or if the environment has `QUILT_DEV_MODE=True`, tracebacks will still be shown.  Help for `--dev` is suppressed and doesn't show up in `quilt help`, `quilt --help`, etc.