### PR TITLE
[WIP] Add capability to build directly from `DataNode` objects

### DIFF
--- a/compiler/quilt/test/test_build.py
+++ b/compiler/quilt/test/test_build.py
@@ -472,7 +472,6 @@ class BuildTest(QuiltTestCase):
         command.build('test/foo/stuff', path, build_file=True)  # Builds a subpackage
 
         pkg = command.load('test/foo')
-        print(pkg.gn._meta)
         assert len(pkg.a.b.c.empty) == 0
         assert len(pkg.gn) == 0
         assert np.array_equal(pkg.dn(), arr)

--- a/compiler/quilt/test/test_build.py
+++ b/compiler/quilt/test/test_build.py
@@ -461,15 +461,24 @@ class BuildTest(QuiltTestCase):
         df = DataFrame(dict(a=[1, 2, 3]))
         arr = np.array([4, 5, 6])
         path = str(mydir / 'build_simple.yml')
+        metadata = {'metadata_key': 'metadata_value'}
 
         command.build('test/foo/a/b/c/empty')
+        command.build('test/foo/gn', GroupNode(metadata))
+        command.build('test/foo/dn', DataNode(None, None, arr, metadata))
         command.build('test/foo/df', df)
         command.build('test/foo/arr', arr)
         command.build('test/foo/file', path)  # Adds as a plain file
         command.build('test/foo/stuff', path, build_file=True)  # Builds a subpackage
 
         pkg = command.load('test/foo')
+        print(pkg.gn._meta)
         assert len(pkg.a.b.c.empty) == 0
+        assert len(pkg.gn) == 0
+        # Fails due to this (I think): compiler/quilt/tools/store.py#L581
+        # assert all(metadata[k] == pkg.gn._meta[k] for k in metadata)
+        assert np.array_equal(pkg.dn(), arr)
+        assert all(metadata[k] == pkg.dn._meta[k] for k in metadata)
         assert pkg.df().equals(df)
         assert np.array_equal(pkg.arr(), arr)
         assert pkg.file

--- a/compiler/quilt/test/test_build.py
+++ b/compiler/quilt/test/test_build.py
@@ -464,7 +464,7 @@ class BuildTest(QuiltTestCase):
         metadata = {'metadata_key': 'metadata_value'}
 
         command.build('test/foo/a/b/c/empty')
-        command.build('test/foo/gn', GroupNode(metadata))
+        command.build('test/foo/gn', GroupNode(dict()))
         command.build('test/foo/dn', DataNode(None, None, arr, metadata))
         command.build('test/foo/df', df)
         command.build('test/foo/arr', arr)
@@ -475,8 +475,6 @@ class BuildTest(QuiltTestCase):
         print(pkg.gn._meta)
         assert len(pkg.a.b.c.empty) == 0
         assert len(pkg.gn) == 0
-        # Fails due to this (I think): compiler/quilt/tools/store.py#L581
-        # assert all(metadata[k] == pkg.gn._meta[k] for k in metadata)
         assert np.array_equal(pkg.dn(), arr)
         assert all(metadata[k] == pkg.dn._meta[k] for k in metadata)
         assert pkg.df().equals(df)

--- a/compiler/quilt/tools/command.py
+++ b/compiler/quilt/tools/command.py
@@ -532,7 +532,7 @@ def _build_internal(package, path, dry_run, env, build_file):
                     rmtree(tmpdir)
         else:
             build_from_path(package, path, dry_run=dry_run, env=env)
-    elif isinstance(path, nodes.GroupNode):
+    elif isinstance(path, (nodes.GroupNode, nodes.DataNode)):
         assert not dry_run  # TODO?
         build_from_node(package, path)
     elif isinstance(path, string_types + (pd.DataFrame, np.ndarray)):

--- a/compiler/quilt/tools/command.py
+++ b/compiler/quilt/tools/command.py
@@ -532,7 +532,7 @@ def _build_internal(package, path, dry_run, env, build_file):
                     rmtree(tmpdir)
         else:
             build_from_path(package, path, dry_run=dry_run, env=env)
-    elif isinstance(path, (nodes.GroupNode, nodes.DataNode)):
+    elif isinstance(path, nodes.Node):
         assert not dry_run  # TODO?
         build_from_node(package, path)
     elif isinstance(path, string_types + (pd.DataFrame, np.ndarray)):


### PR DESCRIPTION
## Description
This PR allows a user to build a package component with a `DataNode` directly (for "on the fly" build workflows). This additional functionality allows users to explicitly craft the new nodes data and metadata simultaneously, representing a ~2x built-time improvement over it's existing workaround on my use case (35s vs 67s).

Workaround:
```python

for dense_data, sparse_data from data_to_build:
    # dense_data = np.random.uniform(0, 1, size=(int(1.5e5), 25, 4))
    # sparse_data = metadata_dict

    # build dense data `numpy` node
    quilt.build(data_node_path, dense_data)

    # re-load the pkg and assign it
    pkg = quilt.load(q_pkg_name)
    
    # add the sparse data to the `_meta` attr
    pkg[group['name']][l_id]._meta.update(sparse_data)
    
    # rebuild w/ additional metadata
    quilt.build(q_pkg_name, pkg)
```

Proposal:
```python

for dense_data, sparse_data from data_to_build:
    # dense_data = np.random.uniform(0, 1, size=(int(1.5e5), 25, 4))
    # sparse_data = metadata_dict

    # build dense data `numpy` node
    quilt.build(
        data_node_path, 
        quilt.nodes.DataNode(None, None, dense_data, sparse_data)
    )
```

## Depends On
As far as I know, there are no dependencies

## TODO
Unit tests run for me in 2.7.13 & 3.6, though I wasn't able to identify where to add a new one or amend an existing one. Also, not sure what documentation would be useful for this.

- [ ] Unit Tests
- [ ] Documentation