### PR TITLE
Fix docker-compose registry on Windows

### DIFF
--- a/catalog/Dockerfile
+++ b/catalog/Dockerfile
@@ -7,7 +7,8 @@ ENV LANG=C.UTF-8
 RUN apt-get update && apt-get install -y \
     nginx \
     curl \
-    gettext
+    gettext \
+    libssl-dev
 RUN curl -sL https://deb.nodesource.com/setup_8.x | bash -
 RUN apt-get install -y nodejs
 

--- a/registry/README.md
+++ b/registry/README.md
@@ -32,7 +32,7 @@ Instructions for popular operating systems:
 * Windows
      * [docker](https://docs.docker.com/docker-for-windows/install/)
      * [docker compose](https://docs.docker.com/compose/install/#install-compose)
-     * [ ] Test these instructions on Windows
+     * Make sure you run both PowerShell and Docker for Windows as administrator.
 
 
 ##  2) Build and start the containers


### PR DESCRIPTION
Currently, build fails on windows (Windows 10 version 1709), but with latest node version it works fine.
By default, docker on windows uses `hyper-V` as provider and there is some bug with older node version. Although, I am pretty sure that current `docker-compose.yml` should work fine with other VM providers on windows.

Important to note that I didn't find the way to run with bare
`docker-compose up`
it raises an error:
`ERROR: Top level object in '.\docker-compose.yml' needs to be an object not '<type 'str'>'.`

Instead, I specified .yml file manually, like this:
`docker-compose -f .\docker-compose-local-auth.yml up --build`
and it works perfectly.

I also check this branch on macos, works fine.