### PR TITLE
Augment log

### DIFF
--- a/registry/quilt_server/views.py
+++ b/registry/quilt_server/views.py
@@ -10,7 +10,7 @@ We disable this behavior because it can cause lots of unexpected queries with
 major performance implications. See `expire_on_commit=False` in `__init__.py`.
 """
 
-from collections import defaultdict, OrderedDict
+from collections import defaultdict
 from datetime import datetime, timedelta, timezone
 from functools import wraps
 import gzip

--- a/registry/quilt_server/views.py
+++ b/registry/quilt_server/views.py
@@ -1138,39 +1138,26 @@ def logs_list(owner, package_name):
         .order_by(Log.created, Log.id)
     )
 
-    """
-    import pdb
-    pdb.set_trace()
-    """
-
-    instances = [dict(
-            hash=instance.hash,
-            created=log.created.timestamp(),
-            author=log.author,
-            tag=(tag.tag if tag else None),
-            version=(version.version if version else None)
-        ) for log, instance, tag, version in logs]
 
     results = OrderedDict()
-    for instance in instances:
-        k = (instance['hash'], instance['created'], instance['author'])
+
+    for log, instance, tag, version in logs:
+        k = (instance.hash, log.created.timestamp(), log.author)
         r = results.get(k, None)
         if not r:
             results[k] = {'tags': set(), 'versions': set()}
-
-        if instance['tag']:
-            results[k]['tags'].add(instance['tag'])
-
-        if instance['version']:
-            results[k]['versions'].add(instance['version'])
+        if tag.tag:
+            results[k]['tags'].add(tag.tag)
+        if version.version:
+            results[k]['versions'].add(version.version)
 
     ret = []
     for key, value in results.items():
         hash = key[0]
         created = key[1]
         author = key[2]
-        tags = list(iter(value['tags']))
-        versions = list(iter(value['versions']))
+        tags = list(value['tags'])
+        versions = list(value['versions'])
         ret.append({
             'hash':hash,
             'created':created,
@@ -1180,7 +1167,7 @@ def logs_list(owner, package_name):
             })
 
 
-    return {'logs':ret}
+    return { 'logs' : ret }
 
     
 

--- a/registry/quilt_server/views.py
+++ b/registry/quilt_server/views.py
@@ -1132,8 +1132,8 @@ def logs_list(owner, package_name):
         db.session.query(Log, Instance, Tag, Version)
         .filter_by(package=package)
         .join(Log.instance)
-        .outerjoin(Version)
-        .outerjoin(Tag)
+        .outerjoin(Instance.versions)
+        .outerjoin(Instance.tags)
         # Sort chronologically, but rely on IDs in case of duplicate created times.
         .order_by(Log.created, Log.id)
     )

--- a/registry/quilt_server/views.py
+++ b/registry/quilt_server/views.py
@@ -1146,9 +1146,9 @@ def logs_list(owner, package_name):
         r = results.get(k, None)
         if not r:
             results[k] = {'tags': set(), 'versions': set()}
-        if tag.tag:
+        if tag:
             results[k]['tags'].add(tag.tag)
-        if version.version:
+        if version:
             results[k]['versions'].add(version.version)
 
     ret = []


### PR DESCRIPTION
Adds versions and tags to log output, now looks like this:
`{'logs': [{'author': 'admin', 'created': 1522281823.012744, 'hash': 'cbc68e5795a890b6c0f0f8c985ac0ecc574cd6ee9544d549dcfe05897399c656', 'tags': ['latest', 'mytag'], 'versions': ['1.0.0']}],
'status': 200}`

TODO:

- [x] unit tests