### PR TITLE
raven: DSN from config, tweak error reporting stuff

### DIFF
--- a/catalog/app/app.js
+++ b/catalog/app/app.js
@@ -3,7 +3,6 @@
 import 'babel-polyfill';
 
 // Import all the third party stuff
-import Raven from 'raven-js';
 import React from 'react';
 import ReactDOM from 'react-dom';
 import FontFaceObserver from 'fontfaceobserver';
@@ -34,67 +33,60 @@ import { translationMessages } from './i18n';
 // Import CSS reset and Global Styles
 import './global-styles';
 
-Raven
-  .config('https://e0c7810a7a0b4ce898d6e78c1b63f52d@sentry.io/300712')
-  .install();
-
-Raven.context(() => {
-  // TODO: factor-out font loading logic
-  // listen for Roboto fonts
-  const robo = new FontFaceObserver('Roboto', {});
-  const roboMono = new FontFaceObserver('Roboto Mono', {});
-  // reload doc when we have all custom fonts
-  Promise.all([robo.load(), roboMono.load()]).then(() => {
-    document.body.classList.add('fontLoaded');
-  });
-
-
-  // Create redux store with history
-  const initialState = {};
-  const history = createHistory();
-  const store = configureStore(initialState, history);
-  const MOUNT_NODE = document.getElementById('app');
-
-  const render = (messages) => {
-    ReactDOM.render(
-      <StoreProvider store={store}>
-        <InjectReducer mount="form" reducer={form}>
-          <LanguageProvider messages={messages}>
-            <RouterProvider history={history}>
-              <App />
-            </RouterProvider>
-          </LanguageProvider>
-        </InjectReducer>
-      </StoreProvider>,
-      MOUNT_NODE
-    );
-  };
-
-  if (module.hot) {
-    // Hot reloadable React components and translation json files
-    // modules.hot.accept does not accept dynamic dependencies,
-    // have to be constants at compile-time
-    module.hot.accept(['./i18n', 'containers/App'], () => {
-      ReactDOM.unmountComponentAtNode(MOUNT_NODE);
-      render(translationMessages);
-    });
-  }
-
-  // Chunked polyfill for browsers without Intl support
-  if (!window.Intl) {
-    import('intl')
-      .then(() => Promise.all([
-        import('intl/locale-data/jsonp/en.js'),
-      ]))
-      .then(() => render(translationMessages));
-  } else {
-    render(translationMessages);
-  }
-
-  // Delete the old service worker.
-  if (navigator.serviceWorker) {
-    navigator.serviceWorker.getRegistrations().then((registrations) => {
-      registrations.forEach((registration) => { registration.unregister(); });
-    });
-  }
+// TODO: factor-out font loading logic
+// listen for Roboto fonts
+const robo = new FontFaceObserver('Roboto', {});
+const roboMono = new FontFaceObserver('Roboto Mono', {});
+// reload doc when we have all custom fonts
+Promise.all([robo.load(), roboMono.load()]).then(() => {
+  document.body.classList.add('fontLoaded');
 });
+
+// Create redux store with history
+const initialState = {};
+const history = createHistory();
+const store = configureStore(initialState, history);
+const MOUNT_NODE = document.getElementById('app');
+
+const render = (messages) => {
+  ReactDOM.render(
+    <StoreProvider store={store}>
+      <InjectReducer mount="form" reducer={form}>
+        <LanguageProvider messages={messages}>
+          <RouterProvider history={history}>
+            <App />
+          </RouterProvider>
+        </LanguageProvider>
+      </InjectReducer>
+    </StoreProvider>,
+    MOUNT_NODE
+  );
+};
+
+if (module.hot) {
+  // Hot reloadable React components and translation json files
+  // modules.hot.accept does not accept dynamic dependencies,
+  // have to be constants at compile-time
+  module.hot.accept(['./i18n', 'containers/App'], () => {
+    ReactDOM.unmountComponentAtNode(MOUNT_NODE);
+    render(translationMessages);
+  });
+}
+
+// Chunked polyfill for browsers without Intl support
+if (!window.Intl) {
+  import('intl')
+    .then(() => Promise.all([
+      import('intl/locale-data/jsonp/en.js'),
+    ]))
+    .then(() => render(translationMessages));
+} else {
+  render(translationMessages);
+}
+
+// Delete the old service worker.
+if (navigator.serviceWorker) {
+  navigator.serviceWorker.getRegistrations().then((registrations) => {
+    registrations.forEach((registration) => { registration.unregister(); });
+  });
+}

--- a/catalog/app/constants/config.js
+++ b/catalog/app/constants/config.js
@@ -26,6 +26,7 @@ const shouldHaveInTeam = {
   name: 'string'
 };
 
+// TODO: use lodash/conformsTo
 // test the config object
 check(mustHave, window.__CONFIG);
 if (window.__CONFIG.team) {

--- a/catalog/app/run.js
+++ b/catalog/app/run.js
@@ -1,0 +1,2 @@
+// eslint-disable-next-line global-require
+require('utils/errorReporting').run(() => require('./app'));

--- a/catalog/app/store.js
+++ b/catalog/app/store.js
@@ -4,6 +4,7 @@ import { fromJS, Iterable } from 'immutable';
 import { routerMiddleware } from 'react-router-redux';
 import { combineReducers } from 'redux-immutable';
 
+import { captureError } from 'utils/errorReporting';
 import { withInjectableReducers } from 'utils/ReducerInjector';
 import { withSaga } from 'utils/SagaInjector';
 
@@ -40,7 +41,7 @@ export default function configureStore(initialState = {}, history) {
     (state) => state, // noop reducer, the actual ones will be injected
     fromJS(initialState),
     composeEnhancers(
-      withSaga,
+      withSaga({ onError: captureError }),
       applyMiddleware(...middlewares),
       withInjectableReducers(combineReducers),
     )

--- a/catalog/app/utils/SagaInjector.js
+++ b/catalog/app/utils/SagaInjector.js
@@ -122,8 +122,8 @@ export const injectSaga = (key, saga, {
     }),
     restoreProps({ key: ownPropsKey }));
 
-export const withSaga = (createStore) => (...args) => {
-  const sagaMiddleware = createSagaMiddleware();
+export const withSaga = (...sagaMWArgs) => (createStore) => (...args) => {
+  const sagaMiddleware = createSagaMiddleware(...sagaMWArgs);
   const store = applyMiddleware(sagaMiddleware)(createStore)(...args);
   return {
     ...store,

--- a/catalog/app/utils/errorReporting.js
+++ b/catalog/app/utils/errorReporting.js
@@ -1,0 +1,83 @@
+import Raven from 'raven-js';
+import createRavenMiddleware from 'raven-for-redux';
+
+import config from 'constants/config';
+
+
+// ignore irrelevant nonactionable stuff, e.g. browser extensions and 3rd-party scripts
+// based on this gist: https://gist.github.com/impressiver/5092952
+const ignoreErrors = [
+  // Random plugins/extensions
+  'top.GLOBALS',
+  // See: http://blog.errorception.com/2012/03/tale-of-unfindable-js-error.html
+  'originalCreateNotification',
+  'canvas.contentDocument',
+  'MyApp_RemoveAllHighlights',
+  'http://tt.epicplay.com',
+  'Can\'t find variable: ZiteReader',
+  'jigsaw is not defined',
+  'ComboSearch is not defined',
+  'http://loading.retry.widdit.com/',
+  'atomicFindClose',
+  // Facebook borked
+  'fb_xd_fragment',
+  // ISP "optimizing" proxy - `Cache-Control: no-transform` seems to reduce this. (thanks @acdha)
+  // See http://stackoverflow.com/questions/4113268/how-to-stop-javascript-injection-from-vodafone-proxy
+  'bmi_SafeAddOnload',
+  'EBCallBackMessageReceived',
+  // See http://toolbar.conduit.com/Developer/HtmlAndGadget/Methods/JSInjection.aspx
+  'conduitPage',
+];
+
+const ignoreUrls = [
+  // Facebook flakiness
+  /graph\.facebook\.com/i,
+  // Facebook blocked
+  /connect\.facebook\.net\/en_US\/all\.js/i,
+  // Woopra flakiness
+  /eatdifferent\.com\.woopra-ns\.com/i,
+  /static\.woopra\.com\/js\/woopra\.js/i,
+  // Chrome extensions
+  /extensions\//i,
+  /^chrome:\/\//i,
+  // Other plugins
+  /127\.0\.0\.1:4001\/isrunning/i, // Cacaoweb
+  /webappstoolbarba\.texthelp\.com\//i,
+  /metrics\.itunes\.apple\.com\.edgesuite\.net\//i,
+];
+
+if (config.sentryDSN) {
+  Raven
+    .config(config.sentryDSN, {
+      ignoreErrors,
+      ignoreUrls,
+      environment: process.env.NODE_ENV,
+      // release: TODO
+      debug: process.env.NODE_ENV === 'development',
+    })
+    .install();
+}
+
+export const captureError = Raven.isSetup()
+  ? (e, data) => Raven.captureException(e, data)
+  : (e, data) => {
+    // eslint-disable-next-line no-console
+    console.log('Error captured, data:', data);
+    // eslint-disable-next-line no-console
+    console.error(e);
+  };
+
+export const captureMessage = Raven.isSetup()
+  ? (m, data) => Raven.captureMessage(m, data)
+  : (m, data) => {
+    // eslint-disable-next-line no-console
+    console.log(m, data);
+  };
+
+export const run = Raven.isSetup()
+  ? (fn) => Raven.context(fn)
+  : (fn) => { try { fn(); } catch (e) { captureError(e); } };
+
+export const reduxMiddleware = Raven.isSetup()
+  ? createRavenMiddleware(Raven, {})
+  : () => (next) => (action) => next(action);

--- a/catalog/config.js.tmpl
+++ b/catalog/config.js.tmpl
@@ -2,6 +2,7 @@
 window.__CONFIG = {
   alwaysRequiresAuth: Boolean('$ALWAYS_REQUIRES_AUTH'),
   api: '$REGISTRY_URL',
+  sentryDSN: '$SENTRY_DSN',
   signOutUrl: '$SIGN_OUT_URL',
   stripeKey: '$STRIPE_KEY',
   // eslint-disable-next-line no-constant-condition

--- a/catalog/internals/webpack/webpack.dev.babel.js
+++ b/catalog/internals/webpack/webpack.dev.babel.js
@@ -39,7 +39,7 @@ module.exports = require('./webpack.base.babel')({
   entry: [
     'eventsource-polyfill', // Necessary for hot reloading with IE
     'webpack-hot-middleware/client?reload=true',
-    path.join(process.cwd(), 'app/app.js'), // Start with js/app.js
+    path.join(process.cwd(), 'app/run.js'), // Start with app/run.js
   ],
 
   // Don't use hashes in dev mode for better performance

--- a/catalog/internals/webpack/webpack.prod.babel.js
+++ b/catalog/internals/webpack/webpack.prod.babel.js
@@ -6,7 +6,7 @@ const HtmlWebpackPlugin = require('html-webpack-plugin');
 module.exports = require('./webpack.base.babel')({
   // In production, we skip all hot-reloading stuff
   entry: [
-    path.join(process.cwd(), 'app/app.js'),
+    path.join(process.cwd(), 'app/run.js'),
   ],
 
   // Utilize long-term caching by adding content hashes (not compilation hashes) to compiled assets

--- a/catalog/package-lock.json
+++ b/catalog/package-lock.json
@@ -12029,6 +12029,11 @@
       "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.0.tgz",
       "integrity": "sha1-9JvmtIeJTdxA3MlKMi9hEJLgDV4="
     },
+    "raven-for-redux": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/raven-for-redux/-/raven-for-redux-1.3.0.tgz",
+      "integrity": "sha512-W0Nbj5vwUCE0t8gNIm+nMziLa5p3g/7qhxF560OL96Pqd3gIc/wEv0TqYkHVYTVyDi2uxljpa+///1vT0a6EKw=="
+    },
     "raven-js": {
       "version": "3.23.1",
       "resolved": "https://registry.npmjs.org/raven-js/-/raven-js-3.23.1.tgz",

--- a/catalog/package.json
+++ b/catalog/package.json
@@ -260,6 +260,7 @@
     "minimist": "^1.2.0",
     "prop-types": "^15.6.0",
     "query-string": "^5.1.0",
+    "raven-for-redux": "^1.3.0",
     "raven-js": "^3.23.1",
     "react": "^16.2.0",
     "react-bootstrap": "^0.32.1",


### PR DESCRIPTION
### Summary

* only load raven if Sentry DSN is present, fallback to console logging;
* wrap all the app code into raven context, including imports;
* integrate raven with redux / saga.

### TODO

* use `captureError` from `utils/errorReporting` for error handling (separate PR(s)).