### PR TITLE
Core changes for TF and Export

### DIFF
--- a/compiler/quilt/tools/compat.py
+++ b/compiler/quilt/tools/compat.py
@@ -12,11 +12,8 @@ import frequently-used objects here for convenience.
 
 import sys as _sys
 
-# XXX: This originally had a few modules, but I've managed to remove the others.
-#      I'm tentatively still keeping compat.py, otherwise the try: except: block ends up in
-#      each module's import stanzas, instead of 'from compat import pathlib'.
 
 if _sys.version_info < (3, 6):
-    from pathlib2 import path
+    import pathlib2 as pathlib
 else:
-    from pathlib import path
+    import pathlib

--- a/registry/tests/push_install_test.py
+++ b/registry/tests/push_install_test.py
@@ -80,19 +80,21 @@ class PushInstallTestCase(QuiltTestCase):
         )),
         file=FileNode(
             hashes=[HASH3],
-            metadata=dict()
+            metadata={'q_path': 'example'}
         )
     ))
 
     CONTENTS_2 = RootNode(dict(
         file=FileNode(
-            hashes=[HASH3]
+            hashes=[HASH3],
+            metadata={'q_path': 'example'}
         )
     ))
 
     HUGE_CONTENTS = RootNode(dict(
         README=FileNode(
-            hashes=[HASH1]
+            hashes=[HASH1],
+            metadata={'q_path': 'example'}
         ),
         group1=GroupNode(dict(
             group2=GroupNode(dict(


### PR DESCRIPTION
These are the changes to `core.py` for Tensorflow support and the export command.

Basically, it has these changes:

* Require `FileNode`s to have `metadata` and `metadata['q_path']` at creation time.
* Require the value of `metadata['q_path']` in `FileNode` and `TableNode` to be relative.
* If a `FileNode` is received from the API, loaded from a database, or loaded from a packagestore, and `metadata['q_path']` is None or blank, set it to the token "::FILENAME_MISSING::".
  * This uses ':', which is illegal in Windows filenames and in Quilt node names.
  * We should probably make any illegal Windows filename characters give warnings on Linux/Mac at build time, but that's a problem for another day.

__Considerations:__

* Should I include a test that verifies (at least for local package store) that blank/empty `q_path` values are replaced?
  * This has been manually verified, and the logic is short
    * Thanks to @dimaryaz for thinking ahead when having the server, client, and API all use the same function to decode JSON.  I really appreciate that kind of coding.