### PR TITLE
Drop a workaround for CLI versions 2.5.0 and older

### DIFF
--- a/registry/quilt_server/views.py
+++ b/registry/quilt_server/views.py
@@ -17,7 +17,6 @@ from flask_json import as_json, jsonify
 import httpagentparser
 from jsonschema import Draft4Validator, ValidationError
 from oauthlib.oauth2 import OAuth2Error
-from packaging.version import Version as PackagingVersion
 import requests
 from requests_oauthlib import OAuth2Session
 import sqlalchemy as sa
@@ -480,22 +479,13 @@ def package_put(auth_user, owner, package_name, package_hash):
             customer = _get_or_create_customer()
             plan = _get_customer_plan(customer)
             if plan == PaymentPlan.FREE:
-                browser = g.user_agent['browser']
-                if (browser['name'] == 'QuiltCli' and
-                        PackagingVersion(browser['version']) <= PackagingVersion('2.5.0')):
-                    # Need 2.5.1 to create public packages.
-                    raise ApiException(
-                        requests.codes.server_error,
-                        "Outdated client. Run `pip install quilt --upgrade` to upgrade."
-                    )
-                else:
-                    raise ApiException(
-                        requests.codes.payment_required,
-                        ("Insufficient permissions. Run `quilt push --public %s/%s` to make " +
-                         "this package public, or upgrade your service plan to create " +
-                         "private packages: https://quiltdata.com/profile.") %
-                        (owner, package_name)
-                    )
+                raise ApiException(
+                    requests.codes.payment_required,
+                    ("Insufficient permissions. Run `quilt push --public %s/%s` to make " +
+                     "this package public, or upgrade your service plan to create " +
+                     "private packages: https://quiltdata.com/profile.") %
+                    (owner, package_name)
+                )
 
         package = Package(owner=owner, name=package_name)
         db.session.add(package)

--- a/registry/tests/push_install_test.py
+++ b/registry/tests/push_install_test.py
@@ -453,7 +453,7 @@ class PushInstallTestCase(QuiltTestCase):
 
     @mock_customer()
     def testCreatePrivateOnFreePlan(self, customer):
-        # New clients: need to upgrade the plan.
+        # Need to upgrade the plan.
         resp = self.app.put(
             '/api/package/test_user/foo/%s' % self.CONTENTS_HASH,
             data=json.dumps(dict(
@@ -463,29 +463,11 @@ class PushInstallTestCase(QuiltTestCase):
             content_type='application/json',
             headers={
                 'Authorization': 'test_user',
-                'User-Agent': 'quilt-cli/2.5.1',
             }
         )
         assert resp.status_code == requests.codes.payment_required
         data = json.loads(resp.data.decode('utf8'))
         assert "upgrade your service plan" in data['message']
-
-        # Old clients: need to upgrade the client first.
-        resp = self.app.put(
-            '/api/package/test_user/foo/%s' % self.CONTENTS_HASH,
-            data=json.dumps(dict(
-                description="",
-                contents=self.CONTENTS
-            ), default=encode_node),
-            content_type='application/json',
-            headers={
-                'Authorization': 'test_user',
-                'User-Agent': 'quilt-cli/2.5.0',
-            }
-        )
-        assert resp.status_code == requests.codes.server_error
-        data = json.loads(resp.data.decode('utf8'))
-        assert "pip install quilt --upgrade" in data['message']
 
     def testCreatePrivateNoPayments(self):
         # Payments disabled; no restrictions on private packages.


### PR DESCRIPTION
We haven't seen any of those since October.