### PR TITLE
Don't expire objects on commit

### DIFF
--- a/registry/quilt_server/__init__.py
+++ b/registry/quilt_server/__init__.py
@@ -34,7 +34,7 @@ class QuiltSQLAlchemy(SQLAlchemy):
         ))
         super(QuiltSQLAlchemy, self).apply_driver_hacks(app, info, options)
 
-db = QuiltSQLAlchemy(app)
+db = QuiltSQLAlchemy(app, session_options=dict(expire_on_commit=False))
 
 FlaskJSON(app)
 Migrate(app, db, compare_type=True)


### PR DESCRIPTION
Turns out, by default, SQLAlchemy expires all objects on commit, and causes them to be re-queried if they're accessed again.
It's particularly bad in case of `package_get`: we commit an audit event, then access blob sizes. If we have 10,000 blobs, SQLAlchemy will issue 10,000 individual queries to look up the size of each one.

We don't depend on the objects getting updated when they're commited, to let's disable this "feature".