### PR TITLE
Run uwsgi in a multi-process single-threaded mode

### DIFF
--- a/registry/uwsgi.ini
+++ b/registry/uwsgi.ini
@@ -2,8 +2,12 @@
 socket = 0.0.0.0:9000
 
 master = true
-processes = 2
-threads = 4
+processes = 8
+
+# We're not using threads for handling requests (to avoid any thread-safety issues) -
+# but we still depend on threads for making MixPanel calls in the background.
+# TODO(dima): Use uwsgi tasks instead.
+enable-threads = true
 
 vacuum = true
 die-on-term = true


### PR DESCRIPTION
We're not really benefitting from threads, but it's nice to not deal with thread-safety.