### PR TITLE
Fix broken version tag

### DIFF
--- a/registry/nginx-s3/Dockerfile
+++ b/registry/nginx-s3/Dockerfile
@@ -1,4 +1,4 @@
-FROM nginx:16.04
+FROM nginx:1.15
 MAINTAINER Quilt Data, Inc. contact@quiltdata.io
 
 COPY nginx-s3.conf /etc/nginx/conf.d/


### PR DESCRIPTION
Looks like the version tag for Ubuntu (16.04) was added to the nginx image in the nginx-s3 Dockerfile by mistake. Pin the version to the most recent nginx release (1.15).

## Description

## Depends On

If your pull request depends on functionality that is not yet merged to `master`,
please note that here. ex: "Depends on #1"

## TODO

Use this section for work-in-progress pull requests. If you're using this section,
please tag your PR "WIP". 

- [N/A ] Unit Tests
- [ N/A] Documentation
