### PR TITLE
Make fragment store read-only

### DIFF
--- a/compiler/quilt/test/test_import.py
+++ b/compiler/quilt/test/test_import.py
@@ -58,6 +58,11 @@ class ImportTest(QuiltTestCase):
         str(dataframes)
         str(README)
 
+        # Store data is read-only
+        with self.assertRaises(IOError):
+            with open(README(), 'w'):
+                pass
+
         # Bad attributes of imported packages
 
         with self.assertRaises(AttributeError):

--- a/compiler/quilt/test/utils.py
+++ b/compiler/quilt/test/utils.py
@@ -4,6 +4,7 @@ Unittest setup.
 
 import os
 import shutil
+from stat import S_IWUSR
 import tempfile
 import unittest
 
@@ -50,7 +51,17 @@ class BasicQuiltTestCase(unittest.TestCase):
 
     def tearDown(self):
         os.chdir(self._old_dir)
-        shutil.rmtree(self._test_dir)
+
+        def _onerror(func, path, exc_info):
+            """
+            Handle read-only files on Windows
+            """
+            if not os.access(path, os.W_OK):
+                os.chmod(path, stat.S_IWUSR)
+                func(path)
+            else:
+                raise
+        shutil.rmtree(self._test_dir, onerror=_onerror)
 
 class QuiltTestCase(BasicQuiltTestCase):
     """

--- a/compiler/quilt/test/utils.py
+++ b/compiler/quilt/test/utils.py
@@ -57,7 +57,7 @@ class BasicQuiltTestCase(unittest.TestCase):
             Handle read-only files on Windows
             """
             if not os.access(path, os.W_OK):
-                os.chmod(path, stat.S_IWUSR)
+                os.chmod(path, S_IWUSR)
                 func(path)
             else:
                 raise

--- a/compiler/quilt/tools/command.py
+++ b/compiler/quilt/tools/command.py
@@ -12,7 +12,7 @@ import json
 import os
 import platform
 import re
-from shutil import rmtree, copy
+from shutil import rmtree, copyfile
 import socket
 import stat
 import subprocess
@@ -1409,7 +1409,7 @@ def export(package, output_path='.', force=False, symlinks=False):
             if use_symlinks is True:
                 fs_link(node(), dest)
             else:
-                copy(node(), str(dest))
+                copyfile(node(), str(dest))
         elif isinstance(node._node, TableNode):
             ext = node._node.metadata['q_ext']
             df = node()

--- a/compiler/quilt/tools/store.py
+++ b/compiler/quilt/tools/store.py
@@ -473,11 +473,9 @@ class PackageStore(object):
         Make the object read-only and move it to the store.
         """
         destpath = self.object_path(objhash)
-        try:
+        if os.path.exists(destpath):
             # Windows: delete any existing object at the destination.
             os.chmod(destpath, S_IWUSR)
             os.remove(destpath)
-        except IOError:
-            pass
         os.chmod(srcpath, S_IRUSR | S_IRGRP | S_IROTH)  # Make read-only
         move(srcpath, destpath)

--- a/compiler/quilt/tools/store.py
+++ b/compiler/quilt/tools/store.py
@@ -4,6 +4,7 @@ Build: parse and add user-supplied files to store
 import json
 import os
 from shutil import copyfile, move, rmtree
+from stat import S_IRUSR, S_IRGRP, S_IROTH
 import uuid
 
 from enum import Enum
@@ -403,12 +404,12 @@ class PackageStore(object):
             for obj in files:
                 path = os.path.join(storepath, obj)
                 objhash = digest_file(path)
-                move(path, self.object_path(objhash))
+                self._move_to_store(path, objhash)
                 hashes.append(objhash)
             rmtree(storepath)
         else:
             filehash = digest_file(storepath)
-            move(storepath, self.object_path(filehash))
+            self._move_to_store(storepath, filehash)
             hashes = [filehash]
 
         return hashes
@@ -426,13 +427,12 @@ class PackageStore(object):
         Save a (raw) file to the store.
         """
         filehash = digest_file(srcfile)
-        objpath = self.object_path(filehash)
-        if not os.path.exists(objpath):
+        if not os.path.exists(self.object_path(filehash)):
             # Copy the file to a temporary location first, then move, to make sure we don't end up with
             # truncated contents if the build gets interrupted.
             tmppath = self.temporary_object_path(filehash)
             copyfile(srcfile, tmppath)
-            move(tmppath, objpath)
+            self._move_to_store(tmppath, filehash)
 
         return filehash
 
@@ -464,5 +464,12 @@ class PackageStore(object):
                 raise StoreException("Metadata is not serializable")
 
         metahash = digest_file(path)
-        move(path, self.object_path(metahash))
+        self._move_to_store(path, metahash)
         return metahash
+
+    def _move_to_store(self, objpath, objhash):
+        """
+        Make the object read-only and move it to the store.
+        """
+        os.chmod(objpath, S_IRUSR | S_IRGRP | S_IROTH)  # Make read-only
+        move(objpath, self.object_path(objhash))


### PR DESCRIPTION
The user should not modify the store fragments since that would change their hashes - so let's make them read-only.