### PR TITLE
Drop support for packages with really old JSON schemas

### DIFF
--- a/compiler/quilt/nodes.py
+++ b/compiler/quilt/nodes.py
@@ -6,7 +6,6 @@ import pandas as pd
 from six import iteritems, string_types
 
 from .tools import core
-from .tools.store import PackageStore
 
 
 class Node(object):
@@ -103,7 +102,7 @@ class PackageNode(GroupNode):
         assert isinstance(path, list) and len(path) > 0
 
         if isinstance(value, pd.DataFrame):
-            core_node = core.TableNode(hashes=[])
+            core_node = core.TableNode(hashes=[], format=core.PackageFormat.default.value)
         elif isinstance(value, string_types):
             core_node = core.FileNode(hashes=[])
         else:

--- a/compiler/quilt/test/test_install.py
+++ b/compiler/quilt/test/test_install.py
@@ -53,7 +53,7 @@ class InstallTest(QuiltTestCase):
     def make_contents(cls, **args):
         contents = RootNode(dict(
             group=GroupNode(dict([
-                (key, TableNode([val]) if 'table' in key else FileNode([val]))
+                (key, TableNode([val], PackageFormat.default.value) if 'table' in key else FileNode([val]))
                 for key, val in args.items()]
             ))
         ))
@@ -286,7 +286,7 @@ packages:
         obj_hash = h.hexdigest()
         contents = GroupNode(dict(
             foo=GroupNode(dict(
-                bar=TableNode([obj_hash])
+                bar=TableNode([obj_hash], PackageFormat.default.value)
             ))
         ))
         contents_hash = 'e867010701edc0b1c8be177e02a93aa3cb1342bb1123046e1f6b40e428c6048e'
@@ -309,7 +309,7 @@ packages:
         obj_hash = 'e867010701edc0b1c8be177e02a93aa3cb1342bb1123046e1f6b40e428c6048e'
         contents = GroupNode(dict(
             foo=GroupNode(dict(
-                bar=TableNode([obj_hash])
+                bar=TableNode([obj_hash], PackageFormat.default.value)
             ))
         ))
         contents_hash = hash_contents(contents)
@@ -337,7 +337,7 @@ packages:
         contents = RootNode(dict(
             file0=FileNode([file_hash_list[0]]),
             file1=FileNode([file_hash_list[1]]),
-        ), format=PackageFormat.HDF5)
+        ))
         contents_hash = hash_contents(contents)
 
         # Create a package store object to use its path helpers

--- a/compiler/quilt/tools/core.py
+++ b/compiler/quilt/tools/core.py
@@ -80,41 +80,24 @@ class GroupNode(Node):
 class RootNode(GroupNode):
     json_type = 'ROOT'
 
-    def __init__(self, children, format=None):
-        super(RootNode, self).__init__(children)
-
-        # Deprecated, but needs to stay for compatibility with old packages.
-        self.format = PackageFormat(format) if format is not None else None
-
-    def __json__(self):
-        val = super(RootNode, self).__json__()
-        if self.format is not None:
-            val['format'] = self.format.value
-        else:
-            del val['format']
-        return val
-
 class TableNode(Node):
     json_type = 'TABLE'
 
-    def __init__(self, hashes, format=None, metadata=None):
+    def __init__(self, hashes, format, metadata=None):
         if metadata is None:
             metadata = {}
 
         assert isinstance(hashes, list)
-        assert format is None or isinstance(format, string_types), '%r' % format
+        assert isinstance(format, string_types), '%r' % format
         assert isinstance(metadata, dict)
 
         self.hashes = hashes
-        self.format = PackageFormat(format) if format is not None else None
+        self.format = PackageFormat(format)
         self.metadata = metadata
 
     def __json__(self):
         val = super(TableNode, self).__json__()
-        if self.format is not None:
-            val['format'] = self.format.value
-        else:
-            del val['format']
+        val['format'] = self.format.value
         return val
 
 class FileNode(Node):

--- a/compiler/quilt/tools/package.py
+++ b/compiler/quilt/tools/package.py
@@ -91,23 +91,7 @@ class Package(object):
             raise PackageException(msg.format(hash=instance_hash, owner=self._user, pkg=self._package))
         
         with open(contents_path, 'r') as contents_file:
-            contents = json.load(contents_file, object_hook=decode_node)
-            if not isinstance(contents, RootNode):
-                # Really old package: no root node.
-                contents = RootNode(contents.children)
-            # Fix packages with no format in data nodes.
-            pkg_format = contents.format or PackageFormat.HDF5
-            self._fix_format(contents, pkg_format)
-            return contents
-
-    @classmethod
-    def _fix_format(cls, contents, pkg_format):
-        for child in itervalues(contents.children):
-            if isinstance(child, GroupNode):
-                cls._fix_format(child, pkg_format)
-            elif isinstance(child, TableNode):
-                if child.format is None:
-                    child.format = pkg_format
+            return json.load(contents_file, object_hook=decode_node)
 
     def file(self, hash_list):
         """

--- a/registry/quilt_server/core.py
+++ b/registry/quilt_server/core.py
@@ -42,41 +42,24 @@ class GroupNode(Node):
 class RootNode(GroupNode):
     json_type = 'ROOT'
 
-    def __init__(self, children, format=None):
-        super(RootNode, self).__init__(children)
-
-        # Deprecated, but needs to stay for compatibility with old packages.
-        self.format = PackageFormat(format) if format is not None else None
-
-    def __json__(self):
-        val = super(RootNode, self).__json__()
-        if self.format is not None:
-            val['format'] = self.format.value
-        else:
-            del val['format']
-        return val
-
 class TableNode(Node):
     json_type = 'TABLE'
 
-    def __init__(self, hashes, format=None, metadata=None):
+    def __init__(self, hashes, format, metadata=None):
         if metadata is None:
             metadata = {}
 
         assert isinstance(hashes, list)
-        assert format is None or isinstance(format, string_types), '%r' % format
+        assert isinstance(format, string_types), '%r' % format
         assert isinstance(metadata, dict)
 
         self.hashes = hashes
-        self.format = PackageFormat(format) if format is not None else None
+        self.format = PackageFormat(format)
         self.metadata = metadata
 
     def __json__(self):
         val = super(TableNode, self).__json__()
-        if self.format is not None:
-            val['format'] = self.format.value
-        else:
-            del val['format']
+        val['format'] = self.format.value
         return val
 
 class FileNode(Node):

--- a/registry/quilt_server/schemas.py
+++ b/registry/quilt_server/schemas.py
@@ -24,10 +24,6 @@ PACKAGE_SCHEMA = {
         'contents': {
             'type': 'object',
             'properties': {
-                'format' : {
-                    # DEPRECATED.
-                    'enum': [fmt.value for fmt in PackageFormat]
-                },
                 'type': {
                     'enum': [RootNode.json_type]
                 },

--- a/registry/tests/push_install_test.py
+++ b/registry/tests/push_install_test.py
@@ -36,7 +36,8 @@ class PushInstallTestCase(QuiltTestCase):
 
     CONTENTS = RootNode(dict(
         foo=TableNode(
-            hashes=[HASH1, HASH2]
+            hashes=[HASH1, HASH2],
+            format=PackageFormat.default.value
         ),
         group1=GroupNode(dict(
             empty=TableNode(


### PR DESCRIPTION
That's per-package rather than per-node format (parquet vs hdf5), and so on. We've already dropped local `quilt_packages` directories, so nobody will run into old packages anymore.