### PR TITLE
`quilt export` original filepaths, additional testing, and minor updates

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,4 +21,5 @@ cov_html/*
 *~
 [#]*
 
-
+# Project Files
+.idea

--- a/compiler/quilt/nodes.py
+++ b/compiler/quilt/nodes.py
@@ -131,10 +131,15 @@ class PackageNode(GroupNode):
         assert isinstance(path, list) and len(path) > 0
 
         if isinstance(value, pd.DataFrame):
+            # TODO: what about dataframe metadata?
             core_node = core.TableNode(hashes=[])
         elif isinstance(value, string_types):
-            core_node = core.FileNode(hashes=[])
+            # If metadata isn't given, the FileNode won't retain the file path.
+            # REVIEW: Should this happen within the filenode itself?
+            metadata = {'q_path': value, 'q_target': 'file', 'q_ext': ''}
+            core_node = core.FileNode(hashes=[], metadata=metadata)
         elif isinstance(value, bytes):
+            # TODO: This seems unused.
             core_node = core.FileNode(hashes=[])
         else:
             # TODO: throw a proper exception?

--- a/compiler/quilt/test/test_build.py
+++ b/compiler/quilt/test/test_build.py
@@ -166,7 +166,6 @@ class BuildTest(QuiltTestCase):
         assert os.path.exists(buildfilepath)
         build.build_package('test_generated', 'generated', buildfilepath)
         os.remove(buildfilepath)
-        # XXX: building now produces README_md instead of README -- intentional?
         from quilt.data.test_generated.generated import bad, foo, nuts, README_md
 
     def test_failover(self):

--- a/compiler/quilt/test/test_build.py
+++ b/compiler/quilt/test/test_build.py
@@ -50,10 +50,10 @@ class BuildTest(QuiltTestCase):
         srcpath = os.path.join(mydir, 'data/10KRows13Cols.csv')
         path_hash = build._path_hash(srcpath, 'csv', {})
         assert os.path.exists(teststore.cache_path(path_hash))
-        
+
         # Build again using the cache
         build.build_package('test_cache', PACKAGE, path)
-        
+
         # TODO load DFs based on contents of .yml file at PATH
         # not hardcoded vals (this will require loading modules from variable
         # names, probably using __module__)
@@ -121,7 +121,7 @@ class BuildTest(QuiltTestCase):
         build.build_package('groups', 'pkg', path)
 
         from quilt.data.groups import pkg
-        
+
         assert isinstance(pkg.group_a.csv(), DataFrame), \
             'Expected parent `transform: csv` to affect group_a.csv()'
         assert isinstance(pkg.group_a.tsv(), DataFrame), \
@@ -142,9 +142,9 @@ class BuildTest(QuiltTestCase):
         assert pkg.group_b.subgroup.many_tsv.one().shape == (1, 3), \
             'Expected local `transform: csv` and one skipped row from group args'
         assert isinstance(pkg.group_b.subgroup.many_tsv.two(), DataFrame), \
-            'Expected `transform: tsv` from ancestor' 
+            'Expected `transform: tsv` from ancestor'
         assert isinstance(pkg.group_b.subgroup.many_tsv.three(), DataFrame), \
-            'Expected `transform: tsv` from ancestor' 
+            'Expected `transform: tsv` from ancestor'
         assert not pkg.group_empty._keys(), 'Expected group_empty to be empty'
         assert not pkg.group_x.empty_child._keys(), 'Expected group_x.emptychild to be empty'
 
@@ -166,7 +166,8 @@ class BuildTest(QuiltTestCase):
         assert os.path.exists(buildfilepath)
         build.build_package('test_generated', 'generated', buildfilepath)
         os.remove(buildfilepath)
-        from quilt.data.test_generated.generated import bad, foo, nuts, README
+        # XXX: building now produces README_md instead of README -- intentional?
+        from quilt.data.test_generated.generated import bad, foo, nuts, README_md
 
     def test_failover(self):
         """

--- a/compiler/quilt/test/test_command.py
+++ b/compiler/quilt/test/test_command.py
@@ -523,45 +523,104 @@ class CommandTest(QuiltTestCase):
         assert isinstance(bar.foo(), pd.DataFrame)
 
     def test_export(self):
+        # pathlib will translate paths to windows or posix paths when needed
         Path = pathlib.Path
         pkg_name = 'testing/foo'
-        pkg_name_subpkg = pkg_name + '/subdir'
+        subpkg_name = 'subdir'
+        single_name = 'single_file'
+        single_bytes = os.urandom(200)
 
-        # pathlib will translate these to windows paths
+        subdir_test_data = [
+            (subpkg_name + '/subdir_example', os.urandom(300)),
+            (subpkg_name + '/9bad-identifier.html', os.urandom(100)),
+            ]
+
         test_data = [
-            ('example', os.urandom(500)),
-            ('subdir/subdir_example', os.urandom(300)),
+            (single_name, single_bytes),
             ('readme.md', os.urandom(200)),
             # these are invalid python identifiers, but should be handled without issue
-            ('subdir/9bad-identifier.html', os.urandom(100)),
             ('3-bad-identifier/bad_parent_identifier.html', os.urandom(100)),
             ('3-bad-identifier/9{}bad-identifier.html', os.urandom(100)),
-            ]
+            ] + subdir_test_data
 
         shash = lambda data: hashlib.sha256(data).hexdigest()
 
         with tempfile.TemporaryDirectory() as temp_dir:
             temp_dir = Path(temp_dir)
             install_dir = temp_dir / 'install'
-            export_dir = temp_dir / 'export'
 
+            # Create and and install build
             for path, data in test_data:
                 path = install_dir / path
                 path.parent.mkdir(parents=True, exist_ok=True)
                 path.write_bytes(data)
+            command.build(pkg_name, str(install_dir))
 
-            command.build('testing/foo', str(install_dir))
-            command.export('testing/foo', str(export_dir))
+            # Test export
+            test_dir = temp_dir / 'test_export'
 
-            exported_paths = [path for path in export_dir.glob('**/*') if path.is_file()]
+            command.export(pkg_name, str(test_dir))
+
+            exported_paths = [path for path in test_dir.glob('**/*') if path.is_file()]
 
             assert len(exported_paths) == len(test_data)
 
             for path, data in test_data:
-                export_path = export_dir / path
+                export_path = test_dir / path
                 install_path = install_dir / path
 
                 # filename matches
                 assert export_path in exported_paths
                 # data matches
                 assert shash(export_path.read_bytes()) == shash(install_path.read_bytes())
+
+            # Test subpackage exports
+            test_dir = temp_dir / 'test_subpkg_export'
+            command.export(pkg_name + '/' + subpkg_name, str(test_dir))
+
+            exported_paths = [path for path in test_dir.glob('**/*') if path.is_file()]
+
+            assert len(exported_paths) == len(subdir_test_data)
+
+            for path, data in subdir_test_data:
+                export_path = test_dir / path
+                install_path = install_dir / path
+
+                # filename matches
+                assert export_path in exported_paths
+                # data matches
+                assert shash(export_path.read_bytes()) == shash(install_path.read_bytes())
+
+            # Test single-file exports
+            test_dir = temp_dir / 'test_single_file_export'
+            pkg_name_single = pkg_name + '/' + single_name
+            single_filepath = test_dir / single_name
+
+            command.export(pkg_name_single, str(test_dir))
+            assert single_filepath.exists()
+            assert shash(single_bytes) == shash(single_filepath.read_bytes())
+
+            # Test filters
+            test_dir = temp_dir / 'test_filters'    # ok on windows too per pathlib
+            included_file = test_dir / single_name
+
+            command.export(pkg_name, str(test_dir),
+                           filter=lambda x: True if x == single_name else False)
+
+            exported_paths = [path for path in test_dir.glob('**/*') if path.is_file()]
+
+            assert len(exported_paths) == 1
+            assert included_file.exists()
+            assert shash(single_bytes) == shash(included_file.read_bytes())
+
+            # Test map
+            test_dir = temp_dir / 'test_mapper'
+            test_filepath = test_dir / single_name    # ok on windows too per pathlib
+            mapped_filepath = test_filepath.with_suffix('.zip')
+
+            command.export(pkg_name + '/' + single_name, str(test_dir),
+                           mapper=lambda x: Path(x).with_suffix('.zip'))
+
+            assert not test_filepath.exists()
+            assert mapped_filepath.exists()
+            assert shash(single_bytes) == shash(mapped_filepath.read_bytes())

--- a/compiler/quilt/test/test_command.py
+++ b/compiler/quilt/test/test_command.py
@@ -531,7 +531,11 @@ class CommandTest(QuiltTestCase):
         test_data = [
             ('example', os.urandom(500)),
             ('subdir/subdir_example', os.urandom(300)),
-            ('readme', os.urandom(200)),
+            ('readme.md', os.urandom(200)),
+            # these are invalid python identifiers, but should be handled without issue
+            ('subdir/9bad-identifier.html', os.urandom(100)),
+            ('3-bad-identifier/bad_parent_identifier.html', os.urandom(100)),
+            ('3-bad-identifier/9{}bad-identifier.html', os.urandom(100)),
             ]
 
         shash = lambda data: hashlib.sha256(data).hexdigest()

--- a/compiler/quilt/test/test_install.py
+++ b/compiler/quilt/test/test_install.py
@@ -53,7 +53,8 @@ class InstallTest(QuiltTestCase):
     def make_contents(cls, **args):
         contents = RootNode(dict(
             group=GroupNode(dict([
-                (key, TableNode([val]) if 'table' in key else FileNode([val]))
+                (key, TableNode([val]) if 'table' in key
+                    else FileNode([val], metadata={'q_path': key}))
                 for key, val in args.items()]
             ))
         ))
@@ -329,15 +330,20 @@ packages:
         """
         file_data_list = []
         file_hash_list = []
+        file_name_list = []
+
         for i in range(2):
-            file_data, file_hash = self.make_file_data('file%d' % i)
+            file_name = 'file{}'.format(i)
+            file_data, file_hash = self.make_file_data(file_name)
             file_data_list.append(file_data)
             file_hash_list.append(file_hash)
+            file_name_list.append(file_name)
 
-        contents = RootNode(dict(
-            file0=FileNode([file_hash_list[0]]),
-            file1=FileNode([file_hash_list[1]]),
-        ), format=PackageFormat.HDF5)
+        contents = RootNode(
+            {name: FileNode([file_hash_list[n]], metadata={'q_path': name})
+             for n, name in enumerate(file_name_list)},
+            format=PackageFormat.HDF5,
+        )
         contents_hash = hash_contents(contents)
 
         # Create a package store object to use its path helpers

--- a/compiler/quilt/tools/command.py
+++ b/compiler/quilt/tools/command.py
@@ -20,7 +20,6 @@ from threading import Thread, Lock
 import time
 import yaml
 import importlib
-import itertools
 
 from packaging.version import Version
 import pandas as pd
@@ -1294,7 +1293,7 @@ def export(package, output_path='.', filter=lambda x: True, mapper=lambda x: x, 
                 orig_path = found_node._node.metadata['q_path']
                 yield (orig_path, storage_filename)
 
-    # Iterate over filename map and filter exports
+    # Iterate over filename map, filtering exports
     exports = ((dest, src) for dest, src in iter_filename_map(node) if filter(dest) is True)
 
     # apply mapping to exports

--- a/compiler/quilt/tools/command.py
+++ b/compiler/quilt/tools/command.py
@@ -1270,17 +1270,25 @@ def export(package, output_path='.', filter=lambda x: True, mapper=lambda x: x, 
     if subpath:
         node = get_node_child_by_path(node, subpath)
 
-    def iter_nodepath_filenames(node):
+    def iter_filename_map(node):
         """Yields [<node path>, <filename>] pairs for FileNodes under `node`"""
         for node_path in node._iterpaths():
             found_node = get_node_child_by_path(node, node_path)
-            filename = getattr(found_node, '_filename', None)
-            if filename is not None:
-                assert filename
-                yield (node_path, filename)
+            storage_filename = getattr(found_node, '_filename', None)
+            if storage_filename is not None:
+                assert storage_filename    # sanity check
+                
+                orig_path = pathlib.Path(found_node._node.metadata['q_path'])
+                orig_path = list(orig_path.parts)
+                print(node_path)
+                print(orig_path)
+                print("Paths equal: {}".format(orig_path[:-1] == node_path[:-1]))
+                print()
+                yield (orig_path, storage_filename)
+    
 
     # gather nodes to be exported
-    exports = ((os.path.join(*dest), src) for dest, src in iter_nodepath_filenames(node))
+    exports = ((os.path.join(*dest), src) for dest, src in iter_filename_map(node))
 
     # filter exports
     exports = ((dest, src) for dest, src in exports if filter(dest) is True)

--- a/compiler/quilt/tools/command.py
+++ b/compiler/quilt/tools/command.py
@@ -1294,7 +1294,7 @@ def export(package, output_path='.', filter=lambda x: True, mapper=lambda x: x, 
                 yield (orig_path, storage_filename)
 
     # Iterate over filename map, filtering exports
-    exports = ((dest, src) for dest, src in iter_filename_map(node) if filter(dest) is True)
+    exports = ((dest, src) for dest, src in iter_filename_map(node) if filter(dest))
 
     # apply mapping to exports
     exports = ((mapper(dest), src) for dest, src in exports)

--- a/compiler/quilt/tools/command.py
+++ b/compiler/quilt/tools/command.py
@@ -1277,15 +1277,9 @@ def export(package, output_path='.', filter=lambda x: True, mapper=lambda x: x, 
             storage_filename = getattr(found_node, '_filename', None)
             if storage_filename is not None:
                 assert storage_filename    # sanity check
-                
                 orig_path = pathlib.Path(found_node._node.metadata['q_path'])
                 orig_path = list(orig_path.parts)
-                print(node_path)
-                print(orig_path)
-                print("Paths equal: {}".format(orig_path[:-1] == node_path[:-1]))
-                print()
                 yield (orig_path, storage_filename)
-    
 
     # gather nodes to be exported
     exports = ((os.path.join(*dest), src) for dest, src in iter_filename_map(node))

--- a/compiler/quilt/tools/command.py
+++ b/compiler/quilt/tools/command.py
@@ -1271,15 +1271,16 @@ def export(package, output_path='.', filter=lambda x: True, mapper=lambda x: x, 
         node = get_node_child_by_path(node, subpath)
 
     def iter_filename_map(node):
-        """Yields [<node path>, <filename>] pairs for FileNodes under `node`"""
+        """Yields [<original path>, <storage file path>] pairs for FileNodes under `node`"""
         for node_path in node._iterpaths():
             found_node = get_node_child_by_path(node, node_path)
             storage_filename = getattr(found_node, '_filename', None)
             if storage_filename is not None:
-                assert storage_filename    # sanity check
+                assert storage_filename    # sanity check -- no blank filenames
                 orig_path = pathlib.Path(found_node._node.metadata['q_path'])
                 orig_path = list(orig_path.parts)
                 yield (orig_path, storage_filename)
+
 
     # gather nodes to be exported
     exports = ((os.path.join(*dest), src) for dest, src in iter_filename_map(node))

--- a/compiler/quilt/tools/compat.py
+++ b/compiler/quilt/tools/compat.py
@@ -8,27 +8,28 @@ For others, import the module here under the python3 name (if there are naming d
 Unfortunately, this *doesn't* allow for `from .tools.compat.foo import bar`, so if needed,
 import frequently-used objects here for convenience.
 """
-# disable unused import warnings
-# pylint: disable=W0611
+# unused imports -- pylint: disable=W0611
 
-import six as _six
+import sys as _sys
 
-if _six.PY34:
-    import pathlib
-    import tempfile
-    # from unittest import mock
 
-    # inspect.argspec is deprecated, so
-    from inspect import signature
-else:
-    import pathlib2 as pathlib
+# Reflecting requirements in setup.py
+# Python < 3.4
+if _sys.version_info < (3, 4):
     from backports import tempfile
-    # import mock
+    from funcsigs import signature  # inspect.argspec is deprecated
+else:
+    import tempfile
+    from inspect import signature   # inspect.argspec is deprecated
 
-    # inspect.argspec is deprecated, so
-    from funcsigs import signature
+# Python < 3.5
+if _sys.version_info < (3, 5):
+    import pathlib2 as pathlib
+else:
+    import pathlib
+
 
 # convenience references (examples) to allow `from .tools.compat import some_obj`
 # path = mock.path
-Path = pathlib.Path
+# Path = pathlib.Path
 # TemporaryDirectory = tempdir.TemporaryDirectory

--- a/compiler/quilt/tools/compat.py
+++ b/compiler/quilt/tools/compat.py
@@ -29,7 +29,8 @@ else:
     import pathlib
 
 
-# convenience references (examples) to allow `from .tools.compat import some_obj`
-# path = mock.path
+# Example convenience references to allow `from .tools.compat import some_obj`
+
+# patch = mock.patch
 # Path = pathlib.Path
-# TemporaryDirectory = tempdir.TemporaryDirectory
+# TemporaryDirectory = tempfile.TemporaryDirectory

--- a/compiler/quilt/tools/core.py
+++ b/compiler/quilt/tools/core.py
@@ -120,12 +120,12 @@ class TableNode(Node):
 class FileNode(Node):
     json_type = 'FILE'
 
-    def __init__(self, hashes, metadata=None):
-        if metadata is None:
-            metadata = {}
-
+    def __init__(self, hashes, metadata):
         assert isinstance(hashes, list)
         assert isinstance(metadata, dict)
+
+        if not metadata.get('q_path'):
+            raise ValueError("`metadata` for a FileNode requires 'q_path' to be set.")
 
         self.hashes = hashes
         self.metadata = metadata

--- a/compiler/quilt/tools/util.py
+++ b/compiler/quilt/tools/util.py
@@ -1,11 +1,14 @@
 """
 Helper functions.
 """
-
+import re
 import gzip
+import keyword
+import tokenize
 
 from appdirs import user_config_dir, user_data_dir
 from six import BytesIO, string_types, Iterator
+
 
 APP_NAME = "QuiltCli"
 APP_AUTHOR = "QuiltData"
@@ -81,3 +84,28 @@ def gzip_compress(data):
     with gzip.GzipFile(fileobj=buf, mode='wb') as fd:
         fd.write(data)
     return buf.getvalue()
+
+
+def is_identifier(string):
+    """Check if string could be a valid python identifier
+
+    :param string: string to be tested
+    :returns: True if string can be a python identifier, False otherwise
+    :rtype: bool
+    """
+    val = re.match(tokenize.Name + '$', string) and not keyword.iskeyword(string)
+    return True if val else False
+
+
+def is_nodename(string):
+    """Check if string could be a valid node name
+
+    Convenience, and a good place to aggregate node-name related checks.
+
+    :param string: string to be tested
+    :returns: True if string could be used as a node name, False otherwise
+    :rtype: bool
+    """
+    if string.startswith('_'):
+        return False
+    return is_identifier(string)

--- a/compiler/quilt/tools/util.py
+++ b/compiler/quilt/tools/util.py
@@ -109,3 +109,80 @@ def is_nodename(string):
     if string.startswith('_'):
         return False
     return is_identifier(string)
+
+
+def to_identifier(string):
+    """Makes a python identifier (perhaps an ugly one) out of any string.
+
+    This isn't an isomorphic change, the original filename can't be recovered
+    from the change in all cases, so it must be stored separately.
+
+    Examples:
+    >>> to_identifier('#if') -> '_if'
+    >>> to_identifier('global') -> 'global_'
+    >>> to_identifier('9foo') -> 'n9foo'
+
+    :param string: string to convert
+    :returns: `string`, converted to python identifier if needed
+    :rtype: string
+    """
+    string = re.sub(r'[^0-9a-zA-Z_]', '_', string)
+
+    if string[0].isdigit():
+        string = "n" + string
+    if keyword.iskeyword(string):
+        string = string + '_'
+
+    return string
+
+
+def to_nodename(string, invalid=None, raise_exc=False):
+    """Makes a Quilt Node name (perhaps an ugly one) out of any string.
+
+    This isn't an isomorphic change, the original filename can't be recovered
+    from the change in all cases, so it must be stored separately.
+
+    If `invalid` is given, it should be an iterable of names that the returned
+    string cannot match -- for example, other node names.
+
+    If `raise_exc` is False (default), an exception is raised when the
+    converted string is present in `invalid`.  Otherwise, the converted string
+    will have a number appended to its name.
+
+    Example:
+    # replace special chars -> remove prefix underscores -> rename keywords
+    # '!if' -> '_if' -> 'if' -> 'if_'
+    >>> to_nodename('!if') -> 'if_'
+    >>> to_nodename('if', ['if_']) -> 'if__2'
+    >>> to_nodename('9#blah') -> 'n9_blah'
+    >>> to_nodename('9:blah', ['n9_blah', 'n9_blah_2']) -> 'n9_blah_3'
+
+    :param string: string to convert to a nodename
+    :param invalid: iterable of names to avoid
+    :type invalid: iterable
+    :param raise_exc: Raise an exception on name conflicts if truthy.
+    :type raise_exc: bool
+    :returns: valid node name
+    :rtype: string
+    """
+    string = to_identifier(string).lstrip('_')
+
+    if keyword.iskeyword(string):
+        string = string + '_'
+
+    if invalid is None:
+        return string
+
+    invalid = set(invalid)
+    if string in invalid and raise_exc:
+        raise ValueError("Conflicting node name after string conversion: {!r}".format(string))
+
+    result = string
+    counter = 1
+    while result in invalid:
+        # first conflicted name will be "somenode_2"
+        # The result is "somenode", "somenode_2", "somenode_3"..
+        counter += 1
+        result = "{}_{}".format(string, counter)
+
+    return result

--- a/compiler/quilt/vfs.py
+++ b/compiler/quilt/vfs.py
@@ -75,6 +75,10 @@ import glob
 from .nodes import GroupNode
 from .tools import command
 from .tools.store import parse_package
+from .tools.util import to_nodename
+
+
+DEFAULT_CHAR_MAPPINGS = to_nodename
 
 # TODO: replace global variable
 PATCHERS = []
@@ -161,22 +165,6 @@ DEFAULT_MODULE_MAPPINGS = {
     #'tensorflow': 'gfile.GFile',
 }
 DEFAULT_MODULE_MAPPINGS = scrub_patchmap(DEFAULT_MODULE_MAPPINGS, True)
-
-
-# simple mapping of illegal chars to underscores, prepending 'n' if needed.
-def to_python_identifier(string):
-    """Makes a python identifier (perhaps an ugly one) out of any string.
-
-    This isn't an isomorphically reversible change, the original filename
-    must be stored as well.
-    """
-    string = re.sub(r'[^0-9a-zA-Z_]', '_', string)
-    if string[0].isdigit():
-        string = "n" + string
-    return string
-
-
-DEFAULT_CHAR_MAPPINGS = to_python_identifier
 
 
 def create_charmap_func(charmap):
@@ -325,7 +313,7 @@ def setup_keras_dataset(data_pkg, keras_dataset_name, hash=None, version=None, t
         return mapfunc(filename)
 
     # TODO: keras checkpoints support
-    
+
     patch('keras.datasets.'+keras_dataset_name, 'get_file', keras_mapfunc)
 
 def setup_tensorflow(data_pkg, chkpt_pkg=None, checkpoints_nodepath="checkpoints",
@@ -386,7 +374,7 @@ def setup_tensorflow_checkpoints(pkg, checkpoints_nodepath="checkpoints",
         path_prefix = obj.save(sess, save_path, global_step, latest_filename,
                                meta_graph_suffix, write_meta_graph, write_state)
         #print('path_prefix={}'.format(path_prefix))
-        
+
         # read the latest checkpoint file and write to quilt
         last_chk_path = tensorflow.train.latest_checkpoint(checkpoint_dir=save_path)
         pkginfo = pkg+'/'+checkpoints_nodepath+'/'+latest_filename

--- a/compiler/setup.py
+++ b/compiler/setup.py
@@ -44,7 +44,7 @@ setup(
         'future>=0.16.0',
         'packaging>=16.8',
         'pandas>=0.19.2',
-        'pathlib2; python_version<"3.4"',    # stdlib backport
+        'pathlib2; python_version<"3.5"',    # stdlib backport
         'pyarrow>=0.4.0,<0.8.0', # TODO(dima): Make unit tests work with 0.8.*.
         'pyOpenSSL>=16.2.0',  # Note: not actually used at the moment.
         'pyyaml>=3.12',

--- a/compiler/setup.py
+++ b/compiler/setup.py
@@ -40,11 +40,11 @@ setup(
         'appdirs>=1.4.0',
         'backports.tempfile; python_version<"3.4"',   # stdlib backport
         'enum34; python_version<"3.4"',     # stdlib backport
-        'funcsigs; python_version<"3.4"'    # stdlib backport
+        'funcsigs; python_version<"3.4"',    # stdlib backport
         'future>=0.16.0',
         'packaging>=16.8',
         'pandas>=0.19.2',
-        'pathlib2; python_version<"3.4"'    # stdlib backport
+        'pathlib2; python_version<"3.4"',    # stdlib backport
         'pyarrow>=0.4.0,<0.8.0', # TODO(dima): Make unit tests work with 0.8.*.
         'pyOpenSSL>=16.2.0',  # Note: not actually used at the moment.
         'pyyaml>=3.12',

--- a/compiler/setup.py
+++ b/compiler/setup.py
@@ -38,7 +38,7 @@ setup(
     keywords='quilt quiltdata shareable data dataframe package platform pandas',
     install_requires=[
         'appdirs>=1.4.0',
-        'backports.tempfile; python_version<"3.4"'   # stdlib backport
+        'backports.tempfile; python_version<"3.4"',   # stdlib backport
         'enum34; python_version<"3.4"',     # stdlib backport
         'funcsigs; python_version<"3.4"'    # stdlib backport
         'future>=0.16.0',

--- a/examples/tensorflow/tensorflow-cifar-10/train-short.py
+++ b/examples/tensorflow/tensorflow-cifar-10/train-short.py
@@ -1,0 +1,135 @@
+# This should just be 'train.py' with a shorter interval.  Feel free to delete or modify.
+
+import numpy as np
+import tensorflow as tf
+from sklearn.metrics import confusion_matrix
+from time import time
+
+from include.data import get_data_set
+from include.model import model
+
+#---------------------------------------------------------------------------
+# QUILT SETUP - added after import statements
+
+import quilt, quilt.vfs
+QUILT_PKG = 'asah/cifar10'
+
+print("Connecting to Quilt...")
+# force=False because otherwise local data in storage is overwritten
+quilt.install(QUILT_PKG, force=False)
+
+print("   reading data from Quilt package: {}...".format(QUILT_PKG))
+quilt.vfs.setup(QUILT_PKG, mappings={'data_set/cifar_10':'data_set.cifar_10'})
+# disable the custom code (include/data.py) that looks for local input files
+quilt.vfs.patch('include.data', 'maybe_download_and_extract', lambda: None)
+
+print("   setting up Tensorflow to read and save checkpoints to/from Quilt...")
+quilt.vfs.setup_tensorflow_checkpoints(QUILT_PKG, checkpoints_nodepath='tensorboard/cifar_10')
+
+# END QUILT
+#---------------------------------------------------------------------------
+
+train_x, train_y, train_l = get_data_set()
+test_x, test_y, test_l = get_data_set("test")
+
+x, y, output, global_step, y_pred_cls = model()
+
+_IMG_SIZE = 32
+_NUM_CHANNELS = 3
+_BATCH_SIZE = 128
+_CLASS_SIZE = 10
+_ITERATION = 10000
+_SAVE_PATH = "./tensorboard/cifar-10/"
+
+
+loss = tf.reduce_mean(tf.nn.softmax_cross_entropy_with_logits(logits=output, labels=y))
+optimizer = tf.train.RMSPropOptimizer(learning_rate=1e-3).minimize(loss, global_step=global_step)
+
+
+correct_prediction = tf.equal(y_pred_cls, tf.argmax(y, axis=1))
+accuracy = tf.reduce_mean(tf.cast(correct_prediction, tf.float32))
+tf.summary.scalar("Accuracy/train", accuracy)
+
+
+merged = tf.summary.merge_all()
+saver = tf.train.Saver()
+sess = tf.Session()
+train_writer = tf.summary.FileWriter(_SAVE_PATH, sess.graph)
+
+
+try:
+    print("Trying to restore last checkpoint ...")
+    last_chk_path = tf.train.latest_checkpoint(checkpoint_dir=_SAVE_PATH)
+    saver.restore(sess, save_path=last_chk_path)
+    print("Restored checkpoint from:", last_chk_path)
+except:
+    print("Failed to restore checkpoint. Initializing variables instead.")
+    sess.run(tf.global_variables_initializer())
+
+
+def train(num_iterations):
+    '''
+        Train CNN
+    '''
+    for i in range(num_iterations):
+        randidx = np.random.randint(len(train_x), size=_BATCH_SIZE)
+        batch_xs = train_x[randidx]
+        batch_ys = train_y[randidx]
+
+        start_time = time()
+        i_global, _ = sess.run([global_step, optimizer], feed_dict={x: batch_xs, y: batch_ys})
+        duration = time() - start_time
+
+        if (i_global % 1 == 0) or (i == num_iterations - 1):
+            _loss, batch_acc = sess.run([loss, accuracy], feed_dict={x: batch_xs, y: batch_ys})
+            msg = "Global Step: {0:>6}, accuracy: {1:>6.1%}, loss = {2:.2f} ({3:.1f} examples/sec, {4:.2f} sec/batch)"
+            print(msg.format(i_global, batch_acc, _loss, _BATCH_SIZE / duration, duration))
+
+        if (i_global % 10 == 0) or (i == num_iterations - 1):
+            data_merged, global_1 = sess.run([merged, global_step], feed_dict={x: batch_xs, y: batch_ys})
+            acc = predict_test()
+
+            summary = tf.Summary(value=[
+                tf.Summary.Value(tag="Accuracy/test", simple_value=acc),
+            ])
+            train_writer.add_summary(data_merged, global_1)
+            train_writer.add_summary(summary, global_1)
+
+            saver.save(sess, save_path=_SAVE_PATH, global_step=global_step)
+            print("Saved checkpoint.")
+
+
+def predict_test(show_confusion_matrix=False):
+    '''
+        Make prediction for all images in test_x
+    '''
+    i = 0
+    predicted_class = np.zeros(shape=len(test_x), dtype=np.int)
+    while i < len(test_x):
+        j = min(i + _BATCH_SIZE, len(test_x))
+        batch_xs = test_x[i:j, :]
+        batch_ys = test_y[i:j, :]
+        predicted_class[i:j] = sess.run(y_pred_cls, feed_dict={x: batch_xs, y: batch_ys})
+        i = j
+
+    correct = (np.argmax(test_y, axis=1) == predicted_class)
+    acc = correct.mean()*100
+    correct_numbers = correct.sum()
+    print("Accuracy on Test-Set: {0:.2f}% ({1} / {2})".format(acc, correct_numbers, len(test_x)))
+
+    if show_confusion_matrix is True:
+        cm = confusion_matrix(y_true=np.argmax(test_y, axis=1), y_pred=predicted_class)
+        for i in range(_CLASS_SIZE):
+            class_name = "({}) {}".format(i, test_l[i])
+            print(cm[i, :], class_name)
+        class_numbers = [" ({0})".format(i) for i in range(_CLASS_SIZE)]
+        print("".join(class_numbers))
+
+    return acc
+
+
+if _ITERATION != 0:
+    train(_ITERATION)
+
+
+sess.close()

--- a/examples/tensorflow/tensorflow-cifar-10/train.py
+++ b/examples/tensorflow/tensorflow-cifar-10/train.py
@@ -13,7 +13,8 @@ import quilt, quilt.vfs
 QUILT_PKG = 'asah/cifar10'
 
 print("Connecting to Quilt...")
-quilt.install(QUILT_PKG, force=True)
+# force=False because otherwise local data in storage is overwritten
+quilt.install(QUILT_PKG, force=False)
 
 print("   reading data from Quilt package: {}...".format(QUILT_PKG))
 quilt.vfs.setup(QUILT_PKG, mappings={'data_set/cifar_10':'data_set.cifar_10'})


### PR DESCRIPTION
* Export now uses exact filenames from original build
* Handle export when a non-GroupNode is specified (single-file export)
* Notify user when result includes no exportable files
* Test subpkg export, single-file export, filters, and mappers

Thanks to to akarve for letting me know that the original filenames were actually retained, and where.