### PR TITLE
Update flask version for security

### DIFF
--- a/registry/requirements.txt
+++ b/registry/requirements.txt
@@ -6,7 +6,7 @@ chardet==3.0.4
 click==6.7
 cookies==2.2.1
 docutils==0.14
-Flask==0.12.2
+Flask==0.12.3
 Flask-Cors==3.0.3
 Flask-JSON==0.3.2
 Flask-Mail==0.9.1


### PR DESCRIPTION
## Description

A vulnerability was found in Flask 0.12.2 and earlier. Updating the registry requirements.txt to require Flask 0.12.3.

