### PR TITLE
Remove the tables dependency from the CI configs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -39,7 +39,7 @@ matrix:
 
 install:
   # install quilt from setup.py
-  - travis_retry pip install --only-binary 'tables' ./compiler['tests']
+  - travis_retry pip install ./compiler['tests']
   - |
     if [[ "$TEST_REGISTRY" = true ]]; then
       travis_retry pip install -r registry/requirements.txt

--- a/circle.yml
+++ b/circle.yml
@@ -28,7 +28,7 @@ dependencies:
     - |
       for version in 2.7.10 3.5.1 3.6.1
       do
-        export PATH="$HOME/miniconda/bin:$PATH" && source activate quilt_env$version && pip install 'tables' ./compiler['tests'] --user && source deactivate quilt_env$version;
+        export PATH="$HOME/miniconda/bin:$PATH" && source activate quilt_env$version && pip install ./compiler['tests'] --user && source deactivate quilt_env$version;
       done
 
 test:


### PR DESCRIPTION
It's obsolete, now that HDF5 support is gone.