### PR TITLE
Better handling for outdated/unsupported formats

### DIFF
--- a/compiler/quilt/tools/core.py
+++ b/compiler/quilt/tools/core.py
@@ -90,7 +90,12 @@ class TableNode(Node):
     def __init__(self, hashes, format, metadata=None, metadata_hash=None):
         super(TableNode, self).__init__(metadata_hash)
 
-        assert PackageFormat(format) == PackageFormat.PARQUET
+        # to report clearly on the cli, we'll raise a TypeError here
+        # instead of asserting -- then reraise that as some kind of QuiltException.
+        # We can't raise QuiltException directly, as this file is identical in
+        # both compiler and registry.
+        if not PackageFormat(format) == PackageFormat.PARQUET:
+            raise TypeError("Bad internal format '{}', this package may be outdated.".format(format))
 
         assert isinstance(hashes, list)
         assert isinstance(format, string_types), '%r' % format

--- a/compiler/quilt/tools/core.py
+++ b/compiler/quilt/tools/core.py
@@ -90,12 +90,9 @@ class TableNode(Node):
     def __init__(self, hashes, format, metadata=None, metadata_hash=None):
         super(TableNode, self).__init__(metadata_hash)
 
-        # to report clearly on the cli, we'll raise a TypeError here
-        # instead of asserting -- then reraise that as some kind of QuiltException.
-        # We can't raise QuiltException directly, as this file is identical in
-        # both compiler and registry.
+        # This AssertionError needed with this message to catch later and present clear user information.
         if not PackageFormat(format) == PackageFormat.PARQUET:
-            raise TypeError("Bad internal format '{}', this package may be outdated.".format(format))
+            raise AssertionError("Bad package format '{}', this package may be outdated.".format(format))
 
         assert isinstance(hashes, list)
         assert isinstance(format, string_types), '%r' % format

--- a/compiler/quilt/tools/store.py
+++ b/compiler/quilt/tools/store.py
@@ -211,9 +211,9 @@ class PackageStore(object):
         with open(contents_path, 'r') as contents_file:
             try:
                 return json.load(contents_file, object_hook=decode_node)
-            except TypeError as err:
-                if str(err).startswith("Bad internal format"):
-                    name = "{}{}/{} v {}".format(
+            except AssertionError as err:
+                if str(err).startswith("Bad package format"):
+                    name = "{}{}/{}, {}".format(
                         team + ':' if team else '',
                         user,
                         package,

--- a/compiler/quilt/tools/store.py
+++ b/compiler/quilt/tools/store.py
@@ -203,13 +203,25 @@ class PackageStore(object):
             with open (latest_tag, 'r') as tagfile:
                 pkghash = tagfile.read()
 
-        assert pkghash is not None  
+        assert pkghash is not None
         contents_path = os.path.join(path, self.CONTENTS_DIR, pkghash)
         if not os.path.isfile(contents_path):
             return None
 
         with open(contents_path, 'r') as contents_file:
-            return json.load(contents_file, object_hook=decode_node)
+            try:
+                return json.load(contents_file, object_hook=decode_node)
+            except TypeError as err:
+                if str(err).startswith("Bad internal format"):
+                    name = "{}{}/{} v {}".format(
+                        team + ':' if team else '',
+                        user,
+                        package,
+                        pkghash
+                        )
+                    raise StoreException("Error in {}: {}".format(name, str(err)))
+                else:
+                    raise
 
     def install_package(self, team, user, package, contents):
         """
@@ -227,7 +239,7 @@ class PackageStore(object):
             os.remove(path)
         except OSError:
             pass
-    
+
     def create_package_node(self, team, user, package, dry_run=False):
         """
         Creates a new package and initializes its contents. See `install_package`.
@@ -541,7 +553,7 @@ class PackageStore(object):
             os.mkdir(os.path.join(pkg_path, self.CONTENTS_DIR))
             os.mkdir(os.path.join(pkg_path, self.TAGS_DIR))
             os.mkdir(os.path.join(pkg_path, self.VERSIONS_DIR))
-            
+
         dest = os.path.join(pkg_path, self.CONTENTS_DIR, instance_hash)
         with open(dest, 'w') as contents_file:
             json.dump(root, contents_file, default=encode_node, indent=2, sort_keys=True)
@@ -573,9 +585,9 @@ class PackageStore(object):
         """
         assert isinstance(node_path, list)
         assert user_meta_hash is None or isinstance(user_meta_hash, str)
-        
+
         contents = pkgroot
-        
+
         if not node_path:
             # Allow setting metadata on the root node, but that's it.
             assert target is TargetType.GROUP
@@ -603,7 +615,7 @@ class PackageStore(object):
             )
 
         ptr.children[node_path[-1]] = node
-        
+
 
 ########################################
 # Methods ported from save_<xyz>
@@ -653,4 +665,4 @@ class PackageStore(object):
         else:
             if root.children:
                 raise PackageException("Attempting to overwrite root node of a non-empty package.")
-            root.children = pkgnode.children.copy()   
+            root.children = pkgnode.children.copy()

--- a/registry/quilt_server/core.py
+++ b/registry/quilt_server/core.py
@@ -90,7 +90,12 @@ class TableNode(Node):
     def __init__(self, hashes, format, metadata=None, metadata_hash=None):
         super(TableNode, self).__init__(metadata_hash)
 
-        assert PackageFormat(format) == PackageFormat.PARQUET
+        # to report clearly on the cli, we'll raise a TypeError here
+        # instead of asserting -- then reraise that as some kind of QuiltException.
+        # We can't raise QuiltException directly, as this file is identical in
+        # both compiler and registry.
+        if not PackageFormat(format) == PackageFormat.PARQUET:
+            raise TypeError("Bad package format '{}', this package may be outdated.".format(format))
 
         assert isinstance(hashes, list)
         assert isinstance(format, string_types), '%r' % format

--- a/registry/quilt_server/core.py
+++ b/registry/quilt_server/core.py
@@ -90,12 +90,9 @@ class TableNode(Node):
     def __init__(self, hashes, format, metadata=None, metadata_hash=None):
         super(TableNode, self).__init__(metadata_hash)
 
-        # to report clearly on the cli, we'll raise a TypeError here
-        # instead of asserting -- then reraise that as some kind of QuiltException.
-        # We can't raise QuiltException directly, as this file is identical in
-        # both compiler and registry.
+        # This AssertionError needed with this message to catch later and present clear user information.
         if not PackageFormat(format) == PackageFormat.PARQUET:
-            raise TypeError("Bad package format '{}', this package may be outdated.".format(format))
+            raise AssertionError("Bad package format '{}', this package may be outdated.".format(format))
 
         assert isinstance(hashes, list)
         assert isinstance(format, string_types), '%r' % format


### PR DESCRIPTION
## Description
re: #760 and #586 (original):

When we load data from disk, and it is in an outdated or unsupported format, provide a message to that effect (quiltcli) or raise a `StoreException` error (Quilt Python api).

In order to minimize impact on `core.py`, instead of:
```python
assert x
```
It now does:
```python
if not x: raise AssertionError(<message>)
```
..where <message> is later re-raised as a `StoreException` to give a nice user message.

..so, it's pretty minimally intrusive.

