### PR TITLE
Add a Quilt nginx Dockerfile to simplify docker execution

### DIFF
--- a/registry/nginx/Dockerfile
+++ b/registry/nginx/Dockerfile
@@ -1,0 +1,12 @@
+# This dockerfile is to simplify installation, and should be pushed as quiltdata/nginx.
+FROM nginx:latest
+
+MAINTAINER Quilt Data, Inc. contact@quiltdata.io
+
+COPY ./nginx-quilt.conf /etc/nginx/nginx-quilt.template
+# Above template populated by these env vars at runtime, unless overridden:
+ENV UWSGI_HOST=localhost
+ENV UWSGI_PORT=9000
+ENV NGINX_PORT=80
+
+CMD /bin/bash -c "envsubst < /etc/nginx/nginx-quilt.template > /etc/nginx/conf.d/default.conf && nginx -g 'daemon off;'"


### PR DESCRIPTION
## Description
This is a pretty simple pull, but I thought someone might want to object or put in their own comments or ideas.  It's basically a means of helping to reduce complexity when setting up a Quilt server.  It's small, but small changes add up.

Currently, in the registry's `README.md`, for AWS, we have the line (formatted for clarity):

```bash
sudo docker run -d -e UWSGI_HOST=localhost -e UWSGI_PORT=9000 -e NGINX_PORT=80 \
    -v /home/ec2-user/nginx-quilt.conf:/etc/nginx/nginx-quilt.template
    --name registry-nginx \
    --network container:registry \
    nginx \
    /bin/bash -c "envsubst < /etc/nginx/nginx-quilt.template > /etc/nginx/conf.d/default.conf && nginx -g 'daemon off;'"
```

..which also doesn't work.  Or, it didn't for me.  The docs referenced a file that didn't exist, and so on the host system, a directory (not a file) was created instead.  ..or something along those lines.

This dockerfile has the following benefits:
* `nginx-quilt.conf` is definitely on the image
* Sane defaults
* Retains capability for those defaults to be overridden by `-e VAR=VALUE`
* Reduced CLI complexity:
```bash
sudo docker run -d --name registry-nginx --env-file <quilt config> 
    --network container:registry \
    quiltdata/nginx
```

Notice the `--env-file <quilt config>` -- this is part of an overall push to enable a Quilt server to be more easily configured and deployable by our users, and a part of that is having the full configuration in one file.

It does require we  push the `quiltdata/nginx` image, but as you can see, the image is minimal.