### PR TITLE
Implement getting/setting metadata on nodes

### DIFF
--- a/compiler/quilt/test/test_command.py
+++ b/compiler/quilt/test/test_command.py
@@ -1209,7 +1209,7 @@ class CommandTest(QuiltTestCase):
         # Set relative path and build dir instead
         node._set(['abs_file'], 'abs_file', str(tempdir))
         # Circumvent absolute path checks by writing value directly
-        node.abs_file._node.metadata['q_path'] = str(abs_file)
+        node.abs_file._meta['filepath'] = str(abs_file)
 
         # build
         command.build(pkg_name, node)

--- a/compiler/quilt/test/test_import.py
+++ b/compiler/quilt/test/test_import.py
@@ -239,6 +239,10 @@ class ImportTest(QuiltTestCase):
         package1._set(['newgroup'], 'data/nuts.csv', build_dir=mydir)
         assert package1.newgroup._data() == new_path
 
+        # Set some custom metadata
+        package1._meta['custom'] = {'foo': 'bar'}
+        package1.newgroup._meta['custom'] = {'x': 'y'}
+
         # Built a new package and verify the new contents
         command.build('foo/package3', package1)
 
@@ -255,6 +259,9 @@ class ImportTest(QuiltTestCase):
 
         new_file = package3.new.file._data()
         assert isinstance(new_file, string_types)
+
+        assert package3._meta['custom'] == {'foo': 'bar'}
+        assert package3.newgroup._meta['custom'] == {'x': 'y'}
 
     def test_set_non_node_attr(self):
         mydir = os.path.dirname(__file__)

--- a/compiler/quilt/test/test_install.py
+++ b/compiler/quilt/test/test_install.py
@@ -58,7 +58,7 @@ class InstallTest(QuiltTestCase):
             group=GroupNode(dict([
                 (key, TableNode([val], PackageFormat.default.value)
                  if 'table' in key
-                 else FileNode([val], metadata={'q_path': key}))
+                 else FileNode([val], metadata={'filepath': key}))
                 for key, val in args.items()]
             ))
         ))
@@ -391,8 +391,8 @@ packages:
             file_hash_list.append(file_hash)
 
         contents = RootNode(dict(
-            file0=FileNode([file_hash_list[0]], metadata={'q_path': 'file0'}),
-            file1=FileNode([file_hash_list[1]], metadata={'q_path': 'file1'}),
+            file0=FileNode([file_hash_list[0]], metadata={'filepath': 'file0'}),
+            file1=FileNode([file_hash_list[1]], metadata={'filepath': 'file1'}),
         ))
         contents_hash = hash_contents(contents)
 

--- a/compiler/quilt/tools/build.py
+++ b/compiler/quilt/tools/build.py
@@ -139,7 +139,7 @@ def _build_node(build_dir, package, node_path, node, checks_contents=None,
     """
     if _is_internal_node(node):
         if not dry_run:
-            package.save_group(node_path)
+            package.save_group(node_path, None)
 
         # Make a consumable copy.  This is to cover a quirk introduced by accepting nodes named
         # like RESERVED keys -- if a RESERVED key is actually matched, it should be removed from
@@ -181,7 +181,7 @@ def _build_node(build_dir, package, node_path, node, checks_contents=None,
         # handle group leaf nodes (empty groups)
         if not node:
             if not dry_run:
-                package.save_group(node_path)
+                package.save_group(node_path, None)
             return
 
         include_package = node.get(RESERVED['package'])
@@ -252,7 +252,7 @@ def _build_node(build_dir, package, node_path, node, checks_contents=None,
                         _run_checks(data, checks, checks_contents, node_path, rel_path, target, env=env)
                 if not dry_run:
                     print("Registering %s..." % path)
-                    package.save_file(path, node_path, rel_path, target)
+                    package.save_file(path, node_path, target, rel_path, transform, None)
             elif transform == PARQUET:
                 if checks:
                     from pyarrow.parquet import ParquetDataset
@@ -262,7 +262,7 @@ def _build_node(build_dir, package, node_path, node, checks_contents=None,
                     _run_checks(dataframe, checks, checks_contents, node_path, rel_path, target, env=env)
                 if not dry_run:
                     print("Registering %s..." % path)
-                    package.save_file(path, node_path, rel_path, target)
+                    package.save_file(path, node_path, target, rel_path, transform, None)
             else:
                 # copy so we don't modify shared ancestor_args
                 handler_args = dict(ancestor_args.get(RESERVED['kwargs'], {}))
@@ -285,7 +285,7 @@ def _build_node(build_dir, package, node_path, node, checks_contents=None,
                 # below is a heavy-handed fix but it's OK for check builds to be slow
                 if not checks and cachedobjs and all(os.path.exists(store.object_path(obj)) for obj in cachedobjs):
                     # Use existing objects instead of rebuilding
-                    package.save_cached_df(cachedobjs, node_path, rel_path, transform, target)
+                    package.save_cached_df(cachedobjs, node_path, target, rel_path, transform, None)
                 else:
                     # read source file into DataFrame
                     print("Serializing %s..." % path)
@@ -302,7 +302,7 @@ def _build_node(build_dir, package, node_path, node, checks_contents=None,
                     # serialize DataFrame to file(s)
                     if not dry_run:
                         print("Saving as binary dataframe...")
-                        obj_hashes = package.save_df(dataframe, node_path, rel_path, transform, target)
+                        obj_hashes = package.save_df(dataframe, node_path, target, rel_path, transform, None)
 
                         # Add to cache
                         cache_entry = dict(

--- a/registry/quilt_server/views.py
+++ b/registry/quilt_server/views.py
@@ -1027,7 +1027,7 @@ def package_preview(owner, package_name, package_hash):
 
     file_types = defaultdict(int)
     for node in _iterate_data_nodes(instance.contents):
-        path = node.metadata.get('q_path')
+        path = node.metadata.get('filepath', node.metadata.get('q_path'))
         if not isinstance(path, str):
             path = ''
         # We don't know if it's a UNIX or a Windows path, so let's treat both \ and / as separators.

--- a/registry/tests/push_install_test.py
+++ b/registry/tests/push_install_test.py
@@ -127,10 +127,10 @@ class PushInstallTestCase(QuiltTestCase):
             q_path='C:\\Windows\\System32\\clock.exe'
         )),
         file6=FileNode(hashes=[HASH1], metadata=dict(
-            q_path='C:\\foo.bar\\BLAH.JPG'
+            filepath='C:\\foo.bar\\BLAH.JPG'
         )),
         README=FileNode(hashes=[HASH2], metadata=dict(
-            q_path='README'
+            filepath='README'
         ))
     ))
 


### PR DESCRIPTION
- Split `DataNode` into two subclasses: dataframes that are backed by the store, and in-memory ones.
- Stop using core nodes when modifying packages: those should only be used for serialization, and aren't relevant there.
- Store metadata in the `Node` class, to make it easily accessible by the user. (Right now, the user can change any metadata, not just "custom" - though changes will be ignored.)
- Save custom metadata when building a new package.