### PR TITLE
Fix schemas for new endpoints

### DIFF
--- a/registry/quilt_server/schemas.py
+++ b/registry/quilt_server/schemas.py
@@ -241,9 +241,6 @@ ROLE_DETAILS_SCHEMA = {
         },
         'arn': {
             'type': 'string'
-        },
-        'id': {
-            'type': 'string'
         }
     },
     'required': ['name', 'arn'],

--- a/registry/quilt_server/views.py
+++ b/registry/quilt_server/views.py
@@ -2435,7 +2435,7 @@ def edit_role(role_id):
     return _role_dict(role)
 
 @app.route('/api/roles/<role_id>', methods=['DELETE'])
-@api(enabled=ENABLE_USER_ENDPOINTS, require_admin=True, schema=ROLE_DETAILS_SCHEMA)
+@api(enabled=ENABLE_USER_ENDPOINTS, require_admin=True)
 @as_json
 def delete_role(role_id):
     """
@@ -2454,7 +2454,7 @@ def delete_role(role_id):
     db.session.commit()
 
 @app.route('/api/roles/<role_id>', methods=['GET'])
-@api(enabled=ENABLE_USER_ENDPOINTS, require_admin=True, schema=ROLE_DETAILS_SCHEMA)
+@api(enabled=ENABLE_USER_ENDPOINTS, require_admin=True)
 @as_json
 def get_role(role_id):
     """

--- a/registry/tests/auth_test.py
+++ b/registry/tests/auth_test.py
@@ -508,6 +508,23 @@ class AuthTestCase(QuiltTestCase):
                     headers=headers
                 )
             assert role_request.status_code == 200
+            role_id = role_request.json['id']
+
+            # get role that does not exist
+            get_request = self.app.get(
+                    '/api/roles/00000000-0000-0000-0000-000000000000',
+                    headers=headers
+                )
+            assert get_request.status_code == 404
+
+            # get role we just created
+            get_request = self.app.get(
+                    '/api/roles/' + role_id,
+                    headers=headers
+                )
+            assert get_request.status_code == 200
+            assert get_request.json['name'] == 'test_role'
+            assert get_request.json['arn'] == 'asdf123'
 
             # attach role to user that does not exist
             params = {
@@ -677,13 +694,8 @@ class AuthTestCase(QuiltTestCase):
             new_role_id = json.loads(role_request.data.decode('utf-8'))['id']
 
             # delete the role
-            params = {
-                'name': 'new_test_role',
-                'arn': 'qwer456'
-            }
             delete_role_request = self.app.delete(
                     '/api/roles/' + role_id,
-                    data=json.dumps(params),
                     headers=headers
                 )
             assert delete_role_request.status_code == 200
@@ -715,6 +727,13 @@ class AuthTestCase(QuiltTestCase):
                 'content-type': 'application/json'
             }
 
+            # get the role
+            get_request = self.app.get(
+                    '/api/roles/' + role_id,
+                    headers=headers
+                )
+            assert get_request.status_code == 403
+
             # change the name
             params = {
                 'name': 'new_test_role',
@@ -740,13 +759,8 @@ class AuthTestCase(QuiltTestCase):
             assert edit_role_request.status_code == 403
 
             # delete the role
-            params = {
-                'name': 'test_role',
-                'arn': 'arn456'
-            }
             edit_role_request = self.app.delete(
                     '/api/roles/' + role_id,
-                    data=json.dumps(params),
                     headers=headers
                 )
             assert edit_role_request.status_code == 403

--- a/registry/tests/auth_test.py
+++ b/registry/tests/auth_test.py
@@ -508,7 +508,8 @@ class AuthTestCase(QuiltTestCase):
                     headers=headers
                 )
             assert role_request.status_code == 200
-            role_id = role_request.json['id']
+            results = json.loads(role_request.data.decode('utf-8'))
+            role_id = results['id']
 
             # get role that does not exist
             get_request = self.app.get(
@@ -523,8 +524,9 @@ class AuthTestCase(QuiltTestCase):
                     headers=headers
                 )
             assert get_request.status_code == 200
-            assert get_request.json['name'] == 'test_role'
-            assert get_request.json['arn'] == 'asdf123'
+            results = json.loads(get_request.data.decode('utf-8'))
+            assert results['name'] == 'test_role'
+            assert results['arn'] == 'asdf123'
 
             # attach role to user that does not exist
             params = {


### PR DESCRIPTION
Some new endpoints are broken due to schemas

Before this change, `delete_role` and `get_role` require JSON that is not necessary or relevant to their function (both should be fine with just the role_id in the URL but the schemas require extra JSON data).

Also, the 'id' property of the schema is redundant now and never used. Removing it.