### PR TITLE
Make sure objects don't get truncated if build is interrupted

### DIFF
--- a/compiler/quilt/tools/package.py
+++ b/compiler/quilt/tools/package.py
@@ -229,7 +229,11 @@ class Package(object):
         self._add_to_contents(fullname, [filehash], '', path, 'file', None)
         objpath = self._store.object_path(filehash)
         if not os.path.exists(objpath):
-            copyfile(srcfile, objpath)
+            # Copy the file to a temporary location first, then move, to make sure we don't end up with
+            # truncated contents if the build gets interrupted.
+            tmppath = self._store.temporary_object_path(filehash)
+            copyfile(srcfile, tmppath)
+            move(tmppath, objpath)
 
     def save_group(self, name):
         """


### PR DESCRIPTION
When adding a file to the store, copy it to a temporary location first, then move it to the real one. Move is atomic, so should guarantee we don't end up with partial content.