### PR TITLE
Drop Python 3.4 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,13 +24,6 @@ matrix:
       python: "2.7"
     - os: linux
       language: python
-      python: "3.4"
-      env:
-        TEST_REGISTRY=true
-      services:
-        - postgresql
-    - os: linux
-      language: python
       python: "3.5"
       env:
         TEST_REGISTRY=true

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 
 | OS | `master` | Python support |
 |----|--------------------|----------------|
-| <img height="20" src="http://icons.iconarchive.com/icons/dakirby309/simply-styled/256/OS-Linux-icon.png"> | [![Linux](https://travis-ci.org/quiltdata/quilt.svg?branch=master)](https://travis-ci.org/quiltdata/quilt/branches) | 2.7, 3.4, 3.5, 3.6 |
+| <img height="20" src="http://icons.iconarchive.com/icons/dakirby309/simply-styled/256/OS-Linux-icon.png"> | [![Linux](https://travis-ci.org/quiltdata/quilt.svg?branch=master)](https://travis-ci.org/quiltdata/quilt/branches) | 2.7, 3.5, 3.6 |
 | <img height="20" src="http://icons.iconarchive.com/icons/icons8/windows-8/128/Systems-Mac-Os-icon.png"> | [![CircleCI branch](https://img.shields.io/circleci/project/github/quiltdata/quilt/master.svg)](https://circleci.com/gh/quiltdata/quilt/tree/master) | 2.7, 3.5, 3.6 |
 | <img height="20" src="http://icons.iconarchive.com/icons/dakirby309/windows-8-metro/128/Folders-OS-Windows-8-Metro-icon.png"> | [![Windows](https://ci.appveyor.com/api/projects/status/tnihllrbmm08x0lt/branch/master?svg=true)](https://ci.appveyor.com/project/quiltdata/quilt-compiler/branch/master) | 3.5, 3.6 |
 

--- a/compiler/setup.py
+++ b/compiler/setup.py
@@ -26,7 +26,6 @@ setup(
         'Operating System :: OS Independent',
         'Programming Language :: Python',
         'Programming Language :: Python :: 2.7',
-        'Programming Language :: Python :: 3.4',
         'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',
     ],
@@ -38,7 +37,6 @@ setup(
     keywords='quilt quiltdata shareable data dataframe package platform pandas',
     install_requires=[
         'appdirs>=1.4.0',
-        'enum34; python_version<"3.4"',
         'future>=0.16.0',
         'packaging>=16.8',
         'pandas>=0.19.2',

--- a/registry/README.md
+++ b/registry/README.md
@@ -167,7 +167,6 @@ If you are very careful, you can run Quilt directly in your host operating syste
 * Postgres
 
 ## Python support
-- 3.4
 - 3.5
 - 3.6
 

--- a/registry/setup.py
+++ b/registry/setup.py
@@ -6,5 +6,5 @@ setup(
     name='quilt_server',
     packages=['quilt_server'],
     include_package_data=True,
-    python_requires='>=3.4, <4',
+    python_requires='>=3.5, <4',
 )


### PR DESCRIPTION
* Makes Travis CI much faster
* Not as widely adopted as 3.5 or 3.6