### PR TITLE
Fix access, tag, and version commands

### DIFF
--- a/compiler/quilt/tools/main.py
+++ b/compiler/quilt/tools/main.py
@@ -87,7 +87,7 @@ def argument_parser():
     # quilt access
     shorthelp = "List, add, or remove who has access to a given package"
     access_p = subparsers.add_parser("access", description=shorthelp, help=shorthelp)
-    access_subparsers = access_p.add_subparsers(title="Access", dest='subcommand')
+    access_subparsers = access_p.add_subparsers(title="Access")
     access_subparsers.required = True
 
     # quilt access add
@@ -227,7 +227,7 @@ def argument_parser():
     # quilt tag
     shorthelp = "List, add, or remove tags for a package on the server"
     tag_p = subparsers.add_parser("tag", description=shorthelp, help=shorthelp)
-    tag_subparsers = tag_p.add_subparsers(dest='subcommand', metavar="<subcommand>")
+    tag_subparsers = tag_p.add_subparsers(metavar="<subcommand>")
     tag_subparsers.required = True
 
     # quilt tag add
@@ -254,7 +254,7 @@ def argument_parser():
     # quilt version
     shorthelp = "List or permanently add a package version to the server"
     version_p = subparsers.add_parser("version", description=shorthelp, help=shorthelp)
-    version_subparsers = version_p.add_subparsers(dest='subcommand', metavar="<subcommand>")
+    version_subparsers = version_p.add_subparsers(metavar="<subcommand>")
     version_subparsers.required = True
 
     # quilt version add


### PR DESCRIPTION
Drop the `dest='subcommand'`; it's not needed, but causes breakage