### PR TITLE
Link to registries at top-level docs

### DIFF
--- a/docs/SUMMARY.md
+++ b/docs/SUMMARY.md
@@ -17,6 +17,7 @@
 * [Work with packages](step-by-step.md)
 * [Articles](articles.md)
 * [Examples](examples.md)
+* [Run a Registry](registries.md)
 
 ## API
 * [Overview](api-overview.md)


### PR DESCRIPTION
## Description
Adding a link to the registries deployment doc in the table of contents.
