### PR TITLE
Export command (python API only)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,8 @@
-[![Python](https://img.shields.io/pypi/pyversions/quilt.svg)](https://pypi.python.org/pypi/quilt)  <img height="20" src="http://icons.iconarchive.com/icons/dakirby309/simply-styled/256/OS-Linux-icon.png">[![Linux](https://travis-ci.org/quiltdata/quilt-compiler.svg?branch=master)](https://travis-ci.org/quiltdata/quilt-compiler) - <img height="20" src="http://icons.iconarchive.com/icons/icons8/windows-8/128/Systems-Mac-Os-icon.png">[![Mac](https://circleci.com/gh/quiltdata/quilt-compiler.png)](https://circleci.com/gh/quiltdata) - <img height="20" src="http://icons.iconarchive.com/icons/dakirby309/windows-8-metro/128/Folders-OS-Windows-8-Metro-icon.png">[![Windows](https://ci.appveyor.com/api/projects/status/github/quiltdata/quilt-compiler?svg=true)](https://ci.appveyor.com/project/quiltdata/quilt-compiler)
+| OS | Build status | Python support |
+|----|--------------|----------------|
+| <img height="20" src="http://icons.iconarchive.com/icons/dakirby309/simply-styled/256/OS-Linux-icon.png"> | [![Linux](https://travis-ci.org/quiltdata/quilt-compiler.svg?branch=master)](https://travis-ci.org/quiltdata/quilt-compiler/branches) | [![Python](https://img.shields.io/pypi/pyversions/quilt.svg)](https://pypi.python.org/pypi/quilt) |
+| <img height="20" src="http://icons.iconarchive.com/icons/icons8/windows-8/128/Systems-Mac-Os-icon.png"> | [![Mac](https://img.shields.io/circleci/project/github/quiltdata/quilt-compiler/master.svg)](https://circleci.com/gh/quiltdata/quilt-compiler/tree/master) | [![Python](https://img.shields.io/pypi/pyversions/quilt.svg)](https://pypi.python.org/pypi/quilt) |
+| <img height="20" src="http://icons.iconarchive.com/icons/dakirby309/windows-8-metro/128/Folders-OS-Windows-8-Metro-icon.png"> | [![Windows](https://img.shields.io/appveyor/ci/quiltdata/quilt-compiler/master.svg)](https://ci.appveyor.com/project/quiltdata/quilt-compiler/branch/master) | 3.5, 3.6 |
 
 # Quilt is a package manager for data
 

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 | OS | Build status | Python support |
 |----|--------------|----------------|
-| <img height="20" src="http://icons.iconarchive.com/icons/dakirby309/simply-styled/256/OS-Linux-icon.png"> | [![Linux](https://travis-ci.org/quiltdata/quilt-compiler.svg?branch=master)](https://travis-ci.org/quiltdata/quilt-compiler/branches) | [![Python](https://img.shields.io/pypi/pyversions/quilt.svg)](https://pypi.python.org/pypi/quilt) |
-| <img height="20" src="http://icons.iconarchive.com/icons/icons8/windows-8/128/Systems-Mac-Os-icon.png"> | [![Mac](https://img.shields.io/circleci/project/github/quiltdata/quilt-compiler/master.svg)](https://circleci.com/gh/quiltdata/quilt-compiler/tree/master) | [![Python](https://img.shields.io/pypi/pyversions/quilt.svg)](https://pypi.python.org/pypi/quilt) |
-| <img height="20" src="http://icons.iconarchive.com/icons/dakirby309/windows-8-metro/128/Folders-OS-Windows-8-Metro-icon.png"> | [![Windows](https://img.shields.io/appveyor/ci/quiltdata/quilt-compiler/master.svg)](https://ci.appveyor.com/project/quiltdata/quilt-compiler/branch/master) | 3.5, 3.6 |
+| <img height="20" src="http://icons.iconarchive.com/icons/dakirby309/simply-styled/256/OS-Linux-icon.png"> | [![Linux](https://travis-ci.org/quiltdata/quilt.svg?branch=master)](https://travis-ci.org/quiltdata/quilt/branches) | [![Python](https://img.shields.io/pypi/pyversions/quilt.svg)](https://pypi.python.org/pypi/quilt) |
+| <img height="20" src="http://icons.iconarchive.com/icons/icons8/windows-8/128/Systems-Mac-Os-icon.png"> | [![Mac](https://img.shields.io/circleci/project/github/quiltdata/quilt/master.svg)](https://circleci.com/gh/quiltdata/quilt/tree/master) | [![Python](https://img.shields.io/pypi/pyversions/quilt.svg)](https://pypi.python.org/pypi/quilt) |
+| <img height="20" src="http://icons.iconarchive.com/icons/dakirby309/windows-8-metro/128/Folders-OS-Windows-8-Metro-icon.png"> | [![Windows](https://img.shields.io/appveyor/ci/quiltdata/quilt/master.svg)](https://ci.appveyor.com/project/quiltdata/quilt/branch/master) | 3.5, 3.6 |
 
 # Quilt is a package manager for data
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 |----|--------------|----------------|
 | <img height="20" src="http://icons.iconarchive.com/icons/dakirby309/simply-styled/256/OS-Linux-icon.png"> | [![Linux](https://travis-ci.org/quiltdata/quilt.svg?branch=master)](https://travis-ci.org/quiltdata/quilt/branches) | [![Python](https://img.shields.io/pypi/pyversions/quilt.svg)](https://pypi.python.org/pypi/quilt) |
 | <img height="20" src="http://icons.iconarchive.com/icons/icons8/windows-8/128/Systems-Mac-Os-icon.png"> | [![Mac](https://img.shields.io/circleci/project/github/quiltdata/quilt/master.svg)](https://circleci.com/gh/quiltdata/quilt/tree/master) | [![Python](https://img.shields.io/pypi/pyversions/quilt.svg)](https://pypi.python.org/pypi/quilt) |
-| <img height="20" src="http://icons.iconarchive.com/icons/dakirby309/windows-8-metro/128/Folders-OS-Windows-8-Metro-icon.png"> | [![Windows](https://img.shields.io/appveyor/ci/quiltdata/quilt/master.svg)](https://ci.appveyor.com/project/quiltdata/quilt/branch/master) | 3.5, 3.6 |
+| <img height="20" src="http://icons.iconarchive.com/icons/dakirby309/windows-8-metro/128/Folders-OS-Windows-8-Metro-icon.png"> | [![Windows](https://ci.appveyor.com/api/projects/status/tnihllrbmm08x0lt/branch/master?svg=true)](https://ci.appveyor.com/project/quiltdata/quilt-compiler/branch/master) | 3.5, 3.6 |
 
 # Quilt is a package manager for data
 
@@ -34,6 +34,6 @@ Quilt consists of two components:
 
 Visit [docs.quiltdata.com](https://docs.quiltdata.com/).
 
-# Feedback/Discussion
+# Questions
 
 [![Gitter](https://img.shields.io/gitter/room/nwjs/nw.js.svg)](https://gitter.im/quilt-data/Lobby)

--- a/README.md
+++ b/README.md
@@ -1,7 +1,6 @@
 | OS | Build status | Python support |
 |----|--------------|----------------|
 | <img height="20" src="http://icons.iconarchive.com/icons/dakirby309/simply-styled/256/OS-Linux-icon.png"> | [![Linux](https://travis-ci.org/quiltdata/quilt.svg?branch=master)](https://travis-ci.org/quiltdata/quilt/branches) | [![Python](https://img.shields.io/pypi/pyversions/quilt.svg)](https://pypi.python.org/pypi/quilt) |
-| <img height="20" src="http://icons.iconarchive.com/icons/icons8/windows-8/128/Systems-Mac-Os-icon.png"> | [![Mac](https://img.shields.io/circleci/project/github/quiltdata/quilt/master.svg)](https://circleci.com/gh/quiltdata/quilt/tree/master) | [![Python](https://img.shields.io/pypi/pyversions/quilt.svg)](https://pypi.python.org/pypi/quilt) |
 | <img height="20" src="http://icons.iconarchive.com/icons/dakirby309/windows-8-metro/128/Folders-OS-Windows-8-Metro-icon.png"> | [![Windows](https://ci.appveyor.com/api/projects/status/tnihllrbmm08x0lt/branch/master?svg=true)](https://ci.appveyor.com/project/quiltdata/quilt-compiler/branch/master) | 3.5, 3.6 |
 
 # Quilt is a package manager for data

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 | OS | Build status | Python support |
 |----|--------------|----------------|
-| <img height="20" src="http://icons.iconarchive.com/icons/dakirby309/simply-styled/256/OS-Linux-icon.png"> | [![Linux](https://travis-ci.org/quiltdata/quilt.svg?branch=master)](https://travis-ci.org/quiltdata/quilt/branches) | [![Python](https://img.shields.io/pypi/pyversions/quilt.svg)](https://pypi.python.org/pypi/quilt) |
+| <img height="20" src="http://icons.iconarchive.com/icons/dakirby309/simply-styled/256/OS-Linux-icon.png"> <img height="20" src="http://icons.iconarchive.com/icons/icons8/windows-8/128/Systems-Mac-Os-icon.png"> | [![Linux](https://travis-ci.org/quiltdata/quilt.svg?branch=master)](https://travis-ci.org/quiltdata/quilt/branches) | [![Python](https://img.shields.io/pypi/pyversions/quilt.svg)](https://pypi.python.org/pypi/quilt) |
 | <img height="20" src="http://icons.iconarchive.com/icons/dakirby309/windows-8-metro/128/Folders-OS-Windows-8-Metro-icon.png"> | [![Windows](https://ci.appveyor.com/api/projects/status/tnihllrbmm08x0lt/branch/master?svg=true)](https://ci.appveyor.com/project/quiltdata/quilt-compiler/branch/master) | 3.5, 3.6 |
 
 # Quilt is a package manager for data

--- a/catalog/app/components/Feature/index.js
+++ b/catalog/app/components/Feature/index.js
@@ -25,7 +25,7 @@ const Feature = () => (
       <TakeAction />
       <div className="framer">
         <iframe
-          src="https://ghbtns.com/github-btn.html?user=quiltdata&repo=quilt-compiler&type=star&count=true&size=large"
+          src="https://ghbtns.com/github-btn.html?user=quiltdata&repo=quilt&type=star&count=true&size=large"
           frameBorder="0"
           scrolling="0"
           width="160px"

--- a/compiler/quilt/nodes.py
+++ b/compiler/quilt/nodes.py
@@ -43,6 +43,11 @@ class DataNode(Node):
     def __call__(self):
         return self._data()
 
+    @property
+    def _filename(self):
+        if isinstance(self._node, core.FileNode):
+            return self._data()
+
     def _data(self):
         """
         Returns the contents of the node: a dataframe or a file path.
@@ -91,6 +96,27 @@ class GroupNode(DataNode):
     def _add_group(self, groupname):
         child = GroupNode(self._package, core.GroupNode({}))
         setattr(self, groupname, child)
+
+    @classmethod
+    def __iterpaths(cls, base_path, node):
+        assert isinstance(base_path, list)
+        assert isinstance(node, GroupNode)
+
+        for name, child_node in node._items():
+            if isinstance(child_node, GroupNode):
+                for path in cls.__iterpaths(base_path + [name], child_node):
+                    yield path
+            elif isinstance(child_node, DataNode):
+                yield base_path + [name]
+
+    def _iterpaths(self):
+        """
+        Iterates paths in this and all child nodes
+
+        :returns: list of path lists
+        """
+        return self.__iterpaths([], self)
+
 
 class PackageNode(GroupNode):
     """

--- a/compiler/quilt/nodes.py
+++ b/compiler/quilt/nodes.py
@@ -61,8 +61,10 @@ class GroupNode(DataNode):
     def __repr__(self):
         pinfo = super(GroupNode, self).__repr__()
         group_info = '\n'.join(name + '/' for name in sorted(self._group_keys()))
+        if group_info:
+            group_info = group_info + '\n'
         data_info = '\n'.join(sorted(self._data_keys()))
-        return '%s\n%s\n%s' % (pinfo, group_info, data_info)
+        return '%s\n%s%s' % (pinfo, group_info, data_info)
 
     def _items(self):
         return ((name, child) for name, child in iteritems(self.__dict__)

--- a/compiler/quilt/tools/command.py
+++ b/compiler/quilt/tools/command.py
@@ -1259,12 +1259,16 @@ def export(package, output_path='.', filter=None, filename_mapper=lambda x: x):
                 yield [node_path, filename]
 
     # alter data to (['mapping', 'altered', 'module', 'path'], <quilt storage filename>)
-    mapped_names = ((filename_mapper(nodepath[:]), filename) for nodepath, filename in iter_nodepath_filenames(node))
+    mapped_names = ((filename_mapper(nodepath[:]), filename)
+                    for nodepath, filename in iter_nodepath_filenames(node))
 
     # alter data to (<export file Path>, <quilt storage Path>)
-    # also, verify all paths
+    # also, verify and clean up paths
     quilt_file_map = []
     for modpath, filename in mapped_names:
+        # no re-rooting
+        modpath = [name.lstrip('/') for name in modpath]
+        # general cleanup
         export_dest = (output_path / os.path.join(*modpath)).expanduser().absolute()
         export_source = Path(filename).expanduser().absolute()
 

--- a/compiler/quilt/tools/package.py
+++ b/compiler/quilt/tools/package.py
@@ -229,7 +229,11 @@ class Package(object):
         self._add_to_contents(fullname, [filehash], '', path, 'file', None)
         objpath = self._store.object_path(filehash)
         if not os.path.exists(objpath):
-            copyfile(srcfile, objpath)
+            # Copy the file to a temporary location first, then move, to make sure we don't end up with
+            # truncated contents if the build gets interrupted.
+            tmppath = self._store.temporary_object_path(filehash)
+            copyfile(srcfile, tmppath)
+            move(tmppath, objpath)
 
     def save_group(self, name):
         """

--- a/compiler/quilt/tools/store.py
+++ b/compiler/quilt/tools/store.py
@@ -322,6 +322,7 @@ def parse_package_extended(name):
     return owner, pkg, subpath, hash, version, tag
 
 def parse_package(name, allow_subpath=False):
+    name = name.rstrip('/')
     try:
         values = name.split('/')
         # Can't do "owner, pkg, *subpath = ..." in Python2 :(

--- a/compiler/setup.py
+++ b/compiler/setup.py
@@ -51,6 +51,7 @@ setup(
         'tables>=3.3.0',
         'tqdm>=4.11.2',
         'xlrd>=1.0.0',
+        'pathlib2>=2.3.0'    # stdlib backport
     ],
     include_package_data=True,
     entry_points={


### PR DESCRIPTION
Allows:
```python
from quilt import command

command.export('some/package')    # exports to current dir
command.export('some/package/submodule')   # exports subset to current dir
command.export('some/package', 'somedir')  # exports to 'somedir' (creates if needed)

# sends each path as a list to some_func, which returns a new (or the same) path list.
# specifically, this allows renaming files as needed with tensorflow exports, since we don't retain filenames
command.export('another/package', mapper=some_func)

# rejects export to files that already exist
# doesn't care if the dir exists
# filename conflicts are checked before any writing happens
command.export('some/package', 'somedir')   # we did this earlier
CommandException: Invalid export path: file already exists: '/home/foo/quilt/compiler/somedir/cifar_10/x_6700_meta'
```

Caveats:
 * this hasn't been tested with the tensorflow branch, but there shouldn't be any conflicts.
 * no tests yet
 * filters not implemented yet
 * export to symlinks / links not implemented yet (is this actually a good idea anyways? *::imagines changes happening to files in storage::*)


..that's all, folks.

