### PR TITLE
Make package nodes iterable

### DIFF
--- a/compiler/quilt/nodes.py
+++ b/compiler/quilt/nodes.py
@@ -95,6 +95,10 @@ class GroupNode(Node):
         data_info = '\n'.join(sorted(self._data_keys()))
         return '%s\n%s%s' % (pinfo, group_info, data_info)
 
+    def __iter__(self):
+        for _, child in self._items():
+            yield child
+
     def _items(self):
         return ((name, child) for name, child in iteritems(self.__dict__)
                 if not name.startswith('_'))

--- a/compiler/quilt/nodes.py
+++ b/compiler/quilt/nodes.py
@@ -47,6 +47,10 @@ class DataNode(Node):
         self._node = node
         self.__cached_data = data
 
+    def __iter__(self):
+        # return an empty iterator (not None, not [], which are non-empty)
+        return iter(())
+
     def _data(self, asa=None):
         """
         Returns the contents of the node: a dataframe or a file path, or passes
@@ -54,8 +58,10 @@ class DataNode(Node):
         """
         if asa is not None:
             if self._package is None or not self._node.hashes:
-                msg = "Can only use asa functions with built dataframes."
-                " Build this package and try again."
+                msg = (
+                    "Can only use asa functions with built dataframes."
+                    " Build this package and try again."
+                )
                 raise ValueError(msg)
             store = self._package.get_store()
             return asa(self, [store.object_path(obj) for obj in self._node.hashes])

--- a/compiler/quilt/test/test_build.py
+++ b/compiler/quilt/test/test_build.py
@@ -10,7 +10,7 @@ from pandas.core.frame import DataFrame
 from six import assertRaisesRegex, string_types
 import yaml
 
-from ..nodes import GroupNode, PackageNode
+from ..nodes import DataNode, GroupNode, PackageNode
 from ..tools.store import ParquetLib, PackageStore
 from ..tools.compat import pathlib
 from ..tools import build, command, store
@@ -468,25 +468,34 @@ class BuildTest(QuiltTestCase):
         mydir = pathlib.Path(os.path.dirname(__file__))
         build_compose_contents = {
             'contents': {
-                'main_group_node': {
-                    'subnode_1': {
-                        'data_node': {
+                'grp': {
+                    'subgrp1': {
+                        'data1': {
                             'file': 'data/foo.csv'
                         }
                     },
-                    'subnode_2': {
-                        'data_node': {
+                    'subgrp2': {
+                        'data2': {
                             'file': 'data/foo.csv'
                         }
                     },
                 }
             }
-       }
+        }
 
-        build.build_package_from_contents(None, 'test', 'group_node', str(mydir), build_compose_contents)
-        from quilt.data.test import group_node
-        for node in group_node:
+        build.build_package_from_contents(None, 'test', 'pkg_node', str(mydir), build_compose_contents)
+
+        from quilt.data.test import pkg_node
+
+        for node in pkg_node:
             assert isinstance(node, GroupNode)
+
+        for grps in pkg_node.grp:
+            assert isinstance(grps, GroupNode)
+            for dat in grps:
+                assert isinstance(dat, DataNode)
+                for nothing in dat:
+                    assert False, 'DataNode should not have iterable children'
 
     def test_package_and_file_raises_exception(self):
         mydir = pathlib.Path(os.path.dirname(__file__))

--- a/compiler/quilt/test/test_build.py
+++ b/compiler/quilt/test/test_build.py
@@ -464,6 +464,30 @@ class BuildTest(QuiltTestCase):
         assert type(compose_root) is PackageNode
         assert simple.foo().equals(compose_root.foo())
 
+    def test_group_node_iter(self):
+        mydir = pathlib.Path(os.path.dirname(__file__))
+        build_compose_contents = {
+            'contents': {
+                'main_group_node': {
+                    'subnode_1': {
+                        'data_node': {
+                            'file': 'data/foo.csv'
+                        }
+                    },
+                    'subnode_2': {
+                        'data_node': {
+                            'file': 'data/foo.csv'
+                        }
+                    },
+                }
+            }
+       }
+
+        build.build_package_from_contents(None, 'test', 'group_node', str(mydir), build_compose_contents)
+        from quilt.data.test import group_node
+        for node in group_node:
+            assert isinstance(node, GroupNode)
+
     def test_package_and_file_raises_exception(self):
         mydir = pathlib.Path(os.path.dirname(__file__))
         bad_build_contents = {

--- a/compiler/quilt/test/test_import.py
+++ b/compiler/quilt/test/test_import.py
@@ -41,15 +41,11 @@ class ImportTest(QuiltTestCase):
         assert set(dataframes._group_keys()) == set()
         assert set(dataframes._data_keys()) == {'csv', 'nulls'}
 
-        # this should contain elements
-        assert list(package)
         assert len(list(package)) == 2
 
         for item in package:
             assert isinstance(item, (GroupNode, DataNode))
 
-        # dataframes contains only DataNode
-        assert list(package)
         for node in dataframes:
             assert isinstance(node, DataNode)
 

--- a/compiler/quilt/test/test_import.py
+++ b/compiler/quilt/test/test_import.py
@@ -41,6 +41,18 @@ class ImportTest(QuiltTestCase):
         assert set(dataframes._group_keys()) == set()
         assert set(dataframes._data_keys()) == {'csv', 'nulls'}
 
+        # this should contain elements
+        assert list(package)
+        assert len(list(package)) == 2
+
+        for item in package:
+            assert isinstance(item, (GroupNode, DataNode))
+
+        # dataframes contains only DataNode
+        assert list(package)
+        for node in dataframes:
+            assert isinstance(node, DataNode)
+
         assert isinstance(README(), string_types)
         assert isinstance(README._data(), string_types)
         assert isinstance(dataframes.csv(), pd.DataFrame)

--- a/docs/api-python.md
+++ b/docs/api-python.md
@@ -140,12 +140,14 @@ from quilt.team.TEAM_NAME.USER import PACKAGE
 ```
 
 ## Using packages
+
 Packages contain three types of nodes:
 * `PackageNode` - the root of the package tree
 * `GroupNode` - like a folder; may contain one or more `GroupNode` or `DataNode` objects
 * `DataNode` - a leaf node in the package; contains actual data
 
 ### Work with package contents
+
 * List node contents with dot notation: `PACKAGE.NODE.ANOTHER_NODE`
 * Retrieve the contents of a `DataNode` with `_data()`, or simply `()`: `PACKAGE.NODE.ANOTHER_NODE()`
   * Columnar data (`XLS`, `CSV`, `TSV`, etc.) returns as a `pandas.DataFrame`
@@ -153,11 +155,13 @@ Packages contain three types of nodes:
   * Provide a custom deserialzer by passing a function to `data(asa=FUNCTION)` with the signature `function(NODE, LIST_OF_FILE_PATHS)`. A single node can contain data in multiple files (e.g., a DataFrame stored as a set of Parquet files). Calling `data(asa=FUNCTION)` on a GroupNode calls FUNCTION with the GroupNode object and a list of the paths to all of the objects in all of the child nodes.
 
 ### Enumerate package contents
+
 * `quilt.inspect("USER/PACKAGE")` shows package columns, types, and shape
 * `NODE._keys()` returns a list of all children
 * `NODE._data_keys()` returns a list of all data children (leaf nodes containing actual data)
 * `NODE._group_keys()` returns a list of all group children (groups are like folders)
 * `NODE._items()` returns a generator of the node's children as (name, node) pairs.
+* `NODE` is iterable: `for child in NODE:...` 
 
 #### Example
 ```


### PR DESCRIPTION
Originally implemented in #534. This PR additionally makes DataNode iterable, resolves merge conflicts, and adds test coverage and pylint fixes.