### PR TITLE
Avoid pytorch 1.0.1

### DIFF
--- a/compiler/setup.py
+++ b/compiler/setup.py
@@ -60,7 +60,7 @@ setup(
         # See quilt.asa.pytorch module
         'pytorch': [
             # May not install on Linux, Windows; See https://pytorch.org/
-            'torch>=0.4.0',
+            'torch>=0.4.0,<1.0.1',
         ],
         # For dev testing
         'tests': [


### PR DESCRIPTION
## Description
Pytorch 1.0.1 looks broken for python 2 (CI is failing as a result) so void installing it for now.

