### PR TITLE
Always use the default store when building packages

### DIFF
--- a/compiler/quilt/tools/command.py
+++ b/compiler/quilt/tools/command.py
@@ -551,8 +551,7 @@ def build_from_node(package, node):
     """
     team, owner, pkg = parse_package(package)
     _check_team_id(team)
-    # deliberate access of protected member
-    store = node._package.get_store()
+    store = PackageStore()
     package_obj = store.create_package(team, owner, pkg)
 
     def _process_node(node, path=[]):


### PR DESCRIPTION
When building a package from a node, build it in the default store, not the node's store:
- That's consistent with the regular build and install commands
- The node might not even have a store