### PR TITLE
Move dataframe saving/loading code from Package to PackageStore

### DIFF
--- a/compiler/quilt/nodes.py
+++ b/compiler/quilt/nodes.py
@@ -50,7 +50,17 @@ class DataNode(Node):
         Returns the contents of the node: a dataframe or a file path.
         """
         if self.__cached_data is None:
-            self.__cached_data = self._package.get_obj(self._node)
+            # TODO(dima): Temporary code.
+            store = self._package.get_store()
+            if isinstance(self._node, core.TableNode):
+                self.__cached_data = store.load_dataframe(self._node.hashes)
+            elif isinstance(self._node, core.FileNode):
+                assert len(self._node.hashes) == 1
+                self.__cached_data = store.object_path(self._node.hashes[0])
+            else:
+                # XXX: This is wrong.
+                hash_list = list(core.find_object_hashes(self._node, sort=True))
+                self.__cached_data = store.load_dataframe(hash_list)
         return self.__cached_data
 
 class GroupNode(DataNode):

--- a/compiler/quilt/test/test_build.py
+++ b/compiler/quilt/test/test_build.py
@@ -11,7 +11,7 @@ from six import assertRaisesRegex, string_types
 import yaml
 
 from ..nodes import GroupNode, PackageNode
-from ..tools.package import ParquetLib, Package
+from ..tools.store import ParquetLib, PackageStore
 from ..tools.compat import pathlib
 from ..tools.const import PRETTY_MAX_LEN
 from ..tools import build, command, store
@@ -25,7 +25,7 @@ class BuildTest(QuiltTestCase):
         """
         Test compilation to Parquet via the default library
         """
-        Package.reset_parquet_lib()
+        PackageStore.reset_parquet_lib()
         mydir = os.path.dirname(__file__)
         path = os.path.join(mydir, './build_large.yml')
         build.build_package(None, 'test_parquet', PACKAGE, path)
@@ -68,17 +68,17 @@ class BuildTest(QuiltTestCase):
         Test setting the parquet library using the env variable.
         """
         try:
-            assert Package.get_parquet_lib() == ParquetLib.ARROW
+            assert PackageStore.get_parquet_lib() == ParquetLib.ARROW
 
             with patch.dict(os.environ, {'QUILT_PARQUET_LIBRARY': ParquetLib.ARROW.value}):
-                Package.reset_parquet_lib()
-                assert Package.get_parquet_lib() == ParquetLib.ARROW
+                PackageStore.reset_parquet_lib()
+                assert PackageStore.get_parquet_lib() == ParquetLib.ARROW
 
             with patch.dict(os.environ, {'QUILT_PARQUET_LIBRARY': ParquetLib.SPARK.value}):
-                Package.reset_parquet_lib()
-                assert Package.get_parquet_lib() == ParquetLib.SPARK
+                PackageStore.reset_parquet_lib()
+                assert PackageStore.get_parquet_lib() == ParquetLib.SPARK
         finally:
-            Package.reset_parquet_lib()
+            PackageStore.reset_parquet_lib()
 
     # shared testing logic between pyarrow and default env
     def _test_dataframes(self, dataframes):

--- a/compiler/quilt/test/test_import.py
+++ b/compiler/quilt/test/test_import.py
@@ -11,8 +11,8 @@ from six import string_types
 from quilt.nodes import GroupNode, DataNode
 from quilt.tools import command
 from quilt.tools.const import PACKAGE_DIR_NAME
-from quilt.tools.package import Package, PackageException
-from quilt.tools.store import PackageStore
+from quilt.tools.package import Package
+from quilt.tools.store import PackageStore, StoreException
 from .utils import patch, QuiltTestCase
 
 class ImportTest(QuiltTestCase):
@@ -150,7 +150,7 @@ class ImportTest(QuiltTestCase):
 
         # Incompatible Schema
         from quilt.data.foo.grppkg import incompatible
-        with self.assertRaises(PackageException):
+        with self.assertRaises(StoreException):
             incompatible._data()
 
     def test_multiple_package_dirs(self):

--- a/compiler/quilt/tools/build.py
+++ b/compiler/quilt/tools/build.py
@@ -3,11 +3,9 @@ parse build file, serialize package
 """
 from collections import defaultdict, Iterable
 import glob
-import importlib
 import json
 import os
 import re
-from types import ModuleType
 
 import numpy as np
 import pandas as pd
@@ -22,8 +20,7 @@ from .const import (DEFAULT_BUILDFILE, PANDAS_PARSERS, DEFAULT_QUILT_YML, PACKAG
                     QuiltException, TargetType)
 from .core import GroupNode
 from .hashing import digest_file, digest_string
-from .package import Package, ParquetLib
-from .store import PackageStore, StoreException
+from .store import PackageStore, ParquetLib, StoreException
 from .util import FileWithReadProgress, is_nodename, to_nodename, to_identifier, parse_package
 
 from . import check_functions as qc            # pylint:disable=W0611
@@ -42,7 +39,7 @@ def _have_pyspark():
     """
     if _have_pyspark.flag is None:
         try:
-            if Package.get_parquet_lib() is ParquetLib.SPARK:
+            if PackageStore.get_parquet_lib() is ParquetLib.SPARK:
                 import pyspark  # pylint:disable=W0612
                 _have_pyspark.flag = True
             else:

--- a/compiler/quilt/tools/command.py
+++ b/compiler/quilt/tools/command.py
@@ -1047,6 +1047,8 @@ def inspect(package):
     if pkgobj is None:
         raise CommandException("Package {package} not found.".format(package=package))
 
+    store = pkgobj.get_store()
+
     def _print_children(children, prefix, path):
         for idx, (name, child) in enumerate(children):
             if idx == len(children) - 1:
@@ -1066,7 +1068,7 @@ def inspect(package):
             print(prefix + name_prefix + name)
             _print_children(children, child_prefix, path + name)
         elif isinstance(node, TableNode):
-            df = pkgobj.get_obj(node)
+            df = store.load_dataframe(node.hashes)
             assert isinstance(df, pd.DataFrame)
             info = "shape %s, type \"%s\"" % (df.shape, df.dtypes)
             print(prefix + name_prefix + ": " + info)

--- a/compiler/quilt/tools/package.py
+++ b/compiler/quilt/tools/package.py
@@ -1,22 +1,12 @@
-from enum import Enum
 import json
 import os
-from shutil import copyfile, move, rmtree
-
-import pandas as pd
 
 from .compat import pathlib
 from .const import TargetType, QuiltException
-from .core import (decode_node, encode_node, find_object_hashes, hash_contents,
+from .core import (decode_node, encode_node, hash_contents,
                    FileNode, GroupNode, TableNode,
                    PackageFormat)
-from .hashing import digest_file
 from .util import is_nodename
-
-
-class ParquetLib(Enum):
-    SPARK = 'pyspark'
-    ARROW = 'pyarrow'
 
 
 class PackageException(QuiltException):
@@ -27,32 +17,10 @@ class PackageException(QuiltException):
 
 
 class Package(object):
-    DF_NAME = 'df'
     CONTENTS_DIR = 'contents'
     TAGS_DIR = 'tags'
     VERSIONS_DIR = 'versions'
     LATEST = 'latest'
-
-    __parquet_lib = None
-
-    @classmethod
-    def get_parquet_lib(cls):
-        """
-        Find/choose a library to read and write Parquet files
-        based on installed options.
-        """
-        if cls.__parquet_lib is None:
-            parq_env = os.environ.get('QUILT_PARQUET_LIBRARY', ParquetLib.ARROW.value)
-            cls.__parquet_lib = ParquetLib(parq_env)
-        return cls.__parquet_lib
-
-    @classmethod
-    def reset_parquet_lib(cls):
-        cls.__parquet_lib = None
-
-    @classmethod
-    def set_parquet_lib(cls, parqlib):
-        cls.__parquet_lib = ParquetLib(parqlib)
 
     def __init__(self, store, user, package, path, contents=None, pkghash=None):
         self._store = store
@@ -137,53 +105,6 @@ class Package(object):
         with open(contents_path, 'r') as contents_file:
             return json.load(contents_file, object_hook=decode_node)
 
-    def file(self, hash_list):
-        """
-        Returns the path to an object file that matches the given hash.
-        """
-        assert isinstance(hash_list, list)
-        assert len(hash_list) == 1, "File objects must be contained in one file."
-        filehash = hash_list[0]
-        return self._store.object_path(filehash)
-
-    def _read_parquet_arrow(self, hash_list):
-        from pyarrow.parquet import ParquetDataset
-
-        objfiles = [self._store.object_path(h) for h in hash_list]
-        dataset = ParquetDataset(objfiles)
-        table = dataset.read(nthreads=4)
-        dataframe = table.to_pandas()
-        return dataframe
-
-    def _read_parquet_spark(self, hash_list):
-        from pyspark import sql as sparksql
-
-        spark = sparksql.SparkSession.builder.getOrCreate()
-        objfiles = [self._store.object_path(h) for h in hash_list]
-        dataframe = spark.read.parquet(*objfiles)
-        return dataframe
-
-    def _dataframe(self, hash_list):
-        """
-        Creates a DataFrame from a set of objects (identified by hashes).
-        """
-        parqlib = self.get_parquet_lib()
-        if parqlib is ParquetLib.SPARK:
-            return self._read_parquet_spark(hash_list)
-        elif parqlib is ParquetLib.ARROW:
-            try:
-                return self._read_parquet_arrow(hash_list)
-            except ValueError as err:
-                raise PackageException(str(err))
-        else:
-            assert False, "Unimplemented Parquet Library %s" % parqlib
-
-    def _check_hashes(self, hash_list):
-        for objhash in hash_list:
-            path = self._store.object_path(objhash)
-            if not os.path.exists(path):
-                raise PackageException("Missing object fragments; re-install the package")
-
     def save_package_tree(self, node_path, pkgnode):
         """
         Adds a package or sub-package tree from an existing package to this package's
@@ -210,54 +131,16 @@ class Package(object):
         """
         Save a DataFrame to the store.
         """
-        storepath = self._store.temporary_object_path('.'.join(node_path))
-
-        # switch parquet lib
-        parqlib = self.get_parquet_lib()
-        if isinstance(dataframe, pd.DataFrame):
-            #parqlib is ParquetLib.ARROW: # other parquet libs are deprecated, remove?
-            import pyarrow as pa
-            from pyarrow import parquet
-            table = pa.Table.from_pandas(dataframe)
-            parquet.write_table(table, storepath)
-        elif parqlib is ParquetLib.SPARK:
-            from pyspark import sql as sparksql
-            assert isinstance(dataframe, sparksql.DataFrame)
-            dataframe.write.parquet(storepath)
-        else:
-            assert False, "Unimplemented ParquetLib %s" % parqlib
-
-        # Move serialized DataFrame to object store
-        if os.path.isdir(storepath): # Pyspark
-            hashes = []
-            files = [ofile for ofile in os.listdir(storepath) if ofile.endswith(".parquet")]
-            for obj in files:
-                path = os.path.join(storepath, obj)
-                objhash = digest_file(path)
-                move(path, self._store.object_path(objhash))
-                hashes.append(objhash)
-            self._add_to_contents(node_path, hashes, ext, source_path, target)
-            rmtree(storepath)
-            return hashes
-        else:
-            filehash = digest_file(storepath)
-            self._add_to_contents(node_path, [filehash], ext, source_path, target)
-            move(storepath, self._store.object_path(filehash))
-            return [filehash]
+        hashes = self._store.save_dataframe(dataframe)
+        self._add_to_contents(node_path, hashes, ext, source_path, target)
+        return hashes
 
     def save_file(self, srcfile, node_path, source_path, target):
         """
         Save a (raw) file to the store.
         """
-        filehash = digest_file(srcfile)
+        filehash = self._store.save_file(srcfile)
         self._add_to_contents(node_path, [filehash], '', source_path, target)
-        objpath = self._store.object_path(filehash)
-        if not os.path.exists(objpath):
-            # Copy the file to a temporary location first, then move, to make sure we don't end up with
-            # truncated contents if the build gets interrupted.
-            tmppath = self._store.temporary_object_path(filehash)
-            copyfile(srcfile, tmppath)
-            move(tmppath, objpath)
 
     def save_group(self, node_path):
         """
@@ -295,26 +178,6 @@ class Package(object):
         latest_tag = os.path.join(self._path, self.TAGS_DIR, self.LATEST)
         with open (latest_tag, 'w') as tagfile:
             tagfile.write("{hsh}".format(hsh=instance_hash))
-
-    def get_obj(self, node):
-        """
-        Read an object from the package given a node from the
-        package tree.
-        """
-        if isinstance(node, TableNode):
-            self._check_hashes(node.hashes)
-            if node.format is PackageFormat.HDF5:
-                raise PackageException("HDF5 format is no longer supported")
-            return self._dataframe(node.hashes)
-        elif isinstance(node, GroupNode):
-            hash_list = list(find_object_hashes(node, sort=True))
-            self._check_hashes(hash_list)
-            return self._dataframe(hash_list)
-        elif isinstance(node, FileNode):
-            self._check_hashes(node.hashes)
-            return self.file(node.hashes)
-        else:
-            assert False, "Unhandled Node {node}".format(node=node)
 
     def get_hash(self):
         """

--- a/compiler/quilt/tools/store.py
+++ b/compiler/quilt/tools/store.py
@@ -2,11 +2,15 @@
 Build: parse and add user-supplied files to store
 """
 import os
+from shutil import copyfile, move, rmtree
+import uuid
 
-from shutil import rmtree
+from enum import Enum
+import pandas as pd
 
 from .const import DEFAULT_TEAM, PACKAGE_DIR_NAME, QuiltException
 from .core import FileNode, RootNode, TableNode, find_object_hashes
+from .hashing import digest_file
 from .package import Package, PackageException
 from .util import BASE_DIR, sub_dirs, sub_files, is_nodename
 
@@ -16,6 +20,10 @@ CHUNK_SIZE = 4096
 def default_store_location():
     package_dir = os.path.join(BASE_DIR, PACKAGE_DIR_NAME)
     return os.getenv('QUILT_PRIMARY_PACKAGE_DIR', package_dir)
+
+class ParquetLib(Enum):
+    SPARK = 'pyspark'
+    ARROW = 'pyarrow'
 
 class StoreException(QuiltException):
     """
@@ -36,6 +44,27 @@ class PackageStore(object):
     PKG_DIR = 'pkgs'
     CACHE_DIR = 'cache'
     VERSION = '1.3'
+
+    __parquet_lib = None
+
+    @classmethod
+    def get_parquet_lib(cls):
+        """
+        Find/choose a library to read and write Parquet files
+        based on installed options.
+        """
+        if cls.__parquet_lib is None:
+            parq_env = os.environ.get('QUILT_PARQUET_LIBRARY', ParquetLib.ARROW.value)
+            cls.__parquet_lib = ParquetLib(parq_env)
+        return cls.__parquet_lib
+
+    @classmethod
+    def reset_parquet_lib(cls):
+        cls.__parquet_lib = None
+
+    @classmethod
+    def set_parquet_lib(cls, parqlib):
+        cls.__parquet_lib = ParquetLib(parqlib)
 
     def __init__(self, location=None):
         if location is None:
@@ -304,3 +333,95 @@ class PackageStore(object):
             if os.path.exists(path):
                 os.remove(path)
         return remove_objs
+
+    def _read_parquet_arrow(self, hash_list):
+        from pyarrow.parquet import ParquetDataset
+
+        objfiles = [self.object_path(h) for h in hash_list]
+        dataset = ParquetDataset(objfiles)
+        table = dataset.read(nthreads=4)
+        dataframe = table.to_pandas()
+        return dataframe
+
+    def _read_parquet_spark(self, hash_list):
+        from pyspark import sql as sparksql
+
+        spark = sparksql.SparkSession.builder.getOrCreate()
+        objfiles = [self.object_path(h) for h in hash_list]
+        dataframe = spark.read.parquet(*objfiles)
+        return dataframe
+
+    def _check_hashes(self, hash_list):
+        for objhash in hash_list:
+            path = self.object_path(objhash)
+            if not os.path.exists(path):
+                raise StoreException("Missing object fragments; re-install the package")
+
+    def load_dataframe(self, hash_list):
+        """
+        Creates a DataFrame from a set of objects (identified by hashes).
+        """
+        self._check_hashes(hash_list)
+        parqlib = self.get_parquet_lib()
+        if parqlib is ParquetLib.SPARK:
+            return self._read_parquet_spark(hash_list)
+        elif parqlib is ParquetLib.ARROW:
+            try:
+                return self._read_parquet_arrow(hash_list)
+            except ValueError as err:
+                raise StoreException(str(err))
+        else:
+            assert False, "Unimplemented Parquet Library %s" % parqlib
+
+    def save_dataframe(self, dataframe):
+        """
+        Save a DataFrame to the store.
+        """
+        storepath = self.temporary_object_path(str(uuid.uuid4()))
+
+        # switch parquet lib
+        parqlib = self.get_parquet_lib()
+        if isinstance(dataframe, pd.DataFrame):
+            #parqlib is ParquetLib.ARROW: # other parquet libs are deprecated, remove?
+            import pyarrow as pa
+            from pyarrow import parquet
+            table = pa.Table.from_pandas(dataframe)
+            parquet.write_table(table, storepath)
+        elif parqlib is ParquetLib.SPARK:
+            from pyspark import sql as sparksql
+            assert isinstance(dataframe, sparksql.DataFrame)
+            dataframe.write.parquet(storepath)
+        else:
+            assert False, "Unimplemented ParquetLib %s" % parqlib
+
+        # Move serialized DataFrame to object store
+        if os.path.isdir(storepath): # Pyspark
+            hashes = []
+            files = [ofile for ofile in os.listdir(storepath) if ofile.endswith(".parquet")]
+            for obj in files:
+                path = os.path.join(storepath, obj)
+                objhash = digest_file(path)
+                move(path, self.object_path(objhash))
+                hashes.append(objhash)
+            rmtree(storepath)
+        else:
+            filehash = digest_file(storepath)
+            move(storepath, self.object_path(filehash))
+            hashes = [filehash]
+
+        return hashes
+
+    def save_file(self, srcfile):
+        """
+        Save a (raw) file to the store.
+        """
+        filehash = digest_file(srcfile)
+        objpath = self.object_path(filehash)
+        if not os.path.exists(objpath):
+            # Copy the file to a temporary location first, then move, to make sure we don't end up with
+            # truncated contents if the build gets interrupted.
+            tmppath = self.temporary_object_path(filehash)
+            copyfile(srcfile, tmppath)
+            move(tmppath, objpath)
+
+        return filehash


### PR DESCRIPTION
The logic belongs in PackageStore rather than Package because objects are owned by the store, and might not even have a package associated with them. (This will be the case once filtering is implemented.)