### PR TITLE
Don't reuse imports in unittests.

### DIFF
--- a/compiler/quilt/test/test_import.py
+++ b/compiler/quilt/test/test_import.py
@@ -183,12 +183,12 @@ class ImportTest(QuiltTestCase):
     def test_set_non_node_attr(self):
         mydir = os.path.dirname(__file__)
         build_path = os.path.join(mydir, './build.yml')
-        command.build('foo/package1', build_path)
+        command.build('foo/package4', build_path)
 
-        from quilt.data.foo import package1
+        from quilt.data.foo import package4
 
         # Assign a DataFrame as a node
         # (should throw exception)
         df = pd.DataFrame(dict(a=[1, 2, 3]))
         with self.assertRaises(AttributeError):
-            package1.newdf = df
+            package4.newdf = df


### PR DESCRIPTION
Python is allowed to cache them across different tests.
TODO: Better solution for this.