### PR TITLE
Treat a blank Stripe key the same as a missing one

### DIFF
--- a/registry/quilt_server/views.py
+++ b/registry/quilt_server/views.py
@@ -84,7 +84,7 @@ s3_client = boto3.client(
 )
 
 stripe.api_key = app.config['STRIPE_SECRET_KEY']
-HAVE_PAYMENTS = stripe.api_key is not None
+HAVE_PAYMENTS = bool(stripe.api_key)
 
 
 class QuiltCli(httpagentparser.Browser):


### PR DESCRIPTION
Makes CloudFormation config easier: we can set the env var unconditionally, but leave it blank for team instances.