### PR TITLE
Implement the teams model and update all endpoints to work with teams.

### DIFF
--- a/registry/migrations/versions/ad01ba55f4e2_add_teams.py
+++ b/registry/migrations/versions/ad01ba55f4e2_add_teams.py
@@ -32,7 +32,10 @@ def upgrade():
         sa.ForeignKeyConstraint(['team_id'], ['team.id'], ),
         sa.PrimaryKeyConstraint('user')
     )
-    op.add_column('package', sa.Column('team_id', sa.BigInteger(), nullable=True))
+
+    op.add_column('package', sa.Column('team_id', sa.BigInteger(), nullable=False))
+    op.execute('''INSERT INTO team VALUES (0, "public")''')
+    op.execute('''UPDATE package, team SET package.team_id = team.id WHERE team.name = "public"''')
 
     op.create_index('idx_team_owner_name', 'package', ['team_id', 'owner', 'name'], unique=True)
     op.drop_index('idx_owner_name', table_name='package')

--- a/registry/migrations/versions/ad01ba55f4e2_add_teams.py
+++ b/registry/migrations/versions/ad01ba55f4e2_add_teams.py
@@ -1,0 +1,53 @@
+"""Add teams
+
+Revision ID: ad01ba55f4e2
+Revises: 6b0f5d5cf148
+Create Date: 2017-12-12 23:53:20.746083
+
+"""
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects import mysql
+
+# revision identifiers, used by Alembic.
+revision = 'ad01ba55f4e2'
+down_revision = '6b0f5d5cf148'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.create_table(
+        'team',
+        sa.Column('id', sa.BigInteger(), nullable=False),
+        sa.Column('name', mysql.VARCHAR(collation='utf8_bin', length=64), nullable=False),
+        sa.PrimaryKeyConstraint('id')
+    )
+    op.create_index(op.f('ix_team_name'), 'team', ['name'], unique=False)
+    op.create_table(
+        'user_team',
+        sa.Column('user', mysql.VARCHAR(collation='utf8_bin', length=64), nullable=False),
+        sa.Column('team_id', sa.BigInteger(), nullable=False),
+        sa.Column('is_admin', mysql.TINYINT(1), nullable=False),
+        sa.ForeignKeyConstraint(['team_id'], ['team.id'], ),
+        sa.PrimaryKeyConstraint('user')
+    )
+    op.add_column('package', sa.Column('team_id', sa.BigInteger(), nullable=True))
+
+    op.create_index('idx_team_owner_name', 'package', ['team_id', 'owner', 'name'], unique=True)
+    op.drop_index('idx_owner_name', table_name='package')
+    op.create_index('idx_owner_name', 'package', ['team_id', 'owner', 'name'], unique=False)
+
+    op.create_foreign_key('package_team_id', 'package', 'team', ['team_id'], ['id'])
+
+def downgrade():
+    op.drop_constraint('package_team_id', 'package', type_='foreignkey')
+
+    op.drop_index('idx_owner_name', table_name='package')
+    op.create_index('idx_owner_name', 'package', ['owner', 'name'], unique=True)
+    op.drop_index('idx_team_owner_name', table_name='package')
+
+    op.drop_column('package', 'team_id')
+    op.drop_table('user_team')
+    op.drop_index(op.f('ix_team_name'), table_name='team')
+    op.drop_table('team')

--- a/registry/quilt_server/const.py
+++ b/registry/quilt_server/const.py
@@ -8,6 +8,7 @@ from enum import Enum
 import re
 
 PUBLIC = 'public' # This username is blocked by Quilt signup
+TEAM = 'team'
 EMAILREGEX = re.compile(r'^([^\s@]+)@([^\s@]+)$')
 
 class PaymentPlan(Enum):

--- a/registry/quilt_server/models.py
+++ b/registry/quilt_server/models.py
@@ -10,6 +10,7 @@ from sqlalchemy.dialects import mysql
 from sqlalchemy.orm import deferred
 
 from . import db
+from .const import PUBLIC
 
 UTF8_BIN = 'utf8_bin'
 UTF8_GENERAL_CI = 'utf8_general_ci'
@@ -22,10 +23,31 @@ USERNAME_TYPE = CaseSensitiveString(64)
 # https://stripe.com/docs/upgrades#what-changes-does-stripe-consider-to-be-backwards-compatible
 STRIPE_ID_TYPE = CaseSensitiveString(255)
 
+class Team(db.Model):
+    id = db.Column(db.BigInteger, primary_key=True)
+    name = db.Column(USERNAME_TYPE, nullable=False, index=True)
+
+    users = db.relationship('UserTeam', back_populates='team')
+
+    @classmethod
+    def get_by_user(cls, user):
+        assert user != PUBLIC
+        return cls.query.join(cls.users).filter_by(user=user).one_or_none()
+
+class UserTeam(db.Model):
+    user = db.Column(USERNAME_TYPE, primary_key=True)
+    team_id = db.Column(db.BigInteger, db.ForeignKey('team.id'), nullable=False)
+    is_admin = db.Column(mysql.TINYINT(1), nullable=False)
+
+    team = db.relationship('Team', back_populates='users')
+
 class Package(db.Model):
     id = db.Column(db.BigInteger, primary_key=True)
+    team_id = db.Column(db.BigInteger, db.ForeignKey('team.id'))
     owner = db.Column(USERNAME_TYPE, nullable=False)
     name = db.Column(CaseSensitiveString(64), nullable=False)
+
+    team = db.relationship('Team')
 
     logs = db.relationship(
         'Log', back_populates='package', cascade='save-update, merge, delete')
@@ -46,7 +68,8 @@ class Package(db.Model):
     def sort_key(self):
         return (self.owner, self.name)
 
-db.Index('idx_owner_name', Package.owner, Package.name, unique=True)
+db.Index('idx_team_owner_name', Package.team_id, Package.owner, Package.name, unique=True)
+db.Index('idx_owner_name', Package.team_id, Package.owner, Package.name)
 
 
 InstanceBlobAssoc = db.Table(

--- a/registry/quilt_server/models.py
+++ b/registry/quilt_server/models.py
@@ -29,10 +29,23 @@ class Team(db.Model):
 
     users = db.relationship('UserTeam', back_populates='team')
 
+    @property
+    def is_public(self):
+        return self.name == PUBLIC
+
+    @classmethod
+    def get_public_team(cls):
+        # TODO(dima): Look it up only once!
+        return cls.query.filter_by(name=PUBLIC).one()
+
     @classmethod
     def get_by_user(cls, user):
         assert user != PUBLIC
-        return cls.query.join(cls.users).filter_by(user=user).one_or_none()
+        team = cls.query.join(cls.users).filter_by(user=user).one_or_none()
+        if team is None:
+            return cls.get_public_team()
+        else:
+            return team
 
 class UserTeam(db.Model):
     user = db.Column(USERNAME_TYPE, primary_key=True)
@@ -43,7 +56,7 @@ class UserTeam(db.Model):
 
 class Package(db.Model):
     id = db.Column(db.BigInteger, primary_key=True)
-    team_id = db.Column(db.BigInteger, db.ForeignKey('team.id'))
+    team_id = db.Column(db.BigInteger, db.ForeignKey('team.id'), nullable=False)
     owner = db.Column(USERNAME_TYPE, nullable=False)
     name = db.Column(CaseSensitiveString(64), nullable=False)
 

--- a/registry/quilt_server/views.py
+++ b/registry/quilt_server/views.py
@@ -27,10 +27,10 @@ import stripe
 
 from . import app, db
 from .analytics import MIXPANEL_EVENT, mp
-from .const import EMAILREGEX, PaymentPlan, PUBLIC
+from .const import EMAILREGEX, PaymentPlan, PUBLIC, TEAM
 from .core import decode_node, encode_node, find_object_hashes, hash_contents, FileNode, GroupNode
 from .models import (Access, Customer, Instance, Invitation, Log, Package,
-                     S3Blob, Tag, UTF8_GENERAL_CI, Version)
+                     S3Blob, Tag, Team, UTF8_GENERAL_CI, UserTeam, Version)
 from .schemas import LOG_SCHEMA, PACKAGE_SCHEMA
 
 QUILT_CDN = 'https://cdn.quiltdata.com/'
@@ -206,13 +206,14 @@ def token():
 CORS(app, resources={"/api/*": {"origins": "*", "max_age": timedelta(days=1)}})
 
 
-class Auth:
+class Auth(object):
     """
     Info about the user making the API request.
     """
-    def __init__(self, user, email):
+    def __init__(self, user, email, team):
         self.user = user
         self.email = email
+        self.team = team
 
 
 class ApiException(Exception):
@@ -267,7 +268,7 @@ def api(require_login=True, schema=None):
     def innerdec(f):
         @wraps(f)
         def wrapper(*args, **kwargs):
-            g.auth = Auth(PUBLIC, None)
+            g.auth = Auth(PUBLIC, None, None)
 
             user_agent_str = request.headers.get('user-agent', '')
             g.user_agent = httpagentparser.detect(user_agent_str, fill_none=True)
@@ -297,7 +298,9 @@ def api(require_login=True, schema=None):
                     assert user
                     email = data['email']
 
-                    g.auth = Auth(user, email)
+                    team = Team.get_by_user(user)
+
+                    g.auth = Auth(user, email, team)
                 except requests.HTTPError as ex:
                     if resp.status_code == requests.codes.unauthorized:
                         raise ApiException(
@@ -312,31 +315,85 @@ def api(require_login=True, schema=None):
         return wrapper
     return innerdec
 
-def _get_package(auth, owner, package_name):
+def _get_team(auth, team_name):
+    """
+    Looks up the team by name, if the user has access to it.
+    Team users can see their own team and the public cloud. Non-team users can only see the public cloud.
+    """
+    if team_name == PUBLIC:
+        return None  # The public cloud
+
+    if auth.team is not None and auth.team.name == team_name:
+        # User's own team.
+        return auth.team
+
+    # We return a 403, unlike a 404 for packages. This seems more logical - and
+    # we're not leaking info about existence of the team regardless.
+    raise ApiException(requests.codes.forbidden, "Cannot access team %r" % team_name)
+
+def _check_team_write(auth, team):
+    """
+    Checks if the user has write access to the given team.
+    For now, users can only write data to their own team - and not the public cloud.
+    """
+    assert team is None or isinstance(team, Team)
+
+    if auth.team != team:
+        raise ApiException(requests.codes.forbidden, "No write access to this team")
+
+def _check_share(auth, team, other_user):
+    """
+    Checks if the user can share a given team's package with the given user.
+    Team users can only share with their own team; public users can only share with public users.
+    """
+    # Should already be enforced by _check_team_write.
+    assert auth.team == team
+
+    if other_user == PUBLIC:
+        other_team = None
+    elif other_user == TEAM:
+        if team is None:
+            raise ApiException(requests.codes.forbidden, "Not a team package")
+        other_team = team
+    else:
+        other_team = Team.get_by_user(other_user)
+
+    if team != other_team:
+        raise ApiException(requests.codes.forbidden, "Cannot share with this user")
+
+def _access_filter(auth, team):
+    query = [PUBLIC]
+    if auth.user != PUBLIC:
+        query.append(auth.user)
+    if auth.team == team and team is not None:
+        query.append(TEAM)
+    return Access.user.in_(query)
+
+def _get_package(auth, team, owner, package_name):
     """
     Helper for looking up a package and checking permissions.
     Only useful for *_list functions; all others should use more efficient queries.
     """
     package = (
         Package.query
-        .filter_by(owner=owner, name=package_name)
+        .filter_by(team=team, owner=owner, name=package_name)
         .join(Package.access)
-        .filter(Access.user.in_([auth.user, PUBLIC]))
+        .filter(_access_filter(auth, team))
         .one_or_none()
     )
     if package is None:
         raise PackageNotFoundException(owner, package_name, auth.user is not PUBLIC)
     return package
 
-def _get_instance(auth, owner, package_name, package_hash):
+def _get_instance(auth, team, owner, package_name, package_hash):
     instance = (
         Instance.query
         .filter_by(hash=package_hash)
         .options(undefer('contents'))  # Contents is deferred by default.
         .join(Instance.package)
-        .filter_by(owner=owner, name=package_name)
+        .filter_by(team=team, owner=owner, name=package_name)
         .join(Package.access)
-        .filter(Access.user.in_([auth.user, PUBLIC]))
+        .filter(_access_filter(auth, team))
         .one_or_none()
     )
     if instance is None:
@@ -428,6 +485,21 @@ def _get_or_create_customer():
 def _get_customer_plan(customer):
     return PaymentPlan(customer.subscriptions.data[0].plan.id)
 
+def team_route(rule, defaults={}, **options):
+    """
+    Decorator that adds the route itself and the corresponding legacy non-team route.
+    """
+    legacy_rule = rule.replace('/<team_name>/', '/')
+    assert legacy_rule != rule, "Failed to create the legacy route for %s" % rule
+
+    legacy_defaults = dict(defaults, team_name=PUBLIC)
+
+    def decorator(f):
+        app.add_url_rule(rule, f.__name__, f, defaults=defaults, **options)
+        app.add_url_rule(legacy_rule, f.__name__ + '-legacy', f, defaults=legacy_defaults, **options)
+        return f
+    return decorator
+
 @app.route('/api/blob/<owner>/<blob_hash>', methods=['GET'])
 @api()
 @as_json
@@ -441,10 +513,13 @@ def blob_get(owner, blob_hash):
         put=_generate_presigned_url(S3_PUT_OBJECT, owner, blob_hash),
     )
 
-@app.route('/api/package/<owner>/<package_name>/<package_hash>', methods=['PUT'])
+@team_route('/api/package/<team_name>/<owner>/<package_name>/<package_hash>', methods=['PUT'])
 @api(schema=PACKAGE_SCHEMA)
 @as_json
-def package_put(owner, package_name, package_hash):
+def package_put(team_name, owner, package_name, package_hash):
+    team = _get_team(g.auth, team_name)
+    _check_team_write(g.auth, team)
+
     # TODO: Write access for collaborators.
     if g.auth.user != owner:
         raise ApiException(requests.codes.forbidden,
@@ -466,7 +541,7 @@ def package_put(owner, package_name, package_hash):
     package = (
         Package.query
         .with_for_update()
-        .filter_by(owner=owner, name=package_name)
+        .filter_by(team=team, owner=owner, name=package_name)
         .one_or_none()
     )
 
@@ -476,6 +551,7 @@ def package_put(owner, package_name, package_hash):
             Package.query
             .filter(
                 sa.and_(
+                    Package.team == team,
                     sa.sql.collate(Package.owner, UTF8_GENERAL_CI) == owner,
                     sa.sql.collate(Package.name, UTF8_GENERAL_CI) == package_name
                 )
@@ -510,7 +586,7 @@ def package_put(owner, package_name, package_hash):
                         (owner, package_name)
                     )
 
-        package = Package(owner=owner, name=package_name)
+        package = Package(team=team, owner=owner, name=package_name)
         db.session.add(package)
 
         owner_access = Access(package=package, user=owner)
@@ -521,6 +597,8 @@ def package_put(owner, package_name, package_hash):
             db.session.add(public_access)
     else:
         if public:
+            _check_share(g.auth, team, PUBLIC)
+
             public_access = (
                 Access.query
                 .filter(sa.and_(
@@ -621,6 +699,7 @@ def package_put(owner, package_name, package_hash):
 
     _mp_track(
         type="push",
+        package_team=team_name,
         package_owner=owner,
         package_name=package_name,
         public=public,
@@ -628,13 +707,14 @@ def package_put(owner, package_name, package_hash):
 
     return dict()
 
-@app.route('/api/package/<owner>/<package_name>/<package_hash>', methods=['GET'])
+@team_route('/api/package/<team_name>/<owner>/<package_name>/<package_hash>', methods=['GET'])
 @api(require_login=False)
 @as_json
-def package_get(owner, package_name, package_hash):
+def package_get(team_name, owner, package_name, package_hash):
     subpath = request.args.get('subpath')
 
-    instance = _get_instance(g.auth, owner, package_name, package_hash)
+    team = _get_team(g.auth, team_name)
+    instance = _get_instance(g.auth, team, owner, package_name, package_hash)
     contents = json.loads(instance.contents, object_hook=decode_node)
 
     subnode = contents
@@ -653,6 +733,7 @@ def package_get(owner, package_name, package_hash):
 
     _mp_track(
         type="install",
+        package_team=team_name,
         package_owner=owner,
         package_name=package_name,
         subpath=subpath,
@@ -680,11 +761,12 @@ def _generate_preview(node, max_depth=PREVIEW_MAX_DEPTH):
     else:
         return None
 
-@app.route('/api/package_preview/<owner>/<package_name>/<package_hash>', methods=['GET'])
+@team_route('/api/package_preview/<team_name>/<owner>/<package_name>/<package_hash>', methods=['GET'])
 @api(require_login=False)
 @as_json
-def package_preview(owner, package_name, package_hash):
-    instance = _get_instance(g.auth, owner, package_name, package_hash)
+def package_preview(team_name, owner, package_name, package_hash):
+    team = _get_team(g.auth, team_name)
+    instance = _get_instance(g.auth, team, owner, package_name, package_hash)
     contents = json.loads(instance.contents, object_hook=decode_node)
 
     readme = contents.children.get('README')
@@ -711,11 +793,12 @@ def package_preview(owner, package_name, package_hash):
         updated_at=_utc_datetime_to_ts(instance.updated_at),
     )
 
-@app.route('/api/package/<owner>/<package_name>/', methods=['GET'])
+@team_route('/api/package/<team_name>/<owner>/<package_name>/', methods=['GET'])
 @api(require_login=False)
 @as_json
-def package_list(owner, package_name):
-    package = _get_package(g.auth, owner, package_name)
+def package_list(team_name, owner, package_name):
+    team = _get_team(g.auth, team_name)
+    package = _get_package(g.auth, team, owner, package_name)
     instances = (
         Instance.query
         .filter_by(package=package)
@@ -725,15 +808,16 @@ def package_list(owner, package_name):
         hashes=[instance.hash for instance in instances]
     )
 
-@app.route('/api/package/<owner>/<package_name>/', methods=['DELETE'])
+@team_route('/api/package/<team_name>/<owner>/<package_name>/', methods=['DELETE'])
 @api()
 @as_json
-def package_delete(owner, package_name):
+def package_delete(team_name, owner, package_name):
     if g.auth.user != owner:
         raise ApiException(requests.codes.forbidden,
                            "Only the package owner can delete packages.")
 
-    package = _get_package(g.auth, owner, package_name)
+    team = _get_team(g.auth, team_name)
+    package = _get_package(g.auth, team, owner, package_name)
 
     db.session.delete(package)
     db.session.commit()
@@ -764,11 +848,12 @@ def user_packages(owner):
         ]
     )
 
-@app.route('/api/log/<owner>/<package_name>/', methods=['GET'])
+@team_route('/api/log/<team_name>/<owner>/<package_name>/', methods=['GET'])
 @api(require_login=False)
 @as_json
-def logs_list(owner, package_name):
-    package = _get_package(g.auth, owner, package_name)
+def logs_list(team_name, owner, package_name):
+    team = _get_team(g.auth, team_name)
+    package = _get_package(g.auth, team, owner, package_name)
 
     logs = (
         db.session.query(Log, Instance)
@@ -804,10 +889,13 @@ def normalize_version(version):
 
     return version
 
-@app.route('/api/version/<owner>/<package_name>/<package_version>', methods=['PUT'])
+@team_route('/api/version/<team_name>/<owner>/<package_name>/<package_version>', methods=['PUT'])
 @api(schema=VERSION_SCHEMA)
 @as_json
-def version_put(owner, package_name, package_version):
+def version_put(team_name, owner, package_name, package_version):
+    team = _get_team(g.auth, team_name)
+    _check_team_write(g.auth, team)
+
     # TODO: Write access for collaborators.
     if g.auth.user != owner:
         raise ApiException(
@@ -825,7 +913,7 @@ def version_put(owner, package_name, package_version):
         Instance.query
         .filter_by(hash=package_hash)
         .join(Instance.package)
-        .filter_by(owner=owner, name=package_name)
+        .filter_by(team=team, owner=owner, name=package_name)
         .one_or_none()
     )
 
@@ -847,12 +935,13 @@ def version_put(owner, package_name, package_version):
 
     return dict()
 
-@app.route('/api/version/<owner>/<package_name>/<package_version>', methods=['GET'])
+@team_route('/api/version/<team_name>/<owner>/<package_name>/<package_version>', methods=['GET'])
 @api(require_login=False)
 @as_json
-def version_get(owner, package_name, package_version):
+def version_get(team_name, owner, package_name, package_version):
+    team = _get_team(g.auth, team_name)
     package_version = normalize_version(package_version)
-    package = _get_package(g.auth, owner, package_name)
+    package = _get_package(g.auth, team, owner, package_name)
 
     instance = (
         Instance.query
@@ -869,6 +958,7 @@ def version_get(owner, package_name, package_version):
 
     _mp_track(
         type="get_hash",
+        package_team=team_name,
         package_owner=owner,
         package_name=package_name,
         package_version=package_version,
@@ -882,11 +972,12 @@ def version_get(owner, package_name, package_version):
         updated_at=_utc_datetime_to_ts(instance.updated_at),
     )
 
-@app.route('/api/version/<owner>/<package_name>/', methods=['GET'])
+@team_route('/api/version/<team_name>/<owner>/<package_name>/', methods=['GET'])
 @api(require_login=False)
 @as_json
-def version_list(owner, package_name):
-    package = _get_package(g.auth, owner, package_name)
+def version_list(team_name, owner, package_name):
+    team = _get_team(g.auth, team_name)
+    package = _get_package(g.auth, team, owner, package_name)
 
     versions = (
         db.session.query(Version, Instance)
@@ -916,10 +1007,13 @@ TAG_SCHEMA = {
     'required': ['hash']
 }
 
-@app.route('/api/tag/<owner>/<package_name>/<package_tag>', methods=['PUT'])
+@team_route('/api/tag/<team_name>/<owner>/<package_name>/<package_tag>', methods=['PUT'])
 @api(schema=TAG_SCHEMA)
 @as_json
-def tag_put(owner, package_name, package_tag):
+def tag_put(team_name, owner, package_name, package_tag):
+    team = _get_team(g.auth, team_name)
+    _check_team_write(g.auth, team)
+
     # TODO: Write access for collaborators.
     if g.auth.user != owner:
         raise ApiException(
@@ -934,7 +1028,7 @@ def tag_put(owner, package_name, package_tag):
         Instance.query
         .filter_by(hash=package_hash)
         .join(Instance.package)
-        .filter_by(owner=owner, name=package_name)
+        .filter_by(team=team, owner=owner, name=package_name)
         .one_or_none()
     )
 
@@ -962,11 +1056,12 @@ def tag_put(owner, package_name, package_tag):
 
     return dict()
 
-@app.route('/api/tag/<owner>/<package_name>/<package_tag>', methods=['GET'])
+@team_route('/api/tag/<team_name>/<owner>/<package_name>/<package_tag>', methods=['GET'])
 @api(require_login=False)
 @as_json
-def tag_get(owner, package_name, package_tag):
-    package = _get_package(g.auth, owner, package_name)
+def tag_get(team_name, owner, package_name, package_tag):
+    team = _get_team(g.auth, team_name)
+    package = _get_package(g.auth, team, owner, package_name)
 
     instance = (
         Instance.query
@@ -983,6 +1078,7 @@ def tag_get(owner, package_name, package_tag):
 
     _mp_track(
         type="get_hash",
+        package_team=team_name,
         package_owner=owner,
         package_name=package_name,
         package_tag=package_tag,
@@ -996,10 +1092,13 @@ def tag_get(owner, package_name, package_tag):
         updated_at=_utc_datetime_to_ts(instance.updated_at),
     )
 
-@app.route('/api/tag/<owner>/<package_name>/<package_tag>', methods=['DELETE'])
+@team_route('/api/tag/<team_name>/<owner>/<package_name>/<package_tag>', methods=['DELETE'])
 @api()
 @as_json
-def tag_delete(owner, package_name, package_tag):
+def tag_delete(team_name, owner, package_name, package_tag):
+    team = _get_team(g.auth, team_name)
+    _check_team_write(g.auth, team)
+
     # TODO: Write access for collaborators.
     if g.auth.user != owner:
         raise ApiException(
@@ -1012,7 +1111,7 @@ def tag_delete(owner, package_name, package_tag):
         .with_for_update()
         .filter_by(tag=package_tag)
         .join(Tag.package)
-        .filter_by(owner=owner, name=package_name)
+        .filter_by(team=team, owner=owner, name=package_name)
         .one_or_none()
     )
     if tag is None:
@@ -1026,11 +1125,12 @@ def tag_delete(owner, package_name, package_tag):
 
     return dict()
 
-@app.route('/api/tag/<owner>/<package_name>/', methods=['GET'])
+@team_route('/api/tag/<team_name>/<owner>/<package_name>/', methods=['GET'])
 @api(require_login=False)
 @as_json
-def tag_list(owner, package_name):
-    package = _get_package(g.auth, owner, package_name)
+def tag_list(team_name, owner, package_name):
+    team = _get_team(g.auth, team_name)
+    package = _get_package(g.auth, team, owner, package_name)
 
     tags = (
         db.session.query(Tag, Instance)
@@ -1049,10 +1149,10 @@ def tag_list(owner, package_name):
         ]
     )
 
-@app.route('/api/access/<owner>/<package_name>/<user>', methods=['PUT'])
+@team_route('/api/access/<team_name>/<owner>/<package_name>/<user>', methods=['PUT'])
 @api()
 @as_json
-def access_put(owner, package_name, user):
+def access_put(team_name, owner, package_name, user):
     # TODO: use re to check for valid username (e.g., not ../, etc.)
     if not user:
         raise ApiException(requests.codes.bad_request, "A valid user is required")
@@ -1063,16 +1163,23 @@ def access_put(owner, package_name, user):
             "Only the package owner can grant access"
         )
 
+    team = _get_team(g.auth, team_name)
+    _check_team_write(g.auth, team)
+
     package = (
         Package.query
         .with_for_update()
-        .filter_by(owner=owner, name=package_name)
+        .filter_by(team=team, owner=owner, name=package_name)
         .one_or_none()
     )
     if package is None:
         raise PackageNotFoundException(owner, package_name)
 
     if EMAILREGEX.match(user):
+        # TODO(dima): What do we do about teams? For now, disallow everything for team users.
+        if g.auth.team is not None:
+            raise ApiException(requests.codes.forbidden, "Invitations not allowed")
+
         email = user
         invitation = Invitation(package=package, email=email)
         db.session.add(invitation)
@@ -1101,7 +1208,9 @@ def access_put(owner, package_name, user):
         return dict()
 
     else:
-        if user != PUBLIC:
+        _check_share(g.auth, team, user)
+
+        if user not in (PUBLIC, TEAM):
             resp = requests.get(OAUTH_PROFILE_API % user)
             if resp.status_code == requests.codes.not_found:
                 raise ApiException(
@@ -1123,10 +1232,12 @@ def access_put(owner, package_name, user):
 
         return dict()
 
-@app.route('/api/access/<owner>/<package_name>/<user>', methods=['GET'])
+@team_route('/api/access/<team_name>/<owner>/<package_name>/<user>', methods=['GET'])
 @api()
 @as_json
-def access_get(owner, package_name, user):
+def access_get(team_name, owner, package_name, user):
+    team = _get_team(g.auth, team_name)
+
     if g.auth.user != owner:
         raise ApiException(
             requests.codes.forbidden,
@@ -1137,7 +1248,7 @@ def access_get(owner, package_name, user):
         db.session.query(Access)
         .filter_by(user=user)
         .join(Access.package)
-        .filter_by(owner=owner, name=package_name)
+        .filter_by(team=team, owner=owner, name=package_name)
         .one_or_none()
     )
     if access is None:
@@ -1145,10 +1256,13 @@ def access_get(owner, package_name, user):
 
     return dict()
 
-@app.route('/api/access/<owner>/<package_name>/<user>', methods=['DELETE'])
+@team_route('/api/access/<team_name>/<owner>/<package_name>/<user>', methods=['DELETE'])
 @api()
 @as_json
-def access_delete(owner, package_name, user):
+def access_delete(team_name, owner, package_name, user):
+    team = _get_team(g.auth, team_name)
+    _check_team_write(g.auth, team)
+
     if g.auth.user != owner:
         raise ApiException(
             requests.codes.forbidden,
@@ -1176,7 +1290,7 @@ def access_delete(owner, package_name, user):
         .with_for_update()
         .filter_by(user=user)
         .join(Access.package)
-        .filter_by(owner=owner, name=package_name)
+        .filter_by(team=team, owner=owner, name=package_name)
         .one_or_none()
     )
     if access is None:
@@ -1186,14 +1300,16 @@ def access_delete(owner, package_name, user):
     db.session.commit()
     return dict()
 
-@app.route('/api/access/<owner>/<package_name>/', methods=['GET'])
+@team_route('/api/access/<team_name>/<owner>/<package_name>/', methods=['GET'])
 @api()
 @as_json
-def access_list(owner, package_name):
+def access_list(team_name, owner, package_name):
+    team = _get_team(g.auth, team_name)
+
     accesses = (
         Access.query
         .join(Access.package)
-        .filter_by(owner=owner, name=package_name)
+        .filter_by(team=team, owner=owner, name=package_name)
     )
 
     can_access = [access.user for access in accesses]
@@ -1432,11 +1548,12 @@ def invitation_user_list():
                                   invited_at=invite.invited_at)
                              for invite, package in invitations])
 
-@app.route('/api/invite/<owner>/<package_name>/', methods=['GET'])
+@team_route('/api/invite/<team_name>/<owner>/<package_name>/', methods=['GET'])
 @api()
 @as_json
-def invitation_package_list(owner, package_name):
-    package = _get_package(g.auth, owner, package_name)
+def invitation_package_list(team_name, owner, package_name):
+    team = _get_team(g.auth, team_name)
+    package = _get_package(g.auth, team, owner, package_name)
     invitations = (
         Invitation.query
         .filter_by(package_id=package.id)

--- a/registry/tests/delete_test.py
+++ b/registry/tests/delete_test.py
@@ -35,7 +35,7 @@ class DeleteTestCase(QuiltTestCase):
 
         # Upload three package instances.
         for contents in self.contents_list:
-            self.put_package(self.user, self.pkg, contents, True)
+            self.put_package(self.user, self.pkg, contents, public=True)
 
     def testSimpleDelete(self):
         resp = self.app.delete(
@@ -176,7 +176,7 @@ class DeleteTestCase(QuiltTestCase):
         assert resp.status_code == requests.codes.ok
 
         # Create a new package with the same name
-        self.put_package(self.user, self.pkg, self.contents_list[0], True)
+        self.put_package(self.user, self.pkg, self.contents_list[0], public=True)
 
         # Verify that users, tags, and versions didn't survive
         assert not _has_access()

--- a/registry/tests/teams_test.py
+++ b/registry/tests/teams_test.py
@@ -1,0 +1,340 @@
+# Copyright (c) 2017 Quilt Data, Inc. All rights reserved.
+
+"""
+Tests for all teams-specific features.
+"""
+
+import json
+
+import requests
+
+from quilt_server import db
+from quilt_server.const import PUBLIC, TEAM
+from quilt_server.core import encode_node, hash_contents, GroupNode, RootNode
+from quilt_server.models import Team, UserTeam
+
+from .utils import QuiltTestCase
+
+
+class TeamsTestCase(QuiltTestCase):
+    """
+    Test access control for all teams features.
+    """
+    def setUp(self):
+        super(TeamsTestCase, self).setUp()
+
+        self.team_a = 'team_a'
+        self.team_b = 'team_b'
+        self.user_a1 = "user_a1"
+        self.user_a2 = "user_a2"
+        self.user_b1 = "user_b1"
+        self.user = "user"
+        self.pkg = "pkg"
+
+        contents1 = RootNode(dict(
+            foo=GroupNode(dict())
+        ))
+        contents2 = RootNode(dict(
+            bar=GroupNode(dict())
+        ))
+        contents3 = RootNode(dict(
+            baz=GroupNode(dict())
+        ))
+
+        self.pkgurl = self.put_package(self.user, self.pkg, contents1)
+
+        # A non-team package owned by a user that will soon become a team member.
+        self.non_team_pkgurl = self.put_package(self.user_a1, self.pkg, contents2)
+
+        # Manually create teams and team users.
+        team_a = Team(name=self.team_a)
+        team_b = Team(name=self.team_b)
+        db.session.add(team_a)
+        db.session.add(team_b)
+        db.session.add(UserTeam(user=self.user_a1, team=team_a, is_admin=False))
+        db.session.add(UserTeam(user=self.user_a2, team=team_a, is_admin=False))
+        db.session.add(UserTeam(user=self.user_b1, team=team_b, is_admin=False))
+        db.session.commit()
+
+        # A "real" team package, with the same owner and name as a non-team package.
+        self.team_pkgurl = self.put_package(self.user_a1, self.pkg, contents3, team=self.team_a)
+
+    def testPackageList(self):
+        # UserA owns two packages with the same name - team and non-team.
+        resp = self.app.get(
+            '/api/package/{owner}/'.format(
+                owner=self.user_a1,
+            ),
+            headers={
+                'Authorization': self.user_a1
+            }
+        )
+        assert resp.status_code == requests.codes.ok
+        data = json.loads(resp.data.decode('utf8'))
+        packages = data['packages']
+
+        assert len(packages) == 2
+        assert packages[0]['name'] == packages[1]['name'] == self.pkg
+
+        # List the non-team package.
+        resp = self.app.get(
+            '/api/package/{team}/{owner}/{pkg}/'.format(
+                team=PUBLIC,
+                owner=self.user_a1,
+                pkg=self.pkg,
+            ),
+            headers={
+                'Authorization': self.user_a1
+            }
+        )
+        assert resp.status_code == requests.codes.ok
+
+        # List the team package.
+        resp = self.app.get(
+            '/api/package/{team}/{owner}/{pkg}/'.format(
+                team=self.team_a,
+                owner=self.user_a1,
+                pkg=self.pkg,
+            ),
+            headers={
+                'Authorization': self.user_a1
+            }
+        )
+        assert resp.status_code == requests.codes.ok
+
+        # Different user on the same team cannot see the package.
+        resp = self.app.get(
+            '/api/package/{team}/{owner}/{pkg}/'.format(
+                team=self.team_a,
+                owner=self.user_a1,
+                pkg=self.pkg,
+            ),
+            headers={
+                'Authorization': self.user_a2
+            }
+        )
+        assert resp.status_code == requests.codes.not_found
+
+        # Other users cannot see the team.
+        for user in [self.user_b1, self.user, None]:
+            resp = self.app.get(
+                '/api/package/{team}/{owner}/{pkg}/'.format(
+                    team=self.team_a,
+                    owner=self.user_a1,
+                    pkg=self.pkg,
+                ),
+                headers={
+                    'Authorization': user
+                }
+            )
+            assert resp.status_code == requests.codes.forbidden
+
+        # Non-existent team.
+        resp = self.app.get(
+            '/api/package/{team}/{owner}/{pkg}/'.format(
+                team='foo',
+                owner=self.user_a1,
+                pkg=self.pkg,
+            ),
+            headers={
+                'Authorization': self.user_a1
+            }
+        )
+        assert resp.status_code == requests.codes.forbidden
+
+    def testInstall(self):
+        # User can install own non-team package.
+        resp = self.app.get(
+            self.non_team_pkgurl,
+            headers={
+                'Authorization': self.user_a1
+            }
+        )
+        assert resp.status_code == requests.codes.ok
+
+        # User can install own team package.
+        resp = self.app.get(
+            self.team_pkgurl,
+            headers={
+                'Authorization': self.user_a1
+            }
+        )
+        assert resp.status_code == requests.codes.ok
+
+        # Different member of the same team cannot install the package.
+        resp = self.app.get(
+            self.team_pkgurl,
+            headers={
+                'Authorization': self.user_a2
+            }
+        )
+        assert resp.status_code == requests.codes.not_found
+
+        # Other users cannot access the team.
+        for user in [self.user_b1, self.user, None]:
+            resp = self.app.get(
+                self.team_pkgurl,
+                headers={
+                    'Authorization': user
+                }
+            )
+            assert resp.status_code == requests.codes.forbidden
+
+    def testPush(self):
+        contents = RootNode(dict())
+
+        # User cannot push own non-team package.
+        pkgurl = '/api/package/{team}/{usr}/{pkg}/{hash}'.format(
+            team=PUBLIC,
+            usr=self.user_a1,
+            pkg=self.pkg,
+            hash=hash_contents(contents)
+        )
+        resp = self.app.put(
+            pkgurl,
+            data=json.dumps(dict(
+                description="",
+                contents=contents,
+                public=False,
+            ), default=encode_node),
+            content_type='application/json',
+            headers={
+                'Authorization': self.user_a1
+            }
+        )
+        assert resp.status_code == requests.codes.forbidden
+
+        # Team users can push a team package.
+        self.put_package(self.user_a1, self.pkg, contents, team=self.team_a)
+        self.put_package(self.user_a2, self.pkg, contents, team=self.team_a)
+
+        # Team users cannot push a public package.
+        pkgurl = '/api/package/{team}/{usr}/{pkg}/{hash}'.format(
+            team=self.team_a,
+            usr=self.user_a1,
+            pkg=self.pkg,
+            hash=hash_contents(contents),
+        )
+        resp = self.app.put(
+            pkgurl,
+            data=json.dumps(dict(
+                description="",
+                contents=contents,
+                public=True,
+            ), default=encode_node),
+            content_type='application/json',
+            headers={
+                'Authorization': self.user_a1
+            }
+        )
+        assert resp.status_code == requests.codes.forbidden
+
+        # Non-members of the team cannot push a team package.
+        for user in [self.user_b1, self.user, None]:
+            pkgurl = '/api/package/{team}/{usr}/{pkg}/{hash}'.format(
+                team=self.team_a,
+                usr=user,
+                pkg=self.pkg,
+                hash=hash_contents(contents)
+            )
+            resp = self.app.put(
+                pkgurl,
+                data=json.dumps(dict(
+                    description="",
+                    contents=contents,
+                    public=False,
+                ), default=encode_node),
+                content_type='application/json',
+                headers={
+                    'Authorization': user
+                }
+            )
+            assert resp.status_code == requests.codes.forbidden
+
+    def testAccessAdd(self):
+        # A team user can give another team member access to a team package.
+        resp = self._share_package(self.user_a1, self.pkg, self.user_a2, self.team_a)
+        assert resp.status_code == requests.codes.ok
+        resp = self.app.get(
+            self.team_pkgurl,
+            headers={
+                'Authorization': self.user_a2
+            }
+        )
+        assert resp.status_code == requests.codes.ok
+        self._unshare_package(self.user_a1, self.pkg, self.user_a2, self.team_a)
+        assert resp.status_code == requests.codes.ok
+
+        # Cannot share a non-team package with a team user.
+        resp = self._share_package(self.user, self.pkg, self.user_a1)
+        assert resp.status_code == requests.codes.forbidden
+
+        # Cannot share a team package with a non-team user or a different team's member.
+        resp = self._share_package(self.user_a1, self.pkg, self.user_b1, self.team_a)
+        assert resp.status_code == requests.codes.forbidden
+        resp = self._share_package(self.user_a1, self.pkg, self.user, self.team_a)
+        assert resp.status_code == requests.codes.forbidden
+
+        # Cannot share a team package with "public"
+        resp = self._share_package(self.user_a1, self.pkg, PUBLIC, self.team_a)
+        assert resp.status_code == requests.codes.forbidden
+
+        # Cannot share a public package with a team user.
+        resp = self._share_package(self.user, self.pkg, self.user_a1)
+        assert resp.status_code == requests.codes.forbidden
+
+        # A team user cannot share own non-team package with anyone - team or not.
+        resp = self._share_package(self.user_a1, self.pkg, self.user)
+        assert resp.status_code == requests.codes.forbidden
+        resp = self._share_package(self.user_a1, self.pkg, self.user_a2)
+        assert resp.status_code == requests.codes.forbidden
+        resp = self._share_package(self.user_a1, self.pkg, self.user_b1)
+        assert resp.status_code == requests.codes.forbidden
+
+        # Invites not allowed for teams.
+        resp = self._share_package(self.user_a1, self.pkg, 'foo@example.com', self.team_a)
+        assert resp.status_code == requests.codes.forbidden
+
+        # Cannot share a non-team package with "team".
+        resp = self._share_package(self.user, self.pkg, TEAM)
+        assert resp.status_code == requests.codes.forbidden
+
+        # Can share a team package with "team".
+        resp = self._share_package(self.user_a1, self.pkg, TEAM, self.team_a)
+        assert resp.status_code == requests.codes.ok
+        resp = self.app.get(
+            self.team_pkgurl,
+            headers={
+                'Authorization': self.user_a2
+            }
+        )
+        assert resp.status_code == requests.codes.ok
+
+        # Team-shared packages still can't be accessed by non-members.
+        resp = self.app.get(
+            self.team_pkgurl,
+            headers={
+                'Authorization': self.user_b1
+            }
+        )
+        assert resp.status_code == requests.codes.forbidden
+        resp = self.app.get(
+            self.team_pkgurl,
+            headers={
+                'Authorization': self.user
+            }
+        )
+        assert resp.status_code == requests.codes.forbidden
+
+        # Removing "team" access works as expected.
+        resp = self._unshare_package(self.user_a1, self.pkg, TEAM, self.team_a)
+        assert resp.status_code == requests.codes.ok
+        resp = self.app.get(
+            self.team_pkgurl,
+            headers={
+                'Authorization': self.user_a2
+            }
+        )
+        assert resp.status_code == requests.codes.not_found
+
+    # TODO(dima): Check that tags, versions, logs, etc. respect teams.

--- a/registry/tests/utils.py
+++ b/registry/tests/utils.py
@@ -18,6 +18,7 @@ import sqlalchemy_utils
 import quilt_server
 from quilt_server.const import PaymentPlan, PUBLIC
 from quilt_server.core import encode_node, hash_contents
+from quilt_server.models import Team
 
 class MockMixpanelConsumer(object):
     """
@@ -59,6 +60,11 @@ class QuiltTestCase(TestCase):
 
         sqlalchemy_utils.create_database(self.db_url)
         quilt_server.db.create_all()
+
+        # Create the "public" team.
+        # It's normally created by a DB migration - but migrations are not used in tests.
+        quilt_server.db.session.add(Team(name=PUBLIC))
+        quilt_server.db.session.commit()
 
     def tearDown(self):
         quilt_server.db.session.remove()

--- a/registry/tests/utils.py
+++ b/registry/tests/utils.py
@@ -16,7 +16,7 @@ import responses
 import sqlalchemy_utils
 
 import quilt_server
-from quilt_server.const import PaymentPlan
+from quilt_server.const import PaymentPlan, PUBLIC
 from quilt_server.core import encode_node, hash_contents
 
 class MockMixpanelConsumer(object):
@@ -96,8 +96,9 @@ class QuiltTestCase(TestCase):
         user_url = quilt_server.app.config['OAUTH']['profile_api'] % user
         self.requests_mock.add(responses.GET, user_url, json.dumps(dict(username=user)))
 
-    def put_package(self, owner, package, contents, public=False):
-        pkgurl = '/api/package/{usr}/{pkg}/{hash}'.format(
+    def put_package(self, owner, package, contents, team=None, public=False):
+        pkgurl = '/api/package/{team}/{usr}/{pkg}/{hash}'.format(
+            team=team or PUBLIC,
             usr=owner,
             pkg=package,
             hash=hash_contents(contents)
@@ -118,22 +119,28 @@ class QuiltTestCase(TestCase):
         assert resp.status_code == requests.codes.ok
         return pkgurl
 
-    def _share_package(self, owner, pkg, other_user):
+    def _share_package(self, owner, pkg, other_user, team=None):
         self._mock_check_user(other_user)
 
         return self.app.put(
-            '/api/access/{owner}/{pkg}/{usr}'.format(
-                owner=owner, usr=other_user, pkg=pkg
+            '/api/access/{team}/{owner}/{pkg}/{usr}'.format(
+                team=team or PUBLIC,
+                owner=owner,
+                usr=other_user,
+                pkg=pkg
             ),
             headers={
                 'Authorization': owner
             }
         )
 
-    def _unshare_package(self, owner, pkg, other_user):
+    def _unshare_package(self, owner, pkg, other_user, team=None):
         return self.app.delete(
-            '/api/access/{owner}/{pkg}/{usr}'.format(
-                owner=owner, usr=other_user, pkg=pkg
+            '/api/access/{team}/{owner}/{pkg}/{usr}'.format(
+                team=team or PUBLIC,
+                owner=owner,
+                usr=other_user,
+                pkg=pkg
             ),
             headers={
                 'Authorization': owner


### PR DESCRIPTION
- `Team` and `UserTeam` tables are added, as well as a `Package.team_id` column.
- Routes that deal with packages now have a `/<team_name>/` component. Old routes work as before, but set team name to "public". Clients are expected to start using the new routes.
- API endpoints look up the team and check if the user has access to it before doing anything else.
- DB queries filter by team_id in addition to owner and package name.

There is no way to actually create teams yet (other than directly updating the DB). All testing was done with unit tests.