### PR TITLE
Add support for group metadata in a somewhat backward-compatible way

### DIFF
--- a/registry/quilt_server/schemas.py
+++ b/registry/quilt_server/schemas.py
@@ -33,6 +33,9 @@ PACKAGE_SCHEMA = {
                 'type': {
                     'enum': [RootNode.json_type]
                 },
+                'metadata': {
+                    'type': 'object'
+                },
                 'children': {
                     'type': 'object',
                     'additionalProperties': {
@@ -85,6 +88,9 @@ PACKAGE_SCHEMA = {
                                 'properties': {
                                     'type': {
                                         'enum': [GroupNode.json_type]
+                                    },
+                                    'metadata': {
+                                        'type': 'object'
                                     },
                                     'children': {
                                         '$ref': '#/properties/contents/properties/children'


### PR DESCRIPTION
Save group metadata if it's not empty.
Old clients will only be able to access packages that don't contain group metadata.