### PR TITLE
Delete a useless test

### DIFF
--- a/compiler/quilt/test/test_command.py
+++ b/compiler/quilt/test/test_command.py
@@ -599,10 +599,6 @@ class CommandTest(QuiltTestCase):
         with self.assertRaises(command.CommandException):
             command.create_user('bob', 'bob@quiltdata.io', team='nonexisting')
 
-    def test_user_disable(self):
-        self._mock_error('users/disable', team='qux', status=201)
-        command.disable_user('bob', team='qux')
-
     def test_user_disable_not_found(self):
         self._mock_error('users/disable', status=404, team='qux')
         with self.assertRaises(command.CommandException):


### PR DESCRIPTION
We already have a test for disabling a user. In fact, it has the same name, `test_user_disable`, so only one of them actually runs.
Also, http code 201 is not an error.