### PR TITLE
Don't run migrations automatically

### DIFF
--- a/registry/Dockerfile
+++ b/registry/Dockerfile
@@ -36,4 +36,4 @@ ENV FLASK_APP=quilt_server
 
 EXPOSE 9000
 
-CMD flask db upgrade && exec uwsgi --ini /etc/uwsgi.ini
+CMD ["uwsgi", "--ini", "/etc/uwsgi.ini"]


### PR DESCRIPTION
Turns out, this was a bad idea after all:
- Creation of new CF stacks fails because the DB doesn't exist yet, so `flask db upgrade` fails
- Reverting back to old code may fail: old `flask db upgrade` gets confused because it doesn't understand the new migrations and throws an exception. In fact, even canceling an update may fail.