### PR TITLE
team demo -- bugfixes, tests for pkgname parsing and imports

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,4 +22,5 @@ cov_html/*
 *~
 [#]*
 
-
+# Pycharm
+.idea

--- a/compiler/quilt/test/test_cli.py
+++ b/compiler/quilt/test/test_cli.py
@@ -531,6 +531,51 @@ class TestCLI(BasicQuiltTestCase):
         assert not result['args']
         assert not result['kwargs']
 
+    def test_cli_command_login(self):
+        """Ensures the 'login' command calls a specific API"""
+        ## This test covers the following arguments that require testing
+        TESTED_PARAMS.extend([
+            [0, 'login'],
+            [0, 'login', 0],
+        ])
+
+        ## This section tests for circumstances expected to be rejected by argparse.
+        expect_fail_2_args = [
+            'login too many params'.split(),
+            ]
+        for args in expect_fail_2_args:
+            assert self.execute(args)['return code'] == 2, 'with args: ' + str(args)
+
+        ## This section tests for acceptable types and values.
+        # plain login
+        cmd = ['login']
+        result = self.execute(cmd)
+
+        # General tests
+        # TODO: update this to use _general_execute_tests once merged
+        assert result['return code'] == 0
+        assert result['matched'] is True  # func name recognized by MockObject class?
+        assert not result['bind failure']
+
+        # Specific tests
+        assert result['func'] == 'login'
+        assert not result['args']
+        assert result['kwargs']['team'] is None
+
+        # login with team name
+        cmd = ['login', 'example_team']
+        result = self.execute(cmd)
+
+        # General tests
+        assert result['return code'] == 0
+        assert result['matched'] is True  # func name recognized by MockObject class?
+        assert not result['bind failure']
+
+        # Specific tests
+        assert result['func'] == 'login'
+        assert not result['args']
+        assert result['kwargs']['team'] == 'example_team'
+
     def test_cli_command_push(self):
         ## This test covers the following arguments that require testing
         TESTED_PARAMS.extend([

--- a/compiler/quilt/test/test_cli.py
+++ b/compiler/quilt/test/test_cli.py
@@ -576,6 +576,51 @@ class TestCLI(BasicQuiltTestCase):
         assert not result['args']
         assert result['kwargs']['team'] == 'example_team'
 
+    def test_cli_command_logout(self):
+        """Ensures the 'login' command calls a specific API"""
+        ## This test covers the following arguments that require testing
+        TESTED_PARAMS.extend([
+            [0, 'logout'],
+            [0, 'logout', 0],
+        ])
+
+        ## This section tests for circumstances expected to be rejected by argparse.
+        expect_fail_2_args = [
+            'logout too many params'.split(),
+            ]
+        for args in expect_fail_2_args:
+            assert self.execute(args)['return code'] == 2, 'with args: ' + str(args)
+
+        ## This section tests for acceptable types and values.
+        # plain login
+        cmd = ['logout']
+        result = self.execute(cmd)
+
+        # General tests
+        # TODO: update this to use _general_execute_tests once merged
+        assert result['return code'] == 0
+        assert result['matched'] is True  # func name recognized by MockObject class?
+        assert not result['bind failure']
+
+        # Specific tests
+        assert result['func'] == 'logout'
+        assert not result['args']
+        assert result['kwargs']['team'] is None
+
+        # login with team name
+        cmd = ['logout', 'example_team']
+        result = self.execute(cmd)
+
+        # General tests
+        assert result['return code'] == 0
+        assert result['matched'] is True  # func name recognized by MockObject class?
+        assert not result['bind failure']
+
+        # Specific tests
+        assert result['func'] == 'logout'
+        assert not result['args']
+        assert result['kwargs']['team'] == 'example_team'
+
     def test_cli_command_push(self):
         ## This test covers the following arguments that require testing
         TESTED_PARAMS.extend([

--- a/compiler/quilt/test/test_cli.py
+++ b/compiler/quilt/test/test_cli.py
@@ -628,6 +628,7 @@ class TestCLI(BasicQuiltTestCase):
             [0, 'push', 0],
             [0, 'push', '--public'],
             [0, 'push', '--reupload'],
+            [0, 'push', '--team'],
         ])
 
         ## This section tests for circumstances expected to be rejected by argparse.
@@ -636,9 +637,11 @@ class TestCLI(BasicQuiltTestCase):
             'push --public'.split(),
             'push --reupload'.split(),
             'push --public --reupload'.split(),
+            'push --public --team'.split(),
+            'push --public --team fakeuser/fakepackage'.split(),  # mutually exclusive options
             ]
         for args in expect_fail_2_args:
-            assert self.execute(args)['return code'] == 2
+            assert self.execute(args)['return code'] == 2, "using args: " + str(args)
 
         ## This section tests for appropriate types and values.
         cmd = 'push fakeuser/fakepackage'.split()
@@ -652,11 +655,16 @@ class TestCLI(BasicQuiltTestCase):
         # Specific tests
         assert not result['args']
         assert result['func'] == 'push'
-        assert result['kwargs']['reupload'] is False
-        assert result['kwargs']['public'] is False
-        assert result['kwargs']['package'] == 'fakeuser/fakepackage'
+        kwargs = result['kwargs']
+        assert kwargs == {
+            'reupload': False,
+            'public': False,
+            'package': 'fakeuser/fakepackage',
+            'team': False,
+        }
 
         ## Test the flags as well..
+        # public (and reupload)
         cmd = 'push --reupload --public fakeuser/fakepackage'.split()
         result = self.execute(cmd)
 
@@ -668,9 +676,34 @@ class TestCLI(BasicQuiltTestCase):
         # Specific tests
         assert not result['args']
         assert result['func'] == 'push'
-        assert result['kwargs']['reupload'] is True
-        assert result['kwargs']['public'] is True
-        assert result['kwargs']['package'] == 'fakeuser/fakepackage'
+        kwargs = result['kwargs']
+        assert kwargs == {
+            'reupload': True,
+            'public': True,
+            'package': 'fakeuser/fakepackage',
+            'team': False,
+        }
+
+        # team (without reupload)
+        cmd = 'push --reupload --team blah:fakeuser/fakepackage'.split()
+        result = self.execute(cmd)
+
+        # General tests
+        assert result['return code'] == 0
+        assert result['matched'] is True  # func name recognized by MockObject class?
+        assert not result['bind failure']
+
+        # Specific tests
+        assert not result['args']
+        assert result['func'] == 'push'
+        kwargs = result['kwargs']
+        assert kwargs == {
+            'reupload': True,
+            'public': False,
+            'package': 'blah:fakeuser/fakepackage',
+            'team': True,
+        }
+
 
 
 @pytest.mark.xfail

--- a/compiler/quilt/test/test_command.py
+++ b/compiler/quilt/test/test_command.py
@@ -11,6 +11,7 @@ import requests
 import responses
 import shutil
 
+import pytest
 import pandas as pd
 from six import assertRaisesRegex
 
@@ -191,6 +192,24 @@ class CommandTest(QuiltTestCase):
         mock_open.assert_called_with('%s/login' % command.get_registry_url('foo'))
 
         mock_login_with_token.assert_called_with('foo', old_refresh_token)
+
+    @patch('quilt.tools.command._open_url')
+    @patch('quilt.tools.command.input')
+    @patch('quilt.tools.command.login_with_token')
+    def test_login_invalid_team(self, mock_login_with_token, mock_input, mock_open):
+        old_refresh_token = "123"
+
+        mock_input.return_value = old_refresh_token
+
+        with pytest.raises(command.CommandException, match='Invalid team name'):
+            command.login('fo!o')
+
+        assert not mock_open.called
+        assert not mock_login_with_token.called
+
+    def test_login_with_token_invalid_team(self):
+        with pytest.raises(command.CommandException, match='Invalid team name'):
+            command.login_with_token('fo!o', '123')
 
     @patch('quilt.tools.command._save_auth')
     def test_login_token(self, mock_save):

--- a/compiler/quilt/test/test_import.py
+++ b/compiler/quilt/test/test_import.py
@@ -186,26 +186,6 @@ class ImportTest(QuiltTestCase):
         # Imports should find the second package
         from quilt.data.foo.nested import dataframes
 
-    def test_team_multiple_package_dirs(self):
-        # First level
-        mydir = os.path.dirname(__file__)
-        build_path = os.path.join(mydir, './build_simple.yml')
-        command.build('test:bar/nested', build_path)
-
-        # Second level: different package
-        os.mkdir("aaa")
-        os.chdir("aaa")
-        build_path = os.path.join(mydir, './build.yml')
-        command.build('test:bar/nested', build_path)
-
-        # Third level: empty package directory
-        os.mkdir("bbb")
-        os.chdir("bbb")
-        os.mkdir(PACKAGE_DIR_NAME)
-
-        # Imports should find the second package
-        from quilt.data.test.bar.nested import dataframes
-
     def test_save(self):
         mydir = os.path.dirname(__file__)
         build_path = os.path.join(mydir, './build.yml')

--- a/compiler/quilt/test/test_import.py
+++ b/compiler/quilt/test/test_import.py
@@ -74,6 +74,65 @@ class ImportTest(QuiltTestCase):
         with self.assertRaises(ImportError):
             from quilt.data.foo.baz import blah
 
+    def test_team_imports(self):
+        mydir = os.path.dirname(__file__)
+        build_path = os.path.join(mydir, './build.yml')
+        command.build('test:bar/package', build_path)
+
+        # Good imports
+
+        from quilt.data.test.bar import package
+        from quilt.data.test.bar.package import dataframes
+        from quilt.data.test.bar.package import README
+
+        # Contents of the imports
+
+        assert isinstance(package, GroupNode)
+        assert isinstance(dataframes, GroupNode)
+        assert isinstance(dataframes.csv, DataNode)
+        assert isinstance(README, DataNode)
+
+        assert package.dataframes == dataframes
+        assert package.README == README
+
+        assert set(dataframes._keys()) == {'xls', 'csv', 'tsv', 'xls_skip', 'nulls'}
+        assert set(dataframes._group_keys()) == set()
+        assert set(dataframes._data_keys()) == {'xls', 'csv', 'tsv', 'xls_skip', 'nulls'}
+
+        assert isinstance(README(), string_types)
+        assert isinstance(README._data(), string_types)
+        assert isinstance(dataframes.csv(), pd.DataFrame)
+        assert isinstance(dataframes.csv._data(), pd.DataFrame)
+
+        str(package)
+        str(dataframes)
+        str(README)
+
+        # Bad attributes of imported packages
+
+        with self.assertRaises(AttributeError):
+            package.foo
+
+        with self.assertRaises(AttributeError):
+            package.dataframes.foo
+
+        with self.assertRaises(AttributeError):
+            package.dataframes.csv.foo
+
+        # Bad imports
+
+        with self.assertRaises(ImportError):
+            import quilt.data.test.bar.bad_package
+
+        with self.assertRaises(ImportError):
+            import quilt.data.test.bad_user.bad_package
+
+        with self.assertRaises(ImportError):
+            from quilt.data.test.bar.dataframes import blah
+
+        with self.assertRaises(ImportError):
+            from quilt.data.test.bar.baz import blah
+
     def test_import_group_as_data(self):
         mydir = os.path.dirname(__file__)
         build_path = os.path.join(mydir, './build_group_data.yml')
@@ -89,6 +148,23 @@ class ImportTest(QuiltTestCase):
         from quilt.data.foo.grppkg import incompatible
         with self.assertRaises(PackageException):
             incompatible._data()
+
+    def test_team_import_group_as_data(self):
+        mydir = os.path.dirname(__file__)
+        build_path = os.path.join(mydir, './build_group_data.yml')
+        command.build('test:bar/grppkg', build_path)
+
+        # Good imports
+        from quilt.data.test.bar.grppkg import dataframes
+        assert isinstance(dataframes, GroupNode)
+        assert isinstance(dataframes.csvs.csv, DataNode)
+        assert isinstance(dataframes._data(), pd.DataFrame)
+
+        # Incompatible Schema
+        from quilt.data.test.bar.grppkg import incompatible
+        with self.assertRaises(PackageException):
+            incompatible._data()
+
 
     def test_multiple_package_dirs(self):
         # First level
@@ -109,6 +185,26 @@ class ImportTest(QuiltTestCase):
 
         # Imports should find the second package
         from quilt.data.foo.nested import dataframes
+
+    def test_team_multiple_package_dirs(self):
+        # First level
+        mydir = os.path.dirname(__file__)
+        build_path = os.path.join(mydir, './build_simple.yml')
+        command.build('test:bar/nested', build_path)
+
+        # Second level: different package
+        os.mkdir("aaa")
+        os.chdir("aaa")
+        build_path = os.path.join(mydir, './build.yml')
+        command.build('test:bar/nested', build_path)
+
+        # Third level: empty package directory
+        os.mkdir("bbb")
+        os.chdir("bbb")
+        os.mkdir(PACKAGE_DIR_NAME)
+
+        # Imports should find the second package
+        from quilt.data.test.bar.nested import dataframes
 
     def test_save(self):
         mydir = os.path.dirname(__file__)
@@ -180,12 +276,95 @@ class ImportTest(QuiltTestCase):
         new_file = package3.new.file._data()
         assert isinstance(new_file, string_types)
 
+    def test_team_save(self):
+        mydir = os.path.dirname(__file__)
+        build_path = os.path.join(mydir, './build.yml')
+        command.build('test:bar/package1', build_path)
+
+        from quilt.data.test.bar import package1
+
+        # Build an identical package
+        command.build('test:bar/package2', package1)
+
+        from quilt.data.test.bar import package2
+        teststore = PackageStore(self._store_dir)
+        contents1 = open(os.path.join(teststore.package_path('test', 'bar', 'package1'),
+                                      Package.CONTENTS_DIR,
+                                      package1._package.get_hash())).read()
+        contents2 = open(os.path.join(teststore.package_path('test', 'bar', 'package2'),
+                                      Package.CONTENTS_DIR,
+                                      package2._package.get_hash())).read()
+        assert contents1 == contents2
+
+        # Rename an attribute
+        package1.dataframes2 = package1.dataframes
+        del package1.dataframes
+
+        # Modify an existing dataframe
+        csv = package1.dataframes2.csv._data()
+        csv.at[0, 'Int0'] = 42
+
+        # Add a new dataframe
+        df = pd.DataFrame(dict(a=[1, 2, 3]))
+        package1._set(['new', 'df'], df)
+        assert package1.new.df._data() is df
+
+        # Add a new file
+        file_path = os.path.join(mydir, 'data/foo.csv')
+        package1._set(['new', 'file'], file_path)
+        assert package1.new.file._data() == file_path
+
+        # Add a new group
+        package1._add_group('newgroup')
+        assert isinstance(package1.newgroup, GroupNode)
+        package1.newgroup._add_group('foo')
+        assert isinstance(package1.newgroup.foo, GroupNode)
+
+        # Overwrite a leaf node
+        new_path = os.path.join(mydir, 'data/nuts.csv')
+        package1._set(['newgroup', 'foo'], new_path)
+        assert package1.newgroup.foo._data() == new_path
+
+        # Overwrite the whole group
+        package1._set(['newgroup'], new_path)
+        assert package1.newgroup._data() == new_path
+
+        # Built a new package and verify the new contents
+        command.build('test:bar/package3', package1)
+
+        from quilt.data.test.bar import package3
+
+        assert hasattr(package3, 'dataframes2')
+        assert not hasattr(package3, 'dataframes')
+
+        new_csv = package3.dataframes2.csv._data()
+        assert new_csv.xs(0)['Int0'] == 42
+
+        new_df = package3.new.df._data()
+        assert new_df.xs(2)['a'] == 3
+
+        new_file = package3.new.file._data()
+        assert isinstance(new_file, string_types)
+
     def test_set_non_node_attr(self):
         mydir = os.path.dirname(__file__)
         build_path = os.path.join(mydir, './build.yml')
         command.build('foo/package4', build_path)
 
         from quilt.data.foo import package4
+
+        # Assign a DataFrame as a node
+        # (should throw exception)
+        df = pd.DataFrame(dict(a=[1, 2, 3]))
+        with self.assertRaises(AttributeError):
+            package4.newdf = df
+
+    def test_team_set_non_node_attr(self):
+        mydir = os.path.dirname(__file__)
+        build_path = os.path.join(mydir, './build.yml')
+        command.build('test:bar/package4', build_path)
+
+        from quilt.data.test.bar import package4
 
         # Assign a DataFrame as a node
         # (should throw exception)

--- a/compiler/quilt/test/test_store.py
+++ b/compiler/quilt/test/test_store.py
@@ -1,0 +1,60 @@
+"""
+Test store functions
+"""
+import pytest
+
+from ..tools import store
+from ..tools.command import CommandException
+from .utils import BasicQuiltTestCase
+
+
+class StoreTest(BasicQuiltTestCase):
+    def test_parse_package_names(self):
+        # good parse strings
+        expected = (None, 'user', 'package')
+        assert store.parse_package('user/package') == expected
+
+        expected = ('team', 'user', 'package')
+        assert store.parse_package('team:user/package') == expected
+
+        expected = (None, 'user', 'package', ['foo', 'bar'])
+        assert store.parse_package('user/package/foo/bar', True) == expected
+
+        expected = ('team', 'user', 'package', ['foo', 'bar'])
+        assert store.parse_package('team:user/package/foo/bar', True) == expected
+
+        expected = ('team', 'user', 'package', [])
+        assert store.parse_package('team:user/package', True) == expected
+
+        # bad parse strings
+        with pytest.raises(CommandException, message='subdir should be rejected'):
+            store.parse_package('user/package/subdir', allow_subpath=False)
+
+        with pytest.raises(CommandException, match="Invalid user name"):
+            store.parse_package('9user/package')
+
+        with pytest.raises(CommandException, match='Invalid package name'):
+            store.parse_package('user/!package')
+
+        with pytest.raises(CommandException, match='Invalid element in subpath'):
+            store.parse_package('user/package/&subdir', True)
+
+        with pytest.raises(CommandException, message='subdir should be rejected'):
+            store.parse_package('team:user/package/subdir', allow_subpath=False)
+
+        with pytest.raises(CommandException, match='Invalid team name'):
+            store.parse_package('team%:user/package/subdir', allow_subpath=True)
+
+        with pytest.raises(CommandException, match="Invalid user name"):
+            store.parse_package('team:9user/package')
+
+        with pytest.raises(CommandException, match='Invalid package name'):
+            store.parse_package('team:user/!package')
+
+        with pytest.raises(CommandException, match='Invalid element in subpath'):
+            store.parse_package('team:user/package/&subdir', True)
+
+        # XXX: in this case, should we just strip the trialing slash?
+        with pytest.raises(CommandException, match='Invalid element in subpath'):
+            store.parse_package('team:user/package/subdir/', True)
+

--- a/compiler/quilt/tools/command.py
+++ b/compiler/quilt/tools/command.py
@@ -37,7 +37,7 @@ from .core import (hash_contents, find_object_hashes, PackageFormat, TableNode, 
                    decode_node, encode_node, exec_yaml_python, CommandException, diff_dataframes,
                    load_yaml)
 from .hashing import digest_file
-from .store import PackageStore, parse_package, parse_package_extended
+from .store import PackageStore, parse_package, parse_package_extended, VALID_NAME_RE
 from .util import BASE_DIR, FileWithReadProgress, gzip_compress
 from . import check_functions as qc
 
@@ -89,6 +89,9 @@ def _save_config(cfg):
 
 def get_registry_url(team):
     if team is not None:
+        # TODO: use utils.is_nodename() once merged
+        if not VALID_NAME_RE.match(team):
+            raise CommandException("Invalid team name: %r" % team)
         return "https://%s-registry.team.quiltdata.com" % team
 
     global _registry_url

--- a/compiler/quilt/tools/command.py
+++ b/compiler/quilt/tools/command.py
@@ -842,7 +842,7 @@ def install_via_requirements(requirements_str, force=False):
     for pkginfo in yaml_data['packages']:
         owner, pkg, subpath, hash, version, tag = parse_package_extended(pkginfo)
         package = owner + '/' + pkg
-        if subpath is not None:
+        if subpath:
             package += '/' + "/".join(subpath)
         install(package, hash, version, tag, force=force)
 

--- a/compiler/quilt/tools/command.py
+++ b/compiler/quilt/tools/command.py
@@ -525,7 +525,7 @@ def build_from_path(package, path, dry_run=False, env='default', outfilename=DEF
             build_package(team, owner, pkg, path, dry_run=dry_run, env=env)
 
         if not dry_run:
-            print("Built %s/%s successfully." % (owner, pkg))
+            print("Built %s%s/%s successfully." % (team + ':' if team else '', owner, pkg))
     except BuildException as ex:
         raise CommandException("Failed to build the package: %s" % ex)
 

--- a/compiler/quilt/tools/command.py
+++ b/compiler/quilt/tools/command.py
@@ -456,11 +456,11 @@ def _build_internal(package, path, dry_run, env):
         build_from_node(package, path)
     elif path is None:
         assert not dry_run  # TODO?
-        build_empty(package)
+        _build_empty(package)
     else:
         raise ValueError("Expected a PackageNode, path or git URL, but got %r" % path)
 
-def build_empty(package):
+def _build_empty(package):
     """
     Create an empty package for convenient editing of de novo packages
     """

--- a/compiler/quilt/tools/main.py
+++ b/compiler/quilt/tools/main.py
@@ -106,12 +106,14 @@ def argument_parser():
 
     push_p = subparsers.add_parser("push", description="Push a data package to the server")
     push_p.add_argument("package", type=str, help=HANDLE)
-    push_p.add_argument("--public", action="store_true",
-                        help=("Create or update a public package " +
-                              "(fails if the package exists and is private)"))
-    push_p.add_argument("--team", action="store_true",
-                        help=("Create or update a team-visible package " +
-                              "(fails if the package exists and is private)"))
+    push_mutexgrp_container = push_p.add_argument_group('team selection options', "(mutually exclusive)")
+    push_mutexgrp = push_mutexgrp_container.add_mutually_exclusive_group()
+    push_mutexgrp.add_argument("--public", action="store_true",
+                               help=("Create or update a public package " +
+                                     "(fails if the package exists and is private)"))
+    push_mutexgrp.add_argument("--team", action="store_true",
+                               help=("Create or update a team-visible package " +
+                                     "(fails if the package exists and is private)"))
     push_p.add_argument("--reupload", action="store_true",
                         help="Re-upload all fragments, even if fragment is already in registry")
     push_p.set_defaults(func=command.push)

--- a/compiler/quilt/tools/store.py
+++ b/compiler/quilt/tools/store.py
@@ -103,13 +103,17 @@ class PackageStore(object):
         return None
 
     @classmethod
-    def check_name(cls, team, user, package):
+    def check_name(cls, team, user, package, subpath=None):
         if team is not None and not VALID_NAME_RE.match(team):
             raise StoreException("Invalid team name: %r" % team)
         if not VALID_NAME_RE.match(user):
             raise StoreException("Invalid user name: %r" % user)
         if not VALID_NAME_RE.match(package):
             raise StoreException("Invalid package name: %r" % package)
+        if subpath:
+            for element in subpath:
+                if not VALID_NAME_RE.match(element):
+                    raise StoreException("Invalid element in subpath: %r" % element)
 
     def _version_path(self):
         return os.path.join(self._path, '.format')
@@ -355,7 +359,7 @@ def parse_package(name, allow_subpath=False):
         raise CommandException("Specify package as %s." % pkg_format)
 
     try:
-        PackageStore.check_name(team, owner, pkg)
+        PackageStore.check_name(team, owner, pkg, subpath)
     except StoreException as ex:
         raise CommandException(str(ex))
 

--- a/compiler/quilt/tools/store.py
+++ b/compiler/quilt/tools/store.py
@@ -229,7 +229,9 @@ class PackageStore(object):
                             pkghash = tagfile.read()
                             pkgmap[pkghash].append(tag)
                     for pkghash, tags in pkgmap.items():
-                        fullpkg = "{owner}/{pkg}".format(owner=user, pkg=pkg)
+                        # add teams here if any other than DEFAULT_TEAM should be hidden.
+                        team_token = '' if team in (DEFAULT_TEAM,) else team + ':'
+                        fullpkg = "{team}{owner}/{pkg}".format(team=team_token, owner=user, pkg=pkg)
                         # Add an empty string tag for untagged hashes
                         displaytags = tags if tags else [""]
                         # Display a separate full line per tag like Docker


### PR DESCRIPTION
* extended `test_import.py` to include versions of each test, but with team designations.
  * provides coverage for `from quilt.data.team.user import pkg` and related actions.
  * very possibly overkill on this one, but it was straightforward to modify existing methods
* added `test_store.py` -- provides coverage for `store.parse_package()`

Discovered and squashed:
* `store.parse_package()` permitted bad subpath elements -- e.g.,` 'user/package/subpath/bad!subpath'`.  Fixed.
  * Brought to light a situation where a trailing slash was being generated incorrectly during testing.
* Traced rogue slash to an `is None` check in `command.install_via_requirements()` where a truthiness check was needed.  Fixed.

Also, there are some minor changes -- added team display for `quilt ls` and `quilt build` output, and _prefixed a private function in command.py.