### PR TITLE
Require Python 3.6 or later

### DIFF
--- a/api/python/setup.py
+++ b/api/python/setup.py
@@ -4,7 +4,7 @@ import sys
 from setuptools import setup, find_packages
 from setuptools.command.install import install
 
-VERSION = "3.0.0"
+VERSION = "3.0.1"
 
 def readme():
     readme_short = """
@@ -40,8 +40,6 @@ setup(
         'Development Status :: 5 - Production/Stable',
         'Intended Audience :: Developers',
         'Operating System :: OS Independent',
-        'Programming Language :: Python',
-        'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',
     ],


### PR DESCRIPTION
## Description

Updating version number to 3.0.1 and removing support for Python2 and Python 3.5. Quilt3 only works on Python 3.6 or newer.