### PR TITLE
Fixes for Teams instances

### DIFF
--- a/registry/quilt_server/mail.py
+++ b/registry/quilt_server/mail.py
@@ -64,9 +64,11 @@ def send_welcome_email(user, link=None):
     needsreset = link is not None
     reseturl = '{base}/reset_password/{link}'.format(base=CATALOG_URL, link=link)
     html = render_template('welcome_email.html', team_id=TEAM_ID, team_name=TEAM_NAME,
-                           frontend=CATALOG_URL, needsreset=needsreset, reseturl=reseturl)
+                           frontend=CATALOG_URL, needsreset=needsreset, reseturl=reseturl,
+                           registry_url=REGISTRY_URL)
     body = render_template('welcome_email.txt', team_id=TEAM_ID, team_name=TEAM_NAME,
-                           frontend=CATALOG_URL, needsreset=needsreset, reseturl=reseturl)
+                           frontend=CATALOG_URL, needsreset=needsreset, reseturl=reseturl,
+                           registry_url=REGISTRY_URL)
     send_email(recipients=[user.email], sender=DEFAULT_SENDER, subject=subject,
                html=html, body=body)
 

--- a/registry/quilt_server/templates/welcome_email.html
+++ b/registry/quilt_server/templates/welcome_email.html
@@ -55,7 +55,7 @@
       <p>To get started, <a href="{{ reseturl }}">click here to set your password</a>.</p>
 {% endif %}
 {% if team_id %}
-      <p>Your team id is "{{ team_id }}". Your team data catalog is available at <a href="{{frontend}}">{{frontend}}</a>. To use Quilt on the command line, <a href="https://docs.quiltdata.com/installation.html">install Quilt</a>, then type `$ quilt config {{ team_id }}`. At the prompt, enter: <span class="code">{{ registry_url }}</span>. Login to your Quilt account by typing <span class="code">$ quilt login {{ team_id }}</span>.</p>
+      <p>Your team id is "{{ team_id }}". Your team data catalog is available at <a href="{{frontend}}">{{frontend}}</a>. To use Quilt on the command line, <a href="https://docs.quiltdata.com/installation.html">install Quilt</a>, then type <span class="code">$ quilt config {{ team_id }}</span>. At the prompt, enter: <span class="code">{{ registry_url }}</span>. Login to your Quilt account by typing <span class="code">$ quilt login {{ team_id }}</span>.</p>
 {% endif %}
       <p>
         Quilt versions, packages, and deploys data so that your workflows are fast, reproducible, and auditable. Below is a brief video to get you started.

--- a/registry/quilt_server/templates/welcome_email.html
+++ b/registry/quilt_server/templates/welcome_email.html
@@ -55,7 +55,7 @@
       <p>To get started, <a href="{{ reseturl }}">click here to set your password</a>.</p>
 {% endif %}
 {% if team_id %}
-      <p>Your team id is "{{ team_id }}". Your team data catalog is available at <a href="{{frontend}}">{{frontend}}</a>. To use Quilt on the command line, <a href="https://docs.quiltdata.com/installation.html">install Quilt</a>, then type <span class="code">$ quilt login {{ team_id }}</span>.</p>
+      <p>Your team id is "{{ team_id }}". Your team data catalog is available at <a href="{{frontend}}">{{frontend}}</a>. To use Quilt on the command line, <a href="https://docs.quiltdata.com/installation.html">install Quilt</a>, then type `$ quilt config {{ team_id }}`. At the prompt, enter: <span class="code">{{ registry_url }}</span>. Login to your Quilt account by typing <span class="code">$ quilt login {{ team_id }}</span>.</p>
 {% endif %}
       <p>
         Quilt versions, packages, and deploys data so that your workflows are fast, reproducible, and auditable. Below is a brief video to get you started.

--- a/registry/quilt_server/templates/welcome_email.txt
+++ b/registry/quilt_server/templates/welcome_email.txt
@@ -3,7 +3,7 @@ Welcome to {% if team_id %}Quilt Team Edition{% else %}Quilt{% endif %}.
 To get started, click here to set your password: {{ reseturl }}.
 {% endif %}
 {% if team_id %}
-Your team id is "{{ team_id }}". Your team data catalog is available at {{frontend}}. To use Quilt on the command line, install Quilt (https://docs.quiltdata.com/installation.html) then type `$ quilt login {{ team_id }}`.
+Your team id is "{{ team_id }}". Your team data catalog is available at {{frontend}}. To use Quilt on the command line, install Quilt (https://docs.quiltdata.com/installation.html) then type `$ quilt config {{ team_id }}`. At the prompt, enter: {{ registry_url }}. Login to your Quilt account by typing `$ quilt login {{ team_id }}`.
 {% endif %}
 Quilt versions, packages, and deploys data so that your workflows are fast, reproducible, and auditable. Here is a brief video to get you started: https://www.youtube.com/watch?v=bKIV1GUVLPc.
 {% if team_id %}

--- a/registry/quilt_server/views.py
+++ b/registry/quilt_server/views.py
@@ -2104,8 +2104,6 @@ def list_users():
     results = [{
         'username': user.name,
         'email': user.email,
-        'first_name': user.first_name,
-        'last_name': user.last_name,
         'date_joined': user.date_joined,
         'last_login': user.last_login,
         'is_superuser': user.is_admin,


### PR DESCRIPTION
## Description
### list_users
Fixing a bug in list users by removing a reference to old columns in the user table (first_name, last_name).

### Explain Config in welcome email
Welcome emails now include instructions on how to configure Quilt to point to the Teams registry.
