### PR TITLE
Cache bug

### DIFF
--- a/compiler/quilt/test/build.yml
+++ b/compiler/quilt/test/build.yml
@@ -2,9 +2,9 @@
 contents:
   dataframes:
     csv: 
-    kwargs:
-      parse_dates: ['Date0']
-    file: data/10KRows13Cols.csv
+      kwargs:
+        parse_dates: ['Date0']
+      file: data/10KRows13Cols.csv
     nulls:
       file: data/nulls.csv
     tsv:

--- a/compiler/quilt/test/build.yml
+++ b/compiler/quilt/test/build.yml
@@ -2,7 +2,9 @@
 contents:
   dataframes:
     csv: 
-      file: data/10KRows13Cols.csv
+    kwargs:
+      parse_dates: ['Date0']
+    file: data/10KRows13Cols.csv
     nulls:
       file: data/nulls.csv
     tsv:

--- a/compiler/quilt/test/build_group_args.yml
+++ b/compiler/quilt/test/build_group_args.yml
@@ -19,6 +19,8 @@ contents:
       file: data/csv.txt
     tsv:
       # should auto-infer as TSV
+      kwargs:
+        parse_dates: ['Date0']
       file: data/10KRows13Cols.tsv
     subgroup:
       # transform and skiprows apply to all children, unless overidden

--- a/compiler/quilt/test/test_build.py
+++ b/compiler/quilt/test/test_build.py
@@ -49,7 +49,7 @@ class BuildTest(QuiltTestCase):
 
         # Verify cache contents
         srcpath = os.path.join(mydir, 'data/10KRows13Cols.csv')
-        path_hash = build._path_hash(srcpath, 'csv', {})
+        path_hash = build._path_hash(srcpath, 'csv',  {'parse_dates': ['Date0']})
         assert os.path.exists(teststore.cache_path(path_hash))
         
         # Build again using the cache

--- a/compiler/quilt/test/test_build.py
+++ b/compiler/quilt/test/test_build.py
@@ -5,6 +5,7 @@ Test the build process
 #the functions that cli calls
 import os
 
+from numpy import dtype
 import pandas.api.types as ptypes
 from pandas.core.frame import DataFrame
 from six import assertRaisesRegex, string_types
@@ -135,6 +136,8 @@ class BuildTest(QuiltTestCase):
         # ENDTODO
         assert isinstance(pkg.group_b.tsv(), DataFrame), \
             'Expected `transform: tsv` to be inferred from file extension'
+        assert pkg.group_b.tsv()['Date0'].dtype == dtype('<M8[ns]'), \
+            'Expected Date0 column to parse as date'
         assert pkg.group_b.subgroup.tsv().shape == (1, 3), \
             'Expected `transform: tsv` and one skipped row from group args'
         assert pkg.group_b.subgroup.csv().shape == (0, 2), \

--- a/compiler/quilt/tools/build.py
+++ b/compiler/quilt/tools/build.py
@@ -9,7 +9,7 @@ import os
 import re
 
 from pandas.errors import ParserError
-from six import iteritems, itervalues
+from six import iteritems, itervalues, string_types
 
 import yaml
 from tqdm import tqdm
@@ -290,9 +290,9 @@ def build_package(username, package, yaml_path, checks_path=None, dry_run=False,
     def find(key, value):
         """
         find matching nodes recursively;
-        only descend iterables
+        only descend iterables that aren't strings
         """
-        if isinstance(value, Iterable):
+        if isinstance(value, Iterable) and not isinstance(value, string_types):
             for k, v in iteritems(value):
                 if k == key:
                     yield v


### PR DESCRIPTION
Not clear why this test fails

```
(dev) apk-mbp-3:compiler karve$ pytest -x
============================= test session starts ==============================
platform darwin -- Python 3.6.3, pytest-3.2.5, py-1.5.2, pluggy-0.4.0
rootdir: /Users/karve/code/quilt/compiler, inifile:
collected 81 items                                                              

quilt/test/test_build.py ..F

=================================== FAILURES ===================================
_______________________ BuildTest.test_build_from_cache ________________________

self = <quilt.test.test_build.BuildTest testMethod=test_build_from_cache>

    def test_build_from_cache(self):
        """
            Build the same package twice and verify that the cache is used and
            that the package is successfully generated.
            """
        mydir = os.path.dirname(__file__)
        path = os.path.join(mydir, './build.yml')
        teststore = store.PackageStore()
    
        # Build once to populate cache
        build.build_package('test_cache', PACKAGE, path)
    
        # Verify cache contents
        srcpath = os.path.join(mydir, 'data/10KRows13Cols.csv')
        path_hash = build._path_hash(srcpath, 'csv', {})
>       assert os.path.exists(teststore.cache_path(path_hash))
E       AssertionError: assert False
E        +  where False = <function exists at 0x107a0d9d8>('/var/folders/nr/x5fzgqxj22d40yj6dqzzdzhc0000gp/T/quilt-test-df9dmtwe/quilt_packages/cache/025dcb7cd7ebbc227be82ae089b7d222b34a51b275e02fdb4c0de18e1b9bfef4')
E        +    where <function exists at 0x107a0d9d8> = <module 'posixpath' from '/Users/karve/anaconda3/envs/dev/lib/python3.6/posixpath.py'>.exists
E        +      where <module 'posixpath' from '/Users/karve/anaconda3/envs/dev/lib/python3.6/posixpath.py'> = os.path
E        +    and   '/var/folders/nr/x5fzgqxj22d40yj6dqzzdzhc0000gp/T/quilt-test-df9dmtwe/quilt_packages/cache/025dcb7cd7ebbc227be82ae089b7d222b34a51b275e02fdb4c0de18e1b9bfef4' = <bound method PackageStore.cache_path of <quilt.tools.store.PackageStore object at 0x10b8fe240>>('025dcb7cd7ebbc227be82ae089b7d222b34a51b275e02fdb4c0de18e1b9bfef4')
E        +      where <bound method PackageStore.cache_path of <quilt.tools.store.PackageStore object at 0x10b8fe240>> = <quilt.tools.store.PackageStore object at 0x10b8fe240>.cache_path

quilt/test/test_build.py:53: AssertionError
----------------------------- Captured stdout call -----------------------------
Inferring 'transform: csv' for data/10KRows13Cols.csv
Serializing /Users/karve/code/quilt/compiler/quilt/test/./data/10KRows13Cols.csv...
Saving as binary dataframe...
Inferring 'transform: csv' for data/nulls.csv
Serializing /Users/karve/code/quilt/compiler/quilt/test/./data/nulls.csv...
Saving as binary dataframe...
Inferring 'transform: tsv' for data/10KRows13Cols.tsv
Serializing /Users/karve/code/quilt/compiler/quilt/test/./data/10KRows13Cols.tsv...
Saving as binary dataframe...
Inferring 'transform: xlsx' for data/10KRows13Cols.xlsx
Serializing /Users/karve/code/quilt/compiler/quilt/test/./data/10KRows13Cols.xlsx...
Saving as binary dataframe...
Inferring 'transform: xlsx' for data/10KRows13Cols.xlsx
Serializing /Users/karve/code/quilt/compiler/quilt/test/./data/10KRows13Cols.xlsx...
Saving as binary dataframe...
Inferring 'transform: id' for data/README.md
Copying /Users/karve/code/quilt/compiler/quilt/test/./data/README.md...
```