### PR TITLE
Export command (incl. filters, cli, and tests)

### DIFF
--- a/compiler/quilt/test/test_cli.py
+++ b/compiler/quilt/test/test_cli.py
@@ -97,10 +97,7 @@ import pytest
 from .utils import BasicQuiltTestCase
 
 # inspect.argspec is deprecated, so
-try:
-    from funcsigs import signature  # python 2.7
-except ImportError:
-    from inspect import signature
+from ..tools.compat import signature
 
 
 ## "Static" vars

--- a/compiler/quilt/tools/command.py
+++ b/compiler/quilt/tools/command.py
@@ -1213,19 +1213,35 @@ def rm(package, force=False):
 #     if pathlist[-1].startswith('x_'):
 #         pathlist[-1] = '-' + pathlist[-1][2:]
 #     return pathlist
-def export(package, output_path='.', filter=None, filename_mapper=lambda x: x):
+def export(package, output_path='.', filter=lambda x: True, filename_mapper=lambda x: x):
     """Export package file data.
 
-    :param package: package name, e.g., user/foo
+    Exports children of specified node to files (if they have file data).
+    Does not export dataframes or other non-file data.
+
+    Node path lists take the form ['foo', 'bar', 'baz'], and refer to a
+    specific node (such as foo.bar.baz) to be exported.
+
+    The `filter` function takes a node path list and should return `True` or
+    `False` to indicate the node's inclusion in the export.
+
+    The `filename_mapper` function takes a node path list, and should return
+    return a node path list indicating any name changes that are desired
+    for the export.  The altered nodepath will be reflected in the exported
+    filename, but will not affect any other resource.
+
+    :param package: package or subpackage name, e.g., user/foo or user/foo/bar
     :param output_path: distination folder
-    :param filter: Not implemented
-    :param filename_mapper:
+    :param filter: function -- takes a node path list, returns True to export
+    :param filename_mapper: function -- takes and returns a node path list
     """
-    # TODO: filters
+    # TODO: CLI interface
     # TODO: tests
-    # TODO: export via symlinks / hardlinks (unwise / messing with datastore? windows compat?)
-    if filter is not None:
-        raise NotImplemented("filters not implemented yet")
+    # TODO: CLI tests
+    # TODO: Update docs
+    # TODO: (future) Support other tags/versions
+    # TODO: (future) export symlinks / hardlinks (Is this unwise for messing with datastore? windows compat?)
+    # TODO: (future) support dataframes
 
     output_path = Path(output_path)
     owner, pkg, subpath = parse_package(package, allow_subpath=True)
@@ -1256,33 +1272,41 @@ def export(package, output_path='.', filter=None, filename_mapper=lambda x: x):
             filename = getattr(found_node, '_filename', None)
             if filename is not None:
                 assert filename
-                yield [node_path, filename]
+                yield (node_path, filename)
 
-    # alter data to (['mapping', 'altered', 'module', 'path'], <quilt storage filename>)
-    mapped_names = ((filename_mapper(nodepath[:]), filename)
-                    for nodepath, filename in iter_nodepath_filenames(node))
+    # gather nodes to be exported
+    exports = iter_nodepath_filenames(node)
+
+    # filter exports
+    exports = ((nodepath, filename) for nodepath, filename in exports if filter(nodepath[:]) is True)
+
+    # apply mapping to exports
+    exports = ((filename_mapper(nodepath[:]), filename) for nodepath, filename in exports)
 
     # alter data to (<export file Path>, <quilt storage Path>)
-    # also, verify and clean up paths
-    quilt_file_map = []
-    for modpath, filename in mapped_names:
+    # verify and clean up paths
+    # pre-check that source exists and dest does not
+    final_export_map = []
+    for nodepath, filename in exports:
         # no re-rooting
-        modpath = [name.lstrip('/') for name in modpath]
+        nodepath = [name.lstrip('/') for name in nodepath]
+        # convert node list to path, and set output path
+        export_dest = output_path / os.path.join(*nodepath)
         # general cleanup
-        export_dest = (output_path / os.path.join(*modpath)).expanduser().absolute()
+        export_dest = export_dest.expanduser().absolute()
         export_source = Path(filename).expanduser().absolute()
 
         assert export_source.exists()
 
         if export_dest.exists():
-            raise CommandException("Invalid export path: file already exists: {!r}"
-                                   .format(str(export_dest)))
-        quilt_file_map.append((export_source, export_dest))
+            raise CommandException("Invalid export path: file already exists: {!r}".format(str(export_dest)))
+
+        final_export_map.append((export_source, export_dest))
 
     # Paths verified, let's export..
     sys.stdout.write('Exporting.')
     sys.stdout.flush()
-    for export_source, export_dest in quilt_file_map:
+    for export_source, export_dest in final_export_map:
         assert not export_dest.exists()   # we've already checked, but who knows, things change..
         if not export_dest.parent.exists():
             export_dest.parent.mkdir(parents=True, exist_ok=True)

--- a/compiler/quilt/tools/command.py
+++ b/compiler/quilt/tools/command.py
@@ -1235,9 +1235,7 @@ def export(package, output_path='.', filter=lambda x: True, filename_mapper=lamb
     :param filter: function -- takes a node path list, returns True to export
     :param filename_mapper: function -- takes and returns a node path list
     """
-    # TODO: CLI interface
     # TODO: tests
-    # TODO: CLI tests
     # TODO: Update docs
     # TODO: (future) Support other tags/versions
     # TODO: (future) export symlinks / hardlinks (Is this unwise for messing with datastore? windows compat?)

--- a/compiler/quilt/tools/compat.py
+++ b/compiler/quilt/tools/compat.py
@@ -1,0 +1,34 @@
+"""
+Python 2 / 3 compatibility
+
+In cases where the `six` lib covers an item, use `six`.
+
+For others, import the module here under the python3 name (if there are naming differences).
+
+Unfortunately, this *doesn't* allow for `from .tools.compat.foo import bar`, so if needed,
+import frequently-used objects here for convenience.
+"""
+# disable unused import warnings
+# pylint: disable=W0611
+
+import six as _six
+
+if _six.PY34:
+    import pathlib
+    import tempfile
+    # from unittest import mock
+
+    # inspect.argspec is deprecated, so
+    from inspect import signature
+else:
+    import pathlib2 as pathlib
+    from backports import tempfile
+    # import mock
+
+    # inspect.argspec is deprecated, so
+    from funcsigs import signature
+
+# convenience references (examples) to allow `from .tools.compat import some_obj`
+# path = mock.path
+Path = pathlib.Path
+# TemporaryDirectory = tempdir.TemporaryDirectory

--- a/compiler/quilt/tools/main.py
+++ b/compiler/quilt/tools/main.py
@@ -76,6 +76,13 @@ def argument_parser():
     config_p = subparsers.add_parser("config", description="Configure Quilt")
     config_p.set_defaults(func=command.config)
 
+    export_p = subparsers.add_parser("export",
+                                     description="Export file data from package or subpackage to filesystem")
+    export_p.add_argument("package", type=str, help=HANDLE)
+    export_p.add_argument("output_path", type=str, default='.', nargs='?',
+                          help="Destination folder (auto-created), default '.'")
+    export_p.set_defaults(func=command.export)
+
     login_p = subparsers.add_parser("login", description="Log in to configured Quilt server")
     login_p.set_defaults(func=command.login)
 

--- a/compiler/setup.py
+++ b/compiler/setup.py
@@ -38,10 +38,13 @@ setup(
     keywords='quilt quiltdata shareable data dataframe package platform pandas',
     install_requires=[
         'appdirs>=1.4.0',
-        'enum34; python_version<"3.4"',
+        'backports.tempfile; python_version<"3.4"'   # stdlib backport
+        'enum34; python_version<"3.4"',     # stdlib backport
+        'funcsigs; python_version<"3.4"'    # stdlib backport
         'future>=0.16.0',
         'packaging>=16.8',
         'pandas>=0.19.2',
+        'pathlib2; python_version<"3.4"'    # stdlib backport
         'pyarrow>=0.4.0',
         'pyOpenSSL>=16.2.0',  # Note: not actually used at the moment.
         'pyyaml>=3.12',
@@ -51,7 +54,6 @@ setup(
         'tables>=3.3.0',
         'tqdm>=4.11.2',
         'xlrd>=1.0.0',
-        'pathlib2>=2.3.0'    # stdlib backport
     ],
     include_package_data=True,
     entry_points={


### PR DESCRIPTION
This is the 'export' command, with future items (according to the spec doc) excluded.

There are some minor changes (some arg names, arg position for output dir) but all of the functionality is there.

It should be a short path to some of the desired "future" items in the specification as well, when our focus shifts there.