### PR TITLE
Tone down QuiltConfig repr

### DIFF
--- a/api/python/quilt3/util.py
+++ b/api/python/quilt3/util.py
@@ -250,7 +250,7 @@ class QuiltConfig(OrderedDict):
 
     # TODO: Make an _html_repr_ for nicer Notebook display
     def __repr__(self):
-        return "<{} at {!r} {}>".format(type(self).__name__, str(self.filepath), json.dumps(self, indent=4))
+        return "Configured to {}".format(self['navigator_url'])
 
 
 def find_bucket_config(bucket_name, catalog_config_url):


### PR DESCRIPTION
Absent this change, `quilt3.config()` volunteers a confusing amount of information.