### PR TITLE
Blacklist pyarrow 0.8.* for now, until the unittest is fixed.

### DIFF
--- a/compiler/setup.py
+++ b/compiler/setup.py
@@ -42,7 +42,7 @@ setup(
         'future>=0.16.0',
         'packaging>=16.8',
         'pandas>=0.19.2',
-        'pyarrow>=0.4.0',
+        'pyarrow>=0.4.0,<0.8.0', # TODO(dima): Make unit tests work with 0.8.*.
         'pyOpenSSL>=16.2.0',  # Note: not actually used at the moment.
         'pyyaml>=3.12',
         'requests>=2.12.4',


### PR DESCRIPTION
(Or until pyarrow is fixed)