### PR TITLE
Use a thread-local session when making requests to the auth server

### DIFF
--- a/registry/quilt_server/views.py
+++ b/registry/quilt_server/views.py
@@ -8,8 +8,8 @@ from collections import defaultdict
 from datetime import datetime, timedelta, timezone
 from functools import wraps
 import json
-import time
 import threading
+import time
 from urllib.parse import urlencode
 
 import boto3


### PR DESCRIPTION
Right now, we're creating a new connection for every auth request, which is pretty inefficient (TCP handshake, TLS, etc.). Sessions allow us to use a connection pool - however, they're not quite thread safe. So, use a session per thread.

(Tested it locally using uwsgi with the production config - and it appears to be doing the right thing.)