### PR TITLE
[trivial] Update test_generate_buildfile, fix missing commas in setup.py

### DIFF
--- a/compiler/quilt/test/test_build.py
+++ b/compiler/quilt/test/test_build.py
@@ -50,10 +50,10 @@ class BuildTest(QuiltTestCase):
         srcpath = os.path.join(mydir, 'data/10KRows13Cols.csv')
         path_hash = build._path_hash(srcpath, 'csv', {})
         assert os.path.exists(teststore.cache_path(path_hash))
-        
+
         # Build again using the cache
         build.build_package('test_cache', PACKAGE, path)
-        
+
         # TODO load DFs based on contents of .yml file at PATH
         # not hardcoded vals (this will require loading modules from variable
         # names, probably using __module__)
@@ -121,7 +121,7 @@ class BuildTest(QuiltTestCase):
         build.build_package('groups', 'pkg', path)
 
         from quilt.data.groups import pkg
-        
+
         assert isinstance(pkg.group_a.csv(), DataFrame), \
             'Expected parent `transform: csv` to affect group_a.csv()'
         assert isinstance(pkg.group_a.tsv(), DataFrame), \
@@ -142,9 +142,9 @@ class BuildTest(QuiltTestCase):
         assert pkg.group_b.subgroup.many_tsv.one().shape == (1, 3), \
             'Expected local `transform: csv` and one skipped row from group args'
         assert isinstance(pkg.group_b.subgroup.many_tsv.two(), DataFrame), \
-            'Expected `transform: tsv` from ancestor' 
+            'Expected `transform: tsv` from ancestor'
         assert isinstance(pkg.group_b.subgroup.many_tsv.three(), DataFrame), \
-            'Expected `transform: tsv` from ancestor' 
+            'Expected `transform: tsv` from ancestor'
         assert not pkg.group_empty._keys(), 'Expected group_empty to be empty'
         assert not pkg.group_x.empty_child._keys(), 'Expected group_x.emptychild to be empty'
 
@@ -166,7 +166,7 @@ class BuildTest(QuiltTestCase):
         assert os.path.exists(buildfilepath)
         build.build_package('test_generated', 'generated', buildfilepath)
         os.remove(buildfilepath)
-        from quilt.data.test_generated.generated import bad, foo, nuts, README
+        from quilt.data.test_generated.generated import bad, foo, nuts, README_md
 
     def test_failover(self):
         """

--- a/compiler/setup.py
+++ b/compiler/setup.py
@@ -38,13 +38,13 @@ setup(
     keywords='quilt quiltdata shareable data dataframe package platform pandas',
     install_requires=[
         'appdirs>=1.4.0',
-        'backports.tempfile; python_version<"3.4"'   # stdlib backport
+        'backports.tempfile; python_version<"3.4"',   # stdlib backport
         'enum34; python_version<"3.4"',     # stdlib backport
-        'funcsigs; python_version<"3.4"'    # stdlib backport
+        'funcsigs; python_version<"3.4"',    # stdlib backport
         'future>=0.16.0',
         'packaging>=16.8',
         'pandas>=0.19.2',
-        'pathlib2; python_version<"3.4"'    # stdlib backport
+        'pathlib2; python_version<"3.4"',    # stdlib backport
         'pyarrow>=0.4.0,<0.8.0', # TODO(dima): Make unit tests work with 0.8.*.
         'pyOpenSSL>=16.2.0',  # Note: not actually used at the moment.
         'pyyaml>=3.12',


### PR DESCRIPTION
When a buildfile is generated, it now generates the name 'README_md' instead of 'README'.  Updated test.