### PR TITLE
Don't call `__getattr__` on the superclass

### DIFF
--- a/compiler/quilt/nodes.py
+++ b/compiler/quilt/nodes.py
@@ -91,7 +91,7 @@ class GroupNode(Node):
 
     def __getattr__(self, name):
         if name.startswith('_'):
-            return super(GroupNode, self).__getattr__(name)
+            raise AttributeError
         else:
             try:
                 return self[name]


### PR DESCRIPTION
It raises an exception, but is also unnecessary: our own `__getattr__` only gets called after the normal attribute lookup has failed.