### PR TITLE
Add 'load' to quilt base module

### DIFF
--- a/compiler/quilt/__init__.py
+++ b/compiler/quilt/__init__.py
@@ -98,6 +98,7 @@ from .tools.command import (
     list_packages,
     list_users,
     list_users_detailed,
+    load,
     log,
     login,
     login_with_token,


### PR DESCRIPTION
### Summary
Adds 'load' to `__init__.py`` so it's available as `quilt.load()` instead of only being available as `quilt.tools.command.load()`.
