### PR TITLE
Clean up `quilt config`

### DIFF
--- a/api/python/quilt3/api.py
+++ b/api/python/quilt3/api.py
@@ -439,34 +439,38 @@ def config(*catalog_url, **config_values):
 
     # Use given catalog's config to replace local configuration
     if catalog_url:
+        catalog_url = catalog_url[0]
+
         config_template = read_yaml(CONFIG_TEMPLATE)
 
-        # Clean up and validate catalog url
-        catalog_url = catalog_url[0].rstrip('/')
-        if catalog_url[:7] not in ('http://', 'https:/'):
-            catalog_url = 'https://' + catalog_url
-        validate_url(catalog_url)
+        # If catalog_url is empty, reset to the default config.
 
-        # Get the new config
-        config_url = catalog_url + '/config.json'
+        if catalog_url:
+            # Clean up and validate catalog url
+            catalog_url = catalog_url.rstrip('/')
+            validate_url(catalog_url)
 
-        response = requests.get(config_url)
-        if not response.ok:
-            message = "An HTTP Error ({code}) occurred: {reason}"
-            raise QuiltException(
-                message.format(code=response.status_code, reason=response.reason),
-                response=response
-                )
-        # QuiltConfig may perform some validation and value scrubbing.
-        new_config = QuiltConfig('', response.json())
+            # Get the new config
+            config_url = catalog_url + '/config.json'
 
-        # 'navigator_url' needs to be renamed, the term is outdated.
-        if not new_config.get('navigator_url'):
-            new_config['navigator_url'] = catalog_url
+            response = requests.get(config_url)
+            if not response.ok:
+                message = "An HTTP Error ({code}) occurred: {reason}"
+                raise QuiltException(
+                    message.format(code=response.status_code, reason=response.reason),
+                    response=response
+                    )
+            # QuiltConfig may perform some validation and value scrubbing.
+            new_config = QuiltConfig('', response.json())
 
-        # Use our template + their configured values, keeping our comments.
-        for key, value in new_config.items():
-            config_template[key] = value
+            # 'navigator_url' needs to be renamed, the term is outdated.
+            if not new_config.get('navigator_url'):
+                new_config['navigator_url'] = catalog_url
+
+            # Use our template + their configured values, keeping our comments.
+            for key, value in new_config.items():
+                config_template[key] = value
+
         write_yaml(config_template, CONFIG_PATH, keep_backup=True)
         return QuiltConfig(CONFIG_PATH, config_template)
 

--- a/api/python/quilt3/main.py
+++ b/api/python/quilt3/main.py
@@ -6,7 +6,19 @@ import argparse
 import sys
 
 from . import api, session
-from .util import QuiltException
+from .util import get_from_config, QuiltException
+
+
+def cmd_config(catalog_url):
+    if catalog_url is None:
+        existing_catalog_url = get_from_config('navigator_url')
+        if existing_catalog_url is not None:
+            print(existing_catalog_url)
+        else:
+            print('<None>')
+    else:
+        api.config(catalog_url)
+
 
 def create_parser():
     parser = argparse.ArgumentParser()
@@ -26,9 +38,13 @@ def create_parser():
 
     shorthelp = "Configure Quilt"
     config_p = subparsers.add_parser("config", description=shorthelp, help=shorthelp)
-    config_p.add_argument("catalog_url", help="URL of catalog to config with",
-                          type=str, nargs="?")
-    config_p.set_defaults(func=lambda catalog_url: api.config(catalog_url))
+    config_p.add_argument(
+        "catalog_url",
+        help="URL of catalog to config with, or empty string to reset the config",
+        type=str,
+        nargs="?"
+    )
+    config_p.set_defaults(func=cmd_config)
 
     return parser
 

--- a/api/python/tests/test_api.py
+++ b/api/python/tests/test_api.py
@@ -27,11 +27,7 @@ class TestAPI(QuiltTestCase):
         mock_config = pathlib.Path('config.yml')
 
         with patch('quilt3.api.CONFIG_PATH', mock_config):
-            he.config('foo.bar')
-
-        # TODO: This seems unnecessary?
-        assert len(self.requests_mock.calls) == 1
-        assert self.requests_mock.calls[0].request.url == 'https://foo.bar/config.json'
+            he.config('https://foo.bar')
 
         yaml = YAML()
         config = yaml.load(mock_config)


### PR DESCRIPTION
- Make `quilt config` with no arguments print the current catalog URL
- Make it possible to unset the catalog URL by passing an empty value
- Remove the weird `('http://', 'https:/')` logic, and just give an error if the user didn't enter a proper URL