### PR TITLE
Hide all plan-related content when there's no Stripe key

### DIFF
--- a/catalog/app/containers/Admin/index.js
+++ b/catalog/app/containers/Admin/index.js
@@ -53,7 +53,7 @@ export default composeComponent('Admin',
   }) => (
     <div>
       <Show>
-        <h1>{formatMessage(msg.teamHeader, { name: teamName })} <Status plan={plan} /></h1>
+        <h1>{formatMessage(msg.teamHeader, { name: teamName })} {config.stripeKey ? <Status plan={plan} /> : null}</h1>
       </Show>
       <Members />
       <Packages />

--- a/catalog/app/containers/Profile/index.js
+++ b/catalog/app/containers/Profile/index.js
@@ -86,6 +86,8 @@ export class Profile extends React.PureComponent { // eslint-disable-line react/
   }
 
   maybeWarn(plan, payment) {
+    if (!config.stripeKey) return false;
+
     let error = false;
     if (plan.error) {
       console.error(printObject(plan.error)); // eslint-disable-line no-console
@@ -177,29 +179,35 @@ export class Profile extends React.PureComponent { // eslint-disable-line react/
           admin: () => <Admin plan={plan.response} location={this.props.location} />,
         })}
 
-        <Plan
-          currentPlan={plan.response}
-          email={this.props.email}
-          handleShowDialog={() => this.showDialog(true)}
-          handleUpdatePayment={this.updatePayment}
-          haveCreditCard={response.have_credit_card}
-          isAdmin={isAdmin}
-          isLoading={isLoading}
-          isWarning={isWarning}
-          locale={this.props.intl.locale}
-          planMessage={planMessage}
-        />
-        <PaymentDialog
-          currentPlan={plan.response}
-          email={this.props.email}
-          locale={this.props.intl.locale}
-          onDowngrade={this.onDowngrade}
-          onRequestClose={() => this.showDialog(false)}
-          onSelectPlan={this.onSelectPlan}
-          open={this.state.showDialog}
-          onToken={this.onToken}
-          selectedPlan={this.state.selectedPlan}
-        />
+        {config.stripeKey
+          ? (
+            <Fragment>
+              <Plan
+                currentPlan={plan.response}
+                email={this.props.email}
+                handleShowDialog={() => this.showDialog(true)}
+                handleUpdatePayment={this.updatePayment}
+                haveCreditCard={response.have_credit_card}
+                isAdmin={isAdmin}
+                isLoading={isLoading}
+                isWarning={isWarning}
+                locale={this.props.intl.locale}
+                planMessage={planMessage}
+              />
+              <PaymentDialog
+                currentPlan={plan.response}
+                email={this.props.email}
+                locale={this.props.intl.locale}
+                onDowngrade={this.onDowngrade}
+                onRequestClose={() => this.showDialog(false)}
+                onSelectPlan={this.onSelectPlan}
+                open={this.state.showDialog}
+                onToken={this.onToken}
+                selectedPlan={this.state.selectedPlan}
+              />
+            </Fragment>
+          ) : null
+        }
       </div>
     );
   }


### PR DESCRIPTION
If there's no Stripe key, it must be a private registry or an AWS marketplace deployment.
In any case, there's no point in displaying payment info when payments are not configured.