### PR TITLE
Let browser set cursor shape

### DIFF
--- a/catalog/app/global-styles.js
+++ b/catalog/app/global-styles.js
@@ -7,6 +7,7 @@ injectGlobal`
   html,
   body {
     background-color: ${backgroundColor};
+    cursor: auto;
     text-rendering: optimizeLegibility;
     height: 100%;
     width: 100%;


### PR DESCRIPTION
Unfortunately, the fortawesome stylesheet (see catalog/app/index.html) sets `cursor: default` on html and body, causing bad things to happen (e.g. cursor stays as pointer when hovering over README text).