### PR TITLE
Fix update timestampts on instances

### DIFF
--- a/registry/quilt_server/models.py
+++ b/registry/quilt_server/models.py
@@ -59,8 +59,7 @@ class Instance(db.Model):
 
     created_at = db.Column(postgresql.TIMESTAMP(True), server_default=db.func.now(), nullable=False)
     created_by = db.Column(USERNAME_TYPE, nullable=False)
-    updated_at = db.Column(postgresql.TIMESTAMP(True), server_default=db.func.now(),
-                           onupdate=db.func.now(), nullable=False)
+    updated_at = db.Column(postgresql.TIMESTAMP(True), server_default=db.func.now(), nullable=False)
     updated_by = db.Column(USERNAME_TYPE, nullable=False)
 
     # Contents can be a potentially large JSON blob, so load it lazily.

--- a/registry/quilt_server/views.py
+++ b/registry/quilt_server/views.py
@@ -801,6 +801,7 @@ def package_put(owner, package_name, package_hash):
         # Just update the contents dictionary.
         # Nothing else could've changed without invalidating the hash.
         instance.contents = contents
+        instance.updated_at = sa.func.now()
         instance.updated_by = g.auth.user
         instance.keywords_tsv = keywords_tsv
 

--- a/registry/scripts/fix_updated_at.py
+++ b/registry/scripts/fix_updated_at.py
@@ -1,0 +1,23 @@
+#!/usr/bin/env python3
+
+"""
+Rebuilds the full-text search index (to fix the language).
+"""
+
+import sys
+
+from quilt_server import db
+
+def main(argv):
+    result = db.engine.execute('''
+        UPDATE instance SET updated_at = t.updated_at
+        FROM (SELECT instance_id, max(created) AS updated_at FROM log GROUP BY instance_id) t
+        WHERE instance.id = t.instance_id AND instance.updated_at != t.updated_at
+    ''')
+
+    print("Updated %d rows." % result.rowcount)
+
+    return 0
+
+if __name__ == '__main__':
+    sys.exit(main(sys.argv))


### PR DESCRIPTION
- Stop using SQLAlchemy's `onupdate` hook; it's not worth it - just update the timestamp manually
- Add a script to fix incorrect timestamps