### PR TITLE
Add path to source directory in name-collision error message

### DIFF
--- a/compiler/quilt/tools/build.py
+++ b/compiler/quilt/tools/build.py
@@ -409,8 +409,8 @@ def generate_contents(startpath, outfilename=DEFAULT_BUILDFILE):
                 existing_name = safename_to_name.get(new_safename)
                 if existing_name is not None:
                     raise BuildException(
-                        "Duplicate node names. %r was renamed to %r, which overlaps with %r" % (
-                            name, new_safename, existing_name)
+                        "Duplicate node names in directory %s. %r was renamed to %r, which overlaps with %r" % (
+                        dir_path, name, new_safename, existing_name)
                     )
                 safename_to_name[new_safename] = name
 

--- a/compiler/quilt/tools/build.py
+++ b/compiler/quilt/tools/build.py
@@ -409,7 +409,7 @@ def generate_contents(startpath, outfilename=DEFAULT_BUILDFILE):
                 existing_name = safename_to_name.get(new_safename)
                 if existing_name is not None:
                     raise BuildException(
-                        "Duplicate node names in directory %s. %r was renamed to %r, which overlaps with %r" % (
+                        "Duplicate node names in directory %r. %r was renamed to %r, which overlaps with %r" % (
                         dir_path, name, new_safename, existing_name)
                     )
                 safename_to_name[new_safename] = name


### PR DESCRIPTION
This improves the error message returned when quilt generate cannot
determine unique node names for files due to collisions in our
source-to-node-name algorithm. The error message now includes both the
conflicting name and the path to the source directory.