### PR TITLE
Fix GroupNode's preorder method

### DIFF
--- a/compiler/quilt/test/test_core.py
+++ b/compiler/quilt/test/test_core.py
@@ -1,0 +1,37 @@
+"""
+Test core.py
+"""
+import os
+
+import quilt
+from ..tools.core import GroupNode, RootNode, FileNode
+from .utils import QuiltTestCase
+
+class CoreTest(QuiltTestCase):
+    def test_compiler_registry_identical(self):
+        """
+        Verify that the compiler and the registry have the same core.py.
+        Not the best way to accomplish this, but oh well...
+        """
+        quilt_dir = os.path.dirname(quilt.__file__)
+        compiler_core = os.path.join(quilt_dir, 'tools', 'core.py')
+        registry_core = os.path.join(quilt_dir, '..', '..', 'registry', 'quilt_server', 'core.py')
+        with open(compiler_core) as fd1, open(registry_core) as fd2:
+            assert fd1.read() == fd2.read()
+
+    def test_preorder(self):
+        """
+        Test that preorder returns nodes in the expected order.
+        """
+
+        a1 = FileNode([], dict())
+        a2 = FileNode([], dict())
+        a = GroupNode(dict(a1=a1, a2=a2))
+
+        b1 = FileNode([], dict())
+        b2 = FileNode([], dict())
+        b = GroupNode(dict(a1=b1, a2=b2))
+
+        root = RootNode(dict(a=a, b=b))
+
+        assert list(root.preorder()) == [root, a, a1, a2, b, b1, b2]

--- a/compiler/quilt/tools/core.py
+++ b/compiler/quilt/tools/core.py
@@ -7,7 +7,6 @@
 
 from enum import Enum
 import hashlib
-import os
 import struct
 
 from six import iteritems, itervalues, string_types
@@ -52,18 +51,14 @@ class GroupNode(Node):
     def preorder(self):
         """
         Performs a pre-order walk of the package tree starting at this node.
-        It returns a list of the nodes in the order visited.
+        It returns a generator of the nodes in the order visited.
         """
         stack = [self]
-        output = []
-
         while stack:
             node = stack.pop()
-            for child in itervalues(node.children):
-                output.append(child)
-                if isinstance(child, GroupNode):
-                    stack.append(child)
-        return output
+            yield node
+            if isinstance(node, GroupNode):
+                stack.extend(child for key, child in sorted(iteritems(node.children), reverse=True))
 
 class RootNode(GroupNode):
     json_type = 'ROOT'

--- a/registry/quilt_server/core.py
+++ b/registry/quilt_server/core.py
@@ -7,7 +7,6 @@
 
 from enum import Enum
 import hashlib
-import os
 import struct
 
 from six import iteritems, itervalues, string_types
@@ -52,18 +51,14 @@ class GroupNode(Node):
     def preorder(self):
         """
         Performs a pre-order walk of the package tree starting at this node.
-        It returns a list of the nodes in the order visited.
+        It returns a generator of the nodes in the order visited.
         """
         stack = [self]
-        output = []
-
         while stack:
             node = stack.pop()
-            for child in itervalues(node.children):
-                output.append(child)
-                if isinstance(child, GroupNode):
-                    stack.append(child)
-        return output
+            yield node
+            if isinstance(node, GroupNode):
+                stack.extend(child for key, child in sorted(iteritems(node.children), reverse=True))
 
 class RootNode(GroupNode):
     json_type = 'ROOT'


### PR DESCRIPTION
Currently, it's:
1) returning nodes in the wrong order
2) not even guaranteeing any particular order cause dictionaries are unordered

Fix that, and also make it return a generator instead of a list.