### PR TITLE
Point flask to a new endpoint for verifying users

### DIFF
--- a/registry/quilt_server/dev_config.py
+++ b/registry/quilt_server/dev_config.py
@@ -17,7 +17,7 @@ if AUTH_PROVIDER == 'quilt':
         client_id='chrOhbIPVtJAey7LcT1ez7PnIaV9tFLqNYXapcG3',
         client_secret=os.getenv('OAUTH_CLIENT_SECRET_QUILT', os.getenv('OAUTH_CLIENT_SECRET')),
         user_api='https://quilt-heroku.herokuapp.com/api-root',
-        profile_api='https://quilt-heroku.herokuapp.com/profiles/%s/',  # Trailing slash
+        profile_api='https://quilt-heroku.herokuapp.com/accounts/profile?user=%s',
         have_refresh_token=True,
     )
 elif AUTH_PROVIDER == 'github':

--- a/registry/quilt_server/docker_config.py
+++ b/registry/quilt_server/docker_config.py
@@ -16,7 +16,7 @@ if AUTH_PROVIDER == 'quilt':
         client_id='chrOhbIPVtJAey7LcT1ez7PnIaV9tFLqNYXapcG3',
         client_secret=os.getenv('OAUTH_CLIENT_SECRET'),
         user_api='http://auth:5002/api-root',
-        profile_api='http://auth:5002/profiles/%s/',
+        profile_api='http://auth:5002/accounts/profile?user=%s',
         have_refresh_token=True,
     )
 elif AUTH_PROVIDER == 'github':

--- a/registry/quilt_server/prod_config.py
+++ b/registry/quilt_server/prod_config.py
@@ -18,7 +18,7 @@ OAUTH = dict(
     client_secret=os.environ['OAUTH_CLIENT_SECRET'],
     redirect_url='https://%s/oauth_callback' % REGISTRY_HOST,
     user_api='https://%s/api-root' % OAUTH_API_HOST,
-    profile_api='https://%s/accounts/profile?user=%%s/' % OAUTH_API_HOST,
+    profile_api='https://%s/accounts/profile?user=%%s' % OAUTH_API_HOST,
     have_refresh_token=True
 )
 

--- a/registry/quilt_server/prod_config.py
+++ b/registry/quilt_server/prod_config.py
@@ -18,7 +18,7 @@ OAUTH = dict(
     client_secret=os.environ['OAUTH_CLIENT_SECRET'],
     redirect_url='https://%s/oauth_callback' % REGISTRY_HOST,
     user_api='https://%s/api-root' % OAUTH_API_HOST,
-    profile_api='https://%s/profiles/%%s/' % OAUTH_API_HOST,
+    profile_api='https://%s/accounts/profile?user=%%s/' % OAUTH_API_HOST,
     have_refresh_token=True
 )
 

--- a/registry/quilt_server/views.py
+++ b/registry/quilt_server/views.py
@@ -1045,7 +1045,7 @@ def access_put(owner, package_name, user):
             "Only the package owner can grant access"
         )
 
-    django_headers = {
+    auth_headers = {
         AUTHORIZATION_HEADER: g.auth_header
         }
 
@@ -1064,9 +1064,9 @@ def access_put(owner, package_name, user):
         db.session.add(invitation)
         db.session.commit()
 
-        # Call to Django to send invitation email        
+        # Call to Auth to send invitation email        
         resp = requests.post(INVITE_SEND_URL,
-                             headers=django_headers,
+                             headers=auth_headers,
                              data=dict(email=email,
                                        owner=g.auth.user,
                                        package=package.name,
@@ -1080,14 +1080,13 @@ def access_put(owner, package_name, user):
                 "Invalid credentials"
                 )
         elif resp.status_code != requests.codes.ok:
-            print(resp.text)
             raise ApiException(requests.codes.server_error, "Server error")
         return dict()
 
     else:
         if user != PUBLIC:
             resp = requests.get(OAUTH_PROFILE_API % user,
-                                headers=django_headers)
+                                headers=auth_headers)
             if resp.status_code == requests.codes.not_found:
                 raise ApiException(
                     requests.codes.not_found,

--- a/registry/quilt_server/views.py
+++ b/registry/quilt_server/views.py
@@ -1045,6 +1045,10 @@ def access_put(owner, package_name, user):
             "Only the package owner can grant access"
         )
 
+    django_headers = {
+        AUTHORIZATION_HEADER: g.auth_header
+        }
+
     package = (
         Package.query
         .with_for_update()
@@ -1060,12 +1064,9 @@ def access_put(owner, package_name, user):
         db.session.add(invitation)
         db.session.commit()
 
-        # Call to Django to send invitation email
-        headers = {
-            AUTHORIZATION_HEADER: g.auth_header
-            }
+        # Call to Django to send invitation email        
         resp = requests.post(INVITE_SEND_URL,
-                             headers=headers,
+                             headers=django_headers,
                              data=dict(email=email,
                                        owner=g.auth.user,
                                        package=package.name,
@@ -1079,12 +1080,14 @@ def access_put(owner, package_name, user):
                 "Invalid credentials"
                 )
         elif resp.status_code != requests.codes.ok:
+            print(resp.text)
             raise ApiException(requests.codes.server_error, "Server error")
         return dict()
 
     else:
         if user != PUBLIC:
-            resp = requests.get(OAUTH_PROFILE_API % user)
+            resp = requests.get(OAUTH_PROFILE_API % user,
+                                headers=django_headers)
             if resp.status_code == requests.codes.not_found:
                 raise ApiException(
                     requests.codes.not_found,


### PR DESCRIPTION
The old /profiles/<username> endpoint in Django was part of the
old-Quilt app and was disabled. Access add relied on that endpoint to
verify that users exist. This change uses a new user-verifying endpoint
in Django.