### PR TITLE
Make team optional in login_with_token

### DIFF
--- a/compiler/quilt/test/test_command.py
+++ b/compiler/quilt/test/test_command.py
@@ -177,7 +177,7 @@ class CommandTest(QuiltTestCase):
 
         mock_open.assert_called_with('%s/login' % command.get_registry_url(None))
 
-        mock_login_with_token.assert_called_with(None, old_refresh_token)
+        mock_login_with_token.assert_called_with(old_refresh_token, None)
 
     @patch('quilt.tools.command._open_url')
     @patch('quilt.tools.command.input')
@@ -191,7 +191,7 @@ class CommandTest(QuiltTestCase):
 
         mock_open.assert_called_with('%s/login' % command.get_registry_url('foo'))
 
-        mock_login_with_token.assert_called_with('foo', old_refresh_token)
+        mock_login_with_token.assert_called_with(old_refresh_token, 'foo')
 
     @patch('quilt.tools.command._open_url')
     @patch('quilt.tools.command.input')
@@ -204,12 +204,12 @@ class CommandTest(QuiltTestCase):
         with pytest.raises(command.CommandException, match='Invalid team name'):
             command.login('fo!o')
 
-        assert not mock_open.called
-        assert not mock_login_with_token.called
+        mock_open.assert_not_called()
+        mock_login_with_token.assert_not_called()
 
     def test_login_with_token_invalid_team(self):
         with pytest.raises(command.CommandException, match='Invalid team name'):
-            command.login_with_token('fo!o', '123')
+            command.login_with_token('123', 'fo!o')
 
     @patch('quilt.tools.command._save_auth')
     def test_login_token(self, mock_save):
@@ -229,7 +229,7 @@ class CommandTest(QuiltTestCase):
             )
         )
 
-        command.login_with_token(None, old_refresh_token)
+        command.login_with_token(old_refresh_token, None)
 
         assert self.requests_mock.calls[0].request.body == "refresh_token=%s" % old_refresh_token
 
@@ -251,7 +251,7 @@ class CommandTest(QuiltTestCase):
         )
 
         with self.assertRaises(command.CommandException):
-            command.login_with_token(None, "123")
+            command.login_with_token("123", None)
 
         mock_save.assert_not_called()
 
@@ -267,7 +267,7 @@ class CommandTest(QuiltTestCase):
         )
 
         with self.assertRaises(command.CommandException):
-            command.login_with_token(None, "123")
+            command.login_with_token("123", None)
 
         mock_save.assert_not_called()
 

--- a/compiler/quilt/tools/command.py
+++ b/compiler/quilt/tools/command.py
@@ -387,9 +387,9 @@ def login(team=None):
     print()
     refresh_token = input("Enter the code from the webpage: ")
 
-    login_with_token(team, refresh_token)
+    login_with_token(refresh_token, team)
 
-def login_with_token(team, refresh_token):
+def login_with_token(refresh_token, team=None):
     """
     Authenticate using an existing token.
     """


### PR DESCRIPTION
login_with_token is a public API; let's not break it by adding teams.