### PR TITLE
Add a param to only get the metadata, with no download URLs

### DIFF
--- a/registry/quilt_server/views.py
+++ b/registry/quilt_server/views.py
@@ -853,6 +853,7 @@ def package_put(owner, package_name, package_hash):
 @as_json
 def package_get(owner, package_name, package_hash):
     subpath = request.args.get('subpath')
+    meta_only = bool(request.args.get('meta_only', ''))
 
     instance = _get_instance(g.auth, owner, package_name, package_hash)
 
@@ -865,7 +866,7 @@ def package_get(owner, package_name, package_hash):
         except (AttributeError, KeyError):
             raise ApiException(requests.codes.not_found, "Invalid subpath: %r" % component)
 
-    all_hashes = set(find_object_hashes(subnode))
+    all_hashes = set() if meta_only else set(find_object_hashes(subnode))
 
     blobs = (
         S3Blob.query

--- a/registry/tests/push_install_test.py
+++ b/registry/tests/push_install_test.py
@@ -223,6 +223,18 @@ class PushInstallTestCase(QuiltTestCase):
         assert url2.path == '/%s/objs/test_user/%s' % (app.config['PACKAGE_BUCKET_NAME'], self.HASH2)
         assert url3.path == '/%s/objs/test_user/%s' % (app.config['PACKAGE_BUCKET_NAME'], self.HASH3)
 
+        # Install just the metadata.
+        resp = self.app.get(
+            '/api/package/test_user/foo/%s?meta_only=true' % self.CONTENTS_HASH,
+        )
+        assert resp.status_code == requests.codes.ok
+
+        data = json.loads(resp.data.decode('utf8'), object_hook=decode_node)
+        contents = data['contents']
+        assert contents == self.CONTENTS
+        assert not data['sizes']
+        assert not data['urls']
+
     @patch('quilt_server.views.ALLOW_ANONYMOUS_ACCESS', True)
     def testPushNewMetadata(self):
         # Push the original contents.


### PR DESCRIPTION
Pretty small optimization, but could be useful if there are lots of objects.