### PR TITLE
TakeAction: hide sign up button if team is set

### DIFF
--- a/catalog/app/components/Feature/index.js
+++ b/catalog/app/components/Feature/index.js
@@ -12,7 +12,7 @@ import strings from './messages';
 const xs = `${breaks.sm - 1}px`;
 
 /* eslint-disable jsx-a11y/no-static-element-interactions */
-const Feature = ({ header, tagline }) => (
+const Feature = ({ header, tagline, signUp }) => (
   <ImageRow backgroundColor="#F6B500" src={background}>
     <Content>
       <h1 className="main">
@@ -21,7 +21,7 @@ const Feature = ({ header, tagline }) => (
       <h2 className="main">
         { tagline }
       </h2>
-      <TakeAction />
+      <TakeAction signUp={signUp} />
       <div className="framer">
         <iframe
           src="https://ghbtns.com/github-btn.html?user=quiltdata&repo=quilt&type=star&count=true&size=large"
@@ -46,6 +46,7 @@ Feature.defaultProps = {
 Feature.propTypes = {
   header: PropTypes.string,
   tagline: PropTypes.string,
+  signUp: PropTypes.bool,
 };
 
 const Content = styled.div`
@@ -94,6 +95,7 @@ const Content = styled.div`
     h2.main {
       font-size: 1.5em;
     }
+  }
 `;
 
 export default Feature;

--- a/catalog/app/components/PaymentDialog/index.js
+++ b/catalog/app/components/PaymentDialog/index.js
@@ -112,7 +112,7 @@ class PaymentDialog extends React.PureComponent { // eslint-disable-line react/p
             />
             <br />
             <br />
-            <Pricing includeSignIn={false} />
+            <Pricing takeAction={false} />
           </Content>
         </Dialog>
         <Confirm

--- a/catalog/app/components/Pricing/index.js
+++ b/catalog/app/components/Pricing/index.js
@@ -55,7 +55,7 @@ const Styler = styled.div`
 
 const perUser = <span className="unit">per user / month</span>;
 
-function Pricing({ signUp }) {
+function Pricing({ signUp, takeAction }) {
   return (
     <Styler>
       <h1 id="pricing">Pricing</h1>
@@ -103,13 +103,18 @@ function Pricing({ signUp }) {
           Contact us
         </a> to start Business service.
       </p>
-      { signUp ? <TakeAction /> : null }
+      { takeAction ? <TakeAction signUp={signUp} /> : null }
     </Styler>
   );
 }
 
 Pricing.propTypes = {
   signUp: PropTypes.bool,
+  takeAction: PropTypes.bool,
+};
+
+Pricing.defaultProps = {
+  takeAction: true,
 };
 
 export default Pricing;

--- a/catalog/app/components/TakeAction/index.js
+++ b/catalog/app/components/TakeAction/index.js
@@ -1,6 +1,6 @@
 /* TakeAction */
 import RaisedButton from 'material-ui/RaisedButton';
-import React from 'react';
+import React, { PropTypes as PT } from 'react';
 import styled from 'styled-components';
 
 import { makeSignInURL } from 'utils/auth';
@@ -17,17 +17,23 @@ const Container = styled.div`
 
 `;
 
-function TakeAction() {
+function TakeAction({ signUp }) {
   return (
     <Container>
-      <RaisedButton href={makeSignInURL()} label="Sign Up" primary />
+      {signUp &&
+        <RaisedButton href={makeSignInURL()} label="Sign Up" primary />
+      }
       <RaisedButton href={installQuilt} label="Install" />
     </Container>
   );
 }
 
 TakeAction.propTypes = {
+  signUp: PT.bool,
+};
 
+TakeAction.defaultProps = {
+  signUp: true,
 };
 
 export default TakeAction;

--- a/catalog/app/containers/HomePage/index.js
+++ b/catalog/app/containers/HomePage/index.js
@@ -31,6 +31,7 @@ export default class HomePage extends React.PureComponent { // eslint-disable-li
     const { team = {} } = config;
     const header = team.name ? team.name : undefined;
     const tagline = team.name ? 'Team data catalog' : undefined;
+    const signUp = !team.name;
 
     return (
       <UnPad>
@@ -39,6 +40,7 @@ export default class HomePage extends React.PureComponent { // eslint-disable-li
           onClickPrimary={makeScrollToId()}
           onClickSecondary={makeScrollToId(id)}
           tagline={tagline}
+          signUp={signUp}
         />
         <Pad top left right bottom>
           <Intro />
@@ -47,7 +49,7 @@ export default class HomePage extends React.PureComponent { // eslint-disable-li
             <Values />
             <Demo />
             <HCenter>
-              <Pricing signUp />
+              <Pricing signUp={signUp} />
             </HCenter>
           </Styler>
         </Pad>


### PR DESCRIPTION
The simplest solution.
I could've kept `TakeAction` dumb by adding a prop to hide the signup button and leaving the decision making to the parent component -- it may make things a little more explicit and future-proof, but requires a little more code.