### PR TITLE
Bucket: Package Detail: fix showing revision message

### DIFF
--- a/catalog/app/containers/Bucket/PackageDetail.js
+++ b/catalog/app/containers/Bucket/PackageDetail.js
@@ -143,7 +143,7 @@ export default ({
                       alignItems="center"
                     >
                       <Box>
-                        <Field label="Message:">{info.commit_message || '<empty>'}</Field>
+                        <Field label="Message:">{info.message || '<empty>'}</Field>
                         <Field label="Date:">{modified.toLocaleString()}</Field>
                         <Field label="Hash:">{hash}</Field>
                       </Box>


### PR DESCRIPTION
seems like modern manifests use `message` field, not `commit_message`, so the ui wasnt picking it up. @akarve @ResidentMario should i keep checking the legacy (i guess) `commit_message` as a fallback or is it ok to just drop it?