### PR TITLE
components/Error: accept nodes

### DIFF
--- a/catalog/app/components/Error/index.js
+++ b/catalog/app/components/Error/index.js
@@ -33,8 +33,8 @@ function Error({
 }
 
 Error.propTypes = {
-  headline: PropTypes.string,
-  detail: PropTypes.string,
+  headline: PropTypes.node,
+  detail: PropTypes.node,
   object: PropTypes.object,
 };
 


### PR DESCRIPTION
Allows `Error` component to accept react nodes, not just strings, as arguments.