### PR TITLE
Return to the original directory after installing/running catalog tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -68,7 +68,7 @@ install:
     fi
   - |
     if [[ "$TEST_CATALOG" = true ]]; then
-      cd catalog && npm ci
+      (cd catalog && npm ci)
     fi
 
 script:
@@ -82,7 +82,7 @@ script:
     fi
   - |
     if [[ "$TEST_CATALOG" = true ]]; then
-      npm test
+      (cd catalog && npm test)
     fi
 
 after_success:


### PR DESCRIPTION
If we ever run catalog tests in the same environment as anything else, `cd catalog` will break things.
Instead, run `cd` and `npm` in a child shell, so the working directory is not persistent.