### PR TITLE
Fix `quilt ls`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@ dist
 *.py[cod]
 tmp_*
 
+node_modules
 quilt_packages
 metastore_db
 derby.log

--- a/compiler/quilt/test/.ipynb_checkpoints/Untitled-checkpoint.ipynb
+++ b/compiler/quilt/test/.ipynb_checkpoints/Untitled-checkpoint.ipynb
@@ -1,0 +1,6 @@
+{
+ "cells": [],
+ "metadata": {},
+ "nbformat": 4,
+ "nbformat_minor": 2
+}

--- a/compiler/quilt/test/.ipynb_checkpoints/Untitled-checkpoint.ipynb
+++ b/compiler/quilt/test/.ipynb_checkpoints/Untitled-checkpoint.ipynb
@@ -1,6 +1,0 @@
-{
- "cells": [],
- "metadata": {},
- "nbformat": 4,
- "nbformat_minor": 2
-}

--- a/compiler/quilt/test/test_util.py
+++ b/compiler/quilt/test/test_util.py
@@ -1,0 +1,46 @@
+"""
+Tests for quilt.tools.util
+"""
+
+import os
+
+from .utils import QuiltTestCase
+from ..tools.util import children
+
+class UtilTest(QuiltTestCase):
+    def test_children(self):
+        mydir = os.path.dirname(__file__)
+        path = os.path.join(mydir, './files')
+        everything = os.listdir(path)
+
+        allvisible = children(path, dirs=True, files=True)
+        # ensure invisible files are not returned by default
+
+        for f in allvisible:
+            assert not f.startswith('.'), 'Expected only visible files'
+
+        visiblefiles = children(path, dirs=False, files=True, noinvisible=True)
+        for f in visiblefiles:
+            assert os.path.isfile(os.path.join(path, f)), 'Expected only files'
+            assert not f.startswith('.'), 'Expected only visible files'
+
+        visiblefiles = children(path, dirs=False, files=True, noinvisible=True)
+        for f in visiblefiles:
+            assert os.path.isfile(os.path.join(path, f)), 'Expected only files'
+            assert not f.startswith('.'), 'Expected only visible files'
+
+        allfiles = children(path, dirs=False, files=True, noinvisible=False)
+        for f in allfiles:
+            assert os.path.isfile(os.path.join(path, f)), 'Expected only files'
+
+        visibledirs = children(path, dirs=True, files=False, noinvisible=True)
+        for d in visibledirs:
+            assert os.path.isdir(os.path.join(path, d)), 'Expected only dirs'
+            assert not d.startswith('.'), 'Expected only visible dirs'
+
+        alldirs = children(path, dirs=True, files=False, noinvisible=True)
+        for d in alldirs:
+            assert os.path.isdir(os.path.join(path, d)), 'Expected only dirs'
+
+        assert set(everything) == set(children(path, files=True, dirs=True, noinvisible=False)), \
+            'Expected same results as os.listdir (files, dirs, visible, and invisible' 

--- a/compiler/quilt/tools/store.py
+++ b/compiler/quilt/tools/store.py
@@ -9,7 +9,7 @@ from shutil import rmtree
 from .const import PACKAGE_DIR_NAME
 from .core import FileNode, RootNode, TableNode, CommandException
 from .package import Package, PackageException
-from .util import BASE_DIR
+from .util import BASE_DIR, sub_dirs
 
 # start with alpha (_ may clobber attrs), continue with alphanumeric or _
 VALID_NAME_RE = re.compile(r'^[a-zA-Z]\w*$')
@@ -205,7 +205,7 @@ class PackageStore(object):
         Return an iterator over all the packages in the PackageStore.
         """
         pkgdir = os.path.join(self._path, self.PKG_DIR)
-        for user in os.listdir(pkgdir):
+        for user in sub_dirs(pkgdir):
             for pkg in os.listdir(os.path.join(pkgdir, user)):
                 pkgpath = os.path.join(pkgdir, user, pkg)
                 for hsh in os.listdir(os.path.join(pkgpath, Package.CONTENTS_DIR)):
@@ -217,8 +217,8 @@ class PackageStore(object):
         """
         packages = []
         pkgdir = os.path.join(self._path, self.PKG_DIR)
-        for user in os.listdir(pkgdir):
-            for pkg in os.listdir(os.path.join(pkgdir, user)):
+        for user in sub_dirs(pkgdir):
+            for pkg in sub_dirs(os.path.join(pkgdir, user)):
                 pkgpath = os.path.join(pkgdir, user, pkg)           
                 pkgmap = {h : [] for h in os.listdir(os.path.join(pkgpath, Package.CONTENTS_DIR))}
                 for tag in os.listdir(os.path.join(pkgpath, Package.TAGS_DIR)):

--- a/compiler/quilt/tools/store.py
+++ b/compiler/quilt/tools/store.py
@@ -9,7 +9,7 @@ from shutil import rmtree
 from .const import PACKAGE_DIR_NAME
 from .core import FileNode, RootNode, TableNode, CommandException
 from .package import Package, PackageException
-from .util import BASE_DIR, sub_dirs
+from .util import BASE_DIR, children
 
 # start with alpha (_ may clobber attrs), continue with alphanumeric or _
 VALID_NAME_RE = re.compile(r'^[a-zA-Z]\w*$')
@@ -186,6 +186,7 @@ class PackageStore(object):
 
         path = self.package_path(user, package)
         remove_objs = set()
+        # TODO: do we really want to delete invisible dirs? consider using children()
         if os.path.isdir(path):
             # Collect objects from all instances for potential cleanup
             contents_path = os.path.join(path, Package.CONTENTS_DIR)
@@ -205,10 +206,10 @@ class PackageStore(object):
         Return an iterator over all the packages in the PackageStore.
         """
         pkgdir = os.path.join(self._path, self.PKG_DIR)
-        for user in sub_dirs(pkgdir):
-            for pkg in os.listdir(os.path.join(pkgdir, user)):
+        for user in children(pkgdir, files=False):
+            for pkg in children(os.path.join(pkgdir, user), files=False):
                 pkgpath = os.path.join(pkgdir, user, pkg)
-                for hsh in os.listdir(os.path.join(pkgpath, Package.CONTENTS_DIR)):
+                for hsh in children(os.path.join(pkgpath, Package.CONTENTS_DIR), dirs=False):
                     yield Package(self, user, pkg, pkgpath, pkghash=hsh)
 
     def ls_packages(self):
@@ -217,11 +218,11 @@ class PackageStore(object):
         """
         packages = []
         pkgdir = os.path.join(self._path, self.PKG_DIR)
-        for user in sub_dirs(pkgdir):
-            for pkg in sub_dirs(os.path.join(pkgdir, user)):
+        for user in children(pkgdir, files=False):
+            for pkg in children(os.path.join(pkgdir, user), files=False):
                 pkgpath = os.path.join(pkgdir, user, pkg)           
-                pkgmap = {h : [] for h in os.listdir(os.path.join(pkgpath, Package.CONTENTS_DIR))}
-                for tag in os.listdir(os.path.join(pkgpath, Package.TAGS_DIR)):
+                pkgmap = { h : [] for h in children(os.path.join(pkgpath, Package.CONTENTS_DIR), dirs=False) }
+                for tag in children(os.path.join(pkgpath, Package.TAGS_DIR), dirs=False):
                     with open(os.path.join(pkgpath, Package.TAGS_DIR, tag), 'r') as tagfile:
                         pkghash = tagfile.read()
                         pkgmap[pkghash].append(tag)

--- a/compiler/quilt/tools/util.py
+++ b/compiler/quilt/tools/util.py
@@ -82,9 +82,10 @@ def gzip_compress(data):
         fd.write(data)
     return buf.getvalue()
 
-def sub_dirs(path):
+def sub_dirs(path, visible=True):
     """
     Enumerate sub-directories.
     Used to avoid descending files (e.g. .DS_Store on Mac OS X)
     """
-    return [x for x in os.listdir(path) if os.path.isdir(os.path.join(path, x))]
+    subs = [x for x in os.listdir(path) if os.path.isdir(os.path.join(path, x))]
+    return subs if not visible else [x for x in subs if not x.startswith('.')]

--- a/compiler/quilt/tools/util.py
+++ b/compiler/quilt/tools/util.py
@@ -1,8 +1,8 @@
 """
 Helper functions.
 """
-
 import gzip
+import os
 
 from appdirs import user_config_dir, user_data_dir
 from six import BytesIO, string_types, Iterator
@@ -81,3 +81,10 @@ def gzip_compress(data):
     with gzip.GzipFile(fileobj=buf, mode='wb') as fd:
         fd.write(data)
     return buf.getvalue()
+
+def sub_dirs(path):
+    """
+    Enumerate sub-directories.
+    Used to avoid descending files (e.g. .DS_Store on Mac OS X)
+    """
+    return [x for x in os.listdir(path) if os.path.isdir(os.path.join(path, x))]

--- a/compiler/quilt/tools/util.py
+++ b/compiler/quilt/tools/util.py
@@ -82,10 +82,19 @@ def gzip_compress(data):
         fd.write(data)
     return buf.getvalue()
 
-def sub_dirs(path, visible=True):
+def children(path, dirs=True, files=True, noinvisible=True):
     """
-    Enumerate sub-directories.
-    Used to avoid descending files (e.g. .DS_Store on Mac OS X)
+    Return children of a given path
+    dirs=True => include dirs
+    files=True => include files
+    invisible=True => include files that do begin with .
     """
-    subs = [x for x in os.listdir(path) if os.path.isdir(os.path.join(path, x))]
-    return subs if not visible else [x for x in subs if not x.startswith('.')]
+    matches = os.listdir(path)
+    if noinvisible:
+        matches = filter(lambda x: not x.startswith('.'), matches)
+    if not dirs:
+        matches = filter(lambda x: not os.path.isdir(os.path.join(path, x)), matches)
+    if not files:
+        matches = filter(lambda x: not os.path.isfile(os.path.join(path, x)), matches)
+
+    return matches


### PR DESCRIPTION
Only descend directories (instead of files, like `.DS_Store` on Mac OS).