### PR TITLE
Load by package hash

### DIFF
--- a/compiler/quilt/test/test_import.py
+++ b/compiler/quilt/test/test_import.py
@@ -475,6 +475,32 @@ class ImportTest(QuiltTestCase):
         pkg._set(['dataframes', 'memory'], pd.DataFrame())
         with self.assertRaises(ValueError):
             assert pkg.dataframes.memory(asa=test_lambda) is testdata
-
-
         
+    def test_load_by_hash(self):
+        """
+        Tests loading two different versions of the same
+        package using command.load and specifying the package
+        hash.
+        """
+        # Old Version
+        mydir = os.path.dirname(__file__)
+        build_path = os.path.join(mydir, './build.yml')
+        command.build('foo/package', build_path)
+        package = command.load('foo/package')
+        pkghash = package._package.get_hash()
+
+        # New Version
+        mydir = os.path.dirname(__file__)
+        build_path = os.path.join(mydir, './build_simple.yml')
+        command.build('foo/package', build_path)
+        command.ls()
+
+        load_pkg_new = command.load('foo/package')
+        load_pkg_old = command.load('foo/package:h:%s' % pkghash)    
+        assert load_pkg_old._package.get_hash() == pkghash
+
+        assert load_pkg_new.foo
+        with self.assertRaises(AttributeError):
+            load_pkg_new.dataframes
+        
+

--- a/compiler/quilt/tools/command.py
+++ b/compiler/quilt/tools/command.py
@@ -1281,16 +1281,19 @@ def reset_password(team, username):
 
 def _load(package):
     info = parse_package_extended(package)
-    team, user, name = info.team, info.user, info.name
-
-    pkgobj = PackageStore.find_package(team, user, name)
+    pkgobj = PackageStore.find_package(info.team,
+                                       info.user,
+                                       info.name,
+                                       pkghash=info.hash)
     if pkgobj is None:
         raise CommandException("Package {package} not found.".format(package=package))
     node = _from_core_node(pkgobj, pkgobj.get_contents())
     return node, pkgobj, info
 
 def load(pkginfo):
-    """functional interface to "from quilt.data.USER import PKG"""
+    """
+    functional interface to "from quilt.data.USER import PKG"
+    """
     # TODO: support hashes/versions/etc.
     return _load(pkginfo)[0]
 

--- a/compiler/quilt/tools/package.py
+++ b/compiler/quilt/tools/package.py
@@ -38,6 +38,8 @@ class Package(object):
             contents = self._load_contents(pkghash)
 
         self._contents = contents
+        if pkghash is not None:
+            assert self.get_hash() == pkghash
 
     def __getitem__(self, item):
         """Get a (core) node from this package.

--- a/compiler/quilt/tools/store.py
+++ b/compiler/quilt/tools/store.py
@@ -119,7 +119,7 @@ class PackageStore(object):
         return store_dirs
 
     @classmethod
-    def find_package(cls, team, user, package, store_dir=None):
+    def find_package(cls, team, user, package, pkghash=None, store_dir=None):
         """
         Finds an existing package in one of the package directories.
         """
@@ -127,7 +127,7 @@ class PackageStore(object):
         dirs = cls.find_store_dirs()
         for store_dir in dirs:
             store = PackageStore(store_dir)
-            pkg = store.get_package(team, user, package)
+            pkg = store.get_package(team, user, package, pkghash=pkghash)
             if pkg is not None:
                 return pkg
         return None
@@ -162,7 +162,7 @@ class PackageStore(object):
 
     # TODO: find a package instance other than 'latest', e.g. by
     # looking-up by hash, tag or version in the local store.
-    def get_package(self, team, user, package):
+    def get_package(self, team, user, package, pkghash=None):
         """
         Gets a package from this store.
         """
@@ -174,7 +174,8 @@ class PackageStore(object):
                     store=self,
                     user=user,
                     package=package,
-                    path=path
+                    path=path,
+                    pkghash=pkghash,
                     )
             except PackageException:
                 pass


### PR DESCRIPTION
Extend the load command to allow find package instances by their hash.

## Description
This PR implemented loading local package instances by hash (assigning local tags and versions isn't supported yet).

## TODO
Add support for load by tag and version (separate PR after local tags and versions are implemented)
