### PR TITLE
Allow insecure catalog connection

### DIFF
--- a/registry/quilt_server/prod_config.py
+++ b/registry/quilt_server/prod_config.py
@@ -11,7 +11,9 @@ REGISTRY_HOST = os.environ['REGISTRY_HOST']
 REGISTRY_URL = os.environ['REGISTRY_URL']
 CATALOG_HOST = os.environ['CATALOG_HOST']
 
-CATALOG_URL = 'https://%s' % CATALOG_HOST
+CATALOG_URL = os.environ.get('CATALOG_URL', 'https://%s' % CATALOG_HOST)
+if not CATALOG_URL.startswith("https"):
+    print("WARNING: INSECURE CONNECTION TO CATALOG")
 
 PACKAGE_BUCKET_NAME = os.environ['PACKAGE_BUCKET_NAME']
 


### PR DESCRIPTION
## Description
Adds logic to allow overriding the default catalog URL, which assumes HTTPS. Print a warning if the URL isn't HTTPS.

## Depends On
New Auth (so merging into flask-sec)
