### PR TITLE
Implement node access using brackets

### DIFF
--- a/compiler/quilt/imports.py
+++ b/compiler/quilt/imports.py
@@ -63,7 +63,7 @@ def _from_core_node(package, core_node):
 
         for name, core_child in iteritems(core_node.children):
             child = _from_core_node(package, core_child)
-            setattr(node, name, child)
+            node[name] = child
 
     return node
 

--- a/compiler/quilt/nodes.py
+++ b/compiler/quilt/nodes.py
@@ -113,6 +113,17 @@ class GroupNode(Node):
             except KeyError:
                 raise AttributeError
 
+    def __dir__(self):
+        attrs = set()
+        try:
+            attrs.update(super(GroupNode, self).__dir__())
+        except AttributeError:
+            # Fallback for PY2
+            attrs.update(dir(type(self)))
+            attrs.update(self.__dict__)
+        attrs.update(self._children)
+        return sorted(attrs)
+
     def __getitem__(self, name):
         return self._children[name]
 

--- a/compiler/quilt/test/test_import.py
+++ b/compiler/quilt/test/test_import.py
@@ -47,6 +47,8 @@ class ImportTest(QuiltTestCase):
         assert len(package) == 2
         assert len(list(package)) == 2
 
+        assert 'dataframes' in dir(package)
+
         for item in package:
             assert isinstance(item, (GroupNode, DataNode))
 

--- a/compiler/quilt/test/test_import.py
+++ b/compiler/quilt/test/test_import.py
@@ -37,10 +37,14 @@ class ImportTest(QuiltTestCase):
         assert package.dataframes == dataframes
         assert package.README == README
 
+        assert package['dataframes'] == dataframes
+        assert package['README'] == README
+
         assert set(dataframes._keys()) == {'csv', 'nulls'}
         assert set(dataframes._group_keys()) == set()
         assert set(dataframes._data_keys()) == {'csv', 'nulls'}
 
+        assert len(package) == 2
         assert len(list(package)) == 2
 
         for item in package:
@@ -357,7 +361,7 @@ class ImportTest(QuiltTestCase):
         # Assign a DataFrame as a node
         # (should throw exception)
         df = pd.DataFrame(dict(a=[1, 2, 3]))
-        with self.assertRaises(AttributeError):
+        with self.assertRaises(TypeError):
             package4.newdf = df
 
     def test_load_update(self):
@@ -380,7 +384,7 @@ class ImportTest(QuiltTestCase):
         command.build(newpkgname, module)
 
         # current spec requires that build() *not* update the in-memory module tree.
-        newpath1 = getattr(module, newfilename)()
+        newpath1 = module[newfilename]()
         assert newpath1 == newfilename
 
         # current spec requires that load() reload from disk, i.e. gets a reference
@@ -388,7 +392,7 @@ class ImportTest(QuiltTestCase):
         # this is important because of potential changes to myfile
         reloaded_module = command.load(newpkgname)
         assert reloaded_module is not module
-        newpath2 = getattr(reloaded_module, newfilename)()
+        newpath2 = reloaded_module[newfilename]()
         assert 'myfile' not in newpath2
 
     def test_multiple_updates(self):
@@ -409,7 +413,7 @@ class ImportTest(QuiltTestCase):
 
         package6._set([newfilename1], newfilename2)
 
-        assert getattr(package6, newfilename1)() == newfilename2
+        assert package6[newfilename1]() == newfilename2
 
     def test_team_non_team_imports(self):
         mydir = os.path.dirname(__file__)
@@ -436,7 +440,7 @@ class ImportTest(QuiltTestCase):
         # Assign a DataFrame as a node
         # (should throw exception)
         df = pd.DataFrame(dict(a=[1, 2, 3]))
-        with self.assertRaises(AttributeError):
+        with self.assertRaises(TypeError):
             package4.newdf = df
 
     def test_datanode_asa(self):
@@ -518,4 +522,3 @@ class ImportTest(QuiltTestCase):
             command.load('foo/package:t:latest')
         with self.assertRaises(command.CommandException):
             command.load('foo/package:v:1.0.0')
-    

--- a/compiler/quilt/tools/command.py
+++ b/compiler/quilt/tools/command.py
@@ -1522,9 +1522,8 @@ def export(package, output_path='.', force=False, symlinks=False):
 
     if info.subpath:
         subpath = pathlib.PureWindowsPath(*info.subpath)
-        # TODO: Change this over to `node['item/subitem']` notation once implemented
         for name in info.subpath:
-            node = getattr(node, name)
+            node = node._get(name)
     else:
         subpath = pathlib.PureWindowsPath()
 


### PR DESCRIPTION
Node children are now stored as an actual dict instead of attributes.
Dot notation works as before - but is now a wrapper around brackets.

Potential problem: A GroupNode now acts like a dict, except that a dict's `__iter__` returns key names - while we're returning values.