### PR TITLE
Fix and clean up admin tests

### DIFF
--- a/registry/quilt_server/schemas.py
+++ b/registry/quilt_server/schemas.py
@@ -126,3 +126,28 @@ LOG_SCHEMA = {
         ]
     }
 }
+
+USERNAME_SCHEMA = {
+    'type': 'object',
+    'properties': {
+        'username': {
+            'type': 'string'
+        }
+    },
+    'required': ['username'],
+    'additionalProperties': False
+}
+
+USERNAME_EMAIL_SCHEMA = {
+    'type': 'object',
+    'properties': {
+        'username': {
+            'type': 'string'
+        },
+        'email': {
+            'type': 'string'
+        }
+    },
+    'required': ['username', 'email'],
+    'additionalProperties': False
+}

--- a/registry/quilt_server/views.py
+++ b/registry/quilt_server/views.py
@@ -32,7 +32,7 @@ from .const import PaymentPlan, PUBLIC, TEAM, VALID_NAME_RE, VALID_EMAIL_RE
 from .core import decode_node, find_object_hashes, hash_contents, FileNode, GroupNode, RootNode
 from .models import (Access, Customer, Event, Instance, Invitation, Log, Package,
                      S3Blob, Tag, Version)
-from .schemas import LOG_SCHEMA, PACKAGE_SCHEMA
+from .schemas import LOG_SCHEMA, PACKAGE_SCHEMA, USERNAME_EMAIL_SCHEMA, USERNAME_SCHEMA
 
 QUILT_CDN = 'https://cdn.quiltdata.com/'
 
@@ -1745,7 +1745,7 @@ def list_users_detailed():
 
 
 @app.route('/api/users/create', methods=['POST'])
-@api(enabled=ENABLE_USER_ENDPOINTS, require_admin=True)
+@api(enabled=ENABLE_USER_ENDPOINTS, require_admin=True, schema=USERNAME_EMAIL_SCHEMA)
 @as_json
 def create_user():
     auth_headers = {
@@ -1754,11 +1754,10 @@ def create_user():
         "Accept": "application/json",
     }
 
-    request_data = request.get_json()
-
     user_create_api = '%s/accounts/users/' % QUILT_AUTH_URL
 
-    username = request_data.get('username')
+    data = request.get_json()
+    username = data['username']
     _validate_username(username)
 
     resp = auth_session.post(user_create_api, headers=auth_headers,
@@ -1766,7 +1765,7 @@ def create_user():
             "username": username,
             "first_name": "",
             "last_name": "",
-            "email": request_data.get('email'),
+            "email": data['email'],
             "is_superuser": False,
             "is_staff": False,
             "is_active": True,
@@ -1800,7 +1799,7 @@ def create_user():
     return resp.json()
 
 @app.route('/api/users/disable', methods=['POST'])
-@api(enabled=ENABLE_USER_ENDPOINTS, require_admin=True)
+@api(enabled=ENABLE_USER_ENDPOINTS, require_admin=True, schema=USERNAME_SCHEMA)
 @as_json
 def disable_user():
     auth_headers = {
@@ -1812,7 +1811,7 @@ def disable_user():
     user_modify_api = '%s/accounts/users/' % QUILT_AUTH_URL
 
     data = request.get_json()
-    username = data.get('username')
+    username = data['username']
     _validate_username(username)
 
     if g.auth.user == username:
@@ -1841,7 +1840,7 @@ def disable_user():
     return resp.json()
 
 @app.route('/api/users/enable', methods=['POST'])
-@api(enabled=ENABLE_USER_ENDPOINTS, require_admin=True)
+@api(enabled=ENABLE_USER_ENDPOINTS, require_admin=True, schema=USERNAME_SCHEMA)
 @as_json
 def enable_user():
     auth_headers = {
@@ -1853,7 +1852,7 @@ def enable_user():
     user_modify_api = '%s/accounts/users/' % QUILT_AUTH_URL
 
     data = request.get_json()
-    username = data.get('username')
+    username = data['username']
     _validate_username(username)
 
     resp = auth_session.patch("%s%s/" % (user_modify_api, username) , headers=auth_headers,
@@ -1877,7 +1876,7 @@ def enable_user():
 
 # This endpoint is disabled pending a rework of authentication
 @app.route('/api/users/delete', methods=['POST'])
-@api(enabled=False, require_admin=True)
+@api(enabled=False, require_admin=True, schema=USERNAME_SCHEMA)
 @as_json
 def delete_user():
     auth_headers = {
@@ -1888,7 +1887,7 @@ def delete_user():
     user_modify_api = '%s/accounts/users/' % QUILT_AUTH_URL
 
     data = request.get_json()
-    username = data.get('username')
+    username = data['username']
     _validate_username(username)
 
     resp = auth_session.delete("%s%s/" % (user_modify_api, username), headers=auth_headers)
@@ -1978,7 +1977,7 @@ def package_summary():
     return {'packages' : results}
 
 @app.route('/api/users/reset_password', methods=['POST'])
-@api(enabled=ENABLE_USER_ENDPOINTS, require_admin=True)
+@api(enabled=ENABLE_USER_ENDPOINTS, require_admin=True, schema=USERNAME_SCHEMA)
 @as_json
 def reset_password():
     auth_headers = {
@@ -1990,7 +1989,7 @@ def reset_password():
     password_reset_api = '%s/accounts/users/' % QUILT_AUTH_URL
 
     data = request.get_json()
-    username = data.get('username')
+    username = data['username']
     _validate_username(username)
 
     resp = auth_session.post("%s%s/reset_pass/" % (password_reset_api, username), headers=auth_headers)

--- a/registry/tests/admin_test.py
+++ b/registry/tests/admin_test.py
@@ -21,8 +21,8 @@ class AdminTestCase(QuiltTestCase):
     def setUp(self):
         super(AdminTestCase, self).setUp()
 
-        self.admin = "test_admin"
-        self.user = "test_user"
+        self.admin = "admin"
+        self.user = "user"
         self.pkg = "pkg"
         self.contents_list = [
             RootNode(dict(

--- a/registry/tests/utils.py
+++ b/registry/tests/utils.py
@@ -85,8 +85,8 @@ class QuiltTestCase(TestCase):
                 return (401, {}, "Not logged in")
             else:
                 # Hack to make it easy to simulate admin users:
-                # if the username contains "admin", it's an "admin".
-                is_staff = 'admin' in auth
+                # if the username is "admin", it's an "admin".
+                is_staff = auth == 'admin'
                 return (200, {}, json.dumps(dict(
                     current_user=auth,
                     email='%s@example.com' % auth,

--- a/registry/tests/utils.py
+++ b/registry/tests/utils.py
@@ -40,7 +40,6 @@ class QuiltTestCase(TestCase):
         self.requests_mock = responses.RequestsMock(assert_all_requests_are_fired=False)
         self.requests_mock.start()
         self._mock_user()
-        self._is_admin = False
         self._mock_email()
 
         mock_mp = Mixpanel('dummy_token', MockMixpanelConsumer())
@@ -85,16 +84,16 @@ class QuiltTestCase(TestCase):
             if auth is None:
                 return (401, {}, "Not logged in")
             else:
+                # Hack to make it easy to simulate admin users:
+                # if the username contains "admin", it's an "admin".
+                is_staff = 'admin' in auth
                 return (200, {}, json.dumps(dict(
                     current_user=auth,
                     email='%s@example.com' % auth,
-                    is_staff=self._is_admin
+                    is_staff=is_staff
                 )))
 
         self.requests_mock.add_callback(responses.GET, user_url, callback=cb)
-
-    def _mock_admin(self, is_admin=True):
-        self._is_admin = is_admin
 
     def _mock_check_user(self, user):
         """Mocks the username check call and returns just the username"""


### PR DESCRIPTION
- Fix the reset password test - it wasn't even testing the correct endpoint :-/
- Add schemas to make sure username and email are actually present in the request
- Change the way admins are mocked: make it part of auth instead of a global variable (to make it easier to mock different users)
- Make admin tests more useful: have the admin audit a different user, not himself