### PR TITLE
Improve help output

### DIFF
--- a/compiler/quilt/test/test_cli.py
+++ b/compiler/quilt/test/test_cli.py
@@ -96,6 +96,7 @@ from time import sleep
 from subprocess import check_output, CalledProcessError, Popen, PIPE
 
 import pytest
+from six import string_types
 
 from ..tools.const import EXIT_KB_INTERRUPT
 from .utils import BasicQuiltTestCase
@@ -623,7 +624,8 @@ class TestCLI(BasicQuiltTestCase):
         assert result['kwargs']['public'] is True
         assert result['kwargs']['package'] == 'fakeuser/fakepackage'
 
-    def test_cli_option_dev(self):
+    def test_cli_option_dev_flag(self):
+        # also test ctrl-c
         if os.name == 'nt':
             pytest.xfail("This test causes appveyor to freeze in windows.")
 
@@ -670,6 +672,80 @@ class TestCLI(BasicQuiltTestCase):
         assert 'Traceback (most recent call last)' in stderr
         # Return code should be the generic exit code '1' for unhandled exception
         assert proc.returncode == 1
+
+
+
+# need capsys, so this isn't in the unittest class
+def test_cli_command_in_help(capsys):
+    """Tests for inclusion in 'help'
+
+    Only tests the base subcommand, not sub-subcommands.
+    """
+    TESTED_PARAMS.append(['--version'])
+
+    from quilt.tools.main import main
+
+    expected_params = set()
+    hidden_params = set()
+    expected_optionals = set()
+    hidden_optionals = {'--dev'}
+
+    for argpath in KNOWN_PARAMS:
+        if len(argpath) == 1:
+            if isinstance(argpath[0], string_types):
+                assert argpath[0].startswith('-'),  "bug in test, not in tested code"
+                expected_optionals.add(argpath[0])
+            continue
+        if isinstance(argpath[1], string_types):
+            expected_params.add(argpath[1])
+
+    try:
+        main(['help'])
+    except SystemExit:
+        pass
+
+    outerr = capsys.readouterr()
+    lines = outerr.out.split('\n')
+
+    for pos, line in enumerate(lines):
+        if line.strip() == '<subcommand>':
+            start = pos + 1
+
+    found_params = []
+    for pos, line in enumerate(lines[start:]):
+        print(line)
+        if line.strip() == "optional arguments:":
+            print("stopping (optionals)")
+            start = pos + 1
+            break
+        splitline = line.split(None, 1)
+        if not splitline:
+            print('skipped (splitline)')
+            continue
+        if line[4] == ' ':  # skip multiline help text
+            print('skipped (char 4)')
+            continue
+        arg = splitline[0]
+        found_params.append(arg)
+
+    assert found_params == sorted(found_params), 'Help params should be sorted properly'
+    assert set(found_params) | hidden_params == expected_params, 'Found params do not match expected params'
+
+    found_optionals = []
+    for line in lines[start:]:
+        splitline = line.split(None, 1)   # ignore second optional form if present (--help, -h)
+        if not splitline:
+            continue
+        optional = splitline[0].rstrip(',')
+        if not optional.startswith('-'):
+            continue
+        print(optional)
+        if optional in ['--help', '-h']:
+            continue
+        found_optionals.append(optional)
+
+    assert found_optionals == sorted(found_optionals)
+    assert set(found_optionals) | hidden_optionals == expected_optionals
 
 
 @pytest.mark.xfail

--- a/compiler/quilt/tools/main.py
+++ b/compiler/quilt/tools/main.py
@@ -43,15 +43,6 @@ class UsageAction(argparse.Action):
         parser.print_usage()
         exit()
 
-#
-# class SubcommandHelpFormatter(argparse.RawDescriptionHelpFormatter):
-#     """Avoid showing the"""
-#     def _format_action(self, action):
-#         parts = super(argparse.RawDescriptionHelpFormatter, self)._format_action(action)
-#         if action.nargs == argparse.PARSER:
-#             parts = "\n".join(parts.split("\n")[1:])
-#         return parts
-#
 
 class CustomHelpParser(argparse.ArgumentParser):
     def __init__(self, *args, **kwargs):

--- a/compiler/quilt/tools/main.py
+++ b/compiler/quilt/tools/main.py
@@ -43,14 +43,29 @@ class UsageAction(argparse.Action):
         parser.print_usage()
         exit()
 
+#
+# class SubcommandHelpFormatter(argparse.RawDescriptionHelpFormatter):
+#     """Avoid showing the"""
+#     def _format_action(self, action):
+#         parts = super(argparse.RawDescriptionHelpFormatter, self)._format_action(action)
+#         if action.nargs == argparse.PARSER:
+#             parts = "\n".join(parts.split("\n")[1:])
+#         return parts
+#
 
 class CustomHelpParser(argparse.ArgumentParser):
     def __init__(self, *args, **kwargs):
         full_help_only = kwargs.pop('full_help_only', False)
+        helpcommand = kwargs.pop('helpcommand', False)
+
         kwargs['add_help'] = False
         super(CustomHelpParser, self).__init__(*args, **kwargs)
         if full_help_only:
-            self.add_argument('-h', '--help', action='help', help="Show help")
+            self.add_argument('--help', '-h', action='help', help="Show help")
+        elif helpcommand:
+            self.add_argument('--help', action='help', help="Show this message")
+            self.add_argument('-h', action=UsageAction, help="Show short help (usage) for the 'help' command",
+                              nargs=0, default=argparse.SUPPRESS)
         else:
             self.add_argument('--help', action='help', help="Show full help for given command")
             self.add_argument('-h', action=UsageAction, help="Show short help (usage) for given command",
@@ -63,100 +78,95 @@ def argument_parser():
         return (hashstr if 6 <= len(hashstr) <= 64 else
                 group.error('hashes must be 6-64 chars long'))
 
-    parser = CustomHelpParser(description="Quilt Command Line", add_help=False, full_help_only=True)
-
+    parser = CustomHelpParser(description="Quilt Command Line", add_help=False, full_help_only=True,)
     parser.add_argument('--version', action='version', version=get_full_version(),
                         help="Show version number and exit")
 
     # Hidden option '--dev' for development
     parser.add_argument('--dev', action='store_true', help=argparse.SUPPRESS)
 
-    subparsers = parser.add_subparsers(title="Commands", dest='cmd')
+    subparsers = parser.add_subparsers(metavar="<subcommand>")
     subparsers.required = True
 
-    help_p = subparsers.add_parser("help", description="Show help for any given Quilt command",
-                                   add_help=False)
-    help_p.add_argument('command', nargs="*", help="Optional -- any Quilt command")
-    help_p.set_defaults(func=lambda command: parser.parse_args(command + ['--help']))
 
-    config_p = subparsers.add_parser("config", description="Configure Quilt")
-    config_p.set_defaults(func=command.config)
+    ## Note for `add_parser()` parameters:
+    #   `description` can be long-form help.
+    #   `help` is short help, listed in the base `quilt help` view.
 
-    login_p = subparsers.add_parser("login", description="Log in to configured Quilt server")
-    login_p.set_defaults(func=command.login)
+    # quilt access
+    shorthelp = "List, add, or remove who has access to a given package"
+    access_p = subparsers.add_parser("access", description=shorthelp, help=shorthelp)
+    access_subparsers = access_p.add_subparsers(title="Access", dest='subcommand')
+    access_subparsers.required = True
 
-    logout_p = subparsers.add_parser("logout", description="Log out of current Quilt server")
-    logout_p.set_defaults(func=command.logout)
+    # quilt access add
+    shorthelp = "Allow a user to access a package"
+    access_add_p = access_subparsers.add_parser("add", description=shorthelp, help=shorthelp)
+    access_add_p.add_argument("package", type=str, help=HANDLE)
+    access_add_p.add_argument("user", type=str, help="User to add")
+    access_add_p.set_defaults(func=command.access_add)
 
-    log_p = subparsers.add_parser("log", description="Show log for a specified package")
-    log_p.add_argument("package", type=str, help=HANDLE)
-    log_p.set_defaults(func=command.log)
+    # quilt access list
+    shorthelp = "List who has access to a given package"
+    access_list_p = access_subparsers.add_parser("list", description=shorthelp, help=shorthelp)
+    access_list_p.add_argument("package", type=str, help=HANDLE)
+    access_list_p.set_defaults(func=command.access_list)
 
-    generate_p = subparsers.add_parser("generate",
-        description="Generate a build-file for Quilt build from a directory of build files")
-    generate_p.add_argument("directory", help="Source file directory")
-    generate_p.set_defaults(func=command.generate)
+    # quilt access remove
+    shorthelp = "Remove a user's access to a package"
+    access_remove_p = access_subparsers.add_parser("remove", description=shorthelp, help=shorthelp)
+    access_remove_p.add_argument("package", type=str, help=HANDLE)
+    access_remove_p.add_argument("user", type=str, help="User to remove")
+    access_remove_p.set_defaults(func=command.access_remove)
 
-    build_p = subparsers.add_parser("build",
-        description="Compile a Quilt data package from directory or YAML file")
+    # quilt build
+    shorthelp = "Compile a Quilt data package from directory or YAML file"
+    build_p = subparsers.add_parser("build", description=shorthelp, help=shorthelp)
     build_p.add_argument("package", type=str, help=HANDLE)
     build_p.add_argument("path", type=str, help="Path to source directory or YAML file")
     build_p.set_defaults(func=command.build)
 
-    check_p = subparsers.add_parser("check", description="Execute checks for a given build")
+    # quilt check
+    shorthelp = "Execute checks for a given build"
+    check_p = subparsers.add_parser("check", description=shorthelp, help=shorthelp)
     check_p.add_argument("path", nargs="?", type=str, help="Path to source directory or YAML file")
     check_p.add_argument("--env", type=str, help="use which environment (default=default)")
     check_p.set_defaults(func=command.check)
 
-    push_p = subparsers.add_parser("push", description="Push a data package to the server")
-    push_p.add_argument("package", type=str, help=HANDLE)
-    push_p.add_argument("--public", action="store_true",
-                        help=("Create or update a public package " +
-                              "(fails if the package exists and is private)"))
-    push_p.add_argument("--reupload", action="store_true",
-                        help="Re-upload all fragments, even if fragment is already in registry")
-    push_p.set_defaults(func=command.push)
+    # quilt config
+    shorthelp = "Configure Quilt"
+    config_p = subparsers.add_parser("config", description=shorthelp, help=shorthelp)
+    config_p.set_defaults(func=command.config)
 
-    version_p = subparsers.add_parser("version",
-        description="List or permanently add a package version to the server")
-    version_subparsers = version_p.add_subparsers(title="version", dest='cmd')
-    version_subparsers.required = True
+    # quilt delete
+    shorthelp = "Delete the package (and all of its history) from the server"
+    delete_p = subparsers.add_parser("delete", description=shorthelp, help=shorthelp)
+    delete_p.add_argument("package", type=str, help="Owner/Package Name")
+    delete_p.set_defaults(func=command.delete)
 
-    version_list_p = version_subparsers.add_parser("list",
-        description="List versions of package on the server")
-    version_list_p.add_argument("package", type=str, help=HANDLE)
-    version_list_p.set_defaults(func=command.version_list)
+    # quilt generate
+    shorthelp = "Generate a build-file for Quilt build from a directory of build files"
+    generate_p = subparsers.add_parser("generate", description=shorthelp, help=shorthelp)
+    generate_p.add_argument("directory", help="Source file directory")
+    generate_p.set_defaults(func=command.generate)
 
-    version_add_p = version_subparsers.add_parser("add",
-        description="Permanently add a version of a package to the server")
-    version_add_p.add_argument("package", type=str, help=HANDLE)
-    version_add_p.add_argument("version", type=str, help="Version")
-    version_add_p.add_argument("pkghash", type=str, help="Package hash")
-    version_add_p.set_defaults(func=command.version_add)
+    # quilt help
+    shorthelp = "Show help for any given Quilt command"
+    help_p = subparsers.add_parser("help", description=shorthelp, help=shorthelp, add_help=False, helpcommand=True)
+    help_p.add_argument('subcommand', nargs="*", help="Optional -- any Quilt subcommand")
+    help_p.set_defaults(func=lambda subcommand=[]: parser.parse_args(subcommand + ['--help']))
 
-    tag_p = subparsers.add_parser("tag", description="List, add, or remove tags for a package on the server")
-    tag_subparsers = tag_p.add_subparsers(title="Tag", dest='cmd')
-    tag_subparsers.required = True
+    # quilt inspect
+    shorthelp = "Inspect package details"
+    inspect_p = subparsers.add_parser("inspect", description=shorthelp, help=shorthelp)
+    inspect_p.add_argument("package", type=str, help=HANDLE)
+    inspect_p.set_defaults(func=command.inspect)
 
-    tag_list_p = tag_subparsers.add_parser("list", description="List tags for a given package on the server")
-    tag_list_p.add_argument("package", type=str, help=HANDLE)
-    tag_list_p.set_defaults(func=command.tag_list)
+    # quilt install
+    shorthelp = "Install a package from the server"
+    install_p = subparsers.add_parser("install", description=shorthelp, help=shorthelp)
 
-    tag_add_p = tag_subparsers.add_parser("add",
-        description="Add a new tag to the server for the given package hash")
-    tag_add_p.add_argument("package", type=str, help=HANDLE)
-    tag_add_p.add_argument("tag", type=str, help="Tag name")
-    tag_add_p.add_argument("pkghash", type=str, help="Package hash")
-    tag_add_p.set_defaults(func=command.tag_add)
-
-    tag_remove_p = tag_subparsers.add_parser("remove", description="Remove a tag from the server")
-    tag_remove_p.add_argument("package", type=str, help=HANDLE)
-    tag_remove_p.add_argument("tag", type=str, help="Tag name")
-    tag_remove_p.set_defaults(func=command.tag_remove)
-
-    install_p = subparsers.add_parser("install", description="Install a package from the server")
-
-    # When default quilt yml file is present, don't require the 'package' argument.
+    # quilt install: When default quilt yml file is present, don't require the 'package' argument.
     pkg_help = ("owner/package_name[/path/...] or @filename (defaults to @{} when present)"
                 .format(DEFAULT_QUILT_YML))
     if os.path.exists(DEFAULT_QUILT_YML):
@@ -166,51 +176,103 @@ def argument_parser():
 
     install_p.set_defaults(func=command.install)
     install_p.add_argument("-f", "--force", action="store_true", help="Overwrite without prompting")
-    install_group = install_p.add_mutually_exclusive_group()
-    install_group.add_argument("-x", "--hash", help="Package hash", type=str)
-    install_group.add_argument("-v", "--version", type=str, help="Package version")
-    install_group.add_argument("-t", "--tag", type=str, help="Package tag - defaults to 'latest'")
+    # not a threading mutex, obv.
+    install_mutex_group = install_p.add_mutually_exclusive_group()
+    install_mutex_group.add_argument("-x", "--hash", help="Package hash", type=str)
+    install_mutex_group.add_argument("-v", "--version", type=str, help="Package version")
+    install_mutex_group.add_argument("-t", "--tag", type=str, help="Package tag - defaults to 'latest'")
 
-    access_p = subparsers.add_parser("access",
-        description="List, add, or remove who has access to a given package")
-    access_subparsers = access_p.add_subparsers(title="Access", dest='cmd')
-    access_subparsers.required = True
+    # quilt log
+    shorthelp = "Show log for a specified package"
+    log_p = subparsers.add_parser("log", description=shorthelp, help=shorthelp)
+    log_p.add_argument("package", type=str, help=HANDLE)
+    log_p.set_defaults(func=command.log)
 
-    access_list_p = access_subparsers.add_parser("list", description="List who has access to a given package")
-    access_list_p.add_argument("package", type=str, help=HANDLE)
-    access_list_p.set_defaults(func=command.access_list)
+    # quilt login
+    shorthelp = "Log in to configured Quilt server"
+    login_p = subparsers.add_parser("login", description=shorthelp, help=shorthelp)
+    login_p.set_defaults(func=command.login)
 
-    access_add_p = access_subparsers.add_parser("add", description="Allow a user to access a package")
-    access_add_p.add_argument("package", type=str, help=HANDLE)
-    access_add_p.add_argument("user", type=str, help="User to add")
-    access_add_p.set_defaults(func=command.access_add)
+    # quilt logout
+    shorthelp = "Log out of current Quilt server"
+    logout_p = subparsers.add_parser("logout", description=shorthelp, help=shorthelp)
+    logout_p.set_defaults(func=command.logout)
 
-    access_remove_p = access_subparsers.add_parser("remove",
-       description="Remove a user's access to a package")
-    access_remove_p.add_argument("package", type=str, help=HANDLE)
-    access_remove_p.add_argument("user", type=str, help="User to remove")
-    access_remove_p.set_defaults(func=command.access_remove)
-
-    delete_p = subparsers.add_parser(
-        "delete", description="Delete the package (including all of its history) from the server")
-    delete_p.add_argument("package", type=str, help="Owner/Package Name")
-    delete_p.set_defaults(func=command.delete)
-
-    search_p = subparsers.add_parser("search", description="Search for a package on the server")
-    search_p.add_argument("query", type=str, help="Search query (max 5 keywords)")
-    search_p.set_defaults(func=command.search)
-
-    ls_p = subparsers.add_parser("ls", description="List locally-installed packages")
+    # quilt ls
+    shorthelp = "List locally-installed packages"
+    ls_p = subparsers.add_parser("ls", description=shorthelp, help=shorthelp)
     ls_p.set_defaults(func=command.ls)
 
-    inspect_p = subparsers.add_parser("inspect", description="Inspect package details")
-    inspect_p.add_argument("package", type=str, help=HANDLE)
-    inspect_p.set_defaults(func=command.inspect)
+    # quilt push
+    shorthelp = "Push a data package to the server"
+    push_p = subparsers.add_parser("push", description=shorthelp, help=shorthelp)
+    push_p.add_argument("package", type=str, help=HANDLE)
+    push_p.add_argument("--public", action="store_true",
+                        help=("Create or update a public package " +
+                              "(fails if the package exists and is private)"))
+    push_p.add_argument("--reupload", action="store_true",
+                        help="Re-upload all fragments, even if fragment is already in registry")
+    push_p.set_defaults(func=command.push)
 
-    rm_p = subparsers.add_parser("rm")
+    # quilt rm
+    shorthelp = "Remove a package locally"
+    rm_p = subparsers.add_parser("rm", description=shorthelp, help=shorthelp)
     rm_p.add_argument("package", type=str, help=HANDLE)
     rm_p.add_argument("-f", "--force", action="store_true", help="Remove without prompting")
     rm_p.set_defaults(func=command.rm)
+
+    # quilt search
+    shorthelp = "Search for a package on the server"
+    search_p = subparsers.add_parser("search", description=shorthelp, help=shorthelp)
+    search_p.add_argument("query", type=str, help="Search query (max 5 keywords)")
+    search_p.set_defaults(func=command.search)
+
+    # quilt tag
+    shorthelp = "List, add, or remove tags for a package on the server"
+    tag_p = subparsers.add_parser("tag", description=shorthelp, help=shorthelp)
+    tag_subparsers = tag_p.add_subparsers(dest='subcommand', metavar="<subcommand>")
+    tag_subparsers.required = True
+
+    # quilt tag add
+    shorthelp = "Add a new tag to the server for the given package hash"
+    tag_add_p = tag_subparsers.add_parser("add", description=shorthelp, help=shorthelp)
+    tag_add_p.add_argument("package", type=str, help=HANDLE)
+    tag_add_p.add_argument("tag", type=str, help="Tag name")
+    tag_add_p.add_argument("pkghash", type=str, help="Package hash")
+    tag_add_p.set_defaults(func=command.tag_add)
+
+    # quilt tag list
+    shorthelp = "List tags for a given package on the server"
+    tag_list_p = tag_subparsers.add_parser("list", description=shorthelp, help=shorthelp)
+    tag_list_p.add_argument("package", type=str, help=HANDLE)
+    tag_list_p.set_defaults(func=command.tag_list)
+
+    # quilt tag remove
+    shorthelp = "Remove a tag from the server"
+    tag_remove_p = tag_subparsers.add_parser("remove", description=shorthelp, help=shorthelp)
+    tag_remove_p.add_argument("package", type=str, help=HANDLE)
+    tag_remove_p.add_argument("tag", type=str, help="Tag name")
+    tag_remove_p.set_defaults(func=command.tag_remove)
+
+    # quilt version
+    shorthelp = "List or permanently add a package version to the server"
+    version_p = subparsers.add_parser("version", description=shorthelp, help=shorthelp)
+    version_subparsers = version_p.add_subparsers(dest='subcommand', metavar="<subcommand>")
+    version_subparsers.required = True
+
+    # quilt version add
+    shorthelp = "Permanently add a version of a package to the server"
+    version_add_p = version_subparsers.add_parser("add", description=shorthelp, help=shorthelp)
+    version_add_p.add_argument("package", type=str, help=HANDLE)
+    version_add_p.add_argument("version", type=str, help="Version")
+    version_add_p.add_argument("pkghash", type=str, help="Package hash")
+    version_add_p.set_defaults(func=command.version_add)
+
+    # quilt version list
+    shorthelp = "List versions of package on the server"
+    version_list_p = version_subparsers.add_parser("list", description=shorthelp, help=shorthelp)
+    version_list_p.add_argument("package", type=str, help=HANDLE)
+    version_list_p.set_defaults(func=command.version_list)
 
     return parser
 
@@ -223,10 +285,13 @@ def main(args=None):
     parser = argument_parser()
     args = parser.parse_args(args)
 
+    # If 'func' isn't present, something is misconfigured above or no (positional) arg was given.
+    if not hasattr(args, 'func'):
+        args = parser.parse_args(['help'])  # show help
+
     # Convert argparse.Namespace into dict and clean it up.
     # We can then pass it directly to the helper function.
     kwargs = vars(args)
-    del kwargs['cmd']
 
     # handle the '--dev' option
     if kwargs.pop('dev') or os.environ.get('QUILT_DEV_MODE', '').strip().lower() == 'true':


### PR DESCRIPTION
Help has a few issues that got mentioned in a conversation with @akarve the other day.  I did some quick improvements on it today -- though, there are a lot of changes in the file due to reorg (output is sorted by when the command was made, not alphabetically).  This includes a test to make sure that the root help output per-option is sorted lexicographically, and that new root options exist in the help output.

Old output:
```
usage: quilt [-h] [--version]
             {help,config,login,logout,log,generate,build,check,push,version,tag,install,access,delete,search,ls,inspect,rm}
             ...

Quilt Command Line

optional arguments:
  -h, --help            Show help
  --version             Show version number and exit

Commands:
  {help,config,login,logout,log,generate,build,check,push,version,tag,install,access,delete,search,ls,inspect,rm}
```

New output:
```
usage: quilt [--help] [--version] <subcommand> ...

Quilt Command Line

positional arguments:
  <subcommand>
    access      List, add, or remove who has access to a given package
    build       Compile a Quilt data package from directory or YAML file
    check       Execute checks for a given build
    config      Configure Quilt
    delete      Delete the package (and all of its history) from the server
    generate    Generate a build-file for Quilt build from a directory of
                build files
    help        Show help for any given Quilt command
    inspect     Inspect package details
    install     Install a package from the server
    log         Show log for a specified package
    login       Log in to configured Quilt server
    logout      Log out of current Quilt server
    ls          List locally-installed packages
    push        Push a data package to the server
    rm          Remove a package locally
    search      Search for a package on the server
    tag         List, add, or remove tags for a package on the server
    version     List or permanently add a package version to the server

optional arguments:
  --help, -h    Show help
  --version     Show version number and exit
```
  