### PR TITLE
Use link cursor for package Cards in Gallery

### DIFF
--- a/catalog/app/containers/Gallery/index.js
+++ b/catalog/app/containers/Gallery/index.js
@@ -86,6 +86,7 @@ const Card = styled.div`
 
   &:hover, &:focus {
     background-color: #efefef;
+    cursor: pointer;
   }
 
   &, &:visited, &:hover, &:focus {


### PR DESCRIPTION
Since we navigate `onClick` with the router, the browser doesn't pick up any `<a>` tags.