### PR TITLE
Disallow simultaneous public cloud and team logins.

### DIFF
--- a/compiler/quilt/test/test_cli.py
+++ b/compiler/quilt/test/test_cli.py
@@ -164,7 +164,6 @@ KNOWN_PARAMS = [
     [0, 'login'],
     [0, 'login', 0],
     [0, 'logout'],
-    [0, 'logout', 0],
     [0, 'ls'],
     [0, 'push'],
     [0, 'push', '--public'],
@@ -626,7 +625,6 @@ class TestCLI(BasicQuiltTestCase):
         ## This test covers the following arguments that require testing
         TESTED_PARAMS.extend([
             [0, 'logout'],
-            [0, 'logout', 0],
         ])
 
         ## This section tests for circumstances expected to be rejected by argparse.
@@ -637,7 +635,6 @@ class TestCLI(BasicQuiltTestCase):
             assert self.execute(args)['return code'] == 2, 'with args: ' + str(args)
 
         ## This section tests for acceptable types and values.
-        # plain login
         cmd = ['logout']
         result = self.execute(cmd)
 
@@ -650,21 +647,6 @@ class TestCLI(BasicQuiltTestCase):
         # Specific tests
         assert result['func'] == 'logout'
         assert not result['args']
-        assert result['kwargs']['team'] is None
-
-        # login with team name
-        cmd = ['logout', 'example_team']
-        result = self.execute(cmd)
-
-        # General tests
-        assert result['return code'] == 0
-        assert result['matched'] is True  # func name recognized by MockObject class?
-        assert not result['bind failure']
-
-        # Specific tests
-        assert result['func'] == 'logout'
-        assert not result['args']
-        assert result['kwargs']['team'] == 'example_team'
 
     def test_cli_command_push(self):
         ## This test covers the following arguments that require testing

--- a/compiler/quilt/test/test_command.py
+++ b/compiler/quilt/test/test_command.py
@@ -233,11 +233,14 @@ class CommandTest(QuiltTestCase):
 
         assert self.requests_mock.calls[0].request.body == "refresh_token=%s" % old_refresh_token
 
-        mock_save.assert_called_with(None, dict(
-            refresh_token=refresh_token,
-            access_token=access_token,
-            expires_at=expires_at
-        ))
+        mock_save.assert_called_with({
+            command.get_registry_url(None): dict(
+                team=None,
+                refresh_token=refresh_token,
+                access_token=access_token,
+                expires_at=expires_at
+            )
+        })
 
     @patch('quilt.tools.command._save_auth')
     def test_login_token_server_error(self, mock_save):
@@ -266,6 +269,54 @@ class CommandTest(QuiltTestCase):
         with self.assertRaises(command.CommandException):
             command.login_with_token(None, "123")
 
+        mock_save.assert_not_called()
+
+    @patch('quilt.tools.command._save_auth')
+    @patch('quilt.tools.command._load_auth')
+    @patch('quilt.tools.command._open_url')
+    @patch('quilt.tools.command.input', lambda x: '')
+    @patch('quilt.tools.command.login_with_token', lambda x, y: None)
+    def test_login_not_allowed(self, mock_open, mock_load, mock_save):
+        # Already logged is as a public user.
+        mock_load.return_value = {
+            command.get_registry_url(None): dict(
+                team=None
+            )
+        }
+
+        # Normal login is ok.
+        command.login(None)
+        mock_open.reset_mock()
+        mock_save.reset_mock()
+
+        # Team login is not allowed.
+        with self.assertRaises(command.CommandException):
+            command.login('foo')
+
+        mock_open.assert_not_called()
+        mock_save.assert_not_called()
+
+        # Already logged is as a team user.
+        mock_load.return_value = {
+            command.get_registry_url('foo'): dict(
+                team='foo'
+            )
+        }
+
+        # Normal login is not allowed.
+        with self.assertRaises(command.CommandException):
+            command.login(None)
+
+        # Login as 'foo' is ok.
+        command.login('foo')
+        mock_open.reset_mock()
+        mock_save.reset_mock()
+
+        # Login as a different team is not allowed.
+        with self.assertRaises(command.CommandException):
+            command.login('bar')
+
+        mock_open.assert_not_called()
         mock_save.assert_not_called()
 
     def test_ls(self):

--- a/compiler/quilt/test/utils.py
+++ b/compiler/quilt/test/utils.py
@@ -41,7 +41,7 @@ class QuiltTestCase(BasicQuiltTestCase):
     def setUp(self):
         super(QuiltTestCase, self).setUp()
 
-        self.auth_patcher = patch('quilt.tools.command._create_auth', lambda team: None)
+        self.auth_patcher = patch('quilt.tools.command._load_auth', lambda: {})
         self.auth_patcher.start()
 
         self._store_dir = os.path.join(self._test_dir, PACKAGE_DIR_NAME)

--- a/compiler/quilt/tools/command.py
+++ b/compiler/quilt/tools/command.py
@@ -12,7 +12,6 @@ import json
 import os
 import re
 from shutil import copyfileobj, move, rmtree
-import stat
 import subprocess
 import sys
 import tempfile
@@ -26,7 +25,7 @@ import pkg_resources
 import requests
 from requests.packages.urllib3.util.retry import Retry
 from requests.adapters import HTTPAdapter
-from six import iteritems, string_types
+from six import iteritems, itervalues, string_types
 from six.moves.urllib.parse import urlparse, urlunparse
 from tqdm import tqdm
 
@@ -87,6 +86,24 @@ def _save_config(cfg):
     with open(config_path, 'w') as fd:
         json.dump(cfg, fd)
 
+def _load_auth():
+    auth_path = os.path.join(BASE_DIR, 'auth.json')
+    if os.path.exists(auth_path):
+        with open(auth_path) as fd:
+            auth = json.load(fd)
+            if 'access_token' in auth:
+                # Old format; ignore it.
+                auth = {}
+            return auth
+    return {}
+
+def _save_auth(cfg):
+    if not os.path.exists(BASE_DIR):
+        os.makedirs(BASE_DIR)
+    auth_path = os.path.join(BASE_DIR, 'auth.json')
+    with open(auth_path, 'w') as fd:
+        json.dump(cfg, fd)
+
 def get_registry_url(team):
     if team is not None:
         # TODO: use utils.is_nodename() once merged
@@ -130,16 +147,6 @@ def config():
     global _registry_url
     _registry_url = None
 
-def get_auth_path(team):
-    url = get_registry_url(team)
-    if url == DEFAULT_REGISTRY_URL:
-        suffix = ''
-    else:
-        # Store different servers' auth in different files.
-        suffix = "-%.8s" % hashlib.md5(url.encode('utf-8')).hexdigest()
-
-    return os.path.join(BASE_DIR, 'auth%s.json' % suffix)
-
 def _update_auth(team, refresh_token):
     response = requests.post("%s/api/token" % get_registry_url(team), data=dict(
         refresh_token=refresh_token
@@ -154,19 +161,11 @@ def _update_auth(team, refresh_token):
         raise CommandException("Failed to log in: %s" % error)
 
     return dict(
+        team=team,
         refresh_token=data['refresh_token'],
         access_token=data['access_token'],
         expires_at=data['expires_at']
     )
-
-def _save_auth(team, auth):
-    if not os.path.exists(BASE_DIR):
-        os.makedirs(BASE_DIR)
-
-    file_path = get_auth_path(team)
-    with open(file_path, 'w') as fd:
-        os.chmod(file_path, stat.S_IRUSR | stat.S_IWUSR)
-        json.dump(auth, fd)
 
 def _handle_response(resp, **kwargs):
     _ = kwargs                  # unused    pylint:disable=W0613
@@ -183,11 +182,11 @@ def _create_auth(team):
     """
     Reads the credentials, updates the access token if necessary, and returns it.
     """
-    file_path = get_auth_path(team)
-    if os.path.exists(file_path):
-        with open(file_path) as fd:
-            auth = json.load(fd)
+    url = get_registry_url(team)
+    contents = _load_auth()
+    auth = contents.get(url)
 
+    if auth is not None:
         # If the access token expires within a minute, update it.
         if auth['expires_at'] < time.time() + 60:
             try:
@@ -196,11 +195,8 @@ def _create_auth(team):
                 raise CommandException(
                     "Failed to update the access token (%s). Run `quilt login` again." % ex
                 )
-            _save_auth(team, auth)
-    else:
-        # The auth file doesn't exist, probably because the
-        # user hasn't run quilt login yet.
-        auth = None
+            contents[url] = auth
+            _save_auth(contents)
 
     return auth
 
@@ -301,6 +297,22 @@ def _match_hash(session, team, owner, pkg, hash):
             .format(**locals()))
     raise CommandException("Invalid hash for package {owner}/{pkg}: {hash}".format(**locals()))
 
+def _check_team_login(team):
+    """
+    Disallow simultaneous public cloud and team logins.
+    """
+    contents = _load_auth()
+
+    for auth in itervalues(contents):
+        existing_team = auth.get('team')
+        if team and team != existing_team:
+            raise CommandException(
+                "Can't log in as team %r; log out first." % team
+            )
+        elif not team and existing_team:
+            raise CommandException(
+                "Can't log in as a public user; log out from team %r first." % existing_team
+            )
 
 def login(team=None):
     """
@@ -308,6 +320,8 @@ def login(team=None):
 
     Launches a web browser and asks the user for a token.
     """
+    _check_team_login(team)
+
     login_url = "%s/login" % get_registry_url(team)
 
     print("Launching a web browser...")
@@ -327,22 +341,25 @@ def login_with_token(team, refresh_token):
     # Get an access token and a new refresh token.
     auth = _update_auth(team, refresh_token)
 
-    _save_auth(team, auth)
+    url = get_registry_url(team)
+    contents = _load_auth()
+    contents[url] = auth
+    _save_auth(contents)
 
     _clear_session(team)
 
-def logout(team=None):
+def logout():
     """
     Become anonymous. Useful for testing.
     """
-    auth_file = get_auth_path(team)
     # TODO revoke refresh token (without logging out of web sessions)
-    if os.path.exists(auth_file):
-        os.remove(auth_file)
+    if _load_auth():
+        _save_auth({})
     else:
         print("Already logged out.")
 
-    _clear_session(team)
+    global _sessions            # pylint:disable=C0103
+    _sessions = {}
 
 def generate(directory, outfilename=DEFAULT_BUILDFILE):
     """

--- a/compiler/quilt/tools/command.py
+++ b/compiler/quilt/tools/command.py
@@ -12,6 +12,7 @@ import json
 import os
 import re
 from shutil import copyfileobj, move, rmtree
+import stat
 import subprocess
 import sys
 import tempfile
@@ -102,6 +103,7 @@ def _save_auth(cfg):
         os.makedirs(BASE_DIR)
     auth_path = os.path.join(BASE_DIR, 'auth.json')
     with open(auth_path, 'w') as fd:
+        os.chmod(auth_path, stat.S_IRUSR | stat.S_IWUSR)
         json.dump(cfg, fd)
 
 def get_registry_url(team):

--- a/compiler/quilt/tools/main.py
+++ b/compiler/quilt/tools/main.py
@@ -188,7 +188,6 @@ def argument_parser():
     # quilt logout
     shorthelp = "Log out of current Quilt server"
     logout_p = subparsers.add_parser("logout", description=shorthelp, help=shorthelp)
-    logout_p.add_argument("team", type=str, nargs='?', help="Specify team to log out from")
     logout_p.set_defaults(func=command.logout)
 
     # quilt ls


### PR DESCRIPTION
- Store all auth info in a single file rather than file per registry
- Remove the "team" parameter from the logout command
- Check for a conflicting auth state before starting the login flow

The logic is not meant to be foolproof since nothing stops the user from messing with auth directly.