### PR TITLE
Yaml security fix

### DIFF
--- a/compiler/pytest.ini
+++ b/compiler/pytest.ini
@@ -1,7 +1,9 @@
 [pytest]
 filterwarnings =
     default
+    ; Warning in cookies module triggered by responses lib.
     ignore:::cookies
+    ; Pandas triggers a bug in the current version of Cython.
+    ; Unfortunately, we lose monitoring of any potential ImportWarnings,
     ignore::ImportWarning
-    ignore:::IPython.lib.pretty
 

--- a/compiler/pytest.ini
+++ b/compiler/pytest.ini
@@ -1,0 +1,7 @@
+[pytest]
+filterwarnings =
+    default
+    ignore:::cookies
+    ignore::ImportWarning
+    ignore:::IPython.lib.pretty
+

--- a/compiler/quilt/test/arbitrary_execution.yml
+++ b/compiler/quilt/test/arbitrary_execution.yml
@@ -1,0 +1,4 @@
+foo: !!python/object/apply:os.system 
+     args: ['echo arbitrary code execution!']
+contents:
+    bar:

--- a/compiler/quilt/test/test_build.py
+++ b/compiler/quilt/test/test_build.py
@@ -212,7 +212,7 @@ class BuildTest(QuiltTestCase):
         assert os.path.exists(buildfilepath)
 
         with open(buildfilepath) as fd:
-            docs = yaml.load_all(fd)
+            docs = yaml.safe_load_all(fd)
             data = next(docs, None)
 
         contents = data['contents']

--- a/compiler/quilt/test/test_build.py
+++ b/compiler/quilt/test/test_build.py
@@ -505,7 +505,7 @@ class TestOutput(QuiltTestCase):
         testdir = pathlib.Path(__file__).parent
 
         with pytest.raises(yaml.constructor.ConstructorError):
-            command.build('test/exec', str(testdir / 'arbitrary_execution.yml'), build_file=True)
+            command.build('test/exec_flaw', str(testdir / 'arbitrary_execution.yml'), build_file=True)
         out, err = self.capfd.readouterr()
         assert not "arbitrary code execution" in out
         assert not "arbitrary code execution" in err

--- a/compiler/quilt/test/test_checks.py
+++ b/compiler/quilt/test/test_checks.py
@@ -15,7 +15,7 @@ def read_yml_file(fn):
     mydir = os.path.dirname(__file__)
     filepath = os.path.join(mydir, fn)
     with open(filepath) as fd:
-        return next(yaml.load_all(fd), None)
+        return next(yaml.safe_load_all(fd), None)
 
 class ChecksTest(QuiltTestCase):
 
@@ -48,7 +48,7 @@ class ChecksTest(QuiltTestCase):
             regexp = "Data check failed: %s" % (check)
         with assertRaisesRegex(self, build.BuildException, regexp):
             self.build_success(check, nodename=nodename)
-        
+
     def test_parse_checks_file(self):
         assert str(self.checks_contents['negative']) == 'False'
         assert self.checks_contents['simple_multiline'] == '# comment\nqc.check(True)\n'
@@ -60,12 +60,12 @@ class ChecksTest(QuiltTestCase):
     def test_external_only(self):
         del self.build_data['checks']
         self.build_fail('inline_only', "Unknown check.+inline_only")
-        
+
     def test_inline_only(self):
         self.checks_contents = self.checks_data = None
         self.build_success('inline_only')
         self.build_fail('hasrecs', "Unknown check.+hasrecs")
-        
+
     def test_simple_checks(self):
         self.build_success('simple')
         self.build_success('simple_multiline')
@@ -87,7 +87,7 @@ class ChecksTest(QuiltTestCase):
         self.build_success('inline_only')
         self.build_success('inline_and_external')
         self.build_success('hasrecs')
-        
+
     def test_many_errors(self):
         # TODO: capture details by line number
         self.build_contents['foo'] = { 'checks': 'lots_uid_errors',

--- a/compiler/quilt/tools/build.py
+++ b/compiler/quilt/tools/build.py
@@ -617,7 +617,7 @@ def load_yaml(filename, optional=False):
     with open(filename, 'r') as fd:
         data = fd.read()
     try:
-        res = yaml.load(data)
+        res = yaml.safe_load(data)
         if not filename.endswith(DEFAULT_QUILT_YML):
             if 'contents' not in res.keys():
                 file_name = os.path.basename(filename)

--- a/compiler/quilt/tools/command.py
+++ b/compiler/quilt/tools/command.py
@@ -867,7 +867,7 @@ def install_via_requirements(requirements_str, force=False):
         else:
             raise CommandException("Requirements file not found: {filename}".format(filename=path))
     else:
-        yaml_data = yaml.load(requirements_str)
+        yaml_data = yaml.safe_load(requirements_str)
     for pkginfo in yaml_data['packages']:
         info = parse_package_extended(pkginfo)
         install(info.full_name, info.hash, info.version, info.tag, force=force)


### PR DESCRIPTION
## Description
We have a minor security issue that allows arbitrary code execution.  While arbitrary execution is typically a major issue, this one is fairly minor because:

* quilt is not typically executed with admin permissions
* attacker must get the user to use a compromised build (or other YAML) file in order to perform the attack

Since we're not loading data from YAML files, just loading configs, this is a trivial issue to fix -- all existing `load()` calls have been replaced by `safe_load()` calls.

## Depends On
Nothing

## TODO
- [x] Bug Fix
- [x] Unit Tests