### PR TITLE
travis: adjust catalog build cfg for bundlesize calculations

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -87,7 +87,7 @@ script:
     fi
   - |
     if [[ "$TEST_CATALOG" = true ]]; then
-      (cd catalog && npm test && npm run build)
+      (cd catalog && npm test && npm run build -- --output-filename='[name].js' --output-chunk-filename='[name].chunk.js')
     fi
 
 after_success:


### PR DESCRIPTION
`bundlesize` couldnt properly compare build size with master because of changing hashes in filenames, so we need to make a build w/o hashes for this to work