### PR TITLE
Raise an error when accessing a file that's not downloaded

### DIFF
--- a/compiler/quilt/nodes.py
+++ b/compiler/quilt/nodes.py
@@ -55,8 +55,7 @@ class DataNode(Node):
             if isinstance(self._node, core.TableNode):
                 self.__cached_data = store.load_dataframe(self._node.hashes)
             elif isinstance(self._node, core.FileNode):
-                assert len(self._node.hashes) == 1
-                self.__cached_data = store.object_path(self._node.hashes[0])
+                self.__cached_data = store.get_file(self._node.hashes)
             else:
                 # XXX: This is wrong.
                 hash_list = list(core.find_object_hashes(self._node, sort=True))

--- a/compiler/quilt/tools/store.py
+++ b/compiler/quilt/tools/store.py
@@ -411,6 +411,14 @@ class PackageStore(object):
 
         return hashes
 
+    def get_file(self, hash_list):
+        """
+        Returns the path of the file - but verifies that the hash is actually present.
+        """
+        assert len(hash_list) == 1
+        self._check_hashes(hash_list)
+        return self.object_path(hash_list[0])
+
     def save_file(self, srcfile):
         """
         Save a (raw) file to the store.


### PR DESCRIPTION
We shouldn't return a path to a non-existant fragment. (I broke this in #578.)