### PR TITLE
Implement `quilt.team` imports

### DIFF
--- a/compiler/.pylintrc
+++ b/compiler/.pylintrc
@@ -191,7 +191,7 @@ notes=FIXME,XXX,TODO,qballs,QBALLS
 
 [TYPECHECK]
 
-ignored-modules=quilt.data
+ignored-modules=quilt.data,quilt.team
 
 # Tells whether missing members accessed in mixin class should be ignored. A
 # mixin class is detected if its name ends with "mixin" (case insensitive).

--- a/compiler/quilt/imports.py
+++ b/compiler/quilt/imports.py
@@ -1,0 +1,130 @@
+"""
+Implementation of imports from `quilt.data` and `quilt.team`.
+
+E.g.:
+  import quilt.data.$user.$package as $package
+  print $package.$table
+or
+  from quilt.data.$user.$package import $table
+  print $table
+"""
+
+import imp
+import os.path
+import sys
+
+from six import iteritems
+
+from .nodes import DataNode, GroupNode, PackageNode
+from .tools import core
+from .tools.store import PackageStore
+
+
+class FakeLoader(object):
+    """
+    Fake module loader used to create intermediate user and package modules.
+    """
+    def __init__(self, path):
+        self._path = path
+
+    def load_module(self, fullname):
+        """
+        Returns an empty module.
+        """
+        mod = sys.modules.setdefault(fullname, imp.new_module(fullname))
+        mod.__file__ = self._path
+        mod.__loader__ = self
+        mod.__path__ = []
+        mod.__package__ = fullname
+        return mod
+
+
+def _from_core_node(package, core_node):
+    if isinstance(core_node, core.TableNode) or isinstance(core_node, core.FileNode):
+        node = DataNode(package, core_node)
+    else:
+        if isinstance(core_node, core.RootNode):
+            node = PackageNode(package, core_node)
+        elif isinstance(core_node, core.GroupNode):
+            node = GroupNode(package, core_node)
+        else:
+            assert "Unexpected node: %r" % core_node
+
+        for name, core_child in iteritems(core_node.children):
+            child = _from_core_node(package, core_child)
+            setattr(node, name, child)
+
+    return node
+
+
+class PackageLoader(object):
+    """
+    Module loader for Quilt tables.
+    """
+    def __init__(self, package):
+        self._package = package
+
+    def load_module(self, fullname):
+        """
+        Returns an object that lazily looks up tables and groups.
+        """
+        mod = sys.modules.get(fullname)
+        if mod is not None:
+            return mod
+
+        # We're creating an object rather than a module. It's a hack, but it's approved by Guido:
+        # https://mail.python.org/pipermail/python-ideas/2012-May/014969.html
+
+        mod = _from_core_node(self._package, self._package.get_contents())
+        sys.modules[fullname] = mod
+        return mod
+
+
+class ModuleFinder(object):
+    def __init__(self, module, teams):
+        self._module_name = module
+        self._teams = teams
+
+    """
+    Looks up submodules.
+    """
+    def find_module(self, fullname, path=None):
+        """
+        Looks up the table based on the module path.
+        """
+        if not fullname.startswith(self._module_name + '.'):
+            # Not a quilt submodule.
+            return None
+
+        submodule = fullname[len(self._module_name) + 1:]
+        parts = submodule.split('.')
+
+        # Pop the team prefix if this is a team import.
+        if self._teams:
+            team = parts.pop(0)
+        else:
+            team = None
+
+        # Handle full paths first.
+        if len(parts) == 2:
+            pkg = PackageStore.find_package(team, parts[0], parts[1])
+            if pkg is not None:
+                return PackageLoader(pkg)
+            else:
+                return None
+
+        # Return fake loaders for partial paths.
+        for store_dir in PackageStore.find_store_dirs():
+            store = PackageStore(store_dir)
+
+            if len(parts) == 0:
+                assert self._teams
+                path = store.team_path(team)
+            elif len(parts) == 1:
+                path = store.user_path(team, parts[0])
+
+            if os.path.isdir(path):
+                return FakeLoader(path)
+
+        # Nothing is found.
+        return None

--- a/compiler/quilt/team.py
+++ b/compiler/quilt/team.py
@@ -1,5 +1,5 @@
 """
-Magic imports for `quilt.data`
+Magic imports for `quilt.team`
 """
 
 import sys
@@ -9,4 +9,4 @@ from .imports import ModuleFinder
 __path__ = []  # Required for submodules to work
 
 
-sys.meta_path.append(ModuleFinder(__name__, False))
+sys.meta_path.append(ModuleFinder(__name__, True))

--- a/compiler/quilt/test/test_import.py
+++ b/compiler/quilt/test/test_import.py
@@ -7,7 +7,7 @@ import os
 import pandas as pd
 from six import string_types
 
-from quilt.data import GroupNode, DataNode
+from quilt.nodes import GroupNode, DataNode
 from quilt.tools import command
 from quilt.tools.const import PACKAGE_DIR_NAME
 from quilt.tools.package import Package, PackageException
@@ -192,3 +192,18 @@ class ImportTest(QuiltTestCase):
         df = pd.DataFrame(dict(a=[1, 2, 3]))
         with self.assertRaises(AttributeError):
             package4.newdf = df
+
+    def test_team_imports(self):
+        mydir = os.path.dirname(__file__)
+        build_path1 = os.path.join(mydir, './build_simple.yml')
+        command.build('my_team:foo/bar', build_path1)
+        build_path2 = os.path.join(mydir, './build_empty.yml')
+        command.build('foo/bar', build_path2)
+
+        # Verify that both imports work, and packages are in fact different.
+
+        from quilt.team.my_team.foo import bar as bar1
+        from quilt.data.foo import bar as bar2
+
+        assert hasattr(bar1, 'foo')
+        assert not hasattr(bar2, 'foo')

--- a/compiler/quilt/test/test_import.py
+++ b/compiler/quilt/test/test_import.py
@@ -196,14 +196,14 @@ class ImportTest(QuiltTestCase):
     def test_team_imports(self):
         mydir = os.path.dirname(__file__)
         build_path1 = os.path.join(mydir, './build_simple.yml')
-        command.build('my_team:foo/bar', build_path1)
+        command.build('my_team:foo/team_imports', build_path1)
         build_path2 = os.path.join(mydir, './build_empty.yml')
-        command.build('foo/bar', build_path2)
+        command.build('foo/team_imports', build_path2)
 
         # Verify that both imports work, and packages are in fact different.
 
-        from quilt.team.my_team.foo import bar as bar1
-        from quilt.data.foo import bar as bar2
+        from quilt.team.my_team.foo import team_imports as pkg1
+        from quilt.data.foo import team_imports as pkg2
 
-        assert hasattr(bar1, 'foo')
-        assert not hasattr(bar2, 'foo')
+        assert hasattr(pkg1, 'foo')
+        assert not hasattr(pkg2, 'foo')


### PR DESCRIPTION
- Refactor the magic imports and use the code for both `quilt.data` and `quilt.team`
- Don't raise `ImportError`s when failing to find a package: that's not actually allowed. Just return `None`.