### PR TITLE
Allow team-wide push to team packages

### DIFF
--- a/registry/docker-compose-dev.yml
+++ b/registry/docker-compose-dev.yml
@@ -44,5 +44,7 @@ services:
     environment:
       - REGISTRY_URL=http://localhost:5000
       - STRIPE_KEY=NOSTRIPE
+      - TEAM_ID
+      - TEAM_NAME
     ports:
       - "3000:80"

--- a/registry/quilt_server/views.py
+++ b/registry/quilt_server/views.py
@@ -681,8 +681,6 @@ def package_put(owner, package_name, package_hash=None, package_path=None):
     if not VALID_NAME_RE.match(package_name):
         raise ApiException(requests.codes.bad_request, "Invalid package name")
 
-    print("%s: %s/%s" % (g.auth.user, owner, package_name))
-
     # TODO: Description.
     data = json.loads(request.data.decode('utf-8'), object_hook=decode_node)
     dry_run = data.get('dry_run', False)
@@ -715,7 +713,7 @@ def package_put(owner, package_name, package_hash=None, package_path=None):
         .filter_by(owner=owner, name=package_name)
         .one_or_none()
     )
-   
+
     if package is None:
         if g.auth.user != owner:
             raise ApiException(requests.codes.forbidden,

--- a/registry/tests/push_install_test.py
+++ b/registry/tests/push_install_test.py
@@ -1021,6 +1021,38 @@ class PushInstallTestCase(QuiltTestCase):
 
         assert resp.status_code == requests.codes.ok
 
+        # Team push from non-owner succeeds.
+        resp = self.app.put(
+            '/api/package/test_user/foo/%s' % self.CONTENTS_HASH,
+            data=json.dumps(dict(
+                is_team=True,
+                description="",
+                contents=self.CONTENTS,
+                sizes=fake_obj_sizes(self.CONTENTS),
+            ), default=encode_node),
+            content_type='application/json',
+            headers={
+                'Authorization': 'share_with'
+            }
+        )
+
+        assert resp.status_code == requests.codes.ok
+
+        # Team push from anonymous user fails.
+        resp = self.app.put(
+            '/api/package/test_user/foo/%s' % self.CONTENTS_HASH,
+            data=json.dumps(dict(
+                is_team=True,
+                description="",
+                contents=self.CONTENTS,
+                sizes=fake_obj_sizes(self.CONTENTS),
+            ), default=encode_node),
+            content_type='application/json',
+        )
+
+        assert resp.status_code == requests.codes.unauthorized
+        
+
     @patch('quilt_server.views.ALLOW_ANONYMOUS_ACCESS', True)
     def testOldPublicParamn(self):
         # Push a package using "public" rather than "is_public".


### PR DESCRIPTION
## Description

Teams users have asked to allow non-owners to push updates to shared packages. This allows a non-owner to push to a package if the package already exists and is shared to the team.
