### PR TITLE
Store READMEs in the DB and return them in package previews and search results

### DIFF
--- a/compiler/quilt/tools/command.py
+++ b/compiler/quilt/tools/command.py
@@ -1284,7 +1284,7 @@ def search(query, team=None):
     response = public_session.get("%s/api/search/" % get_registry_url(None), params=dict(q=query))
     packages = response.json()['packages']
     for pkg in packages:
-        print("%(owner)s/%(name)s" % pkg)
+        print("%(owner)s/%(name)s  %(readme_preview)s" % pkg)
     if len(packages) == 0:
         print("(No results)")
 

--- a/compiler/quilt/tools/command.py
+++ b/compiler/quilt/tools/command.py
@@ -34,9 +34,9 @@ from tqdm import tqdm
 
 from .build import (build_package, build_package_from_contents, generate_build_file,
                     generate_contents, BuildException, exec_yaml_python, load_yaml)
-from .const import DEFAULT_BUILDFILE, LATEST_TAG
+from .const import DEFAULT_BUILDFILE
 from .core import (hash_contents, find_object_hashes, PackageFormat, TableNode, FileNode, GroupNode,
-                   decode_node, encode_node)
+                   decode_node, encode_node, LATEST_TAG)
 from .hashing import digest_file
 from .store import PackageStore, StoreException
 from .util import BASE_DIR, FileWithReadProgress, gzip_compress, is_nodename

--- a/compiler/quilt/tools/command.py
+++ b/compiler/quilt/tools/command.py
@@ -1284,7 +1284,7 @@ def search(query, team=None):
     response = public_session.get("%s/api/search/" % get_registry_url(None), params=dict(q=query))
     packages = response.json()['packages']
     for pkg in packages:
-        print("%(owner)s/%(name)s  %(readme_preview)s" % pkg)
+        print("%(owner)s/%(name)s" % pkg)
     if len(packages) == 0:
         print("(No results)")
 

--- a/compiler/quilt/tools/const.py
+++ b/compiler/quilt/tools/const.py
@@ -14,7 +14,6 @@ class TargetType(Enum):
 DATEF = '%Y-%m-%d'
 TIMEF = '%H:%M:%S'
 DTIMEF = '%s %s' % (DATEF, TIMEF)
-LATEST_TAG = 'latest'
 PACKAGE_DIR_NAME = 'quilt_packages'
 DEFAULT_BUILDFILE = 'build.yml'
 DEFAULT_QUILT_YML = 'quilt.yml'

--- a/compiler/quilt/tools/core.py
+++ b/compiler/quilt/tools/core.py
@@ -14,6 +14,7 @@ from six import iteritems, itervalues, string_types
 
 
 LATEST_TAG = 'latest'
+README = 'README'
 
 
 class PackageFormat(Enum):

--- a/compiler/quilt/tools/core.py
+++ b/compiler/quilt/tools/core.py
@@ -13,6 +13,9 @@ import struct
 from six import iteritems, itervalues, string_types
 
 
+LATEST_TAG = 'latest'
+
+
 class PackageFormat(Enum):
     HDF5 = 'HDF5'
     PARQUET = 'PARQUET'

--- a/registry/migrations/versions/9451a38411a1_add_a_preview_column_to_s3_blob.py
+++ b/registry/migrations/versions/9451a38411a1_add_a_preview_column_to_s3_blob.py
@@ -1,0 +1,24 @@
+"""Add a preview column to s3_blob
+
+Revision ID: 9451a38411a1
+Revises: 6daddb340397
+Create Date: 2018-02-07 16:44:54.309904
+
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = '9451a38411a1'
+down_revision = '6daddb340397'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.add_column('s3_blob', sa.Column('preview', sa.TEXT(), nullable=True))
+
+
+def downgrade():
+    op.drop_column('s3_blob', 'preview')

--- a/registry/quilt_server/core.py
+++ b/registry/quilt_server/core.py
@@ -14,6 +14,7 @@ from six import iteritems, itervalues, string_types
 
 
 LATEST_TAG = 'latest'
+README = 'README'
 
 
 class PackageFormat(Enum):

--- a/registry/quilt_server/core.py
+++ b/registry/quilt_server/core.py
@@ -13,6 +13,9 @@ import struct
 from six import iteritems, itervalues, string_types
 
 
+LATEST_TAG = 'latest'
+
+
 class PackageFormat(Enum):
     HDF5 = 'HDF5'
     PARQUET = 'PARQUET'

--- a/registry/quilt_server/models.py
+++ b/registry/quilt_server/models.py
@@ -125,8 +125,6 @@ class Version(db.Model):
         return PackagingVersion(self.version)
 
 class Tag(db.Model):
-    LATEST = 'latest'
-
     package_id = db.Column(db.BigInteger, db.ForeignKey('package.id'), primary_key=True)
     tag = db.Column(db.String(64), primary_key=True)
     instance_id = db.Column(db.BigInteger, db.ForeignKey('instance.id'))

--- a/registry/quilt_server/models.py
+++ b/registry/quilt_server/models.py
@@ -71,6 +71,11 @@ class Instance(db.Model):
     tags = db.relationship('Tag', back_populates='instance')
     blobs = db.relationship('S3Blob', secondary=InstanceBlobAssoc)
 
+    @classmethod
+    def readme_hash(cls):
+        """Helper method for querying the hash of the README file"""
+        return cls.contents['children']['README']['hashes'][0].astext  # pylint:disable=E1136
+
 db.Index('idx_hash', Instance.package_id, Instance.hash, unique=True)
 
 
@@ -79,6 +84,10 @@ class S3Blob(db.Model):
     owner = db.Column(USERNAME_TYPE, nullable=False)
     hash = db.Column(db.String(64), nullable=False)
     size = db.Column(db.BigInteger)
+
+    preview = deferred(db.Column(db.TEXT))
+
+    instances = db.relationship('Instance', secondary=InstanceBlobAssoc)
 
 db.Index('idx', S3Blob.owner, S3Blob.hash, unique=True)
 
@@ -116,6 +125,8 @@ class Version(db.Model):
         return PackagingVersion(self.version)
 
 class Tag(db.Model):
+    LATEST = 'latest'
+
     package_id = db.Column(db.BigInteger, db.ForeignKey('package.id'), primary_key=True)
     tag = db.Column(db.String(64), primary_key=True)
     instance_id = db.Column(db.BigInteger, db.ForeignKey('instance.id'))

--- a/registry/quilt_server/views.py
+++ b/registry/quilt_server/views.py
@@ -31,7 +31,7 @@ import stripe
 from . import app, db
 from .analytics import MIXPANEL_EVENT, mp
 from .const import PaymentPlan, PUBLIC, TEAM, VALID_NAME_RE, VALID_EMAIL_RE
-from .core import decode_node, find_object_hashes, hash_contents, FileNode, GroupNode, RootNode
+from .core import decode_node, find_object_hashes, hash_contents, FileNode, GroupNode, RootNode, LATEST_TAG
 from .models import (Access, Customer, Event, Instance, Invitation, Log, Package,
                      S3Blob, Tag, Version)
 from .schemas import LOG_SCHEMA, PACKAGE_SCHEMA
@@ -1530,7 +1530,7 @@ def search():
         )
         .join(Package.instances)
         .join(Instance.tags)
-        .filter(Tag.tag == Tag.LATEST)
+        .filter(Tag.tag == LATEST_TAG)
         .join(Instance.blobs)
         .filter(Instance.readme_hash() == S3Blob.hash)
         .subquery()

--- a/registry/quilt_server/views.py
+++ b/registry/quilt_server/views.py
@@ -31,7 +31,8 @@ import stripe
 from . import app, db
 from .analytics import MIXPANEL_EVENT, mp
 from .const import PaymentPlan, PUBLIC, TEAM, VALID_NAME_RE, VALID_EMAIL_RE
-from .core import decode_node, find_object_hashes, hash_contents, FileNode, GroupNode, RootNode, LATEST_TAG
+from .core import (decode_node, find_object_hashes, hash_contents,
+                   FileNode, GroupNode, RootNode, LATEST_TAG, README)
 from .models import (Access, Customer, Event, Instance, Invitation, Log, Package,
                      S3Blob, Tag, Version)
 from .schemas import LOG_SCHEMA, PACKAGE_SCHEMA
@@ -682,7 +683,7 @@ def package_put(owner, package_name, package_hash):
         return Response(_generate(), content_type='application/json')
 
     if instance is None:
-        readme = contents.children.get('README')
+        readme = contents.children.get(README)
         if isinstance(readme, FileNode):
             assert len(readme.hashes) == 1
             readme_hash = readme.hashes[0]
@@ -852,7 +853,7 @@ def package_preview(owner, package_name, package_hash):
     instance = _get_instance(g.auth, owner, package_name, package_hash)
     assert isinstance(instance.contents, RootNode)
 
-    readme = instance.contents.children.get('README')
+    readme = instance.contents.children.get(README)
     if isinstance(readme, FileNode):
         assert len(readme.hashes) == 1
         readme_hash = readme.hashes[0]

--- a/registry/quilt_server/views.py
+++ b/registry/quilt_server/views.py
@@ -519,7 +519,7 @@ def download_object_preview(owner, obj_hash):
 
         body = resp['Body']
         with gzip.GzipFile(fileobj=body, mode='rb') as fd:
-            data = fd.read(100)  # MAX_PREVIEW_SIZE)
+            data = fd.read(MAX_PREVIEW_SIZE)
 
         return data.decode(errors='ignore')  # Data may be truncated in the middle of a UTF-8 character.
     except ClientError as ex:

--- a/registry/scripts/backfill_readme.py
+++ b/registry/scripts/backfill_readme.py
@@ -1,0 +1,33 @@
+#!/usr/bin/env python
+
+"""
+Changes the object layout in S3 from user/package/hash to user/hash.
+Only copies the objects; does not delete the old ones. Safe to run multiple times.
+"""
+
+import sys
+
+from quilt_server import db
+from quilt_server.models import Instance, Package, S3Blob
+from quilt_server.views import download_object_preview
+
+def main(argv):
+    rows = (
+        S3Blob.query
+        .filter(S3Blob.preview.is_(None))
+        .join(S3Blob.instances)
+        .filter(Instance.readme_hash() == S3Blob.hash)
+    )
+
+    for blob in rows:
+        print("Downloading %s/%s..." % (blob.owner, blob.hash))
+        preview = download_object_preview(blob.owner, blob.hash)
+        blob.preview = preview
+        db.session.commit()
+
+    print("Done!")
+
+    return 0
+
+if __name__ == '__main__':
+    sys.exit(main(sys.argv))

--- a/registry/tests/push_install_test.py
+++ b/registry/tests/push_install_test.py
@@ -660,6 +660,9 @@ class PushInstallTestCase(QuiltTestCase):
     def testPreview(self):
         huge_contents_hash = hash_contents(self.HUGE_CONTENTS)
 
+        readme_contents = 'Hello, World!'
+        self._mock_object('test_user', self.HASH1, readme_contents.encode())
+
         # Push.
         resp = self.app.put(
             '/api/package/test_user/foo/%s' % huge_contents_hash,
@@ -692,6 +695,7 @@ class PushInstallTestCase(QuiltTestCase):
 
         data = json.loads(resp.data.decode('utf8'), object_hook=decode_node)
         assert data['readme_url']
+        assert data['readme_preview'] == readme_contents
         preview = data['preview']
 
         assert preview == [

--- a/registry/tests/tag_test.py
+++ b/registry/tests/tag_test.py
@@ -7,7 +7,7 @@ Tag tests
 import json
 import requests
 
-from quilt_server.core import encode_node, hash_contents, GroupNode, RootNode
+from quilt_server.core import hash_contents, GroupNode, RootNode
 from .utils import QuiltTestCase
 
 
@@ -46,7 +46,7 @@ class TagTestCase(QuiltTestCase):
             ),
             data=json.dumps(dict(
                 hash=pkghash
-            ), default=encode_node),
+            )),
             content_type='application/json',
             headers={
                 'Authorization': self.user

--- a/registry/tests/utils.py
+++ b/registry/tests/utils.py
@@ -21,7 +21,7 @@ import sqlalchemy_utils
 import quilt_server
 from quilt_server.const import PaymentPlan
 from quilt_server.core import encode_node, hash_contents
-from quilt_server.views import s3_client
+from quilt_server.views import s3_client, MAX_PREVIEW_SIZE
 
 class MockMixpanelConsumer(object):
     """
@@ -161,7 +161,8 @@ class QuiltTestCase(TestCase):
             Body=BytesIO(contents_gzipped)
         ), dict(
             Bucket=quilt_server.app.config['PACKAGE_BUCKET_NAME'],
-            Key='objs/%s/%s' % (owner, blob_hash)
+            Key='objs/%s/%s' % (owner, blob_hash),
+            Range='bytes=-%d' % MAX_PREVIEW_SIZE
         ))
 
 

--- a/registry/tests/version_test.py
+++ b/registry/tests/version_test.py
@@ -7,7 +7,7 @@ Version tests
 import json
 import requests
 
-from quilt_server.core import encode_node, hash_contents, GroupNode, RootNode
+from quilt_server.core import hash_contents, GroupNode, RootNode
 from .utils import QuiltTestCase
 
 
@@ -46,7 +46,7 @@ class VersionTestCase(QuiltTestCase):
             ),
             data=json.dumps(dict(
                 hash=pkghash
-            ), default=encode_node),
+            )),
             content_type='application/json',
             headers={
                 'Authorization': self.user


### PR DESCRIPTION
Storing the README in the DB allows us to access it quickly, so we can return it in search results.