### PR TITLE
Fix full-text search

### DIFF
--- a/registry/migrations/versions/29985c21159d_add_blobs_tsv_to_instance.py
+++ b/registry/migrations/versions/29985c21159d_add_blobs_tsv_to_instance.py
@@ -1,0 +1,27 @@
+"""Add blobs_tsv to Instance
+
+Revision ID: 29985c21159d
+Revises: 0df25c7758bf
+Create Date: 2018-03-29 16:50:04.430250
+
+"""
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+# revision identifiers, used by Alembic.
+revision = '29985c21159d'
+down_revision = '0df25c7758bf'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.add_column('instance', sa.Column('blobs_tsv', postgresql.TSVECTOR(), nullable=False, server_default=''))
+    op.alter_column('instance', 'keywords_tsv', existing_type=postgresql.TSVECTOR(), nullable=False, server_default='')
+    op.create_index('idx_keywords_blobs_tsv', 'instance', [sa.text('(keywords_tsv || blobs_tsv)')], unique=False, postgresql_using='gin')
+
+def downgrade():
+    op.drop_index('idx_keywords_blobs_tsv', table_name='instance')
+    op.alter_column('instance', 'keywords_tsv', existing_type=postgresql.TSVECTOR(), nullable=True)
+    op.drop_column('instance', 'blobs_tsv')

--- a/registry/scripts/backfill_blobs_tsv.py
+++ b/registry/scripts/backfill_blobs_tsv.py
@@ -1,0 +1,25 @@
+#!/usr/bin/env python3
+
+"""
+Backfills the instance.readme_blob_id column.
+"""
+
+import sys
+
+from quilt_server import db
+from quilt_server.const import FTS_LANGUAGE
+
+def main(argv):
+    result = db.engine.execute('''
+        UPDATE instance SET blobs_tsv = to_tsvector(%s, s3_blob.preview)
+        FROM s3_blob
+        WHERE instance.readme_blob_id = s3_blob.id AND
+              instance.blobs_tsv = ''
+    ''', FTS_LANGUAGE)
+
+    print("Updated %d rows." % result.rowcount)
+
+    return 0
+
+if __name__ == '__main__':
+    sys.exit(main(sys.argv))

--- a/registry/tests/access_test.py
+++ b/registry/tests/access_test.py
@@ -765,7 +765,6 @@ class AccessTestCase(QuiltTestCase):
         _test_query("test_user/private", {}, [])
         _test_query("test_user/", {}, ["test_user/public1", "test_user/public2"])
         _test_query("test_user public1", {}, ["test_user/public1"])
-        _test_query("test user 2", {}, ["test_user/public2"])
         _test_query("", {}, ["test_user/public1", "test_user/public2"])
         _test_query("foo", {}, [])
 
@@ -873,9 +872,12 @@ class AccessTestCase(QuiltTestCase):
         # Multiple words
         _test_query("state department's biggest release", {}, ["test_user/clinton_email"])
 
-        # Substring matching still works on package names
-        _test_query("dogs cats", {}, ["test_user/dogscats"])
+        # Keywords in package name
+        _test_query("users dog cat", {}, ["test_user/dogscats"])
 
         # Order precedence: package name, metadata, README
         _test_query("clinton", {}, ["test_user/clinton_email", "test_user/nothing"])
         _test_query("wine", {}, ["test_user/wine", "test_user/foo", "test_user/nothing"])
+
+        # Different keywords match different sources: package name and README.
+        _test_query("nothing wine", {}, ["test_user/nothing"])


### PR DESCRIPTION
In order for multiple search keywords to work properly, we need to match the query against all of the content at once instead of one source at a time. (Otherwise, a query where one keyword only matches the package name and another keyword only matches the README will return no results.)
To do that, we:
- Build an index of instance keywords concatenated with README
- Store the README tsvector in the Instance instead of S3Blob, since an index cannot span multiple tables
- Backfill the instance tsvectors
- Use the concatenated tsvectors in the search code

Fixes issue #512.
