### PR TITLE
Allow sourcing DataFrames from existing Parquet files

### DIFF
--- a/compiler/quilt/test/test_build.py
+++ b/compiler/quilt/test/test_build.py
@@ -484,3 +484,22 @@ class BuildTest(QuiltTestCase):
             }
         with self.assertRaises(build.BuildException):
             build.build_package_from_contents(None, 'test', 'shouldfail', str(mydir), bad_build_contents)
+
+    def test_parquet_source_file(self):
+        df = DataFrame(dict(a=[1, 2, 3])) # pylint:disable=C0103
+        import pyarrow as pa
+        table = pa.Table.from_pandas(df)
+        pa.parquet.write_table(table, 'simpledf.parquet')
+
+        build_contents = {
+            'contents': {
+                'df': {
+                    'file': 'simpledf.parquet'
+                    }
+                }
+            }
+        build.build_package_from_contents(None, 'test', 'fromparquet', '.', build_contents)
+        pkg = command.load('test/fromparquet')
+        assert df.equals(pkg.df()) # pylint:disable=E1101
+
+    #TODO: Add test for checks on a parquet-sourced dataframe

--- a/compiler/quilt/tools/build.py
+++ b/compiler/quilt/tools/build.py
@@ -235,7 +235,7 @@ def _build_node(build_dir, package, name, node, fmt, checks_contents=None,
                 _, ext = splitext_no_dot(rel_path)
                 
                 if ext in DEFAULT_PARSERS:
-                    transform = transform or DEFAULT_PARSERS[ext]['transform']
+                    transform =  DEFAULT_PARSERS[ext]['transform']
                     target = DEFAULT_PARSERS[ext]['target']
                 else:
                     transform = ID

--- a/compiler/quilt/tools/build.py
+++ b/compiler/quilt/tools/build.py
@@ -219,7 +219,7 @@ def _build_node(build_dir, package, name, node, fmt, checks_contents=None,
 
             # get either the locally defined transform and target or inherit from an ancestor
             transform = node.get(RESERVED['transform']) or ancestor_args.get(RESERVED['transform'])
-            
+
             ID = 'id' # pylint:disable=C0103
             if transform:
                 transform = transform.lower()

--- a/compiler/quilt/tools/build.py
+++ b/compiler/quilt/tools/build.py
@@ -238,7 +238,7 @@ def _build_node(build_dir, package, name, node, fmt, checks_contents=None,
                 _, ext = splitext_no_dot(rel_path)
                 
                 if ext in PANDAS_PARSERS:
-                    transform =  ext
+                    transform = ext
                     target = TargetType.PANDAS.value
                 elif ext == PARQUET:
                     transform = ext

--- a/compiler/quilt/tools/const.py
+++ b/compiler/quilt/tools/const.py
@@ -26,6 +26,7 @@ RESERVED = {
     'file': 'file',
     'kwargs': 'kwargs',
     'package': 'package',
+    'target': 'target',
     'transform': 'transform'
 }
 

--- a/compiler/quilt/tools/const.py
+++ b/compiler/quilt/tools/const.py
@@ -26,7 +26,6 @@ RESERVED = {
     'file': 'file',
     'kwargs': 'kwargs',
     'package': 'package',
-    'target': 'target',
     'transform': 'transform'
 }
 
@@ -39,32 +38,46 @@ RSA_BITS = 2048
 _kwargs = {} # default kwargs pylint:disable=C0103
 # Supported build targets and file types
 # file_extension should be lowercase
-PANDAS_PARSERS = {
+DEFAULT_PARSERS = {
     'csv': {
+        'target': TargetType.PANDAS.value,
+        'transform': 'csv',
         'attr': 'read_csv',
         'failover' : {'engine' : 'python'},
         'kwargs': _kwargs
     },
     'ssv': {
+        'target': TargetType.PANDAS.value,
+        'transform': 'ssv',
         'attr': 'read_csv',
         'failover' : {'engine' : 'python'},
         'kwargs': dict(_kwargs, sep=';')
     },
     'tsv': {
+        'target': TargetType.PANDAS.value,
+        'transform': 'tsv',
         'attr': 'read_csv',
         'failover' : {'engine' : 'python'},
         'kwargs': dict(_kwargs, sep='\t')
     },
     'xls': {
+        'target': TargetType.PANDAS.value,
+        'transform': 'xls',
         'attr': 'read_excel',
         # TODO set sheetname='None' to get all sheets?
         # Currently defaults to sheetname=0, which imports first sheet only
         'kwargs': _kwargs
     },
     'xlsx': {
+        'target': TargetType.PANDAS.value,
+        'transform': 'xlsx',
         'attr': 'read_excel',
         # see comments under 'xls'
         'kwargs': _kwargs
+    },
+    'parquet': {
+        'target': TargetType.PANDAS.value,
+        'transform': 'id'
     }
 }
 

--- a/compiler/quilt/tools/const.py
+++ b/compiler/quilt/tools/const.py
@@ -38,47 +38,33 @@ RSA_BITS = 2048
 _kwargs = {} # default kwargs pylint:disable=C0103
 # Supported build targets and file types
 # file_extension should be lowercase
-DEFAULT_PARSERS = {
+PANDAS_PARSERS = {
     'csv': {
-        'target': TargetType.PANDAS.value,
-        'transform': 'csv',
         'attr': 'read_csv',
         'failover' : {'engine' : 'python'},
         'kwargs': _kwargs
     },
     'ssv': {
-        'target': TargetType.PANDAS.value,
-        'transform': 'ssv',
         'attr': 'read_csv',
         'failover' : {'engine' : 'python'},
         'kwargs': dict(_kwargs, sep=';')
     },
     'tsv': {
-        'target': TargetType.PANDAS.value,
-        'transform': 'tsv',
         'attr': 'read_csv',
         'failover' : {'engine' : 'python'},
         'kwargs': dict(_kwargs, sep='\t')
     },
     'xls': {
-        'target': TargetType.PANDAS.value,
-        'transform': 'xls',
         'attr': 'read_excel',
         # TODO set sheetname='None' to get all sheets?
         # Currently defaults to sheetname=0, which imports first sheet only
         'kwargs': _kwargs
     },
     'xlsx': {
-        'target': TargetType.PANDAS.value,
-        'transform': 'xlsx',
         'attr': 'read_excel',
         # see comments under 'xls'
         'kwargs': _kwargs
     },
-    'parquet': {
-        'target': TargetType.PANDAS.value,
-        'transform': 'id'
-    }
 }
 
 # Exit codes

--- a/compiler/quilt/tools/const.py
+++ b/compiler/quilt/tools/const.py
@@ -64,7 +64,7 @@ PANDAS_PARSERS = {
         'attr': 'read_excel',
         # see comments under 'xls'
         'kwargs': _kwargs
-    },
+    }
 }
 
 # Exit codes

--- a/compiler/quilt/tools/package.py
+++ b/compiler/quilt/tools/package.py
@@ -276,13 +276,13 @@ class Package(object):
             move(storepath, self._store.object_path(filehash))
             return [filehash]
 
-    def save_file(self, srcfile, name, path):
+    def save_file(self, srcfile, name, path, target='file'):
         """
         Save a (raw) file to the store.
         """
         filehash = digest_file(srcfile)
         fullname = name.lstrip('/').replace('/', '.')
-        self._add_to_contents(fullname, [filehash], '', path, 'file', None)
+        self._add_to_contents(fullname, [filehash], '', path, target)
         objpath = self._store.object_path(filehash)
         if not os.path.exists(objpath):
             # Copy the file to a temporary location first, then move, to make sure we don't end up with
@@ -392,7 +392,7 @@ class Package(object):
         """
         return self.UploadFile(self, hash)
 
-    def _add_to_contents(self, fullname, hashes, ext, path, target, fmt):
+    def _add_to_contents(self, fullname, hashes, ext, path, target, fmt=PackageFormat.default):
         """
         Adds an object (name-hash mapping) or group to package contents.
         """


### PR DESCRIPTION
This change allows setting a Pandas target from existing parquet files
and cleans up the target parameter handling in build.py.