### PR TITLE
Reject the package upload if the README download fails

### DIFF
--- a/registry/nginx-s3/nginx-s3.conf
+++ b/registry/nginx-s3/nginx-s3.conf
@@ -5,6 +5,9 @@ server {
 	charset utf-8;
 	client_max_body_size 5G;
 
+	# S3 returns 403s instead of 404s.
+	error_page 404 =403 /;
+
 	location / {
 		root /var/www/s3;
 		dav_methods PUT DELETE;

--- a/registry/nginx-s3/nginx-s3.conf
+++ b/registry/nginx-s3/nginx-s3.conf
@@ -5,9 +5,6 @@ server {
 	charset utf-8;
 	client_max_body_size 5G;
 
-	# S3 returns 403s instead of 404s.
-	error_page 404 =403 /;
-
 	location / {
 		root /var/www/s3;
 		dav_methods PUT DELETE;

--- a/registry/quilt_server/views.py
+++ b/registry/quilt_server/views.py
@@ -565,7 +565,7 @@ def download_object_preview(owner, obj_hash):
             obj_hash=obj_hash,
             error=str(ex),
         )
-        if ex.response['ResponseMetadata']['HTTPStatusCode'] == requests.codes.forbidden:
+        if ex.response['ResponseMetadata']['HTTPStatusCode'] == requests.codes.not_found:
             # The client somehow failed to upload the README.
             raise ApiException(
                 requests.codes.forbidden,


### PR DESCRIPTION
- Check for 403 instead of 404 - that's what S3 returns
- Return an error if the README download fails
- Log README failures to MixPanel
- Update the nginx config to match S3