### PR TITLE
Make Python setup more sane

### DIFF
--- a/registry/Dockerfile
+++ b/registry/Dockerfile
@@ -21,13 +21,13 @@ COPY uwsgi.ini /etc/uwsgi.ini
 # Install the Flask app
 # Do this as the last step to maximize caching.
 COPY quilt_server /usr/src/quilt-server/quilt_server
-COPY migrations /usr/src/quilt-server/migrations
-COPY scripts /usr/src/quilt-server/scripts
 COPY setup.py MANIFEST.in /usr/src/quilt-server/
-WORKDIR /usr/src/quilt-server/
 RUN pip3 install /usr/src/quilt-server/
 
 USER quilt
+WORKDIR /home/quilt
+COPY scripts ./scripts
+COPY migrations ./migrations
 
 ENV QUILT_SERVER_CONFIG=prod_config.py
 


### PR DESCRIPTION
Apparently, the code we've `pip install`ed gets completely ignored because the current directory takes precedence. Even if it's the same code, that's kind of wrong. Also, the installed code is pre-compiled, which is a tiny benefit.
So:
- Run everything from the home dir instead of the source code dir
- Keep scripts and migrations in the current dir - those aren't part of the pip package