### PR TITLE
Let's not use ubuntu:latest in our Dockerfiles

### DIFF
--- a/catalog/Dockerfile
+++ b/catalog/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:latest
+FROM ubuntu:16.04
 MAINTAINER Quilt Data, Inc. contact@quiltdata.io
 
 ENV LC_ALL=C.UTF-8

--- a/registry/Dockerfile
+++ b/registry/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:latest
+FROM ubuntu:16.04
 MAINTAINER Quilt Data, Inc. contact@quiltdata.io
 
 ENV LC_ALL=C.UTF-8

--- a/registry/auth/Dockerfile
+++ b/registry/auth/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:latest
+FROM ubuntu:16.04
 MAINTAINER Quilt Data, Inc. contact@quiltdata.io
 
 ENV LC_ALL=C.UTF-8

--- a/registry/nginx-s3/Dockerfile
+++ b/registry/nginx-s3/Dockerfile
@@ -1,4 +1,4 @@
-FROM nginx:latest
+FROM nginx:16.04
 MAINTAINER Quilt Data, Inc. contact@quiltdata.io
 
 COPY nginx-s3.conf /etc/nginx/conf.d/


### PR DESCRIPTION
That causes accidental OS upgrades. Hardcode 16.04, which is what we've been using.