### PR TITLE
Reduce name collisions

### DIFF
--- a/compiler/quilt/test/test_build.py
+++ b/compiler/quilt/test/test_build.py
@@ -225,8 +225,8 @@ class BuildTest(QuiltTestCase):
             'a': {},
             # Directories don't actually have extensions, so include them even with no conficts
             'dir_ext': {},
-            # Weird characters replaced with a single "_"
-            'a_b_c': {'file': 'a%%b___c'},
+            # Weird characters replaced with "_"
+            'a__b___c': {'file': 'a%%b___c'},
             # Prepend "n" to files that start with a number
             'n1': {'file': '1'},
             # ... even if there used to be an underscore there

--- a/compiler/quilt/tools/util.py
+++ b/compiler/quilt/tools/util.py
@@ -195,8 +195,8 @@ def to_identifier(string):
     from the change in all cases, so it must be stored separately.
 
     Examples:
-    >>> to_identifier('#if') -> '_if'
-    >>> to_identifier('global') -> 'global_'
+    >>> to_identifier('Alice\'s Restaurant') -> 'Alice_s_Restaurant'
+    >>> to_identifier('#if') -> 'if' -> QuiltException
     >>> to_identifier('9foo') -> 'n9foo'
 
     :param string: string to convert
@@ -204,7 +204,7 @@ def to_identifier(string):
     :rtype: string
     """
     # Not really useful to expose as a CONSTANT, and python will compile and cache
-    result = re.sub(r'[^0-9a-zA-Z]+', '_', string)
+    result = re.sub(r'[^0-9a-zA-Z_]', '_', string)
 
     # compatibility with older behavior and tests, doesn't hurt anyways -- "_" is a
     # pretty useless name to translate to.  With this, it'll raise an exception.


### PR DESCRIPTION
## Description
Map each python-illegal character into an underscore (instead of replacing multiple consecutive python-illegal characters with a single underscore) to reduce the likelihood of node name collisons.
Fixes #681 