### PR TITLE
Source maps and stuff

### DIFF
--- a/catalog/internals/webpack/webpack.prod.babel.js
+++ b/catalog/internals/webpack/webpack.prod.babel.js
@@ -16,6 +16,10 @@ module.exports = require('./webpack.base.babel')({
   },
 
   plugins: [
+    new webpack.optimize.UglifyJsPlugin({
+      sourceMap: true,
+    }),
+
     new webpack.optimize.ModuleConcatenationPlugin(),
     new webpack.optimize.CommonsChunkPlugin({
       name: 'vendor',
@@ -42,6 +46,8 @@ module.exports = require('./webpack.base.babel')({
       inject: true,
     }),
   ],
+
+  devtool: 'source-map',
 
   performance: {
     assetFilter: (assetFilename) => !(/(\.map$)|(^(main\.|favicon\.))/.test(assetFilename)),

--- a/catalog/package.json
+++ b/catalog/package.json
@@ -21,7 +21,7 @@
     "preinstall": "npm run npmcheckversion",
     "postinstall": "npm run build:dll",
     "prebuild": "npm run build:clean",
-    "build": "cross-env NODE_ENV=production webpack --config internals/webpack/webpack.prod.babel.js --color -p --progress --hide-modules --display-optimization-bailout",
+    "build": "cross-env NODE_ENV=production webpack --config internals/webpack/webpack.prod.babel.js --color --progress --hide-modules --display-optimization-bailout",
     "build:clean": "rimraf ./build",
     "build:dll": "node ./internals/scripts/dependencies.js",
     "start": "cross-env NODE_ENV=development node server",

--- a/catalog/server/middlewares/frontendMiddleware.js
+++ b/catalog/server/middlewares/frontendMiddleware.js
@@ -3,10 +3,10 @@ const express = require('express');
 const path = require('path');
 const compression = require('compression');
 const pkg = require(path.resolve(process.cwd(), 'package.json'));
+const serveConfig = require('./config');
 
 // Dev middleware
 const addDevMiddlewares = (app, webpackConfig) => {
-  const serveConfig = require('./config');
   app.get('/config.js',
     serveConfig(path.resolve(process.cwd(), 'config.js.tmpl'), process.env));
 
@@ -49,11 +49,13 @@ const addDevMiddlewares = (app, webpackConfig) => {
 const addProdMiddlewares = (app, options) => {
   const publicPath = options.publicPath || '/';
   const outputPath = options.outputPath || path.resolve(process.cwd(), 'build');
+  const configPath = options.configPath || path.resolve(process.cwd(), 'config.js.tmpl');
 
   // compression middleware compresses your server responses which makes them
   // smaller (applies also to assets). You can read more about that technique
   // and other good practices on official Express.js docs http://mxs.is/googmy
   app.use(compression());
+  app.get('/config.js', serveConfig(configPath, process.env));
   app.use(publicPath, express.static(outputPath));
 
   app.get('*', (req, res) => res.sendFile(path.resolve(outputPath, 'index.html')));


### PR DESCRIPTION
- serve config in production mode
- generate source maps

Source maps will help dealing with error reports in sentry. It's not recommended, generally, to expose source maps in production, but since all the code is open source anyways, I don't see any undesirable implications.