### PR TITLE
quilt.load uses hash= keyword

### DIFF
--- a/compiler/quilt/test/test_import.py
+++ b/compiler/quilt/test/test_import.py
@@ -504,11 +504,18 @@ class ImportTest(QuiltTestCase):
         command.ls()
 
         load_pkg_new = command.load('foo/package')
-        load_pkg_old = command.load('foo/package:h:%s' % pkghash)    
+        load_pkg_old = command.load('foo/package', hash=pkghash)    
         assert load_pkg_old._package.get_hash() == pkghash
 
         assert load_pkg_new.foo
         with self.assertRaises(AttributeError):
             load_pkg_new.dataframes
-        
-
+        # Known failure cases
+        # At present load does not support extended package syntax
+        with self.assertRaises(command.CommandException):
+            command.load('foo/package:h:%s' % pkghash)
+        with self.assertRaises(command.CommandException):
+            command.load('foo/package:t:latest')
+        with self.assertRaises(command.CommandException):
+            command.load('foo/package:v:1.0.0')
+    

--- a/compiler/quilt/tools/command.py
+++ b/compiler/quilt/tools/command.py
@@ -1279,28 +1279,31 @@ def reset_password(team, username):
             ), data=json.dumps({'username':username})
     )
 
-def _load(package):
+def _load(package, hash=None):
     info = parse_package_extended(package)
     # TODO: support tags & versions.
-    if info.tag is not None:
+    if info.tag:
         raise CommandException("Loading packages by tag is not supported.")
-    if info.version is not None:
+    elif info.version:
         raise CommandException("Loading packages by version is not supported.")
+    elif info.hash:
+        raise CommandException("Use hash=HASH to specify package hash.")
 
     pkgobj = PackageStore.find_package(info.team,
                                        info.user,
                                        info.name,
-                                       pkghash=info.hash)
+                                       pkghash=hash)
     if pkgobj is None:
         raise CommandException("Package {package} not found.".format(package=package))
     node = _from_core_node(pkgobj, pkgobj.get_contents())
+
     return node, pkgobj, info
 
-def load(pkginfo):
+def load(pkginfo, hash=None):
     """
     functional interface to "from quilt.data.USER import PKG"
     """
-    return _load(pkginfo)[0]
+    return _load(pkginfo, hash)[0]
 
 def export(package, output_path='.', force=False, symlinks=False):
     """Export package file data.

--- a/docs/api-python.md
+++ b/docs/api-python.md
@@ -130,14 +130,26 @@ If a node references raw (file) data, symbolic links may be used instead of copy
   * Symbolic links may require administrative access (even if an administrator has the appropriate permissions)
 
 ## Import and use data
+
 For a package in the public cloud:
+
 ```python
 from quilt.data.USER import PACKAGE
 ```
+
 For a package in a team registry:
+
 ```python
 from quilt.team.TEAM_NAME.USER import PACKAGE
 ```
+
+### `quilt.load("USR/PKG[:h:HASH])`
+
+Returns the specified package. You can use `quilt.load` to simultaneously load
+different versions of the same package.
+
+> Note, since Python module loads are cached by name, importing different versions of
+> the same package using `import` syntax will fail.
 
 ## Using packages
 

--- a/docs/api-python.md
+++ b/docs/api-python.md
@@ -143,7 +143,7 @@ For a package in a team registry:
 from quilt.team.TEAM_NAME.USER import PACKAGE
 ```
 
-### `quilt.load("USR/PKG[:h:HASH])`
+### `quilt.load("USR/PKG", hash=None)`
 
 Returns the specified package. You can use `quilt.load` to simultaneously load
 different versions of the same package.


### PR DESCRIPTION
* Makes syntax consistent with `quilt.install`
* Add negative test cases
* Remove redundant `if not None`