### PR TITLE
Change the auth client ID to just "packages" in dev and docker configs

### DIFF
--- a/registry/docker-compose-local-auth.yml
+++ b/registry/docker-compose-local-auth.yml
@@ -35,7 +35,7 @@ services:
       - AWS_ACCESS_KEY_ID=ddccbbaa
       - AWS_SECRET_ACCESS_KEY=abcd
       - QUILT_SERVER_CONFIG=docker_config.py
-      - OAUTH_CLIENT_ID=QUILTPKGS
+      - OAUTH_CLIENT_ID=packages
       - OAUTH_CLIENT_SECRET=TESTING
       - OAUTHLIB_INSECURE_TRANSPORT=1
       - AUTH_PROVIDER=quilt
@@ -96,7 +96,7 @@ services:
     environment:
       - DATABASE_URL=postgres://postgres:testing@db/packages
       - OAUTH_REDIRECT_URI=http://flask:5000/oauth_callback
-      - OAUTH_CLIENT_ID=QUILTPKGS
+      - OAUTH_CLIENT_ID=packages
       - OAUTH_CLIENT_SECRET=TESTING
     depends_on:
       db:

--- a/registry/quilt_server/dev_config.py
+++ b/registry/quilt_server/dev_config.py
@@ -14,7 +14,7 @@ if AUTH_PROVIDER == 'quilt':
     OAUTH = dict(
         access_token_url='https://quilt-heroku.herokuapp.com/o/token/',
         authorize_url='https://quilt-heroku.herokuapp.com/o/authorize/',
-        client_id='chrOhbIPVtJAey7LcT1ez7PnIaV9tFLqNYXapcG3',
+        client_id='packages',
         client_secret=os.getenv('OAUTH_CLIENT_SECRET_QUILT', os.getenv('OAUTH_CLIENT_SECRET')),
         user_api='https://quilt-heroku.herokuapp.com/api-root',
         profile_api='https://quilt-heroku.herokuapp.com/accounts/profile?user=%s',


### PR DESCRIPTION
This also matches the ID in the CloudFormation config - making everything more consistent.