### PR TITLE
Minor todos

### DIFF
--- a/compiler/quilt/test/test_command.py
+++ b/compiler/quilt/test/test_command.py
@@ -83,7 +83,7 @@ from six import assertRaisesRegex
 from .utils import QuiltTestCase, patch, quilt_dev_mode
 from ..tools import command, store
 from ..tools.compat import pathlib
-from ..tools.const import TEAM_ID_ERROR
+from ..tools.const import TEAM_ID_ERROR, QuiltException
 
 
 class CommandTest(QuiltTestCase):
@@ -1602,13 +1602,13 @@ class CommandTest(QuiltTestCase):
         assert command.parse_package_extended('team:user/package/sub/path:tag:some') == expected
 
         # bad parse strings
-        with pytest.raises(command.CommandException):
+        with pytest.raises(QuiltException):
             command.parse_package_extended('user/package:a:aaa111')
 
-        with pytest.raises(command.CommandException):
+        with pytest.raises(QuiltException):
             command.parse_package_extended('team:user/package:a:aaa111')
 
-        with pytest.raises(command.CommandException):
+        with pytest.raises(QuiltException):
             command.parse_package_extended('foo:bar:baz')
 
 

--- a/compiler/quilt/test/test_install.py
+++ b/compiler/quilt/test/test_install.py
@@ -15,7 +15,7 @@ from six import assertRaisesRegex
 from six.moves import urllib
 
 from ..tools import command
-from ..tools.const import HASH_TYPE
+from ..tools.const import HASH_TYPE, QuiltException
 from ..tools.core import (
     decode_node,
     encode_node,
@@ -298,15 +298,15 @@ packages:
         contents1, contents_hash1 = self.make_contents(table1=table_hash1)
 
         # missing/malformed requests
-        with assertRaisesRegex(self, command.CommandException, "package name is empty"):
+        with assertRaisesRegex(self, QuiltException, "package name is empty"):
             command.install(" ")
         with assertRaisesRegex(self, command.CommandException, "file not found: quilt.yml"):
             command.install("@quilt.yml")
-        with assertRaisesRegex(self, command.CommandException, "Specify package as"):
+        with assertRaisesRegex(self, QuiltException, "Specify package as"):
             command.install("packages:\n")
-        with assertRaisesRegex(self, command.CommandException, "Specify package as"):
+        with assertRaisesRegex(self, QuiltException, "Specify package as"):
             command.install("packages:\n- foo")
-        with assertRaisesRegex(self, command.CommandException, "Specify package as"):
+        with assertRaisesRegex(self, QuiltException, "Specify package as"):
             command.install("packages:\n- foo/bar:xxx:bar")
         with assertRaisesRegex(self, Exception, "No such file or directory"):
             self.validate_file('foo', 'bar', contents_hash1, contents1, table_hash1, table_data1)

--- a/compiler/quilt/tools/command.py
+++ b/compiler/quilt/tools/command.py
@@ -37,8 +37,8 @@ from .core import (hash_contents, find_object_hashes, TableNode, FileNode, Group
                    decode_node, encode_node, LATEST_TAG)
 from .data_transfer import download_fragments, upload_fragments
 from .store import PackageStore, StoreException
-from .util import (BASE_DIR, gzip_compress, is_nodename, fs_link, parse_package as parse_package_util,
-                   parse_package_extended as parse_package_extended_util)
+from .util import (BASE_DIR, gzip_compress, is_nodename, fs_link, parse_package_extended,
+                   parse_package as parse_package_util)
 from ..imports import _from_core_node
 
 from .. import nodes
@@ -65,34 +65,12 @@ class HTTPResponseException(CommandException):
 
 _registry_url = None
 
-def parse_package_extended(identifier):
-    #TODO: Unwrap this and modify 'util' version to raise QuiltException
-    try:
-        return parse_package_extended_util(identifier)
-    except ValueError:
-        pkg_format = '[team:]owner/package_name/path[:v:<version> or :t:<tag> or :h:<hash>]'
-        raise CommandException("Specify package as %s." % pkg_format)
-
 def parse_package(name, allow_subpath=False):
-    #TODO: Unwrap this and modify 'util' version to raise QuiltException and call check_name()
+    # Many usages -- left as wrapper for "CommandException" usage
     try:
-        if allow_subpath:
-            team, owner, pkg, subpath = parse_package_util(name, allow_subpath)
-        else:
-            team, owner, pkg = parse_package_util(name, allow_subpath)
-            subpath = None
-    except ValueError:
-        pkg_format = '[team:]owner/package_name/path' if allow_subpath else '[team:]owner/package_name'
-        raise CommandException("Specify package as %s." % pkg_format)
-
-    try:
-        PackageStore.check_name(team, owner, pkg, subpath)
-    except StoreException as ex:
-        raise CommandException(str(ex))
-
-    if allow_subpath:
-        return team, owner, pkg, subpath
-    return team, owner, pkg
+        return parse_package_util(name, allow_subpath)
+    except QuiltException as err:
+        raise CommandException(str(err), original_error=err)
 
 
 def _load_config():

--- a/compiler/quilt/tools/const.py
+++ b/compiler/quilt/tools/const.py
@@ -89,8 +89,8 @@ class QuiltException(Exception):
     even if not expected to be seen by a user.  This is available as the
     'message' attribute, or as `str(error)`.
 
-    **kwargs will be added directly as attributes to the error, so a
-    dict of `{'code': 90, 'original_error': <OSError Object>}` would be
+    **kwargs will be added directly as attributes to the error, e.g. the
+    params `(code=90, original_error=<OSError Object>)` would be
     added as `self.code` and `self.original_error`.
 
     :param message: Error message to display

--- a/compiler/quilt/tools/main.py
+++ b/compiler/quilt/tools/main.py
@@ -255,55 +255,55 @@ def argument_parser():
     tag_remove_p.add_argument("tag", type=str, help="Tag name")
     tag_remove_p.set_defaults(func=command.tag_remove)
 
-    # user
-    shorthelp = "Commands for managing users. Only available to admins"
+    # quilt user
+    shorthelp = "Commands for managing users -- Only available to admins"
     users_p = subparsers.add_parser("user", description=shorthelp, help=shorthelp)
     users_subparsers = users_p.add_subparsers(metavar='<subcommand>')
     users_subparsers.required = True
 
-    #TODO: Correctly order user_create, user_delete, user_disable, user_list, user_reset
-    # user list
-    shorthelp = "List users in your team."
-    user_list_p = users_subparsers.add_parser("list", help=shorthelp)
-    user_list_p.add_argument("team", type=str)
-    user_list_p.set_defaults(func=command._cli_list_users)
-
-    # user create
-    shorthelp = "Create a user. Must provide username and email. Username must be unique."
-    user_create_p = users_subparsers.add_parser("create", help=shorthelp)
+    # quilt user create
+    shorthelp = "Create a user"
+    longhelp = "Must provide team, username and email. Username must be unique."
+    user_create_p = users_subparsers.add_parser("create", description=longhelp, help=shorthelp)
     user_create_p.add_argument("team", type=str)
     user_create_p.add_argument("username", type=str)
     user_create_p.add_argument("email", type=str)
     user_create_p.set_defaults(func=command.create_user)
 
-    # user disable
-    shorthelp = "Disable a user."
-    user_disable_p = users_subparsers.add_parser("disable", help=shorthelp)
-    user_disable_p.add_argument("team", type=str)
-    user_disable_p.add_argument("username", type=str)
-    user_disable_p.set_defaults(func=command.disable_user)
-
-    # user disable
-    shorthelp = "Enable a user."
-    user_enable_p = users_subparsers.add_parser("enable", help=shorthelp)
-    user_enable_p.add_argument("team", type=str)
-    user_enable_p.add_argument("username", type=str)
-    user_enable_p.set_defaults(func=command.enable_user)
-
-    # user delete
-    shorthelp = "Delete a user. Use with caution."
+    # quilt user delete
+    shorthelp = "Delete a user -- Use with caution"
     user_delete_p = users_subparsers.add_parser("delete", help=shorthelp)
     user_delete_p.add_argument("team", type=str)
     user_delete_p.add_argument("username", type=str)
     user_delete_p.add_argument("-f", "--force", action="store_true", help="Skip warning prompt")
     user_delete_p.set_defaults(func=command.delete_user)
 
-    shorthelp = "Reset a user's password and send them a password reset email."
+    # quilt user disable
+    shorthelp = "Disable a user"
+    user_disable_p = users_subparsers.add_parser("disable", help=shorthelp)
+    user_disable_p.add_argument("team", type=str)
+    user_disable_p.add_argument("username", type=str)
+    user_disable_p.set_defaults(func=command.disable_user)
+
+    # quilt user enable
+    shorthelp = "Enable a user"
+    user_enable_p = users_subparsers.add_parser("enable", help=shorthelp)
+    user_enable_p.add_argument("team", type=str)
+    user_enable_p.add_argument("username", type=str)
+    user_enable_p.set_defaults(func=command.enable_user)
+
+    # quilt user list
+    shorthelp = "List users in your team"
+    user_list_p = users_subparsers.add_parser("list", help=shorthelp)
+    user_list_p.add_argument("team", type=str)
+    user_list_p.set_defaults(func=command._cli_list_users)
+
+    # quilt user reset-password
+    shorthelp = "Reset a user's password and send them a password reset email"
     user_reset_password_p = users_subparsers.add_parser("reset-password", help=shorthelp)
     user_reset_password_p.add_argument("team", type=str)
     user_reset_password_p.add_argument("username", type=str)
     user_reset_password_p.set_defaults(func=command.reset_password)
-
 
     # quilt version
     shorthelp = "List or permanently add a package version to the server"

--- a/compiler/quilt/tools/main.py
+++ b/compiler/quilt/tools/main.py
@@ -56,11 +56,6 @@ class CustomHelpParser(argparse.ArgumentParser):
 
 
 def argument_parser():
-    def check_hash(group, hashstr):
-        # TODO: add this universally once short hashes are supported in other functions.
-        return (hashstr if 6 <= len(hashstr) <= 64 else
-                group.error('hashes must be 6-64 chars long'))
-
     description = ("Quilt Command Line\n"
                    "Visit our online docs at https://docs.quiltdata.com/")
     parser = CustomHelpParser(description=description, add_help=False)

--- a/compiler/quilt/tools/store.py
+++ b/compiler/quilt/tools/store.py
@@ -13,7 +13,7 @@ from .const import DEFAULT_TEAM, PACKAGE_DIR_NAME, QuiltException, SYSTEM_METADA
 from .core import FileNode, RootNode, TableNode, find_object_hashes
 from .hashing import digest_file
 from .package import Package, PackageException
-from .util import BASE_DIR, sub_dirs, sub_files, is_nodename
+from .util import BASE_DIR, sub_dirs, sub_files, check_name
 
 CHUNK_SIZE = 4096
 
@@ -134,16 +134,10 @@ class PackageStore(object):
 
     @classmethod
     def check_name(cls, team, user, package, subpath=None):
-        if team is not None and not is_nodename(team):
-            raise StoreException("Invalid team name: %r" % team)
-        if not is_nodename(user):
-            raise StoreException("Invalid user name: %r" % user)
-        if not is_nodename(package):
-            raise StoreException("Invalid package name: %r" % package)
-        if subpath:
-            for element in subpath:
-                if not is_nodename(element):
-                    raise StoreException("Invalid element in subpath: %r" % element)
+        try:
+            check_name(team, user, package, subpath)
+        except QuiltException as err:
+            raise StoreException(str(err), original_error=err)
 
     def _version_path(self):
         return os.path.join(self._path, '.format')

--- a/compiler/quilt/tools/util.py
+++ b/compiler/quilt/tools/util.py
@@ -297,7 +297,6 @@ def fs_link(path, linkpath, linktype='soft'):
     """
     global WIN_SOFTLINK
     global WIN_HARDLINK
-    WIN_NO_ERROR = 22
 
     assert linktype in ('soft', 'hard')
 
@@ -313,7 +312,7 @@ def fs_link(path, linkpath, linktype='soft'):
     if os.name == 'nt':
         # clear out any pre-existing, un-checked errors
         ctypes.WinError()
-            
+
         # Check Windows version (reasonably) supports symlinks
         if not sys.getwindowsversion()[0] >= 6:
             raise QuiltException("Unsupported operation: This version of Windows does not support linking.")


### PR DESCRIPTION
### Summary
These are a few minor TODOs and cleanup from various things I've noticed, the most significant effects being the following:

* `command.parse_package` wrapper of `util.parse_package` mostly removed, functionality absorbed (calling `check_name`)
* `check_name` moved to `utils` to avoid (probably harmless, but still..) import loop
* Minor bug in `util.parse_package` fixed:  `QuiltException` now raised instead of `ValueError`
* Exceptions for `parse_package` and `parse_package_extended` changed from ValueError to `QuiltException`, and appropriate minor changes made.
* Ordering for help params of `quilt user xxx`
* Some minor general cleanup

### Depends On
Nothin'.

### TODO
[ ] sleep