### PR TITLE
Set the language to "english" in the full-text search index

### DIFF
--- a/registry/migrations/versions/9576b2ed4073_add_a_full_text_search_index_to_s3blob.py
+++ b/registry/migrations/versions/9576b2ed4073_add_a_full_text_search_index_to_s3blob.py
@@ -18,7 +18,6 @@ depends_on = None
 
 def upgrade():
     op.add_column('s3_blob', sa.Column('preview_tsv', postgresql.TSVECTOR(), nullable=True))
-    op.execute('UPDATE s3_blob SET preview_tsv = to_tsvector(preview)')
     op.create_index('idx_tsv', 's3_blob', ['preview_tsv'], unique=False, postgresql_using='gin')
 
 

--- a/registry/quilt_server/const.py
+++ b/registry/quilt_server/const.py
@@ -20,3 +20,5 @@ class PaymentPlan(Enum):
     BUSINESS_MEMBER = 'business_member'
     TEAM = 'team_monthly_490'
     TEAM_UNPAID = 'team_unpaid'
+
+FTS_LANGUAGE = 'english'

--- a/registry/scripts/backfill_preview_tsv.py
+++ b/registry/scripts/backfill_preview_tsv.py
@@ -1,0 +1,23 @@
+#!/usr/bin/env python3
+
+"""
+Rebuilds the full-text search index (to fix the language).
+"""
+
+import sys
+
+from quilt_server import db
+from quilt_server.const import FTS_LANGUAGE
+
+def main(argv):
+    result = db.engine.execute('''
+        UPDATE s3_blob SET preview_tsv = to_tsvector(%s, preview)
+        WHERE preview IS NOT NULL AND preview_tsv IS NULL
+    ''', FTS_LANGUAGE)
+
+    print("Updated %d rows." % result.rowcount)
+
+    return 0
+
+if __name__ == '__main__':
+    sys.exit(main(sys.argv))

--- a/registry/scripts/backfill_readme.py
+++ b/registry/scripts/backfill_readme.py
@@ -17,14 +17,13 @@ def main(argv):
         S3Blob.query
         .select_from(Instance)
         .join(Instance.readme_blob)
-        .filter(S3Blob.preview_tsv.is_(None))
+        .filter(S3Blob.preview.is_(None))
     )
 
     for blob in rows:
         print("Downloading %s/%s..." % (blob.owner, blob.hash))
         preview = download_object_preview(blob.owner, blob.hash)
         blob.preview = preview
-        blob.preview_tsv = sa.func.to_tsvector(preview)
         db.session.commit()
 
     print("Done!")


### PR DESCRIPTION
- Set the language when creating vectors and queries
- Move the index backfill into a standalone script