### PR TITLE
Local store hack to avoid lots of code-rewrite

### DIFF
--- a/compiler/quilt/data.py
+++ b/compiler/quilt/data.py
@@ -114,7 +114,6 @@ class ModuleFinder(object):
                 if os.path.isdir(file_path):
                     return FakeLoader(file_path)
                 elif glob.glob("{path}:*".format(path=file_path)):
-                    print("Making Fake Loader: for team path")
                     return FakeLoader(glob.glob("{path}:*".format(path=file_path))[0])
                 else:
                     raise ImportError('Could not find any installed packages by user {user!r}.\n  '

--- a/compiler/quilt/data.py
+++ b/compiler/quilt/data.py
@@ -15,6 +15,7 @@ in ancestors of the current directory.
 """
 
 import imp
+import glob
 import os.path
 import sys
 
@@ -112,21 +113,45 @@ class ModuleFinder(object):
                 file_path = store.user_path(parts[0])
                 if os.path.isdir(file_path):
                     return FakeLoader(file_path)
+                elif glob.glob("{path}:*".format(path=file_path)):
+                    print("Making Fake Loader: for team path")
+                    return FakeLoader(glob.glob("{path}:*".format(path=file_path))[0])
                 else:
                     raise ImportError('Could not find any installed packages by user {user!r}.\n  '
                                       'Check the name, or use "quilt install {user}/<packagename>" to install'
                                       .format(user=parts[0]))
         elif len(parts) == 2:
+            # Try Default Case: Quilt Public Cloud Registry
             user, package = parts
-            pkgobj = PackageStore.find_package(user, package)
-            if pkgobj:
-                file_path = pkgobj.get_path()
-                return PackageLoader(file_path, pkgobj)
-            else:
-                raise ImportError('Could not find package by user {user!r} named {package!r}.\n  '
-                                  'Check the name, or use "quilt install {user}/{package}" to install'
-                                  .format(**locals()))
+            for store_dir in PackageStore.find_store_dirs():
+                store = PackageStore(store_dir)
+                pkgobj = PackageStore.find_package(user, package)
+                if pkgobj:
+                    file_path = pkgobj.get_path()
+                    return PackageLoader(file_path, pkgobj)
 
+                # Try A Team/Other-Registry Path
+                team, user = parts
+                file_path = store.user_path("{team}:{user}".format(team=parts[0], user=parts[1]))
+                if os.path.isdir(file_path):
+                    return FakeLoader(file_path)
+
+            raise ImportError('Could not find package by user {user!r} named {package!r}.\n  '
+                              'Check the name, or use "quilt install {user}/{package}" to install'
+                              .format(**locals()))
+        elif len(parts) == 3:
+            for store_dir in PackageStore.find_store_dirs():
+                store = PackageStore(store_dir)
+
+                team, user, package = parts
+                pkgobj = PackageStore.find_package("{team}:{user}".format(team=team, user=user), package)
+                if pkgobj:
+                    file_path = pkgobj.get_path()
+                    return PackageLoader(file_path, pkgobj)
+                else:
+                    raise ImportError('Could not find any installed packages by user {user!r}.\n  '
+                                      'Check the name, or use "quilt install {team}:{user}/<packagename>" to install'
+                                      .format(team=team, user=user))
         return None
 
 sys.meta_path.append(ModuleFinder)

--- a/compiler/quilt/tools/store.py
+++ b/compiler/quilt/tools/store.py
@@ -12,7 +12,7 @@ from .package import Package, PackageException
 from .util import BASE_DIR
 
 # start with alpha (_ may clobber attrs), continue with alphanumeric or _
-VALID_NAME_RE = re.compile(r'^[a-zA-Z]\w*$')
+VALID_NAME_RE = re.compile(r'^[a-zA-Z]\w*(:[a-zA-Z]\w*)?$')
 CHUNK_SIZE = 4096
 
 # Helper function to return the default package store path


### PR DESCRIPTION
Instead of adding an extra level in the local-store directory
hierarchy, which seems more solid, just prepend the package owner with
the registry/team.

Build and import is working.

To do:
- parse the team:owner/pkg syntax (might be some issue with overuse of
colon for both team and version info)
- connect to separate registries based on team