### PR TITLE
Stop patching the "put_package" helper function.

### DIFF
--- a/registry/tests/delete_test.py
+++ b/registry/tests/delete_test.py
@@ -36,9 +36,8 @@ class DeleteTestCase(QuiltTestCase):
 
         # Upload three package instances.
         for contents in self.contents_list:
-            self.put_package(self.user, self.pkg, contents, True)
+            self.put_package(self.user, self.pkg, contents)
 
-    @patch('quilt_server.views.ALLOW_ANONYMOUS_ACCESS', True)
     def testSimpleDelete(self):
         resp = self.app.delete(
             '/api/package/{usr}/{pkg}/'.format(
@@ -70,7 +69,6 @@ class DeleteTestCase(QuiltTestCase):
         assert event.package_owner == self.user
         assert event.package_name == self.pkg
 
-    @patch('quilt_server.views.ALLOW_ANONYMOUS_ACCESS', True)
     def testDeleteAccessTagVersionLog(self):
         hashes = [hash_contents(contents) for contents in self.contents_list]
 
@@ -186,7 +184,7 @@ class DeleteTestCase(QuiltTestCase):
         assert resp.status_code == requests.codes.ok
 
         # Create a new package with the same name
-        self.put_package(self.user, self.pkg, self.contents_list[0], True)
+        self.put_package(self.user, self.pkg, self.contents_list[0])
 
         # Verify that users, tags, and versions didn't survive
         assert not _has_access()
@@ -206,7 +204,6 @@ class DeleteTestCase(QuiltTestCase):
         )
         assert resp.status_code == requests.codes.not_found
 
-    @patch('quilt_server.views.ALLOW_ANONYMOUS_ACCESS', True)
     def testNoAccess(self):
         # Wrong user
         resp = self.app.delete(

--- a/registry/tests/tag_test.py
+++ b/registry/tests/tag_test.py
@@ -36,7 +36,7 @@ class TagTestCase(QuiltTestCase):
 
         # Upload three package instances.
         for contents in self.contents_list:
-            self.put_package(self.user, self.pkg, contents, is_public=True)
+            self.put_package(self.user, self.pkg, contents)
 
     def _add_tag(self, tag, pkghash):
         return self.app.put(
@@ -65,7 +65,6 @@ class TagTestCase(QuiltTestCase):
             }
         )
 
-    @patch('quilt_server.views.ALLOW_ANONYMOUS_ACCESS', True)
     def testGetTag(self):
         resp = self._add_tag('foo', self.hashes[0])
         assert resp.status_code == requests.codes.ok
@@ -86,7 +85,6 @@ class TagTestCase(QuiltTestCase):
         assert data['created_by'] == data['updated_by'] == self.user
         assert data['created_at'] == data['updated_at']
 
-    @patch('quilt_server.views.ALLOW_ANONYMOUS_ACCESS', True)
     def testMultipleTags(self):
         # Add a few tags.
         resp = self._add_tag('old', self.hashes[0])
@@ -119,7 +117,6 @@ class TagTestCase(QuiltTestCase):
             )
         ]
 
-    @patch('quilt_server.views.ALLOW_ANONYMOUS_ACCESS', True)
     def testInvalidHash(self):
         resp = self._add_tag('latest', '000')
         assert resp.status_code == requests.codes.not_found
@@ -127,7 +124,6 @@ class TagTestCase(QuiltTestCase):
         data = json.loads(resp.data.decode('utf8'))
         assert 'message' in data
 
-    @patch('quilt_server.views.ALLOW_ANONYMOUS_ACCESS', True)
     def testUpdateTag(self):
         resp = self._add_tag('latest', self.hashes[0])
         assert resp.status_code == requests.codes.ok
@@ -146,7 +142,6 @@ class TagTestCase(QuiltTestCase):
             )
         ]
 
-    @patch('quilt_server.views.ALLOW_ANONYMOUS_ACCESS', True)
     def testDelete(self):
         resp = self._add_tag('foo', self.hashes[0])
         assert resp.status_code == requests.codes.ok
@@ -169,7 +164,6 @@ class TagTestCase(QuiltTestCase):
         data = json.loads(resp.data.decode('utf8'))
         assert data['tags'] == []
 
-    @patch('quilt_server.views.ALLOW_ANONYMOUS_ACCESS', True)
     def testAccess(self):
         resp = self._add_tag('foo', self.hashes[0])
         assert resp.status_code == requests.codes.ok

--- a/registry/tests/utils.py
+++ b/registry/tests/utils.py
@@ -109,7 +109,6 @@ class QuiltTestCase(TestCase):
         user_url = quilt_server.app.config['OAUTH']['profile_api'] % user
         self.requests_mock.add(responses.GET, user_url, json.dumps(dict(username=user)))
 
-    @patch('quilt_server.views.ALLOW_ANONYMOUS_ACCESS', True)
     def put_package(self, owner, package, contents, is_public=False, is_team=False):
         pkgurl = '/api/package/{usr}/{pkg}/{hash}'.format(
             usr=owner,

--- a/registry/tests/version_test.py
+++ b/registry/tests/version_test.py
@@ -36,7 +36,7 @@ class VersionTestCase(QuiltTestCase):
 
         # Upload three package instances.
         for contents in self.contents_list:
-            self.put_package(self.user, self.pkg, contents, is_public=True)
+            self.put_package(self.user, self.pkg, contents)
 
     def _add_version(self, version, pkghash):
         return self.app.put(
@@ -54,7 +54,6 @@ class VersionTestCase(QuiltTestCase):
             }
         )
 
-    @patch('quilt_server.views.ALLOW_ANONYMOUS_ACCESS', True)
     def testGetVersion(self):
         resp = self._add_version('1', self.hashes[0])
         assert resp.status_code == requests.codes.ok
@@ -91,7 +90,6 @@ class VersionTestCase(QuiltTestCase):
         assert data['created_by'] == data['updated_by'] == self.user
         assert data['created_at'] == data['updated_at']
 
-    @patch('quilt_server.views.ALLOW_ANONYMOUS_ACCESS', True)
     def testListVersions(self):
         # Add a few versions in a random order, with random whitespace.
 
@@ -145,7 +143,6 @@ class VersionTestCase(QuiltTestCase):
             )
         ]
 
-    @patch('quilt_server.views.ALLOW_ANONYMOUS_ACCESS', True)
     def testInvalidVersion(self):
         resp = self._add_version('foo', self.hashes[0])
         assert resp.status_code == requests.codes.bad_request
@@ -165,7 +162,6 @@ class VersionTestCase(QuiltTestCase):
         data = json.loads(resp.data.decode('utf8'))
         assert 'message' in data
 
-    @patch('quilt_server.views.ALLOW_ANONYMOUS_ACCESS', True)
     def testInvalidHash(self):
         resp = self._add_version('1.0', '000')
         assert resp.status_code == requests.codes.not_found
@@ -173,7 +169,6 @@ class VersionTestCase(QuiltTestCase):
         data = json.loads(resp.data.decode('utf8'))
         assert 'message' in data
 
-    @patch('quilt_server.views.ALLOW_ANONYMOUS_ACCESS', True)
     def testDuplicateVersion(self):
         resp = self._add_version('1.0', self.hashes[0])
         assert resp.status_code == requests.codes.ok
@@ -192,7 +187,6 @@ class VersionTestCase(QuiltTestCase):
         data = json.loads(resp.data.decode('utf8'))
         assert 'message' in data
 
-    @patch('quilt_server.views.ALLOW_ANONYMOUS_ACCESS', True)
     def testDelete(self):
         resp = self._add_version('1.0', self.hashes[0])
         assert resp.status_code == requests.codes.ok
@@ -210,7 +204,6 @@ class VersionTestCase(QuiltTestCase):
 
         assert resp.status_code == requests.codes.method_not_allowed
 
-    @patch('quilt_server.views.ALLOW_ANONYMOUS_ACCESS', True)
     def testAccess(self):
         resp = self._add_version('1.0', self.hashes[0])
         assert resp.status_code == requests.codes.ok


### PR DESCRIPTION
Patching `ALLOW_ANONYMOUS_USERS` in a helper function and not the whole test does not represent a realistic environment, so kinda defeats the point of testing anything.

Also, remove unnecessary patching from unit tests that don't really need it, and can just use private packages.