### PR TITLE
Use a small dataset in most of the tests

### DIFF
--- a/compiler/quilt/test/build.yml
+++ b/compiler/quilt/test/build.yml
@@ -2,18 +2,8 @@
 contents:
   dataframes:
     csv: 
-      kwargs:
-        parse_dates: ['Date0']
-      file: data/10KRows13Cols.csv
+      file: data/foo.csv
     nulls:
       file: data/nulls.csv
-    tsv:
-      file: data/10KRows13Cols.tsv
-    xls:
-      file: data/10KRows13Cols.xlsx
-    xls_skip:
-      kwargs:
-        skiprows: [0,10,100]
-      file: data/10KRows13Cols.xlsx
   README:
     file: data/README.md

--- a/compiler/quilt/test/build_large.yml
+++ b/compiler/quilt/test/build_large.yml
@@ -1,0 +1,19 @@
+---
+contents:
+  dataframes:
+    csv:
+      kwargs:
+        parse_dates: ['Date0']
+      file: data/10KRows13Cols.csv
+    nulls:
+      file: data/nulls.csv
+    tsv:
+      file: data/10KRows13Cols.tsv
+    xls:
+      file: data/10KRows13Cols.xlsx
+    xls_skip:
+      kwargs:
+        skiprows: [0,10,100]
+      file: data/10KRows13Cols.xlsx
+  README:
+    file: data/README.md

--- a/compiler/quilt/test/test_import.py
+++ b/compiler/quilt/test/test_import.py
@@ -36,9 +36,9 @@ class ImportTest(QuiltTestCase):
         assert package.dataframes == dataframes
         assert package.README == README
 
-        assert set(dataframes._keys()) == {'xls', 'csv', 'tsv', 'xls_skip', 'nulls'}
+        assert set(dataframes._keys()) == {'csv', 'nulls'}
         assert set(dataframes._group_keys()) == set()
-        assert set(dataframes._data_keys()) == {'xls', 'csv', 'tsv', 'xls_skip', 'nulls'}
+        assert set(dataframes._data_keys()) == {'csv', 'nulls'}
 
         assert isinstance(README(), string_types)
         assert isinstance(README._data(), string_types)
@@ -95,9 +95,9 @@ class ImportTest(QuiltTestCase):
         assert package.dataframes == dataframes
         assert package.README == README
 
-        assert set(dataframes._keys()) == {'xls', 'csv', 'tsv', 'xls_skip', 'nulls'}
+        assert set(dataframes._keys()) == {'csv', 'nulls'}
         assert set(dataframes._group_keys()) == set()
-        assert set(dataframes._data_keys()) == {'xls', 'csv', 'tsv', 'xls_skip', 'nulls'}
+        assert set(dataframes._data_keys()) == {'csv', 'nulls'}
 
         assert isinstance(README(), string_types)
         assert isinstance(README._data(), string_types)


### PR DESCRIPTION
Unless we're specifically testing large inputs, different data types, caching, etc., there's no need to use a huge dataset.

So:
- Change `build.yml` use small inputs
- Rename the existing `build.yml` to `build_large.yml` and use it in two tests that do thorough checks
- Remove a redundant test for pyarrow (which is the default) and instead just test that the env variables work

This cuts the time to run `pytest` in half.