### PR TITLE
Add a `flask createdb` command.

### DIFF
--- a/registry/docker-compose-local-auth.yml
+++ b/registry/docker-compose-local-auth.yml
@@ -84,7 +84,7 @@ services:
     environment:
       - USE_CONSOLE_EMAIL=True
       - LOGFILE=/tmp/debug.log
-      - DATABASE_URL=postgres://postgres:testing@db/packages
+      - DATABASE_URL=postgresql://postgres:testing@db/packages
       - FRONTEND_URL=http://catalog:3000
       - ALLOW_HTTP=1
     depends_on:
@@ -94,7 +94,7 @@ services:
   djangomigration:
     image: quiltdata/django
     environment:
-      - DATABASE_URL=postgres://postgres:testing@db/packages
+      - DATABASE_URL=postgresql://postgres:testing@db/packages
       - OAUTH_REDIRECT_URI=http://flask:5000/oauth_callback
       - OAUTH_CLIENT_ID=packages
       - OAUTH_CLIENT_SECRET=TESTING

--- a/registry/quilt_server/__init__.py
+++ b/registry/quilt_server/__init__.py
@@ -35,10 +35,14 @@ class QuiltSQLAlchemy(SQLAlchemy):
         super(QuiltSQLAlchemy, self).apply_driver_hacks(app, info, options)
 
 db = QuiltSQLAlchemy(app)
-db.apply_driver_hacks
 
 FlaskJSON(app)
 Migrate(app, db)
+
+@app.cli.command('createdb')
+def createdb_command():
+    import sqlalchemy_utils
+    sqlalchemy_utils.create_database(db.engine.url)
 
 # Need to import views.py in order for the routes to get set up.
 from . import views

--- a/registry/quilt_server/dev_config.py
+++ b/registry/quilt_server/dev_config.py
@@ -6,7 +6,7 @@ Config file for dev. Overrides values in config.py.
 import os
 import socket
 
-SQLALCHEMY_DATABASE_URI = 'postgres://postgres@localhost/packages'
+SQLALCHEMY_DATABASE_URI = 'postgresql://postgres@localhost/packages'
 
 AUTH_PROVIDER = os.getenv('AUTH_PROVIDER', 'quilt')
 

--- a/registry/quilt_server/docker_config.py
+++ b/registry/quilt_server/docker_config.py
@@ -5,7 +5,7 @@ Config file for dev in Docker. Overrides values in config.py.
 """
 import os
 
-SQLALCHEMY_DATABASE_URI = 'postgres://postgres:testing@db/packages'
+SQLALCHEMY_DATABASE_URI = 'postgresql://postgres:testing@db/packages'
 
 AUTH_PROVIDER = os.getenv('AUTH_PROVIDER', 'quilt')
 

--- a/registry/tests/utils.py
+++ b/registry/tests/utils.py
@@ -50,7 +50,7 @@ class QuiltTestCase(TestCase):
         self.payments_patcher.start()
 
         random_name = ''.join(random.sample(string.ascii_lowercase, 10))
-        self.db_url = 'postgres://postgres@localhost/test_%s' % random_name
+        self.db_url = 'postgresql://postgres@localhost/test_%s' % random_name
 
         self.app = quilt_server.app.test_client()
         quilt_server.app.config['TESTING'] = True


### PR DESCRIPTION
None of the built-in `flask db` commands support creating the database - but it's nice to have when setting up ECS.

Also, switch from "postgres://" to "postgresql://". This works around a bug in sqlalchemy_utils - but also matches the SQLAlchemy docs.