### PR TITLE
Explicitly create group nodes instead of creating them as needed

### DIFF
--- a/compiler/quilt/tools/build.py
+++ b/compiler/quilt/tools/build.py
@@ -138,6 +138,9 @@ def _build_node(build_dir, package, node_path, node, checks_contents=None,
       Child transform or kwargs override ancestor k:v pairs.
     """
     if _is_internal_node(node):
+        if not dry_run:
+            package.save_group(node_path)
+
         # Make a consumable copy.  This is to cover a quirk introduced by accepting nodes named
         # like RESERVED keys -- if a RESERVED key is actually matched, it should be removed from
         # the node, or it gets treated like a subnode (or like a node with invalid content)

--- a/compiler/quilt/tools/command.py
+++ b/compiler/quilt/tools/command.py
@@ -555,6 +555,7 @@ def build_from_node(package, node):
 
     def _process_node(node, path=[]):
         if isinstance(node, nodes.GroupNode):
+            package_obj.save_group(path)
             for key, child in node._items():
                 _process_node(child, path + [key])
         elif isinstance(node, nodes.DataNode):

--- a/compiler/quilt/tools/package.py
+++ b/compiler/quilt/tools/package.py
@@ -344,7 +344,7 @@ class Package(object):
 
         ptr = contents
         for node in node_path[:-1]:
-            ptr = ptr.children.setdefault(node, GroupNode(dict()))
+            ptr = ptr.children[node]
 
         metadata = dict(
             q_ext=ext,


### PR DESCRIPTION
Group nodes will soon contain metadata, so we can't just create/delete them when it's convenient.
Also fixes a bug where empty groups get dropped when building a package from another package node.
