### PR TITLE
Use uwsgi tasks instead of a thread pool to send MixPanel events

### DIFF
--- a/registry/quilt_server/analytics.py
+++ b/registry/quilt_server/analytics.py
@@ -12,8 +12,12 @@ try:
     from uwsgidecorators import spool
 except ImportError:
     # Running using Flask in dev; just run everything synchronously.
-    assert app.debug
-    spool = lambda x: x
+    class spool(object):
+        def __init__(self, func):
+            self.func = func
+        def spool(self, **args):
+            assert app.debug
+            self.func(args)
 
 
 MIXPANEL_EVENT = 'SERVER'

--- a/registry/quilt_server/analytics.py
+++ b/registry/quilt_server/analytics.py
@@ -4,35 +4,42 @@
 Analytics code: Mixpanel, async consumer.
 """
 
-import atexit
-from concurrent.futures import ThreadPoolExecutor
-
 from mixpanel import Consumer, Mixpanel
 
 from . import app
 
+try:
+    from uwsgidecorators import spool
+except ImportError:
+    # Running using Flask in dev; just run everything synchronously.
+    assert app.debug
+    spool = lambda x: x
+
+
 MIXPANEL_EVENT = 'SERVER'
+
+_consumer_impl = Consumer()
+
+@spool
+def _send_event_task(args):
+    """
+    Actually sends the MixPanel event. Runs in a uwsgi worker process.
+    """
+    endpoint = args['endpoint']
+    json_message = args['json_message']
+    _consumer_impl.send(endpoint, json_message)
 
 
 class AsyncConsumer(object):
     """
-    Wrapper around mixpanel.Consumer that sends messages in a background thread.
+    Forwards MixPanel events to a task running in a background process.
     """
-    def __init__(self):
-        self._consumer = Consumer()
-        self._executor = ThreadPoolExecutor(max_workers=1)
-
     def send(self, endpoint, json_message):
         """
         Queues the message to be sent.
         """
-        self._executor.submit(self._consumer.send, endpoint, json_message)
+        _send_event_task.spool(endpoint=endpoint, json_message=json_message)
 
-    def shutdown(self):
-        """
-        Shuts down the background thread.
-        """
-        self._executor.shutdown(wait=True)
 
 class NoopConsumer(object):
     def send(self, endpoint, json_message):
@@ -46,7 +53,6 @@ if mp_token is None:
 
 if mp_token:
     mp_consumer = AsyncConsumer()
-    atexit.register(mp_consumer.shutdown)
 else:
     # For testing, dev, etc.
     mp_consumer = NoopConsumer()

--- a/registry/quilt_server/dev_config.py
+++ b/registry/quilt_server/dev_config.py
@@ -6,6 +6,8 @@ Config file for dev. Overrides values in config.py.
 import os
 import socket
 
+DEBUG = True
+
 SQLALCHEMY_DATABASE_URI = 'postgresql://postgres@localhost/packages'
 
 AUTH_PROVIDER = os.getenv('AUTH_PROVIDER', 'quilt')

--- a/registry/uwsgi.ini
+++ b/registry/uwsgi.ini
@@ -4,12 +4,10 @@ socket = 0.0.0.0:9000
 master = true
 processes = 8
 
-# We're not using threads for handling requests (to avoid any thread-safety issues) -
-# but we still depend on threads for making MixPanel calls in the background.
-# TODO(dima): Use uwsgi tasks instead.
-enable-threads = true
-
 vacuum = true
 die-on-term = true
 
 module = quilt_server:app
+
+spooler = /tmp/uwsgi-spooler
+spooler-processes = 1


### PR DESCRIPTION
That allows us to completely disable threads and the global interpreter lock.