### PR TITLE
This assert breaks on existing packages

### DIFF
--- a/registry/quilt_server/core.py
+++ b/registry/quilt_server/core.py
@@ -74,7 +74,6 @@ class TableNode(Node):
         assert isinstance(hashes, list)
         assert isinstance(format, string_types), '%r' % format
         assert isinstance(metadata, dict)
-        assert not os.path.isabs(metadata.get('q_path') or '')  # handles q_path when None
 
         self.hashes = hashes
         self.format = PackageFormat(format)
@@ -94,7 +93,6 @@ class FileNode(Node):
 
         assert isinstance(hashes, list)
         assert isinstance(metadata, dict)
-        assert not os.path.isabs(metadata.get('q_path') or '')  # handles q_path when None
 
         self.hashes = hashes
         self.metadata = metadata


### PR DESCRIPTION
Some existing packages have absolute paths in some nodes. Until we can
remove those packages, this assert will fail.