### PR TITLE
Add an endpoint to get download URLs for a list of hashes

### DIFF
--- a/registry/quilt_server/schemas.py
+++ b/registry/quilt_server/schemas.py
@@ -151,3 +151,11 @@ USERNAME_EMAIL_SCHEMA = {
     'required': ['username', 'email'],
     'additionalProperties': False
 }
+
+GET_OBJECTS_SCHEMA = {
+    'type': 'array',
+    'items': {
+        'type': 'string',
+        'pattern': SHA256_PATTERN
+    }
+}


### PR DESCRIPTION
The user needs to have access to those objects, but not necessarily own them.