### PR TITLE
Clean up group nodes. Fix `GroupNode._data()` as much as possible.

### DIFF
--- a/compiler/quilt/imports.py
+++ b/compiler/quilt/imports.py
@@ -44,9 +44,9 @@ def _from_core_node(package, core_node):
         node = DataNode(package, core_node)
     else:
         if isinstance(core_node, core.RootNode):
-            node = PackageNode(package, core_node)
+            node = PackageNode(package)
         elif isinstance(core_node, core.GroupNode):
-            node = GroupNode(package, core_node)
+            node = GroupNode()
         else:
             assert "Unexpected node: %r" % core_node
 

--- a/compiler/quilt/nodes.py
+++ b/compiler/quilt/nodes.py
@@ -26,11 +26,12 @@ class Node(object):
     def __repr__(self):
         return self._class_repr()
 
-    def __setattr__(self, name, value):
-        if name.startswith('_') or isinstance(value, Node):
-            super(Node, self).__setattr__(name, value)
-        else:
-            raise AttributeError("{val} is not a valid package node".format(val=value))
+    def __call__(self):
+        return self._data()
+
+    def _data(self):
+        raise NotImplementedError
+
 
 class DataNode(Node):
     """
@@ -41,9 +42,6 @@ class DataNode(Node):
         self._package = package
         self._node = node
         self.__cached_data = data
-
-    def __call__(self):
-        return self._data()
 
     def _data(self):
         """
@@ -57,17 +55,24 @@ class DataNode(Node):
             elif isinstance(self._node, core.FileNode):
                 self.__cached_data = store.get_file(self._node.hashes)
             else:
-                # XXX: This is wrong.
-                hash_list = list(core.find_object_hashes(self._node, sort=True))
-                self.__cached_data = store.load_dataframe(hash_list)
+                assert False
         return self.__cached_data
 
-class GroupNode(DataNode):
+
+class GroupNode(Node):
     """
     Represents a group in a package. Allows accessing child objects using the dot notation.
     Warning: calling _data() on a large dataset may exceed local memory capacity in Python (Only
     supported for Parquet packages).
     """
+    def __init__(self):
+        super(GroupNode, self).__init__()
+
+    def __setattr__(self, name, value):
+        if name.startswith('_') or isinstance(value, Node):
+            super(Node, self).__setattr__(name, value)
+        else:
+            raise AttributeError("{val} is not a valid package node".format(val=value))
 
     def __repr__(self):
         pinfo = super(GroupNode, self).__repr__()
@@ -108,13 +113,43 @@ class GroupNode(DataNode):
         return [name for name in self.__dict__ if not name.startswith('_')]
 
     def _add_group(self, groupname):
-        child = GroupNode(self._package, core.GroupNode({}))
+        child = GroupNode()
         setattr(self, groupname, child)
+
+    def _data(self):
+        """
+        Merges all child dataframes. Only works for dataframes stored on disk - not in memory.
+        """
+        store = None
+        hash_list = []
+        stack = [self]
+        while stack:
+            node = stack.pop()
+            if isinstance(node, GroupNode):
+                stack.extend(child for _, child in sorted(node._items(), reverse=True))
+            else:
+                if not isinstance(node._node, core.TableNode) or not node._node.hashes:
+                    raise NotImplementedError("Can only merge on-disk dataframes")
+                node_store = node._package.get_store()
+                if store is None:
+                    store = node_store
+                elif node_store is not store:
+                    raise NotImplementedError("Can only merge dataframes from the same store")
+                hash_list += node._node.hashes
+
+        if not hash_list:
+            return None
+
+        return store.load_dataframe(hash_list)
+
 
 class PackageNode(GroupNode):
     """
     Represents a package.
     """
+    def __init__(self, package):
+        super(PackageNode, self).__init__()
+        self._package = package
 
     def _class_repr(self):
         finfo = self._package.get_path()
@@ -170,7 +205,7 @@ class PackageNode(GroupNode):
         for key in path[:-1]:
             child = getattr(node, key, None)
             if not isinstance(child, GroupNode):
-                child = GroupNode(self._package, core.GroupNode({}))
+                child = GroupNode()
                 setattr(node, key, child)
 
             node = child

--- a/compiler/quilt/nodes.py
+++ b/compiler/quilt/nodes.py
@@ -128,8 +128,10 @@ class GroupNode(Node):
             if isinstance(node, GroupNode):
                 stack.extend(child for _, child in sorted(node._items(), reverse=True))
             else:
-                if not isinstance(node._node, core.TableNode) or not node._node.hashes:
-                    raise NotImplementedError("Can only merge on-disk dataframes")
+                if not isinstance(node._node, core.TableNode):
+                    raise ValueError("Group contains non-dataframe nodes")
+                if not node._node.hashes:
+                    raise NotImplementedError("Can only merge built dataframes. Build this package and try again.")
                 node_store = node._package.get_store()
                 if store is None:
                     store = node_store

--- a/compiler/quilt/test/test_import.py
+++ b/compiler/quilt/test/test_import.py
@@ -140,18 +140,26 @@ class ImportTest(QuiltTestCase):
         command.build('foo/grppkg', build_path)
 
         # Good imports
-        from quilt.data.foo.grppkg import dataframes
-        assert isinstance(dataframes, GroupNode)
+        from quilt.data.foo import grppkg
+        assert isinstance(grppkg.dataframes, GroupNode)
 
         # Make sure child dataframes were concatenated in the correct order (alphabetically by node name).
-        df = dataframes._data()
+        df = grppkg.dataframes._data()
         assert df['x'].tolist() == [1, 2, 3, 4]
         assert df['y'].tolist() == [1, 4, 9, 16]
 
         # Incompatible Schema
-        from quilt.data.foo.grppkg import incompatible
         with self.assertRaises(StoreException):
-            incompatible._data()
+            grppkg.incompatible._data()
+
+        # Empty group
+        grppkg.dataframes._add_group("empty")
+        assert grppkg.dataframes.empty._data() is None
+
+        # In-memory dataframe
+        grppkg._set(['dataframes', 'foo'], pd.DataFrame([1, 2, 3]))
+        with self.assertRaises(NotImplementedError):
+            grppkg.dataframes._data()
 
     def test_multiple_package_dirs(self):
         mydir = os.path.dirname(__file__)

--- a/compiler/quilt/tools/core.py
+++ b/compiler/quilt/tools/core.py
@@ -59,16 +59,6 @@ class Node(object):
     def get_children(self):
         return {}
 
-    def preorder(self):
-        """
-        Iterator that returns all nodes in the tree starting with the current node.
-        """
-        stack = [self]
-        while stack:
-            obj = stack.pop()
-            yield obj
-            stack.extend(itervalues(obj.get_children()))
-
 class GroupNode(Node):
     __slots__ = ('children',)
 
@@ -188,7 +178,10 @@ def find_object_hashes(root):
 
     :param root: starting node
     """
-    for obj in root.preorder():
+    stack = [root]
+    while stack:
+        obj = stack.pop()
         if isinstance(obj, (TableNode, FileNode)):
             for objhash in obj.hashes:
                 yield objhash
+        stack.extend(itervalues(obj.get_children()))

--- a/compiler/quilt/tools/core.py
+++ b/compiler/quilt/tools/core.py
@@ -59,20 +59,15 @@ class Node(object):
     def get_children(self):
         return {}
 
-    def preorder(self, sort=False):
+    def preorder(self):
         """
         Iterator that returns all nodes in the tree starting with the current node.
-
-        :param sort: within each group, sort child nodes by name
         """
         stack = [self]
         while stack:
             obj = stack.pop()
             yield obj
-            if sort:
-                stack.extend(child for name, child in sorted(iteritems(obj.get_children()), reverse=True))
-            else:
-                stack.extend(itervalues(obj.get_children()))
+            stack.extend(itervalues(obj.get_children()))
 
 class GroupNode(Node):
     __slots__ = ('children',)
@@ -187,14 +182,13 @@ def hash_contents(contents):
 
     return result.hexdigest()
 
-def find_object_hashes(root, sort=False):
+def find_object_hashes(root):
     """
     Iterator that returns hashes of all of the file and table nodes.
 
     :param root: starting node
-    :param sort: within each group, sort child nodes by name
     """
-    for obj in root.preorder(sort=sort):
+    for obj in root.preorder():
         if isinstance(obj, (TableNode, FileNode)):
             for objhash in obj.hashes:
                 yield objhash

--- a/registry/quilt_server/core.py
+++ b/registry/quilt_server/core.py
@@ -59,16 +59,6 @@ class Node(object):
     def get_children(self):
         return {}
 
-    def preorder(self):
-        """
-        Iterator that returns all nodes in the tree starting with the current node.
-        """
-        stack = [self]
-        while stack:
-            obj = stack.pop()
-            yield obj
-            stack.extend(itervalues(obj.get_children()))
-
 class GroupNode(Node):
     __slots__ = ('children',)
 
@@ -188,7 +178,10 @@ def find_object_hashes(root):
 
     :param root: starting node
     """
-    for obj in root.preorder():
+    stack = [root]
+    while stack:
+        obj = stack.pop()
         if isinstance(obj, (TableNode, FileNode)):
             for objhash in obj.hashes:
                 yield objhash
+        stack.extend(itervalues(obj.get_children()))

--- a/registry/quilt_server/core.py
+++ b/registry/quilt_server/core.py
@@ -59,20 +59,15 @@ class Node(object):
     def get_children(self):
         return {}
 
-    def preorder(self, sort=False):
+    def preorder(self):
         """
         Iterator that returns all nodes in the tree starting with the current node.
-
-        :param sort: within each group, sort child nodes by name
         """
         stack = [self]
         while stack:
             obj = stack.pop()
             yield obj
-            if sort:
-                stack.extend(child for name, child in sorted(iteritems(obj.get_children()), reverse=True))
-            else:
-                stack.extend(itervalues(obj.get_children()))
+            stack.extend(itervalues(obj.get_children()))
 
 class GroupNode(Node):
     __slots__ = ('children',)
@@ -187,14 +182,13 @@ def hash_contents(contents):
 
     return result.hexdigest()
 
-def find_object_hashes(root, sort=False):
+def find_object_hashes(root):
     """
     Iterator that returns hashes of all of the file and table nodes.
 
     :param root: starting node
-    :param sort: within each group, sort child nodes by name
     """
-    for obj in root.preorder(sort=sort):
+    for obj in root.preorder():
         if isinstance(obj, (TableNode, FileNode)):
             for objhash in obj.hashes:
                 yield objhash


### PR DESCRIPTION
- Make `GroupNode` a subclass of `Node` rather than `DataNode`
- In `_data()`, iterate over the actual children of the group, rather than whatever they used to be when the package was loaded
- Return errors in corner cases like data nodes from different stores or in-memory dataframes