### PR TITLE
Make '<command> -h' show full help instead of usage

### DIFF
--- a/compiler/quilt/tools/main.py
+++ b/compiler/quilt/tools/main.py
@@ -71,16 +71,12 @@ class CustomHelpParser(argparse.ArgumentParser):
         helpcommand = kwargs.pop('helpcommand', False)
 
         kwargs['add_help'] = False
+        kwargs.setdefault('formatter_class', argparse.RawDescriptionHelpFormatter)
         super(CustomHelpParser, self).__init__(*args, **kwargs)
         if helpcommand:
             self.add_argument('--help', '-h', action='help', help="Show this message")
-            # self.add_argument('-h', action=UsageAction, help="Show short help (usage) for the 'help' command",
-            #                   nargs=0, default=argparse.SUPPRESS)
         else:
-            self.add_argument('--help', '-h', action='help', help="Show help")
-            # self.add_argument('--help', action='help', help="Show full help for given command")
-            # self.add_argument('-h', action=UsageAction, help="Show short help (usage) for given command",
-            #                   nargs=0, default=argparse.SUPPRESS)
+            self.add_argument('--help', '-h', action='help', help="Show help for given command")
 
 
 def argument_parser():
@@ -101,8 +97,8 @@ def argument_parser():
 
 
     ## Note for `add_parser()` parameters:
-    #   `description` can be long-form help.
-    #   `help` is short help, listed in the base `quilt help` view.
+    #   `description` can be a full, detailed description of usage and characteristics  (displayed as-is/raw)
+    #   `help` is short help, shown in command lists like 'quilt help' or 'quilt help access' (auto-formatted)
 
     # quilt access
     shorthelp = "List, add, or remove who has access to a given package"

--- a/compiler/quilt/tools/main.py
+++ b/compiler/quilt/tools/main.py
@@ -68,21 +68,19 @@ class UsageAction(argparse.Action):
 
 class CustomHelpParser(argparse.ArgumentParser):
     def __init__(self, *args, **kwargs):
-        full_help_only = kwargs.pop('full_help_only', False)
         helpcommand = kwargs.pop('helpcommand', False)
 
         kwargs['add_help'] = False
         super(CustomHelpParser, self).__init__(*args, **kwargs)
-        if full_help_only:
-            self.add_argument('--help', '-h', action='help', help="Show help")
-        elif helpcommand:
-            self.add_argument('--help', action='help', help="Show this message")
-            self.add_argument('-h', action=UsageAction, help="Show short help (usage) for the 'help' command",
-                              nargs=0, default=argparse.SUPPRESS)
+        if helpcommand:
+            self.add_argument('--help', '-h', action='help', help="Show this message")
+            # self.add_argument('-h', action=UsageAction, help="Show short help (usage) for the 'help' command",
+            #                   nargs=0, default=argparse.SUPPRESS)
         else:
-            self.add_argument('--help', action='help', help="Show full help for given command")
-            self.add_argument('-h', action=UsageAction, help="Show short help (usage) for given command",
-                              nargs=0, default=argparse.SUPPRESS)
+            self.add_argument('--help', '-h', action='help', help="Show help")
+            # self.add_argument('--help', action='help', help="Show full help for given command")
+            # self.add_argument('-h', action=UsageAction, help="Show short help (usage) for given command",
+            #                   nargs=0, default=argparse.SUPPRESS)
 
 
 def argument_parser():
@@ -91,7 +89,7 @@ def argument_parser():
         return (hashstr if 6 <= len(hashstr) <= 64 else
                 group.error('hashes must be 6-64 chars long'))
 
-    parser = CustomHelpParser(description="Quilt Command Line", add_help=False, full_help_only=True,)
+    parser = CustomHelpParser(description="Quilt Command Line", add_help=False)
     parser.add_argument('--version', action='version', version=get_full_version(),
                         help="Show version number and exit")
 


### PR DESCRIPTION
"usage" is the brief help info, like `usage: quilt user [--help] <subcommand> ...`.

```bash
# Previous behavior
quilt <command> -h          # Show short-form help (usage) for command

# New behavior
quilt <command> -h          # Show long-form help message for command

# Unchanged:
quilt help <command>
quilt <command> --help
quilt help
quilt --help
quilt -?
```
Usage is still displayed when a command fails.

Also, set descriptions to use raw formatting in case they get used more extensively (currently we just use the `help=` blurb in `description=`).