### PR TITLE
Implement a better download progress

### DIFF
--- a/compiler/quilt/test/test_install.py
+++ b/compiler/quilt/test/test_install.py
@@ -500,7 +500,11 @@ packages:
         )
         self.requests_mock.add(responses.GET, pkg_url, body=json.dumps(
             dict(message=message) if message else
-            dict(contents=contents, urls={h: 'https://example.com/%s' % h for h in hashes})
+            dict(
+                contents=contents,
+                sizes={h: None for h in hashes},
+                urls={h: 'https://example.com/%s' % h for h in hashes}
+            )
         , default=encode_node), match_querystring=True, status=status)
 
     def _mock_s3(self, pkg_hash, contents):

--- a/registry/Dockerfile
+++ b/registry/Dockerfile
@@ -22,7 +22,7 @@ RUN pip3 install -r /usr/src/quilt-server/requirements.txt
 # Do this as the last step to maximize caching.
 COPY quilt_server /usr/src/quilt-server/quilt_server
 COPY migrations /usr/src/quilt-server/migrations
-COPY setup.py MANIFEST.in /usr/src/quilt-server/
+COPY setup.py MANIFEST.in fix_sizes.py /usr/src/quilt-server/
 WORKDIR /usr/src/quilt-server/
 RUN pip3 install /usr/src/quilt-server/
 

--- a/registry/fix_sizes.py
+++ b/registry/fix_sizes.py
@@ -1,0 +1,49 @@
+#!/usr/bin/env python3
+
+"""
+Backfills S3Blob.size for all of the objects in S3.
+
+We store sizes of the original content, so we need to download the data and ungzip it.
+"""
+
+import gzip
+
+from botocore.exceptions import ClientError
+
+from quilt_server import db
+from quilt_server.models import S3Blob
+from quilt_server.views import s3_client, PACKAGE_BUCKET_NAME, OBJ_DIR
+
+CHUNK_SIZE = 4096
+
+rows = S3Blob.query.filter(S3Blob.size.is_(None)).all()
+
+for idx, blob in enumerate(rows):
+    name = '%s/%s' % (blob.owner, blob.hash)
+    print("Processing %s (%d/%d)..." % (name, idx + 1, len(rows)))
+    try:
+        resp = s3_client.get_object(
+            Bucket=PACKAGE_BUCKET_NAME,
+            Key='%s/%s/%s' % (OBJ_DIR, blob.owner, blob.hash)
+        )
+    except ClientError as ex:
+        print("Failed to get %s: %s" % (name, ex))
+        continue
+
+    body = resp['Body']
+    size = 0
+
+    try:
+        with gzip.GzipFile(fileobj=body, mode='rb') as fd:
+            for chunk in iter(lambda: fd.read(CHUNK_SIZE), b''):
+                size += len(chunk)
+    except OSError as ex:
+        print("Failed to ungzip %s: %s" % (name, ex))
+        continue
+
+    blob.size = size
+
+    db.session.add(blob)
+    db.session.commit()
+
+print("Done")


### PR DESCRIPTION
Show progress based on the total number of bytes, not the number of objects.

Currently, we're not storing object sizes in the registry, so the change comes in three parts:
- Upload object sizes during pushes
- When installing, use object sizes if available
- Backfill the sizes of existing objects (will need to do this periodically until we stop supporting older clients)