### PR TITLE
Switch from TIMESTAMP datatype to TIMESTAMPTZ

### DIFF
--- a/registry/migrations/versions/6daddb340397_use_timestamptz_instead_of_timestamp_.py
+++ b/registry/migrations/versions/6daddb340397_use_timestamptz_instead_of_timestamp_.py
@@ -1,0 +1,72 @@
+"""Use TIMESTAMPTZ instead of TIMESTAMP type
+
+Revision ID: 6daddb340397
+Revises: a96ca1dce4d5
+Create Date: 2018-02-15 15:15:44.942813
+
+"""
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+# revision identifiers, used by Alembic.
+revision = '6daddb340397'
+down_revision = 'a96ca1dce4d5'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.alter_column('event', 'created',
+               existing_type=postgresql.TIMESTAMP(),
+               type_=postgresql.TIMESTAMP(timezone=True),
+               existing_nullable=False,
+               existing_server_default=sa.text('now()'))
+    op.alter_column('instance', 'created_at',
+               existing_type=postgresql.TIMESTAMP(),
+               type_=postgresql.TIMESTAMP(timezone=True),
+               existing_nullable=False,
+               existing_server_default=sa.text('now()'))
+    op.alter_column('instance', 'updated_at',
+               existing_type=postgresql.TIMESTAMP(),
+               type_=postgresql.TIMESTAMP(timezone=True),
+               existing_nullable=False,
+               existing_server_default=sa.text('now()'))
+    op.alter_column('invitation', 'invited_at',
+               existing_type=postgresql.TIMESTAMP(),
+               type_=postgresql.TIMESTAMP(timezone=True),
+               existing_nullable=False,
+               existing_server_default=sa.text('now()'))
+    op.alter_column('log', 'created',
+               existing_type=postgresql.TIMESTAMP(),
+               type_=postgresql.TIMESTAMP(timezone=True),
+               existing_nullable=False,
+               existing_server_default=sa.text('now()'))
+
+
+def downgrade():
+    op.alter_column('log', 'created',
+               existing_type=postgresql.TIMESTAMP(timezone=True),
+               type_=postgresql.TIMESTAMP(),
+               existing_nullable=False,
+               existing_server_default=sa.text('now()'))
+    op.alter_column('invitation', 'invited_at',
+               existing_type=postgresql.TIMESTAMP(timezone=True),
+               type_=postgresql.TIMESTAMP(),
+               existing_nullable=False,
+               existing_server_default=sa.text('now()'))
+    op.alter_column('instance', 'updated_at',
+               existing_type=postgresql.TIMESTAMP(timezone=True),
+               type_=postgresql.TIMESTAMP(),
+               existing_nullable=False,
+               existing_server_default=sa.text('now()'))
+    op.alter_column('instance', 'created_at',
+               existing_type=postgresql.TIMESTAMP(timezone=True),
+               type_=postgresql.TIMESTAMP(),
+               existing_nullable=False,
+               existing_server_default=sa.text('now()'))
+    op.alter_column('event', 'created',
+               existing_type=postgresql.TIMESTAMP(timezone=True),
+               type_=postgresql.TIMESTAMP(),
+               existing_nullable=False,
+               existing_server_default=sa.text('now()'))

--- a/registry/quilt_server/__init__.py
+++ b/registry/quilt_server/__init__.py
@@ -37,7 +37,7 @@ class QuiltSQLAlchemy(SQLAlchemy):
 db = QuiltSQLAlchemy(app)
 
 FlaskJSON(app)
-Migrate(app, db)
+Migrate(app, db, compare_type=True)
 
 @app.cli.command('createdb')
 def createdb_command():

--- a/registry/quilt_server/models.py
+++ b/registry/quilt_server/models.py
@@ -57,9 +57,9 @@ class Instance(db.Model):
     package_id = db.Column(db.BigInteger, db.ForeignKey('package.id'), nullable=False)
     hash = db.Column(db.String(64), nullable=False)
 
-    created_at = db.Column(db.DateTime, server_default=db.func.now(), nullable=False)
+    created_at = db.Column(postgresql.TIMESTAMP(True), server_default=db.func.now(), nullable=False)
     created_by = db.Column(USERNAME_TYPE, nullable=False)
-    updated_at = db.Column(db.DateTime, server_default=db.func.now(),
+    updated_at = db.Column(postgresql.TIMESTAMP(True), server_default=db.func.now(),
                            onupdate=db.func.now(), nullable=False)
     updated_by = db.Column(USERNAME_TYPE, nullable=False)
 
@@ -87,7 +87,7 @@ class Log(db.Model):
     id = db.Column(db.BigInteger, primary_key=True)
     package_id = db.Column(db.BigInteger, db.ForeignKey('package.id'), nullable=False, index=True)
     instance_id = db.Column(db.BigInteger, db.ForeignKey('instance.id'))
-    created = db.Column(db.DateTime, server_default=db.func.now(), nullable=False)
+    created = db.Column(postgresql.TIMESTAMP(True), server_default=db.func.now(), nullable=False)
     author = db.Column(USERNAME_TYPE, nullable=False)
 
     package = db.relationship('Package', back_populates='logs')
@@ -135,7 +135,7 @@ class Invitation(db.Model):
     id = db.Column(db.BigInteger, primary_key=True)
     package_id = db.Column(db.BigInteger, db.ForeignKey('package.id'))
     email = db.Column(db.String(254), nullable=False)
-    invited_at = db.Column(db.DateTime, server_default=db.func.now(), nullable=False)
+    invited_at = db.Column(postgresql.TIMESTAMP(True), server_default=db.func.now(), nullable=False)
 
     package = db.relationship('Package', back_populates='invitation')
 
@@ -155,7 +155,7 @@ class Event(db.Model):
         def __str__(self): return '%d' % self
 
     id = db.Column(db.BigInteger, primary_key=True)
-    created = db.Column(db.DateTime, server_default=db.func.now(), nullable=False, index=True)
+    created = db.Column(postgresql.TIMESTAMP(True), server_default=db.func.now(), nullable=False, index=True)
     user = db.Column(USERNAME_TYPE, index=True)
     type = db.Column(db.SmallInteger, nullable=False)
     package_owner = db.Column(USERNAME_TYPE)

--- a/registry/quilt_server/views.py
+++ b/registry/quilt_server/views.py
@@ -412,12 +412,6 @@ def _get_instance(auth, owner, package_name, package_hash):
         )
     return instance
 
-def _utc_datetime_to_ts(dt):
-    """
-    Convert a UTC datetime object to a UNIX timestamp.
-    """
-    return dt.replace(tzinfo=timezone.utc).timestamp()
-
 def _mp_track(**kwargs):
     if g.user_agent['browser']['name'] == 'QuiltCli':
         source = 'cli'
@@ -792,9 +786,9 @@ def package_get(owner, package_name, package_hash):
         urls=urls,
         sizes={blob.hash: blob.size for blob in blobs},
         created_by=instance.created_by,
-        created_at=_utc_datetime_to_ts(instance.created_at),
+        created_at=instance.created_at.timestamp(),
         updated_by=instance.updated_by,
-        updated_at=_utc_datetime_to_ts(instance.updated_at),
+        updated_at=instance.updated_at.timestamp(),
     )
 
 def _generate_preview(node, max_depth=PREVIEW_MAX_DEPTH):
@@ -848,9 +842,9 @@ def package_preview(owner, package_name, package_hash):
         preview=contents_preview,
         readme_url=readme_url,
         created_by=instance.created_by,
-        created_at=_utc_datetime_to_ts(instance.created_at),
+        created_at=instance.created_at.timestamp(),
         updated_by=instance.updated_by,
-        updated_at=_utc_datetime_to_ts(instance.updated_at),
+        updated_at=instance.updated_at.timestamp(),
     )
 
 @app.route('/api/package/<owner>/<package_name>/', methods=['GET'])
@@ -966,7 +960,7 @@ def logs_list(owner, package_name):
     return dict(
         logs=[dict(
             hash=instance.hash,
-            created=_utc_datetime_to_ts(log.created),
+            created=log.created.timestamp(),
             author=log.author
         ) for log, instance in logs]
     )
@@ -1062,9 +1056,9 @@ def version_get(owner, package_name, package_version):
     return dict(
         hash=instance.hash,
         created_by=instance.created_by,
-        created_at=_utc_datetime_to_ts(instance.created_at),
+        created_at=instance.created_at.timestamp(),
         updated_by=instance.updated_by,
-        updated_at=_utc_datetime_to_ts(instance.updated_at),
+        updated_at=instance.updated_at.timestamp(),
     )
 
 @app.route('/api/version/<owner>/<package_name>/', methods=['GET'])
@@ -1176,9 +1170,9 @@ def tag_get(owner, package_name, package_tag):
     return dict(
         hash=instance.hash,
         created_by=instance.created_by,
-        created_at=_utc_datetime_to_ts(instance.created_at),
+        created_at=instance.created_at.timestamp(),
         updated_by=instance.updated_by,
-        updated_at=_utc_datetime_to_ts(instance.updated_at),
+        updated_at=instance.updated_at.timestamp(),
     )
 
 @app.route('/api/tag/<owner>/<package_name>/<package_tag>', methods=['DELETE'])
@@ -1878,7 +1872,7 @@ def audit_package(owner, package_name):
 
     return dict(
         events=[dict(
-            created=_utc_datetime_to_ts(event.created),
+            created=event.created.timestamp(),
             user=event.user,
             type=Event.Type(event.type).name,
             package_owner=event.package_owner,
@@ -1899,7 +1893,7 @@ def audit_user(user):
 
     return dict(
         events=[dict(
-            created=_utc_datetime_to_ts(event.created),
+            created=event.created.timestamp(),
             user=event.user,
             type=Event.Type(event.type).name,
             package_owner=event.package_owner,
@@ -1923,8 +1917,7 @@ def package_summary():
     packages = set()
     for event_owner, event_package, event_type, event_count, latest in events:
         package = "{owner}/{pkg}".format(owner=event_owner, pkg=event_package)
-        ts = _utc_datetime_to_ts(latest)
-        event_results[(package, event_type)] = {'latest':ts, 'count':event_count}
+        event_results[(package, event_type)] = {'latest':latest.timestamp(), 'count':event_count}
         packages.add(package)
 
     results = {


### PR DESCRIPTION
According to pretty much every Postgres expert, timestamp with timezone is the correct way to store timestamps. Postgres doesn't actually _store_ the timezone - just converts everything to UTC first.

Makes the hacky helper function unnecessary, and fixes a unit test (when the current timezone is not UTC).