### PR TITLE
Allow subpath loads by using `PackageInfo.subpath` to traverse the tree

### DIFF
--- a/compiler/quilt/tools/command.py
+++ b/compiler/quilt/tools/command.py
@@ -1327,7 +1327,11 @@ def load(pkginfo, hash=None):
     """
     functional interface to "from quilt.data.USER import PKG"
     """
-    return _load(pkginfo, hash)[0]
+    node, pkgroot, info = _load(pkginfo, hash)
+    for subnode_name in info.subpath:
+        node = node[subnode_name]
+
+    return node
 
 def export(package, output_path='.', force=False, symlinks=False):
     """Export package file data.


### PR DESCRIPTION
## Description

This PR attempts to allow functional subpath loads using the `quilt.load` method. This is accomplished by traversing the node tree based on information parsed by `parse_package_extended` which was already in use. I am not sure what downstream affects this may have, but all unit tests succeed after this change.

**Example:**
```python
import quilt
q_path = 'user/pkg/subpkg_a'
q_node_name = 'table'

quilt.install(q_path)
subpkg_a = quilt.load(q_path)
data = subpkg_a.table()
```

## Depends On

No additional dependencies.

## TODO

Use this section for work-in-progress pull requests. If you're using this section,
please tag your PR "WIP". 

- [ ] Unit Tests
- [ ] Documentation