### PR TITLE
Upgrade SQLAlchemy and use the new "pre-ping" option

### DIFF
--- a/registry/quilt_server/__init__.py
+++ b/registry/quilt_server/__init__.py
@@ -26,11 +26,14 @@ app.config.from_envvar('QUILT_SERVER_CONFIG')
 class QuiltSQLAlchemy(SQLAlchemy):
     def apply_driver_hacks(self, app, info, options):
         """
-        Teach SQLAlchemy to encode and decode our node objects.
+        Set custom SQLAlchemy engine options:
+        - Teach it to encode and decode our node objects
+        - Enable pre-ping (i.e., test the DB connection before trying to use it)
         """
         options.update(dict(
             json_serializer=lambda data: json.dumps(data, default=encode_node),
-            json_deserializer=lambda data: json.loads(data, object_hook=decode_node)
+            json_deserializer=lambda data: json.loads(data, object_hook=decode_node),
+            pool_pre_ping=True,
         ))
         super(QuiltSQLAlchemy, self).apply_driver_hacks(app, info, options)
 

--- a/registry/requirements.txt
+++ b/registry/requirements.txt
@@ -30,9 +30,9 @@ requests==2.18.3
 requests-oauthlib==0.8.0
 responses==0.7.0
 s3transfer==0.1.10
-six==1.10.0
-SQLAlchemy==1.1.13
-SQLAlchemy-Utils==0.32.14
+six==1.11.0
+SQLAlchemy==1.2.5
+SQLAlchemy-Utils==0.33.1
 stripe==1.62.0
 urllib3==1.22
 Werkzeug==0.12.2


### PR DESCRIPTION
Currently, if the DB connection goes away (DB gets restarted, network settings change, etc.), SQLAlchemy will still try to use the stale connection, fail, and remove the stale connection out of the pool. However, because we have 16 registry processes, we can expect 16 exceptions (each one causing a 500 error) when this happens.

SQLAlchemy has a new option to "pre-ping" a connection (using a `SELECT 1` query) before trying to use it. It seems to have negligible overhead, so let's use it.

Of course, upgrading SQLAlchemy is a slightly risky change.