### PR TITLE
Print the package URL returned by the registry

### DIFF
--- a/compiler/quilt/test/test_push.py
+++ b/compiler/quilt/test/test_push.py
@@ -63,7 +63,7 @@ class PushTest(QuiltTestCase):
         pkg_url = '%s/api/package/%s/%s' % (command.get_registry_url(None), package, pkg_hash)
         # Dry run, then the real thing.
         self.requests_mock.add(responses.PUT, pkg_url, json.dumps(dict(upload_urls=upload_urls)))
-        self.requests_mock.add(responses.PUT, pkg_url, json.dumps(dict()))
+        self.requests_mock.add(responses.PUT, pkg_url, json.dumps(dict(package_url='https://example.com/')))
 
     def _mock_put_tag(self, package, tag):
         tag_url = '%s/api/tag/%s/%s' % (command.get_registry_url(None), package, tag)

--- a/compiler/quilt/tools/command.py
+++ b/compiler/quilt/tools/command.py
@@ -758,7 +758,8 @@ def push(package, public=False, team=False, reupload=False):
         raise CommandException("Failed to upload fragments")
 
     print("Uploading package metadata...")
-    _push_package(sizes=obj_sizes)
+    resp = _push_package(sizes=obj_sizes)
+    package_url = resp.json()['package_url']
 
     print("Updating the 'latest' tag...")
     session.put(
@@ -774,13 +775,11 @@ def push(package, public=False, team=False, reupload=False):
     )
 
     if team is None:
-        url = "https://quiltdata.com/package/%s/%s" % (owner, pkg)
         teamstr = ""
     else:
-        url = "https://%s.team.quiltdata.com/package/%s/%s" % (team, owner, pkg)
-        teamstr = "%s:" % (team)
+        teamstr = "%s:" % (team,)
 
-    print("Push complete. %s%s/%s is live:\n%s" % (teamstr, owner, pkg, url))
+    print("Push complete. %s%s/%s is live:\n%s" % (teamstr, owner, pkg, package_url))
 
 def version_list(package):
     """


### PR DESCRIPTION
The registry now returns the package URL in the catalog, so let's use it.