### PR TITLE
Make "team" a separate access type instead of reusing "public"

### DIFF
--- a/compiler/quilt/test/test_cli.py
+++ b/compiler/quilt/test/test_cli.py
@@ -671,6 +671,7 @@ class TestCLI(BasicQuiltTestCase):
             [0, 'push', '--public'],
             [0, 'push', '--reupload'],
             [0, 'push', '--team'],
+            [0, 'push', '--team', '--public'],
         ])
 
         ## This section tests for circumstances expected to be rejected by argparse.
@@ -680,7 +681,6 @@ class TestCLI(BasicQuiltTestCase):
             'push --reupload'.split(),
             'push --public --reupload'.split(),
             'push --public --team'.split(),
-            'push --public --team fakeuser/fakepackage'.split(),  # mutually exclusive options
             ]
         for args in expect_fail_2_args:
             assert self.execute(args)['return code'] == 2, "using args: " + str(args)

--- a/compiler/quilt/test/test_cli.py
+++ b/compiler/quilt/test/test_cli.py
@@ -694,9 +694,9 @@ class TestCLI(BasicQuiltTestCase):
         kwargs = result['kwargs']
         assert kwargs == {
             'reupload': False,
-            'public': False,
+            'is_public': False,
             'package': 'fakeuser/fakepackage',
-            'team': False,
+            'is_team': False,
         }
 
         ## Test the flags as well..
@@ -709,9 +709,9 @@ class TestCLI(BasicQuiltTestCase):
         kwargs = result['kwargs']
         assert kwargs == {
             'reupload': True,
-            'public': True,
+            'is_public': True,
             'package': 'fakeuser/fakepackage',
-            'team': False,
+            'is_team': False,
         }
 
         # team (without reupload)
@@ -729,9 +729,9 @@ class TestCLI(BasicQuiltTestCase):
         kwargs = result['kwargs']
         assert kwargs == {
             'reupload': True,
-            'public': False,
+            'is_public': False,
             'package': 'blah:fakeuser/fakepackage',
-            'team': True,
+            'is_team': True,
         }
 
 

--- a/compiler/quilt/tools/command.py
+++ b/compiler/quilt/tools/command.py
@@ -626,11 +626,10 @@ def log(package):
         nice = ugly.strftime("%Y-%m-%d %H:%M:%S")
         print(format_str % (entry['hash'], nice, entry['author']))
 
-def push(package, public=False, team=False, reupload=False):
+def push(package, is_public=False, is_team=False, reupload=False):
     """
     Push a Quilt data package to the server
     """
-    using_team = team
     team, owner, pkg = parse_package(package)
     session = _get_session(team)
 
@@ -643,8 +642,8 @@ def push(package, public=False, team=False, reupload=False):
     def _push_package(dry_run=False, sizes=dict()):
         data = json.dumps(dict(
             dry_run=dry_run,
-            public=public,
-            team=using_team,
+            is_public=is_public,
+            is_team=is_team,
             contents=pkgobj.get_contents(),
             description="",  # TODO
             sizes=sizes

--- a/compiler/quilt/tools/command.py
+++ b/compiler/quilt/tools/command.py
@@ -638,25 +638,13 @@ def push(package, public=False, team=False, reupload=False):
     if pkgobj is None:
         raise CommandException("Package {owner}/{pkg} not found.".format(owner=owner, pkg=pkg))
 
-    if using_team and public:
-        raise CommandException("--team and --public are incompatible")
-
-    if using_team and team is None:
-        raise CommandException("--team cannot be used on non-team packages")
-
-    if public and team is not None:
-        raise CommandException("--public is not compatible with team packages, " +
-                               "Maybe you meant --team")
-
-    if using_team and team is not None:
-        public = True
-
     pkghash = pkgobj.get_hash()
 
     def _push_package(dry_run=False, sizes=dict()):
         data = json.dumps(dict(
             dry_run=dry_run,
             public=public,
+            team=using_team,
             contents=pkgobj.get_contents(),
             description="",  # TODO
             sizes=sizes

--- a/compiler/quilt/tools/main.py
+++ b/compiler/quilt/tools/main.py
@@ -227,10 +227,10 @@ def argument_parser():
     shorthelp = "Push a data package to the server"
     push_p = subparsers.add_parser("push", description=shorthelp, help=shorthelp)
     push_p.add_argument("package", type=str, help=HANDLE)
-    push_p.add_argument("--public", action="store_true",
+    push_p.add_argument("--public", action="store_true", dest='is_public',
                         help=("Create or update a public package " +
                               "(fails if the package exists and is private)"))
-    push_p.add_argument("--team", action="store_true",
+    push_p.add_argument("--team", action="store_true", dest='is_team',
                         help=("Create or update a team-visible package " +
                               "(fails if the package exists and is private)"))
     push_p.add_argument("--reupload", action="store_true",

--- a/compiler/quilt/tools/main.py
+++ b/compiler/quilt/tools/main.py
@@ -227,14 +227,12 @@ def argument_parser():
     shorthelp = "Push a data package to the server"
     push_p = subparsers.add_parser("push", description=shorthelp, help=shorthelp)
     push_p.add_argument("package", type=str, help=HANDLE)
-    push_mutexgrp_container = push_p.add_argument_group('team selection options', "(mutually exclusive)")
-    push_mutexgrp = push_mutexgrp_container.add_mutually_exclusive_group()
-    push_mutexgrp.add_argument("--public", action="store_true",
-                               help=("Create or update a public package " +
-                                     "(fails if the package exists and is private)"))
-    push_mutexgrp.add_argument("--team", action="store_true",
-                               help=("Create or update a team-visible package " +
-                                     "(fails if the package exists and is private)"))
+    push_p.add_argument("--public", action="store_true",
+                        help=("Create or update a public package " +
+                              "(fails if the package exists and is private)"))
+    push_p.add_argument("--team", action="store_true",
+                        help=("Create or update a team-visible package " +
+                              "(fails if the package exists and is private)"))
     push_p.add_argument("--reupload", action="store_true",
                         help="Re-upload all fragments, even if fragment is already in registry")
     push_p.set_defaults(func=command.push)

--- a/registry/quilt_server/config.py
+++ b/registry/quilt_server/config.py
@@ -8,8 +8,8 @@ See `app.config.from_object('...')` in __init__.py.
 """
 import os
 
-DISALLOW_PUBLIC_USERS = bool(os.getenv('DISALLOW_PUBLIC_USERS', ''))
-ALLOW_TEAM_USERS = bool(os.getenv('ALLOW_TEAM_USERS', ''))
+ALLOW_ANONYMOUS_ACCESS = not bool(os.getenv('DISALLOW_ANONYMOUS_ACCESS', ''))
+ALLOW_TEAM_ACCESS = bool(os.getenv('ALLOW_TEAM_ACCESS', ''))
 
 SQLALCHEMY_TRACK_MODIFICATIONS = False
 SQLALCHEMY_ECHO = False  # Turn it on for debugging.

--- a/registry/quilt_server/config.py
+++ b/registry/quilt_server/config.py
@@ -9,6 +9,7 @@ See `app.config.from_object('...')` in __init__.py.
 import os
 
 DISALLOW_PUBLIC_USERS = bool(os.getenv('DISALLOW_PUBLIC_USERS', ''))
+ALLOW_TEAM_USERS = bool(os.getenv('ALLOW_TEAM_USERS', ''))
 
 SQLALCHEMY_TRACK_MODIFICATIONS = False
 SQLALCHEMY_ECHO = False  # Turn it on for debugging.

--- a/registry/quilt_server/const.py
+++ b/registry/quilt_server/const.py
@@ -8,6 +8,8 @@ from enum import Enum
 import re
 
 PUBLIC = 'public' # This username is blocked by Quilt signup
+TEAM = 'team'
+
 VALID_NAME_RE = re.compile(r'^[a-zA-Z]\w*$')
 VALID_EMAIL_RE = re.compile(r'^([^\s@]+)@([^\s@]+)$')
 

--- a/registry/quilt_server/schemas.py
+++ b/registry/quilt_server/schemas.py
@@ -18,6 +18,9 @@ PACKAGE_SCHEMA = {
         'public': {
             'type': 'boolean'
         },
+        'team': {
+            'type': 'boolean'
+        },
         'description': {
             'type': 'string'
         },

--- a/registry/quilt_server/schemas.py
+++ b/registry/quilt_server/schemas.py
@@ -15,10 +15,13 @@ PACKAGE_SCHEMA = {
         'dry_run': {
             'type': 'boolean'
         },
-        'public': {
+        'is_public': {
             'type': 'boolean'
         },
-        'team': {
+        'is_team': {
+            'type': 'boolean'
+        },
+        'public': {  # DEPRECATED
             'type': 'boolean'
         },
         'description': {

--- a/registry/quilt_server/views.py
+++ b/registry/quilt_server/views.py
@@ -524,8 +524,8 @@ def package_put(owner, package_name, package_hash):
     # TODO: Description.
     data = json.loads(request.data.decode('utf-8'), object_hook=decode_node)
     dry_run = data.get('dry_run', False)
-    public = data.get('public', False)
-    team = data.get('team', False)
+    public = data.get('is_public', data.get('public', False))
+    team = data.get('is_team', False)
     contents = data['contents']
     sizes = data.get('sizes', {})
 

--- a/registry/quilt_server/views.py
+++ b/registry/quilt_server/views.py
@@ -1409,9 +1409,9 @@ def recent_packages():
         count = 10
 
     if ALLOW_ANONYMOUS_ACCESS:
-        user = PUBLIC
+        max_visibility = PUBLIC
     elif ALLOW_TEAM_ACCESS:
-        user = TEAM
+        max_visibility = TEAM
     else:
         # Shouldn't really happen, but let's handle this case.
         raise ApiException(requests.codes.forbidden, "Not allowed")
@@ -1419,7 +1419,7 @@ def recent_packages():
     results = (
         db.session.query(Package, sa.func.max(Instance.updated_at))
         .join(Package.access)
-        .filter_by(user=user)
+        .filter_by(user=max_visibility)
         .join(Package.instances)
         .group_by(Package.id)
         .order_by(sa.func.max(Instance.updated_at).desc())

--- a/registry/quilt_server/views.py
+++ b/registry/quilt_server/views.py
@@ -28,7 +28,7 @@ import stripe
 
 from . import app, db
 from .analytics import MIXPANEL_EVENT, mp
-from .const import PaymentPlan, PUBLIC, VALID_NAME_RE, VALID_EMAIL_RE
+from .const import PaymentPlan, PUBLIC, TEAM, VALID_NAME_RE, VALID_EMAIL_RE
 from .core import decode_node, find_object_hashes, hash_contents, FileNode, GroupNode, RootNode
 from .models import (Access, Customer, Event, Instance, Invitation, Log, Package,
                      S3Blob, Tag, Version)
@@ -60,7 +60,8 @@ INVITE_SEND_URL = app.config['INVITE_SEND_URL']
 PACKAGE_BUCKET_NAME = app.config['PACKAGE_BUCKET_NAME']
 PACKAGE_URL_EXPIRATION = app.config['PACKAGE_URL_EXPIRATION']
 
-DISALLOW_PUBLIC_USERS = app.config['DISALLOW_PUBLIC_USERS']
+ALLOW_PUBLIC_USERS = not app.config['DISALLOW_PUBLIC_USERS']
+ALLOW_TEAM_USERS = app.config['ALLOW_TEAM_USERS']
 
 ENABLE_USER_ENDPOINTS = app.config['ENABLE_USER_ENDPOINTS']
 
@@ -244,9 +245,10 @@ class Auth:
     """
     Info about the user making the API request.
     """
-    def __init__(self, user, email, is_admin):
+    def __init__(self, user, email, is_logged_in, is_admin):
         self.user = user
         self.email = email
+        self.is_logged_in = is_logged_in
         self.is_admin = is_admin
 
 
@@ -305,7 +307,7 @@ def api(require_login=True, schema=None, enabled=True, require_admin=False):
     def innerdec(f):
         @wraps(f)
         def wrapper(*args, **kwargs):
-            g.auth = Auth(PUBLIC, None, False)
+            g.auth = Auth(user=None, email=None, is_logged_in=False, is_admin=False)
 
             user_agent_str = request.headers.get('user-agent', '')
             g.user_agent = httpagentparser.detect(user_agent_str, fill_none=True)
@@ -323,7 +325,7 @@ def api(require_login=True, schema=None, enabled=True, require_admin=False):
             auth = request.headers.get(AUTHORIZATION_HEADER)
             g.auth_header = auth
             if auth is None:
-                if require_login or DISALLOW_PUBLIC_USERS:
+                if require_login or not ALLOW_PUBLIC_USERS:
                     raise ApiException(requests.codes.unauthorized, "Not logged in")
             else:
                 headers = {
@@ -339,7 +341,8 @@ def api(require_login=True, schema=None, enabled=True, require_admin=False):
                     assert user
                     email = data['email']
                     is_admin = data.get('is_staff', False)
-                    g.auth = Auth(user, email, is_admin)
+
+                    g.auth = Auth(user=user, email=email, is_logged_in=True, is_admin=is_admin)
                 except requests.HTTPError as ex:
                     if resp.status_code == requests.codes.unauthorized:
                         raise ApiException(
@@ -361,6 +364,20 @@ def api(require_login=True, schema=None, enabled=True, require_admin=False):
         return wrapper
     return innerdec
 
+def _access_filter(auth):
+    query = []
+    if ALLOW_PUBLIC_USERS:
+        query.append(PUBLIC)
+
+    if auth.is_logged_in:
+        assert auth.user not in [None, PUBLIC, TEAM]  # Sanity check
+        query.append(auth.user)
+
+        if ALLOW_TEAM_USERS:
+            query.append(TEAM)
+
+    return Access.user.in_(query)
+
 def _get_package(auth, owner, package_name):
     """
     Helper for looking up a package and checking permissions.
@@ -370,11 +387,11 @@ def _get_package(auth, owner, package_name):
         Package.query
         .filter_by(owner=owner, name=package_name)
         .join(Package.access)
-        .filter(Access.user.in_([auth.user, PUBLIC]))
+        .filter(_access_filter(auth))
         .one_or_none()
     )
     if package is None:
-        raise PackageNotFoundException(owner, package_name, auth.user is not PUBLIC)
+        raise PackageNotFoundException(owner, package_name, auth.is_logged_in)
     return package
 
 def _get_instance(auth, owner, package_name, package_hash):
@@ -385,7 +402,7 @@ def _get_instance(auth, owner, package_name, package_hash):
         .join(Instance.package)
         .filter_by(owner=owner, name=package_name)
         .join(Package.access)
-        .filter(Access.user.in_([auth.user, PUBLIC]))
+        .filter(_access_filter(auth))
         .one_or_none()
     )
     if instance is None:
@@ -408,7 +425,7 @@ def _mp_track(**kwargs):
         source = 'web'
 
     # Use the user ID if the user is logged in; otherwise, let MP use the IP address.
-    distinct_id = g.auth.user if g.auth.user != PUBLIC else None
+    distinct_id = g.auth.user
 
     # Try to get the ELB's forwarded IP, and fall back to the actual IP (in dev).
     ip_addr = request.headers.get('x-forwarded-for', request.remote_addr)
@@ -443,7 +460,7 @@ def _generate_presigned_url(method, owner, blob_hash):
 
 def _get_or_create_customer():
     assert HAVE_PAYMENTS, "Payments are not enabled"
-    assert g.auth.user != PUBLIC
+    assert g.auth.user
 
     db_customer = Customer.query.filter_by(id=g.auth.user).one_or_none()
 
@@ -508,8 +525,14 @@ def package_put(owner, package_name, package_hash):
     data = json.loads(request.data.decode('utf-8'), object_hook=decode_node)
     dry_run = data.get('dry_run', False)
     public = data.get('public', False)
+    team = data.get('team', False)
     contents = data['contents']
     sizes = data.get('sizes', {})
+
+    if public and not ALLOW_PUBLIC_USERS:
+        raise ApiException(requests.codes.forbidden, "Public access not allowed")
+    if team and not ALLOW_TEAM_USERS:
+        raise ApiException(requests.codes.forbidden, "Team access not allowed")
 
     if hash_contents(contents) != package_hash:
         raise ApiException(requests.codes.bad_request, "Wrong contents hash")
@@ -569,6 +592,10 @@ def package_put(owner, package_name, package_hash):
         if public:
             public_access = Access(package=package, user=PUBLIC)
             db.session.add(public_access)
+
+        if team:
+            team_access = Access(package=package, user=TEAM)
+            db.session.add(team_access)
     else:
         if public:
             public_access = (
@@ -584,6 +611,22 @@ def package_put(owner, package_name, package_hash):
                     requests.codes.forbidden,
                     ("%(user)s/%(pkg)s is private. To make it public, " +
                      "run `quilt access add %(user)s/%(pkg)s public`.") %
+                    dict(user=owner, pkg=package_name)
+                )
+        if team:
+            team_access = (
+                Access.query
+                .filter(sa.and_(
+                    Access.package == package,
+                    Access.user == TEAM
+                ))
+                .one_or_none()
+            )
+            if team_access is None:
+                raise ApiException(
+                    requests.codes.forbidden,
+                    ("%(user)s/%(pkg)s is private. To share it with the team, " +
+                     "run `quilt access add %(user)s/%(pkg)s team`.") %
                     dict(user=owner, pkg=package_name)
                 )
 
@@ -854,10 +897,14 @@ def package_delete(owner, package_name):
 @as_json
 def user_packages(owner):
     packages = (
-        db.session.query(Package, sa.func.bool_or(Access.user == PUBLIC))
+        db.session.query(
+            Package,
+            sa.func.bool_or(Access.user == PUBLIC),
+            sa.func.bool_or(Access.user == TEAM)
+        )
         .filter_by(owner=owner)
         .join(Package.access)
-        .filter(Access.user.in_([g.auth.user, PUBLIC]))
+        .filter(_access_filter(g.auth))
         .group_by(Package.id)
         .order_by(Package.name)
         .all()
@@ -867,9 +914,10 @@ def user_packages(owner):
         packages=[
             dict(
                 name=package.name,
-                is_public=is_public
+                is_public=is_public,
+                is_team=is_team,
             )
-            for package, is_public in packages
+            for package, is_public, is_team in packages
         ]
     )
 
@@ -878,7 +926,11 @@ def user_packages(owner):
 @as_json
 def list_user_packages(owner):
     packages = (
-        db.session.query(Package, sa.func.bool_or(Access.user == PUBLIC))
+        db.session.query(
+            Package,
+            sa.func.bool_or(Access.user == PUBLIC),
+            sa.func.bool_or(Access.user == TEAM)
+        )
         .filter_by(owner=owner)
         .join(Package.access)
         .group_by(Package.id)
@@ -890,9 +942,10 @@ def list_user_packages(owner):
         packages=[
             dict(
                 name=package.name,
-                is_public=is_public
+                is_public=is_public,
+                is_team=is_team,
             )
-            for package, is_public in packages
+            for package, is_public, is_team in packages
         ]
     )
 
@@ -1234,7 +1287,13 @@ def access_put(owner, package_name, user):
         return dict()
 
     else:
-        if user != PUBLIC:
+        if user == PUBLIC:
+            if not ALLOW_PUBLIC_USERS:
+                raise ApiException(requests.codes.forbidden, "Public access not allowed")
+        elif user == TEAM:
+            if not ALLOW_TEAM_USERS:
+                raise ApiException(requests.codes.forbidden, "Team access not allowed")
+        else:
             resp = requests.get(OAUTH_PROFILE_API % user,
                                 headers=auth_headers)
             if resp.status_code == requests.codes.not_found:
@@ -1332,9 +1391,10 @@ def access_list(owner, package_name):
 
     can_access = [access.user for access in accesses]
     is_collaborator = g.auth.user in can_access
-    is_public = PUBLIC in can_access
+    is_public = ALLOW_PUBLIC_USERS and (PUBLIC in can_access)
+    is_team = ALLOW_TEAM_USERS and (TEAM in can_access)
 
-    if is_public or is_collaborator:
+    if is_public or is_team or is_collaborator:
         return dict(users=can_access)
     else:
         raise PackageNotFoundException(owner, package_name)
@@ -1348,10 +1408,18 @@ def recent_packages():
     except ValueError:
         count = 10
 
+    if ALLOW_PUBLIC_USERS:
+        user = PUBLIC
+    elif ALLOW_TEAM_USERS:
+        user = TEAM
+    else:
+        # Shouldn't really happen, but let's handle this case.
+        raise ApiException(requests.codes.forbidden, "Not allowed")
+
     results = (
         db.session.query(Package, sa.func.max(Instance.updated_at))
         .join(Package.access)
-        .filter_by(user=PUBLIC)
+        .filter_by(user=user)
         .join(Package.instances)
         .group_by(Package.id)
         .order_by(sa.func.max(Instance.updated_at).desc())
@@ -1389,10 +1457,14 @@ def search():
     ]
 
     results = (
-        db.session.query(Package, sa.func.bool_or(Access.user == PUBLIC))
+        db.session.query(
+            Package,
+            sa.func.bool_or(Access.user == PUBLIC),
+            sa.func.bool_or(Access.user == TEAM)
+        )
         .filter(sa.and_(*filter_list))
         .join(Package.access)
-        .filter(Access.user.in_([g.auth.user, PUBLIC]))
+        .filter(_access_filter(g.auth))
         .group_by(Package.id)
         .order_by(
             sa.func.lower(Package.owner),
@@ -1407,7 +1479,8 @@ def search():
                 owner=package.owner,
                 name=package.name,
                 is_public=is_public,
-            ) for package, is_public in results
+                is_team=is_team,
+            ) for package, is_public, is_team in results
         ]
     )
 
@@ -1441,9 +1514,13 @@ def profile():
     # but also show whether they're public, in case a package is both public and shared with the user.
     # So do a "GROUP BY" to get the public info, then "HAVING" to filter out packages that aren't shared.
     packages = (
-        db.session.query(Package, sa.func.bool_or(Access.user == PUBLIC))
+        db.session.query(
+            Package,
+            sa.func.bool_or(Access.user == PUBLIC),
+            sa.func.bool_or(Access.user == TEAM)
+        )
         .join(Package.access)
-        .filter(Access.user.in_([g.auth.user, PUBLIC]))
+        .filter(_access_filter(g.auth))
         .group_by(Package.id)
         .order_by(
             sa.func.lower(Package.owner),
@@ -1460,16 +1537,18 @@ def profile():
                     owner=package.owner,
                     name=package.name,
                     is_public=is_public,
+                    is_team=is_team,
                 )
-                for package, is_public in packages if package.owner == g.auth.user
+                for package, is_public, is_team in packages if package.owner == g.auth.user
             ],
             shared=[
                 dict(
                     owner=package.owner,
                     name=package.name,
                     is_public=is_public,
+                    is_team=is_team,
                 )
-                for package, is_public in packages if package.owner != g.auth.user
+                for package, is_public, is_team in packages if package.owner != g.auth.user
             ],
         ),
         plan=plan,

--- a/registry/tests/access_test.py
+++ b/registry/tests/access_test.py
@@ -453,8 +453,8 @@ class AccessTestCase(QuiltTestCase):
         resp = self._share_package(self.user, self.pkg, 'team')
         assert resp.status_code == requests.codes.forbidden
 
-    @patch('quilt_server.views.ALLOW_PUBLIC_USERS', False)
-    @patch('quilt_server.views.ALLOW_TEAM_USERS', True)
+    @patch('quilt_server.views.ALLOW_ANONYMOUS_ACCESS', False)
+    @patch('quilt_server.views.ALLOW_TEAM_ACCESS', True)
     def testSharePublicFails(self):
         resp = self._share_package(self.user, self.pkg, 'public')
         assert resp.status_code == requests.codes.forbidden
@@ -536,8 +536,8 @@ class AccessTestCase(QuiltTestCase):
         assert data['own'] == []
         assert data['shared'] == [dict(owner=self.user, name=self.pkg, is_public=True, is_team=False)]
 
-    @patch('quilt_server.views.ALLOW_PUBLIC_USERS', False)
-    @patch('quilt_server.views.ALLOW_TEAM_USERS', True)
+    @patch('quilt_server.views.ALLOW_ANONYMOUS_ACCESS', False)
+    @patch('quilt_server.views.ALLOW_TEAM_ACCESS', True)
     def testTeamProfile(self):
         """
         Test the profile endpoint but with teams and no public access.

--- a/registry/tests/access_test.py
+++ b/registry/tests/access_test.py
@@ -385,7 +385,7 @@ class AccessTestCase(QuiltTestCase):
     @mock_customer()
     def testRemovePublicBasicUser(self, customer):
         public_pkg = "publicpkg"
-        self.put_package(self.user, public_pkg, RootNode(children=dict()), public=True)
+        self.put_package(self.user, public_pkg, RootNode(children=dict()), is_public=True)
 
         # Try deleting the PUBLIC user
         resp = self.app.delete(
@@ -399,7 +399,7 @@ class AccessTestCase(QuiltTestCase):
     @mock_customer(plan=PaymentPlan.INDIVIDUAL)
     def testRemovePublicIndividualUser(self, customer):
         public_pkg = "publicpkg"
-        self.put_package(self.user, public_pkg, RootNode(children=dict()), public=True)
+        self.put_package(self.user, public_pkg, RootNode(children=dict()), is_public=True)
 
         # Delete the PUBLIC user
         resp = self.app.delete(
@@ -425,7 +425,7 @@ class AccessTestCase(QuiltTestCase):
 
     def testRemovePublicNoPayments(self):
         public_pkg = "publicpkg"
-        self.put_package(self.user, public_pkg, RootNode(children=dict()), public=True)
+        self.put_package(self.user, public_pkg, RootNode(children=dict()), is_public=True)
 
         # Delete the PUBLIC user
         resp = self.app.delete(
@@ -464,7 +464,7 @@ class AccessTestCase(QuiltTestCase):
         List all accessible packages.
         """
         public_pkg = "publicpkg"
-        self.put_package(self.user, public_pkg, RootNode(children=dict()), public=True)
+        self.put_package(self.user, public_pkg, RootNode(children=dict()), is_public=True)
 
         # The user can see own packages.
         resp = self.app.get(
@@ -543,7 +543,7 @@ class AccessTestCase(QuiltTestCase):
         Test the profile endpoint but with teams and no public access.
         """
         public_pkg = "publicpkg"
-        self.put_package(self.user, public_pkg, RootNode(children=dict()), team=True)
+        self.put_package(self.user, public_pkg, RootNode(children=dict()), is_team=True)
 
         # The user can see own packages.
         resp = self.app.get(
@@ -619,9 +619,9 @@ class AccessTestCase(QuiltTestCase):
         """
         Test the profile endpoint but with teams *AND* public packages.
         """
-        self.put_package(self.user, 'pkg1', RootNode(children=dict()), team=True)
-        self.put_package(self.user, 'pkg2', RootNode(children=dict()), public=True)
-        self.put_package(self.user, 'pkg3', RootNode(children=dict()), team=True, public=True)
+        self.put_package(self.user, 'pkg1', RootNode(children=dict()), is_team=True)
+        self.put_package(self.user, 'pkg2', RootNode(children=dict()), is_public=True)
+        self.put_package(self.user, 'pkg3', RootNode(children=dict()), is_team=True, is_public=True)
 
         # The user can see own packages.
         resp = self.app.get(
@@ -685,14 +685,14 @@ class AccessTestCase(QuiltTestCase):
         # Push two public packages.
         for i in range(2):
             pkg = 'pkg%d' % i
-            self.put_package(self.user, pkg, RootNode(children=dict()), public=True)
+            self.put_package(self.user, pkg, RootNode(children=dict()), is_public=True)
 
         time.sleep(1)  # This sucks, but package timestamps only have a resolution of 1s.
 
         # Push two more.
         for i in range(2, 4):
             pkg = 'pkg%d' % i
-            self.put_package(self.user, pkg, RootNode(children=dict()), public=True)
+            self.put_package(self.user, pkg, RootNode(children=dict()), is_public=True)
 
         # Update pkg0.
         self.put_package(self.user, 'pkg0', RootNode(children=dict()))
@@ -721,7 +721,7 @@ class AccessTestCase(QuiltTestCase):
     def testSearch(self):
         for i in [1, 2]:
             pkg = 'public%d' % i
-            self.put_package(self.user, pkg, RootNode(children=dict()), public=True)
+            self.put_package(self.user, pkg, RootNode(children=dict()), is_public=True)
 
         def _test_query(query, headers, expected_results):
             params = dict(q=query)
@@ -759,7 +759,7 @@ class AccessTestCase(QuiltTestCase):
 
     def testSearchOrder(self):
         for pkg in ['a', 'B', 'c', 'D']:
-            self.put_package(self.user, pkg, RootNode(children=dict()), public=True)
+            self.put_package(self.user, pkg, RootNode(children=dict()), is_public=True)
 
         params = dict(q=self.user)
         resp = self.app.get(

--- a/registry/tests/push_install_test.py
+++ b/registry/tests/push_install_test.py
@@ -793,8 +793,8 @@ class PushInstallTestCase(QuiltTestCase):
 
         assert resp.status_code == requests.codes.forbidden
 
-    @patch('quilt_server.views.ALLOW_PUBLIC_USERS', False)
-    @patch('quilt_server.views.ALLOW_TEAM_USERS', True)
+    @patch('quilt_server.views.ALLOW_ANONYMOUS_ACCESS', False)
+    @patch('quilt_server.views.ALLOW_TEAM_ACCESS', True)
     def testTeams(self):
         # Public push fails.
         resp = self.app.put(

--- a/registry/tests/push_install_test.py
+++ b/registry/tests/push_install_test.py
@@ -127,7 +127,7 @@ class PushInstallTestCase(QuiltTestCase):
         resp = self.app.put(
             '/api/package/test_user/foo/%s' % self.CONTENTS_HASH,
             data=json.dumps(dict(
-                public=True,
+                is_public=True,
                 description="",
                 contents=self.CONTENTS,
                 sizes={self.HASH1: 1, self.HASH2: 2, self.HASH3: 3}
@@ -212,7 +212,7 @@ class PushInstallTestCase(QuiltTestCase):
         resp = self.app.put(
             '/api/package/test_user/foo/%s' % self.CONTENTS_HASH,
             data=json.dumps(dict(
-                public=True,
+                is_public=True,
                 description="",
                 contents=self.CONTENTS
             ), default=encode_node),
@@ -227,7 +227,7 @@ class PushInstallTestCase(QuiltTestCase):
         resp = self.app.put(
             '/api/package/test_user/foo/%s' % self.CONTENTS_HASH,
             data=json.dumps(dict(
-                public=True,
+                is_public=True,
                 description="",
                 contents=self.CONTENTS_WITH_METADATA
             ), default=encode_node),
@@ -355,7 +355,7 @@ class PushInstallTestCase(QuiltTestCase):
         resp = self.app.put(
             '/api/package/Test_User/foo/%s' % self.CONTENTS_HASH,
             data=json.dumps(dict(
-                public=True,
+                is_public=True,
                 description="",
                 contents=self.CONTENTS
             ), default=encode_node),
@@ -370,7 +370,7 @@ class PushInstallTestCase(QuiltTestCase):
         resp = self.app.put(
             '/api/package/test_user/foo/%s' % self.CONTENTS_HASH,
             data=json.dumps(dict(
-                public=True,
+                is_public=True,
                 description="",
                 contents=self.CONTENTS
             ), default=encode_node),
@@ -385,7 +385,7 @@ class PushInstallTestCase(QuiltTestCase):
         resp = self.app.put(
             '/api/package/Test_User/foo/%s' % self.CONTENTS_HASH,
             data=json.dumps(dict(
-                public=True,
+                is_public=True,
                 description="",
                 contents=self.CONTENTS
             ), default=encode_node),
@@ -400,7 +400,7 @@ class PushInstallTestCase(QuiltTestCase):
         resp = self.app.put(
             '/api/package/test_user/Foo/%s' % self.CONTENTS_HASH,
             data=json.dumps(dict(
-                public=True,
+                is_public=True,
                 description="",
                 contents=self.CONTENTS
             ), default=encode_node),
@@ -449,7 +449,7 @@ class PushInstallTestCase(QuiltTestCase):
         resp = self.app.put(
             '/api/package/test_user/foo/%s' % self.CONTENTS_HASH,
             data=json.dumps(dict(
-                public=True,
+                is_public=True,
                 description="",
                 contents=self.CONTENTS
             ), default=encode_node),
@@ -485,7 +485,7 @@ class PushInstallTestCase(QuiltTestCase):
         resp = self.app.put(
             '/api/package/test_user/bar/%s' % self.CONTENTS_HASH,
             data=json.dumps(dict(
-                public=True,
+                is_public=True,
                 description="",
                 contents=self.CONTENTS
             ), default=encode_node),
@@ -535,7 +535,7 @@ class PushInstallTestCase(QuiltTestCase):
             '/api/package/test_user/foo/%s' % self.CONTENTS_HASH,
             data=json.dumps(dict(
                 dry_run=True,
-                public=True,
+                is_public=True,
                 description="",
                 contents=self.CONTENTS
             ), default=encode_node),
@@ -572,7 +572,7 @@ class PushInstallTestCase(QuiltTestCase):
             '/api/package/test_user/foo/%s' % 'bad hash',
             data=json.dumps(dict(
                 dry_run=True,
-                public=True,
+                is_public=True,
                 description="",
                 contents=self.CONTENTS
             ), default=encode_node),
@@ -591,7 +591,7 @@ class PushInstallTestCase(QuiltTestCase):
         resp = self.app.put(
             '/api/package/test_user/foo/%s' % self.CONTENTS_HASH,
             data=json.dumps(dict(
-                public=True,
+                is_public=True,
                 description="",
                 contents=self.CONTENTS,
                 sizes={self.HASH1: 1, self.HASH2: 2, self.HASH3: 3}
@@ -671,7 +671,7 @@ class PushInstallTestCase(QuiltTestCase):
         resp = self.app.put(
             '/api/package/test_user/foo/%s' % huge_contents_hash,
             data=json.dumps(dict(
-                public=True,
+                is_public=True,
                 description="",
                 contents=self.HUGE_CONTENTS
             ), default=encode_node),
@@ -737,7 +737,7 @@ class PushInstallTestCase(QuiltTestCase):
         resp = self.app.put(
             '/api/package/test_user/foo/%s' % self.CONTENTS_HASH,
             data=json.dumps(dict(
-                public=True,
+                is_public=True,
                 description="",
                 contents=self.CONTENTS
             ), default=encode_node),
@@ -758,7 +758,7 @@ class PushInstallTestCase(QuiltTestCase):
         resp = self.app.put(
             '/api/package/test_user/foo/%s' % self.CONTENTS_2_HASH,
             data=json.dumps(dict(
-                public=True,
+                is_public=True,
                 description="",
                 contents=self.CONTENTS_2
             ), default=encode_node),
@@ -780,7 +780,7 @@ class PushInstallTestCase(QuiltTestCase):
         resp = self.app.put(
             '/api/package/test_user/foo/%s' % self.CONTENTS_HASH,
             data=json.dumps(dict(
-                team=True,
+                is_team=True,
                 description="",
                 contents=self.CONTENTS,
                 sizes={self.HASH1: 1, self.HASH2: 2, self.HASH3: 3}
@@ -800,7 +800,7 @@ class PushInstallTestCase(QuiltTestCase):
         resp = self.app.put(
             '/api/package/test_user/foo/%s' % self.CONTENTS_HASH,
             data=json.dumps(dict(
-                public=True,
+                is_public=True,
                 description="",
                 contents=self.CONTENTS,
                 sizes={self.HASH1: 1, self.HASH2: 2, self.HASH3: 3}
@@ -817,7 +817,7 @@ class PushInstallTestCase(QuiltTestCase):
         resp = self.app.put(
             '/api/package/test_user/foo/%s' % self.CONTENTS_HASH,
             data=json.dumps(dict(
-                team=True,
+                is_team=True,
                 description="",
                 contents=self.CONTENTS,
                 sizes={self.HASH1: 1, self.HASH2: 2, self.HASH3: 3}
@@ -829,3 +829,34 @@ class PushInstallTestCase(QuiltTestCase):
         )
 
         assert resp.status_code == requests.codes.ok
+
+    def testOldPublicParamn(self):
+        # Push a package using "public" rather than "is_public".
+        resp = self.app.put(
+            '/api/package/test_user/foo/%s' % self.CONTENTS_HASH,
+            data=json.dumps(dict(
+                public=True,
+                description="",
+                contents=self.CONTENTS,
+                sizes={self.HASH1: 1, self.HASH2: 2, self.HASH3: 3}
+            ), default=encode_node),
+            content_type='application/json',
+            headers={
+                'Authorization': 'test_user'
+            }
+        )
+
+        assert resp.status_code == requests.codes.ok
+
+        # Verify that "is_public" is set.
+        resp = self.app.get(
+            '/api/package/test_user/',
+            headers={
+                'Authorization': 'test_user'
+            }
+        )
+
+        assert resp.status_code == requests.codes.ok
+
+        data = json.loads(resp.data.decode('utf8'))
+        assert data['packages'] == [dict(name='foo', is_public=True, is_team=False)]

--- a/registry/tests/tag_test.py
+++ b/registry/tests/tag_test.py
@@ -35,7 +35,7 @@ class TagTestCase(QuiltTestCase):
 
         # Upload three package instances.
         for contents in self.contents_list:
-            self.put_package(self.user, self.pkg, contents, public=True)
+            self.put_package(self.user, self.pkg, contents, is_public=True)
 
     def _add_tag(self, tag, pkghash):
         return self.app.put(

--- a/registry/tests/utils.py
+++ b/registry/tests/utils.py
@@ -101,7 +101,7 @@ class QuiltTestCase(TestCase):
         user_url = quilt_server.app.config['OAUTH']['profile_api'] % user
         self.requests_mock.add(responses.GET, user_url, json.dumps(dict(username=user)))
 
-    def put_package(self, owner, package, contents, public=False):
+    def put_package(self, owner, package, contents, public=False, team=False):
         pkgurl = '/api/package/{usr}/{pkg}/{hash}'.format(
             usr=owner,
             pkg=package,
@@ -114,6 +114,7 @@ class QuiltTestCase(TestCase):
                 description="",
                 contents=contents,
                 public=public,
+                team=team,
             ), default=encode_node),
             content_type='application/json',
             headers={

--- a/registry/tests/utils.py
+++ b/registry/tests/utils.py
@@ -101,7 +101,7 @@ class QuiltTestCase(TestCase):
         user_url = quilt_server.app.config['OAUTH']['profile_api'] % user
         self.requests_mock.add(responses.GET, user_url, json.dumps(dict(username=user)))
 
-    def put_package(self, owner, package, contents, public=False, team=False):
+    def put_package(self, owner, package, contents, is_public=False, is_team=False):
         pkgurl = '/api/package/{usr}/{pkg}/{hash}'.format(
             usr=owner,
             pkg=package,
@@ -113,8 +113,8 @@ class QuiltTestCase(TestCase):
             data=json.dumps(dict(
                 description="",
                 contents=contents,
-                public=public,
-                team=team,
+                is_public=is_public,
+                is_team=is_team,
             ), default=encode_node),
             content_type='application/json',
             headers={

--- a/registry/tests/version_test.py
+++ b/registry/tests/version_test.py
@@ -35,7 +35,7 @@ class VersionTestCase(QuiltTestCase):
 
         # Upload three package instances.
         for contents in self.contents_list:
-            self.put_package(self.user, self.pkg, contents, public=True)
+            self.put_package(self.user, self.pkg, contents, is_public=True)
 
     def _add_version(self, version, pkghash):
         return self.app.put(


### PR DESCRIPTION
Also refactor the auth code and use an `is_logged_in` boolean instead of (ab)using the "public" user.

- Cleaner and safer
- Allows us to some day support teams that allow public access
- Prevents the word "public" from showing up where it shouldn't

TODO: What are good names for env vars and configs? I don't like configs that default to "true", but "ALLOW_..." and "DISALLOW_..." are kind of inconsistent.