### PR TITLE
Remove READMEs from search results for now

### DIFF
--- a/registry/quilt_server/models.py
+++ b/registry/quilt_server/models.py
@@ -71,11 +71,6 @@ class Instance(db.Model):
     tags = db.relationship('Tag', back_populates='instance')
     blobs = db.relationship('S3Blob', secondary=InstanceBlobAssoc)
 
-    @classmethod
-    def readme_hash(cls):
-        """Helper method for querying the hash of the README file"""
-        return cls.contents['children']['README']['hashes'][0].astext  # pylint:disable=E1136
-
 db.Index('idx_hash', Instance.package_id, Instance.hash, unique=True)
 
 

--- a/registry/tests/access_test.py
+++ b/registry/tests/access_test.py
@@ -9,6 +9,7 @@ import time
 from unittest.mock import patch
 import urllib
 
+import pytest
 import requests
 
 from quilt_server.const import PaymentPlan, PUBLIC, TEAM
@@ -781,6 +782,7 @@ class AccessTestCase(QuiltTestCase):
         names = [pkg['name'] for pkg in data['packages']]
         assert names == ['a', 'B', 'c', 'D']
 
+    @pytest.mark.xfail  # TODO(dima): Re-enable after fixing READMEs in search results.
     def testSearchReadme(self):
         readme_contents = 'foo' * 1000
         blob_hash = '8db466bdfc3265dd1347843b31ed34af0a0c2e6ff0fd4d6a5853755f0e68b8a0'


### PR DESCRIPTION
Using JSON expressions destroys performance and takes down the DB.

For now, just disable READMEs in search results.