### PR TITLE
GroupNode iter

### DIFF
--- a/compiler/quilt/nodes.py
+++ b/compiler/quilt/nodes.py
@@ -67,6 +67,10 @@ class GroupNode(DataNode):
         data_info = '\n'.join(sorted(self._data_keys()))
         return '%s\n%s%s' % (pinfo, group_info, data_info)
 
+    def __iter__(self):
+        for child in self._group_keys():
+            yield getattr(self, child)
+
     def _items(self):
         return ((name, child) for name, child in iteritems(self.__dict__)
                 if not name.startswith('_'))

--- a/compiler/quilt/test/test_build.py
+++ b/compiler/quilt/test/test_build.py
@@ -470,6 +470,30 @@ class BuildTest(QuiltTestCase):
         assert type(compose_root) is PackageNode
         assert simple.foo().equals(compose_root.foo())
 
+    def test_group_node_iter(self):
+        mydir = pathlib.Path(os.path.dirname(__file__))
+        build_compose_contents = {
+            'contents': {
+                'main_group_node': {
+                    'subnode_1': {
+                        'data_node': {
+                            'file': 'data/foo.csv'
+                        }
+                    },
+                    'subnode_2': {
+                        'data_node': {
+                            'file': 'data/foo.csv'
+                        }
+                    },
+                }
+            }
+       }
+
+        build.build_package_from_contents(None, 'test', 'group_node', str(mydir), build_compose_contents)
+        from quilt.data.test import group_node
+        for node in group_node:
+            assert isinstance(node, GroupNode)
+
     def test_package_and_file_raises_exception(self):
         mydir = pathlib.Path(os.path.dirname(__file__))
         bad_build_contents = {

--- a/compiler/quilt/test/test_import.py
+++ b/compiler/quilt/test/test_import.py
@@ -41,6 +41,13 @@ class ImportTest(QuiltTestCase):
         assert set(dataframes._group_keys()) == set()
         assert set(dataframes._data_keys()) == {'csv', 'nulls'}
 
+        # this should contain elements
+        for node in package:
+            assert node
+        # iter over an empty GroupNode
+        for node in dataframes:
+            assert not node
+
         assert isinstance(README(), string_types)
         assert isinstance(README._data(), string_types)
         assert isinstance(dataframes.csv(), pd.DataFrame)


### PR DESCRIPTION
### Iteration

Add iteration over GroupNode. Relates to #494 

Example:
```
from quilt.data.test import group_node
        for node in group_node:
            assert isinstance(node, GroupNode)
```