### PR TITLE
Catalog should use same distinct_id as registry

### DIFF
--- a/catalog/app/utils/tracking.js
+++ b/catalog/app/utils/tracking.js
@@ -17,8 +17,11 @@ export const mkTracker = (token) => {
 
   return {
     nav: (loc, user) => tracker.then((inst) =>
+    // use same distinct_id as registry for event attribution
+    // else undefined to let mixpanel decide
       inst.track('WEB', {
         type: 'navigation',
+        distinct_id: user || undefined,
         origin: window.location.origin,
         location: `${loc.pathname}${loc.search}${loc.hash}`,
         user,


### PR DESCRIPTION
To resolve user sessions (across registry and catalog) properly. See: https://help.mixpanel.com/hc/en-us/articles/115004495783-Assigning-Your-Own-Unique-IDs-to-Users.