### PR TITLE
Keep build_from_cache in sync with test/build.yml

### DIFF
--- a/compiler/quilt/test/build.yml
+++ b/compiler/quilt/test/build.yml
@@ -2,9 +2,9 @@
 contents:
   dataframes:
     csv: 
-    kwargs:
-      parse_dates: ['Date0']
-    file: data/10KRows13Cols.csv
+      kwargs:
+        parse_dates: ['Date0']
+      file: data/10KRows13Cols.csv
     nulls:
       file: data/nulls.csv
     tsv:

--- a/compiler/quilt/test/test_build.py
+++ b/compiler/quilt/test/test_build.py
@@ -49,7 +49,7 @@ class BuildTest(QuiltTestCase):
 
         # Verify cache contents
         srcpath = os.path.join(mydir, 'data/10KRows13Cols.csv')
-        path_hash = build._path_hash(srcpath, 'csv', {})
+        path_hash = build._path_hash(srcpath, 'csv',  {'parse_dates': ['Date0']})
         assert os.path.exists(teststore.cache_path(path_hash))
         
         # Build again using the cache


### PR DESCRIPTION
The test test_build_from_cache contains an assertion that verifies that
the cache is actually filled. The hash key in the cache is generated
from both the source file and kwargs so it needs to be kept in sync
with the build file (test/build.yml).

Fix an indentation bug in test/build.yml.