### PR TITLE
Fix yml team based packages and add tests

### DIFF
--- a/compiler/quilt/test/test_command.py
+++ b/compiler/quilt/test/test_command.py
@@ -654,53 +654,53 @@ class CommandTest(QuiltTestCase):
     def test_parse_package_extended_names(self):
         # good parse strings
         expected = ('user/package', None, None, None)
-        assert store.parse_package_extended('user/package') == expected
+        assert command.parse_package_extended('user/package') == expected
 
         expected = ('team:user/package', None, None, None)
-        assert store.parse_package_extended('team:user/package') == expected
+        assert command.parse_package_extended('team:user/package') == expected
 
         expected = ('team:user/package/sub/path', None, None, None)
-        assert store.parse_package_extended('team:user/package/sub/path') == expected
+        assert command.parse_package_extended('team:user/package/sub/path') == expected
 
         expected = ('user/package', 'abc123', None, None)
-        assert store.parse_package_extended('user/package:h:abc123') == expected
+        assert command.parse_package_extended('user/package:h:abc123') == expected
 
         expected = ('user/package', 'abc123', None, None)
-        assert store.parse_package_extended('user/package:hash:abc123') == expected
+        assert command.parse_package_extended('user/package:hash:abc123') == expected
 
         expected = ('user/package', None, '123', None)
-        assert store.parse_package_extended('user/package:v:123') == expected
+        assert command.parse_package_extended('user/package:v:123') == expected
 
         expected = ('user/package', None, '123', None)
-        assert store.parse_package_extended('user/package:version:123') == expected
+        assert command.parse_package_extended('user/package:version:123') == expected
 
         expected = ('user/package', None, None, 'some')
-        assert store.parse_package_extended('user/package:t:some') == expected
+        assert command.parse_package_extended('user/package:t:some') == expected
 
         expected = ('user/package', None, None, 'some')
-        assert store.parse_package_extended('user/package:tag:some') == expected
+        assert command.parse_package_extended('user/package:tag:some') == expected
 
         expected = ('team:user/package', 'abc123', None, None)
-        assert store.parse_package_extended('team:user/package:h:abc123') == expected
+        assert command.parse_package_extended('team:user/package:h:abc123') == expected
 
         expected = ('team:user/package', 'abc123', None, None)
-        assert store.parse_package_extended('team:user/package:hash:abc123') == expected
+        assert command.parse_package_extended('team:user/package:hash:abc123') == expected
 
         expected = ('team:user/package', None, '123', None)
-        assert store.parse_package_extended('team:user/package:v:123') == expected
+        assert command.parse_package_extended('team:user/package:v:123') == expected
 
         expected = ('team:user/package', None, '123', None)
-        assert store.parse_package_extended('team:user/package:version:123') == expected
+        assert command.parse_package_extended('team:user/package:version:123') == expected
 
         expected = ('team:user/package', None, None, 'some')
-        assert store.parse_package_extended('team:user/package:t:some') == expected
+        assert command.parse_package_extended('team:user/package:t:some') == expected
 
         expected = ('team:user/package', None, None, 'some')
-        assert store.parse_package_extended('team:user/package:tag:some') == expected
+        assert command.parse_package_extended('team:user/package:tag:some') == expected
 
         # bad parse strings
         with pytest.raises(CommandException, match='Invalid versioninfo'):
-            store.parse_package_extended('user/package:a:aaa111')
+            command.parse_package_extended('user/package:a:aaa111')
 
         with pytest.raises(CommandException, match='Invalid versioninfo'):
-            store.parse_package_extended('team:user/package:a:aaa111')
+            command.parse_package_extended('team:user/package:a:aaa111')

--- a/compiler/quilt/test/test_command.py
+++ b/compiler/quilt/test/test_command.py
@@ -650,3 +650,57 @@ class CommandTest(QuiltTestCase):
         # XXX: in this case, should we just strip the trialing slash?
         with pytest.raises(command.CommandException, match='Invalid element in subpath'):
             command.parse_package('team:user/package/subdir/', True)
+
+    def test_parse_package_extended_names(self):
+        # good parse strings
+        expected = ('user/package', None, None, None)
+        assert store.parse_package_extended('user/package') == expected
+
+        expected = ('team:user/package', None, None, None)
+        assert store.parse_package_extended('team:user/package') == expected
+
+        expected = ('team:user/package/sub/path', None, None, None)
+        assert store.parse_package_extended('team:user/package/sub/path') == expected
+
+        expected = ('user/package', 'abc123', None, None)
+        assert store.parse_package_extended('user/package:h:abc123') == expected
+
+        expected = ('user/package', 'abc123', None, None)
+        assert store.parse_package_extended('user/package:hash:abc123') == expected
+
+        expected = ('user/package', None, '123', None)
+        assert store.parse_package_extended('user/package:v:123') == expected
+
+        expected = ('user/package', None, '123', None)
+        assert store.parse_package_extended('user/package:version:123') == expected
+
+        expected = ('user/package', None, None, 'some')
+        assert store.parse_package_extended('user/package:t:some') == expected
+
+        expected = ('user/package', None, None, 'some')
+        assert store.parse_package_extended('user/package:tag:some') == expected
+
+        expected = ('team:user/package', 'abc123', None, None)
+        assert store.parse_package_extended('team:user/package:h:abc123') == expected
+
+        expected = ('team:user/package', 'abc123', None, None)
+        assert store.parse_package_extended('team:user/package:hash:abc123') == expected
+
+        expected = ('team:user/package', None, '123', None)
+        assert store.parse_package_extended('team:user/package:v:123') == expected
+
+        expected = ('team:user/package', None, '123', None)
+        assert store.parse_package_extended('team:user/package:version:123') == expected
+
+        expected = ('team:user/package', None, None, 'some')
+        assert store.parse_package_extended('team:user/package:t:some') == expected
+
+        expected = ('team:user/package', None, None, 'some')
+        assert store.parse_package_extended('team:user/package:tag:some') == expected
+
+        # bad parse strings
+        with pytest.raises(CommandException, match='Invalid versioninfo'):
+            store.parse_package_extended('user/package:a:aaa111')
+
+        with pytest.raises(CommandException, match='Invalid versioninfo'):
+            store.parse_package_extended('team:user/package:a:aaa111')

--- a/compiler/quilt/test/test_command.py
+++ b/compiler/quilt/test/test_command.py
@@ -699,8 +699,8 @@ class CommandTest(QuiltTestCase):
         assert command.parse_package_extended('team:user/package:tag:some') == expected
 
         # bad parse strings
-        with pytest.raises(CommandException, match='Invalid versioninfo'):
+        with pytest.raises(command.CommandException, match='Invalid versioninfo'):
             command.parse_package_extended('user/package:a:aaa111')
 
-        with pytest.raises(CommandException, match='Invalid versioninfo'):
+        with pytest.raises(command.CommandException, match='Invalid versioninfo'):
             command.parse_package_extended('team:user/package:a:aaa111')

--- a/compiler/quilt/test/test_install.py
+++ b/compiler/quilt/test/test_install.py
@@ -295,7 +295,7 @@ packages:
             command.install("packages:\n")
         with assertRaisesRegex(self, command.CommandException, "Specify package as"):
             command.install("packages:\n- foo")
-        with assertRaisesRegex(self, command.CommandException, "Invalid versioninfo"):
+        with assertRaisesRegex(self, command.CommandException, "Specify package as"):
             command.install("packages:\n- foo/bar:xxx:bar")
         with assertRaisesRegex(self, Exception, "No such file or directory"):
             self.validate_file('foo', 'bar', contents_hash1, contents1, table_hash1, table_data1)

--- a/compiler/quilt/test/test_install.py
+++ b/compiler/quilt/test/test_install.py
@@ -78,8 +78,7 @@ class InstallTest(QuiltTestCase):
         command.install('foo/bar')
         teststore = PackageStore(self._store_dir)
 
-        with open(os.path.join(teststore.package_path(None, 'foo', 'bar'),
-                               Package.CONTENTS_DIR,
+        with open(os.path.join(teststore.package_path(None, 'foo', 'bar'), Package.CONTENTS_DIR,
                                contents_hash)) as fd:
             file_contents = json.load(fd, object_hook=decode_node)
             assert file_contents == contents
@@ -98,20 +97,17 @@ class InstallTest(QuiltTestCase):
         """
         table_data, table_hash = self.make_table_data()
         file_data, file_hash = self.make_file_data()
-        contents, contents_hash = self.make_contents(table=table_hash,
-                                                     file=file_hash)
+        contents, contents_hash = self.make_contents(table=table_hash, file=file_hash)
 
         self._mock_tag('foo/bar', 'latest', contents_hash, team='qux')
-        self._mock_package('foo/bar', contents_hash, '',
-                           contents, [table_hash, file_hash], team='qux')
+        self._mock_package('foo/bar', contents_hash, '', contents, [table_hash, file_hash], team='qux')
         self._mock_s3(table_hash, table_data)
         self._mock_s3(file_hash, file_data)
 
         command.install('qux:foo/bar')
         teststore = PackageStore(self._store_dir)
 
-        with open(os.path.join(teststore.package_path('qux', 'foo', 'bar'),
-                               Package.CONTENTS_DIR,
+        with open(os.path.join(teststore.package_path('qux', 'foo', 'bar'), Package.CONTENTS_DIR,
                                contents_hash)) as fd:
             file_contents = json.load(fd, object_hook=decode_node)
             assert file_contents == contents
@@ -130,16 +126,13 @@ class InstallTest(QuiltTestCase):
         """
         table_data, table_hash = self.make_table_data()
         file_data, file_hash = self.make_file_data()
-        contents, contents_hash = self.make_contents(table=table_hash,
-                                                     file=file_hash)
+        contents, contents_hash = self.make_contents(table=table_hash, file=file_hash)
 
         self._mock_log('foo/bar', contents_hash)
-        self._mock_tag('foo/bar', 'mytag', contents_hash[0:6],
-                       cmd=responses.PUT)
+        self._mock_tag('foo/bar', 'mytag', contents_hash[0:6], cmd=responses.PUT)
         command.tag_add('foo/bar', 'mytag', contents_hash[0:6])
 
-        self._mock_version('foo/bar', '1.0', contents_hash[0:6],
-                           cmd=responses.PUT)
+        self._mock_version('foo/bar', '1.0', contents_hash[0:6], cmd=responses.PUT)
         command.version_add('foo/bar', '1.0', contents_hash[0:6], force=True)
 
     def test_team_short_hashes(self):
@@ -148,18 +141,14 @@ class InstallTest(QuiltTestCase):
         """
         table_data, table_hash = self.make_table_data()
         file_data, file_hash = self.make_file_data()
-        contents, contents_hash = self.make_contents(table=table_hash,
-                                                     file=file_hash)
+        contents, contents_hash = self.make_contents(table=table_hash, file=file_hash)
 
         self._mock_log('foo/bar', contents_hash, team='qux')
-        self._mock_tag('foo/bar', 'mytag', contents_hash[0:6],
-                       cmd=responses.PUT, team='qux')
+        self._mock_tag('foo/bar', 'mytag', contents_hash[0:6], cmd=responses.PUT, team='qux')
         command.tag_add('qux:foo/bar', 'mytag', contents_hash[0:6])
 
-        self._mock_version('foo/bar', '1.0', contents_hash[0:6],
-                           cmd=responses.PUT, team='qux')
-        command.version_add('qux:foo/bar', '1.0', contents_hash[0:6],
-                            force=True)
+        self._mock_version('foo/bar', '1.0', contents_hash[0:6], cmd=responses.PUT, team='qux')
+        command.version_add('qux:foo/bar', '1.0', contents_hash[0:6], force=True)
 
     def test_install_subpackage(self):
         """
@@ -191,19 +180,15 @@ class InstallTest(QuiltTestCase):
         table_data, table_hash = self.make_table_data()
         contents, contents_hash = self.make_contents(table=table_hash)
         self._mock_tag('foo/bar', 'latest', contents_hash, team='qux')
-        self._mock_package('foo/bar', contents_hash, 'group/table', contents,
-                           [table_hash], team='qux')
+        self._mock_package('foo/bar', contents_hash, 'group/table', contents, [table_hash], team='qux')
         self._mock_s3(table_hash, table_data)
         command.install('qux:foo/bar/group/table')
-        self.validate_file('foo', 'bar', contents_hash, contents, table_hash,
-                           table_data, team='qux')
+        self.validate_file('foo', 'bar', contents_hash, contents, table_hash, table_data, team='qux')
 
-    def validate_file(self, user, package, contents_hash, contents, table_hash,
-                      table_data, team=None):
+    def validate_file(self, user, package, contents_hash, contents, table_hash, table_data, team=None):
         teststore = PackageStore(self._store_dir)
 
-        with open(os.path.join(teststore.package_path(team, user, package),
-                               Package.CONTENTS_DIR,
+        with open(os.path.join(teststore.package_path(team, user, package), Package.CONTENTS_DIR,
                                contents_hash), 'r') as fd:
             file_contents = json.load(fd, object_hook=decode_node)
             assert file_contents == contents

--- a/compiler/quilt/test/test_install.py
+++ b/compiler/quilt/test/test_install.py
@@ -295,7 +295,7 @@ packages:
             command.install("packages:\n")
         with assertRaisesRegex(self, command.CommandException, "Specify package as"):
             command.install("packages:\n- foo")
-        with assertRaisesRegex(self, command.CommandException, "Specify package as"):
+        with assertRaisesRegex(self, command.CommandException, "Invalid versioninfo"):
             command.install("packages:\n- foo/bar:xxx:bar")
         with assertRaisesRegex(self, Exception, "No such file or directory"):
             self.validate_file('foo', 'bar', contents_hash1, contents1, table_hash1, table_data1)

--- a/compiler/quilt/test/test_install.py
+++ b/compiler/quilt/test/test_install.py
@@ -308,7 +308,7 @@ packages:
             command.install("packages:\n")
         with assertRaisesRegex(self, command.CommandException, "Specify package as"):
             command.install("packages:\n- foo")
-        with assertRaisesRegex(self, command.CommandException, "Invalid versioninfo"):
+        with assertRaisesRegex(self, command.CommandException, "Specify package as"):
             command.install("packages:\n- foo/bar:xxx:bar")
         with assertRaisesRegex(self, Exception, "No such file or directory"):
             self.validate_file('foo', 'bar', contents_hash1, contents1, table_hash1, table_data1)
@@ -333,7 +333,7 @@ packages:
         contents1, contents_hash1 = self.make_contents(table1=table_hash1)
         self._mock_version('akarve/sales', '99.99', contents_hash1,
                            status=404, message='Version 99.99 does not exist')
-        with assertRaisesRegex(self, command.CommandException, "Version 99.99 does not exist"):
+        with assertRaisesRegex(self, command.CommandException, "Specify package as"):
             command.install("packages:\n- akarve/sales:v:99.99")
 
     def test_quilt_yml_unknown_team(self):

--- a/compiler/quilt/tools/command.py
+++ b/compiler/quilt/tools/command.py
@@ -908,10 +908,7 @@ def install_via_requirements(requirements_str, force=False):
     else:
         yaml_data = yaml.load(requirements_str)
     for pkginfo in yaml_data['packages']:
-        owner, pkg, subpath, hash, version, tag = parse_package_extended(pkginfo)
-        package = owner + '/' + pkg
-        if subpath:
-            package += '/' + "/".join(subpath)
+        package, hash, version, tag = parse_package_extended(pkginfo)
         install(package, hash, version, tag, force=force)
 
 def install(package, hash=None, version=None, tag=None, force=False):
@@ -1207,7 +1204,7 @@ def delete(package):
     Irreversibly deletes the package along with its history, tags, versions, etc.
     """
     team, owner, pkg = parse_package(package)
-    
+
     teamstr = "{}:".format(team) if team else ""
     answer = input(
         "Are you sure you want to delete this package and its entire history? " +

--- a/compiler/quilt/tools/command.py
+++ b/compiler/quilt/tools/command.py
@@ -66,7 +66,8 @@ S3_CONNECT_TIMEOUT = 30
 S3_READ_TIMEOUT = 30
 S3_TIMEOUT_RETRIES = 3
 CONTENT_RANGE_RE = re.compile(r'^bytes (\d+)-(\d+)/(\d+)$')
-
+VALID_EXTENDED_PCKG_RE = re.compile(r'^((\w+:)?\w+/[\w/]+)(:(version|tag|hash|v|t|h):(.+)$)?',
+                                    flags=re.IGNORECASE)
 LOG_TIMEOUT = 3  # 3 seconds
 
 VERSION = pkg_resources.require('quilt')[0].version
@@ -80,31 +81,23 @@ class CommandException(Exception):
 
 def parse_package_extended(name):
     hash = version = tag = None
+    package = name
     try:
-        if ':' in name:
-            name, versioninfo = name.split(':', 1)
-            if ':' in versioninfo:
-                info = versioninfo.split(':', 1)
-                if len(info) == 2:
-                    if 'version'.startswith(info[0]):
-                        # usr/pkg:v:<string>  usr/pkg:version:<string>  etc
-                        version = info[1]
-                    elif 'tag'.startswith(info[0]):
-                        # usr/pkg:t:<tag>  usr/pkg:tag:<tag>  etc
-                        tag = info[1]
-                    elif 'hash'.startswith(info[0]):
-                        # usr/pkg:h:<hash>  usr/pkg:hash:<hash>  etc
-                        hash = info[1]
-                    else:
-                        raise CommandException("Invalid versioninfo: %s." % info)
-                else:
-                    # usr/pkg:hashval
-                    hash = versioninfo
-        team, owner, pkg, subpath = parse_package(name, allow_subpath=True)
-    except ValueError:
-        pkg_format = 'owner/package_name/path[:v:<version> or :t:tag or :h:hash]'
+        package, _, _, info_type, info = VALID_EXTENDED_PCKG_RE.match(name).groups()
+        if info_type:
+            if info_type[0] == 'v':
+                version = info
+            elif info_type[0] == 'h':
+                hash = info
+            else:
+                tag = info
+        # e.g. 'owner/package:aaa:bbb'
+        elif package != name:
+            raise CommandException("Invalid versioninfo")
+    except AttributeError:
+        pkg_format = '[team:]owner/package_name/path[:v:<version> or :t:tag or :h:hash]'
         raise CommandException("Specify package as %s." % pkg_format)
-    return owner, pkg, subpath, hash, version, tag
+    return package, hash, version, tag
 
 def parse_package(name, allow_subpath=False):
     try:


### PR DESCRIPTION
`parse_package_extended` might be confused by adding team based packages to .yml. This should fix it.
Added tests for team installation and parse_package_extended helper