### PR TITLE
Set the default catalog to None and provide a helpful authentication error

### DIFF
--- a/api/python/quilt3/api.py
+++ b/api/python/quilt3/api.py
@@ -410,19 +410,19 @@ def config(*catalog_url, **config_values):
 
     To retrieve the current config, call directly, without arguments:
 
-        >>> import quilt
-        >>> quilt.config()
+        >>> import quilt3
+        >>> quilt3.config()
 
     To trigger autoconfiguration, call with just the navigator URL:
 
-        >>> quilt.config('https://example.com')
+        >>> quilt3.config('https://example.com')
 
     To set config values, call with one or more key=value pairs:
 
-        >>> quilt.config(navigator_url='http://example.com',
-        ...           elastic_search_url='http://example.com/queries')
+        >>> quilt3.config(navigator_url='http://example.com',
+        ...               elastic_search_url='http://example.com/queries')
 
-    Default config values can be found in `quilt.util.CONFIG_TEMPLATE`.
+    Default config values can be found in `quilt3.util.CONFIG_TEMPLATE`.
 
     Args:
         catalog_url: A (single) URL indicating a location to configure from

--- a/api/python/quilt3/session.py
+++ b/api/python/quilt3/session.py
@@ -169,6 +169,14 @@ def login():
 
     Launches a web browser and asks the user for a token.
     """
+    registry_url = get_registry_url()
+    if registry_url is None:
+        raise QuiltException(
+            f"You attempted to authenticate to a Quilt catalog, but your home catalog is "
+            f"currently set to None. Please first specify your home catalog by running "
+            f"\"t4.config('$URL')\", replacing '$URL' with your catalog homepage."
+        )
+
     login_url = "%s/login" % get_registry_url()
 
     print("Launching a web browser...")

--- a/api/python/quilt3/util.py
+++ b/api/python/quilt3/util.py
@@ -60,7 +60,7 @@ default_remote_registry:
 default_install_location:
 
 # Identity service URL
-registryUrl: https://quilt-t4-staging-registry.quiltdata.com
+registryUrl:
 """.format(BASE_PATH.as_uri())
 
 


### PR DESCRIPTION
This PR changes the default catalog to `None` and adds an error message explaining the need to authenticate using `t4.config` before logging in using `t4.login` (it also fixes a docstring).