### PR TITLE
Implement persistent logins and refactor sessions

### DIFF
--- a/api/python/quilt3/api.py
+++ b/api/python/quilt3/api.py
@@ -11,7 +11,7 @@ import requests
 import humanize
 
 from .data_transfer import (copy_file, get_bytes, put_bytes, delete_object, list_objects,
-                            list_object_versions, _update_credentials)
+                            list_object_versions)
 from .formats import FormatRegistry
 from .packages import get_package_registry, Package
 from .session import get_registry_url, get_session

--- a/api/python/quilt3/search_util.py
+++ b/api/python/quilt3/search_util.py
@@ -10,7 +10,7 @@ from aws_requests_auth.boto_utils import BotoAWSRequestsAuth
 from aws_requests_auth.aws_auth import AWSRequestsAuth
 from elasticsearch import Elasticsearch, RequestsHttpConnection
 
-from .session import get_credentials
+from .session import create_botocore_session
 from .util import QuiltException
 
 ES_INDEX = 'drive'
@@ -22,7 +22,7 @@ def _create_es(search_endpoint, aws_region):
     """
     es_url = urlparse(search_endpoint)
 
-    credentials = get_credentials()
+    credentials = create_botocore_session().get_credentials()
     if credentials:
         # use registry-provided credentials
         creds = credentials.get_frozen_credentials()

--- a/api/python/tests/test_api.py
+++ b/api/python/tests/test_api.py
@@ -69,33 +69,6 @@ class TestAPI(QuiltTestCase):
         assert np.array_equal(data, data2)
         assert meta == meta2
 
-    @patch('quilt3.session.get_session')
-    def test_credentials_from_registry(self, get_session):
-        mock_session = Mock()
-        get_session.return_value = mock_session
-
-        mock_response = Mock()
-        mock_response.ok = True
-        mock_session.post.return_value = mock_response
-
-        mock_creds_response = Mock()
-        exp = datetime.now(timezone.utc) + timedelta(hours=2)
-        creds_data = {
-            'AccessKeyId': 'asdf',
-            'SecretAccessKey': 'asdf',
-            'SessionToken': 'asdf',
-            'Expiration': exp.isoformat()
-        }
-        mock_creds_response.json.return_value = creds_data
-        mock_session.get.return_value = mock_creds_response
-
-        he.session.set_credentials_from_registry()
-
-        credentials = he.session.get_credentials()
-        frozen_creds = credentials.get_frozen_credentials()
-        assert frozen_creds.access_key == 'asdf'
-        assert frozen_creds.secret_key == 'asdf'
-
     def test_empty_list_role(self):
         empty_list_response = { 'results': [] }
         self.requests_mock.add(responses.GET, DEFAULT_URL + '/api/roles',

--- a/api/python/tests/test_bucket.py
+++ b/api/python/tests/test_bucket.py
@@ -146,14 +146,7 @@ class TestBucket(QuiltTestCase):
         self.s3_stubber.add_response('head_object', response, params)
 
         boto_return_val = {'Payload': iter(records)}
-        patched_s3 = patch.object(
-            data_transfer.s3_client,
-            'select_object_content',
-            return_value=boto_return_val,
-            autospec=True,
-        )
-
-        with patched_s3 as patched:
+        with patch.object(self.s3_client, 'select_object_content', return_value=boto_return_val) as patched:
             bucket = Bucket('s3://test-bucket')
 
             result = bucket.select('test', 'select * from S3Object')

--- a/api/python/tests/test_data_transfer.py
+++ b/api/python/tests/test_data_transfer.py
@@ -78,25 +78,13 @@ class DataTransferTest(QuiltTestCase):
             'OutputSerialization': {'JSON': {}},
             }
         boto_return_val = {'Payload': iter(records)}
-        patched_s3 = mock.patch.object(
-            data_transfer.s3_client,
-            'select_object_content',
-            return_value=boto_return_val,
-            autospec=True,
-        )
-        with patched_s3 as patched:
+        with mock.patch.object(self.s3_client, 'select_object_content', return_value=boto_return_val) as patched:
             result = data_transfer.select('s3://foo/bar/baz.json', 'select * from S3Object')
 
             patched.assert_called_once_with(**expected_args)
             assert result.equals(expected_result)
 
-        # test no format specified
-        patched_s3 = mock.patch.object(
-            data_transfer.s3_client,
-            'select_object_content',
-            autospec=True,
-        )
-        with patched_s3:
+        with mock.patch.object(self.s3_client, 'select_object_content'):
             # No format determined.
             with pytest.raises(data_transfer.QuiltException):
                 result = data_transfer.select('s3://foo/bar/baz', 'select * from S3Object')
@@ -115,13 +103,7 @@ class DataTransferTest(QuiltTestCase):
         }
 
         boto_return_val = {'Payload': iter(records)}
-        patched_s3 = mock.patch.object(
-            data_transfer.s3_client,
-            'select_object_content',
-            return_value=boto_return_val,
-            autospec=True,
-        )
-        with patched_s3 as patched:
+        with mock.patch.object(self.s3_client, 'select_object_content', return_value=boto_return_val) as patched:
             result = data_transfer.select('s3://foo/bar/baz', 'select * from S3Object', meta={'target': 'json'})
             assert result.equals(expected_result)
             patched.assert_called_once_with(**expected_args)
@@ -139,13 +121,7 @@ class DataTransferTest(QuiltTestCase):
             'OutputSerialization': {'JSON': {}},
             }
         boto_return_val = {'Payload': iter(records)}
-        patched_s3 = mock.patch.object(
-            data_transfer.s3_client,
-            'select_object_content',
-            return_value=boto_return_val,
-            autospec=True,
-        )
-        with patched_s3 as patched:
+        with mock.patch.object(self.s3_client, 'select_object_content', return_value=boto_return_val) as patched:
             # result ignored -- returned data isn't compressed, and this has already been tested.
             data_transfer.select('s3://foo/bar/baz.json.gz', 'select * from S3Object')
             patched.assert_called_once_with(**expected_args)

--- a/api/python/tests/test_session.py
+++ b/api/python/tests/test_session.py
@@ -1,0 +1,121 @@
+"""
+Tests for login and logout.
+"""
+
+import datetime
+from unittest.mock import patch
+
+import responses
+
+import quilt3
+from .utils import QuiltTestCase
+
+
+class TestSession(QuiltTestCase):
+    @patch('quilt3.session._open_url')
+    @patch('quilt3.session.input', return_value='123456')
+    @patch('quilt3.session.login_with_token')
+    def test_login(self, mock_login_with_token, mock_input, mock_open_url):
+        quilt3.login()
+
+        url = quilt3.session.get_registry_url()
+
+        mock_open_url.assert_called_with(f'{url}/login')
+        mock_login_with_token.assert_called_with('123456')
+
+    @patch('quilt3.session._save_auth')
+    @patch('quilt3.session._save_credentials')
+    def test_login_with_token(self, mock_save_credentials, mock_save_auth):
+        url = quilt3.session.get_registry_url()
+
+        mock_auth = dict(
+            refresh_token='refresh-token',
+            access_token='access-token',
+            expires_at=123456789
+        )
+
+        self.requests_mock.add(
+            responses.POST,
+            f'{url}/api/token',
+            json=mock_auth,
+            status=200
+        )
+
+        self.requests_mock.add(
+            responses.GET,
+            f'{url}/api/auth/get_credentials',
+            json=dict(
+                AccessKeyId='access-key',
+                SecretAccessKey='secret-key',
+                SessionToken='session-token',
+                Expiration="2019-05-28T23:58:07+00:00"
+            ),
+            status=200
+        )
+
+        quilt3.session.login_with_token('123456')
+
+        mock_save_auth.assert_called_with({url: mock_auth})
+        mock_save_credentials.assert_called_with(dict(
+            access_key='access-key',
+            secret_key='secret-key',
+            token='session-token',
+            expiry_time="2019-05-28T23:58:07+00:00"
+        ))
+
+    @patch('quilt3.session._save_credentials')
+    @patch('quilt3.session._load_credentials')
+    def test_create_botocore_session(self, mock_load_credentials, mock_save_credentials):
+        def format_date(date):
+            return date.replace(tzinfo=datetime.timezone.utc, microsecond=0).isoformat()
+
+        # Test good credentials.
+        future_date = datetime.datetime.utcnow() + datetime.timedelta(hours=1)
+
+        mock_load_credentials.return_value = dict(
+            access_key='access-key',
+            secret_key='secret-key',
+            token='session-token',
+            expiry_time=format_date(future_date)
+        )
+
+        session = quilt3.session.create_botocore_session()
+        credentials = session.get_credentials()
+
+        assert credentials.access_key == 'access-key'
+        assert credentials.secret_key == 'secret-key'
+        assert credentials.token == 'session-token'
+
+        mock_save_credentials.assert_not_called()
+
+        # Test expired credentials.
+        past_date = datetime.datetime.utcnow() - datetime.timedelta(minutes=5)
+
+        mock_load_credentials.return_value = dict(
+            access_key='access-key',
+            secret_key='secret-key',
+            token='session-token',
+            expiry_time=format_date(past_date)
+        )
+
+        url = quilt3.session.get_registry_url()
+        self.requests_mock.add(
+            responses.GET,
+            f'{url}/api/auth/get_credentials',
+            json=dict(
+                AccessKeyId='access-key2',
+                SecretAccessKey='secret-key2',
+                SessionToken='session-token2',
+                Expiration=format_date(future_date)
+            ),
+            status=200
+        )
+
+        session = quilt3.session.create_botocore_session()
+        credentials = session.get_credentials()
+
+        assert credentials.access_key == 'access-key2'
+        assert credentials.secret_key == 'secret-key2'
+        assert credentials.token == 'session-token2'
+
+        mock_save_credentials.assert_called()


### PR DESCRIPTION
- Store boto credentials in a file
- Use a CredentialProvider instead of changing private variables of a boto session
- Refactor data_session to create an s3 client on demand, instead of session replacing the client when credentials change. It's slightly more expensive/annoying, but probably the correct design: data_transfer should depend on session, not the other way around. Also, theoretically, in a multithreaded program, we shouldn't replace an s3 client in the middle of an upload or download.