### PR TITLE
Don't skip header row when reading csv/excel files in unit tests

### DIFF
--- a/compiler/quilt/test/build_globbing.yml
+++ b/compiler/quilt/test/build_globbing.yml
@@ -10,7 +10,7 @@ contents:
   excel:
     "data/100*.xlsx":
       kwargs:
-        skiprows: [0,10,17,90,95]
+        skiprows: [1,10,17,90,95]
   # acceptable collision, data/csv.txt and data/subdir/csv.txt -- results in rename of second file
   collision:
     "data/**/csv.txt":

--- a/compiler/quilt/test/build_large.yml
+++ b/compiler/quilt/test/build_large.yml
@@ -13,7 +13,7 @@ contents:
       file: data/10KRows13Cols.xlsx
     xls_skip:
       kwargs:
-        skiprows: [0,10,100]
+        skiprows: [1,10,100]
       file: data/10KRows13Cols.xlsx
   README:
     file: data/README.md

--- a/compiler/setup.py
+++ b/compiler/setup.py
@@ -42,7 +42,7 @@ setup(
         'packaging>=16.8',
         'pandas>=0.19.2',
         'pathlib2; python_version<"3.6"',   # stdlib backport
-        'pyarrow>=0.4.0',
+        'pyarrow>=0.9.0',
         'pyyaml>=3.12',
         'requests>=2.12.4',
         'six>=1.10.0',

--- a/compiler/setup.py
+++ b/compiler/setup.py
@@ -42,7 +42,7 @@ setup(
         'packaging>=16.8',
         'pandas>=0.19.2',
         'pathlib2; python_version<"3.6"',   # stdlib backport
-        'pyarrow>=0.4.0,<0.8.0',            # TODO(dima): Make unit tests work with 0.8+
+        'pyarrow>=0.4.0',
         'pyyaml>=3.12',
         'requests>=2.12.4',
         'six>=1.10.0',

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -165,3 +165,16 @@ Symbolic links on Windows have a few quirks to be aware of.
  
  ### Solution
  `sudo pip install quilt # ¯\_(ツ)_/¯`
+
+## `TypeError: data type "mixed-integer" not understood` when reading a DataFrame from a package
+This error can occur for package nodes built using the Pandas "skiprows" parameter to skip a source file's header row (usually row 0). For example, this build.yml file, skips the header row in source.xlsx:
+```yaml
+    foo:
+        file: source.xlsx
+        kwargs:
+            skiprows: [0,...]
+            names: ['column0',...]
+```
+To skip the header row and supply a different set of column names, use the "names" parameter:
+
+

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -167,7 +167,7 @@ Symbolic links on Windows have a few quirks to be aware of.
  `sudo pip install quilt # ¯\_(ツ)_/¯`
 
 ## `TypeError: data type "mixed-integer" not understood` when reading a DataFrame from a package
-This error can occur for package nodes built using the Pandas "skiprows" parameter to skip a source file's header row (usually row 0). For example, this build.yml file, skips the header row in source.xlsx:
+This error occurs when trying to round-trip Pandas DataFrames that have a column name that is a number to Parquet using Arrow 0.9. This can occur during `quilt build` for package nodes built using the Pandas "skiprows" parameter in read_csv or read_excel to skip a source file's header row (usually row 0). For example, this build.yml file, skips the header row in source.xlsx:
 ```yaml
     foo:
         file: source.xlsx
@@ -175,6 +175,4 @@ This error can occur for package nodes built using the Pandas "skiprows" paramet
             skiprows: [0,...]
             names: ['column0',...]
 ```
-To skip the header row and supply a different set of column names, use the "names" parameter:
-
 


### PR DESCRIPTION
## Description
Skipping the header in Pandas read_csv and read_excel can produce DataFrames with funky column names and indexes, the testing of which is outside the scope of the current unit tests that specify the line skips.

In future, we should add Parquet/Pandas round-trip tests that cover all types of Pandas DataFrames, including uncommon indexing and column names.
