### PR TITLE
Pass the DISABLE_SIGNUP env variable to django

### DIFF
--- a/registry/docker-compose-local-auth.yml
+++ b/registry/docker-compose-local-auth.yml
@@ -90,6 +90,7 @@ services:
       - AUTH_URL=http://auth:5002
       - OAUTH_WEB_APPLICATION=Quilt
       - QUILT_PKG_URL=http://flask:5000
+      - DISABLE_SIGNUP    
     depends_on:
       db:
         condition: service_healthy


### PR DESCRIPTION
Pass the DISABLE_SIGNUP environment variable to django in
docker-compose so that developers can choose to test with signups
disabled or not without changing the docker-compose file.