### PR TITLE
Make dev catalog talk to dev registry instead of stage

### DIFF
--- a/catalog/static/config.js
+++ b/catalog/static/config.js
@@ -8,7 +8,7 @@ if (window.location.hostname === 'quiltdata.com') {
   };
 } else {
   window.__CONFIG = {
-    api: 'https://pkg-stage.quiltdata.com',
+    api: window.location.hostname === 'localhost' ? 'http://localhost:5000' : 'https://pkg-stage.quiltdata.com',
     stripeKey: 'pk_test_DzvjoWzXwIB1DRtQqywxDjWp',
 
     // Quilt auth


### PR DESCRIPTION
Right now, the registry has no concept of "the catalog URL" simply because stage registry supports both stage catalog and dev catalog. This prevents us from doing things like:
- Giving the CLI a link to a newly-pushed package
- Linking to the catalog in oauth success/failure page

Now that it's easier to bring up a dev environment using docker-compose, we should drop support for dev catalog with stage registry.