### PR TITLE
Catalog: fix vega-lite rendering

### DIFF
--- a/catalog/app/components/Preview/loaders/Json.js
+++ b/catalog/app/components/Preview/loaders/Json.js
@@ -10,9 +10,11 @@ import * as utils from './utils'
 const MAX_SIZE = 1024 * 1024
 const SCHEMA_RE = /"\$schema":\s*"https:\/\/vega\.github\.io\/schema\/([\w-]+)\/([\w.-]+)\.json"/
 
+const map = (fn) => R.ifElse(Array.isArray, R.map(fn), fn)
+
 const signVegaSpec = ({ signer, handle }) =>
   R.evolve({
-    data: R.map(
+    data: map(
       R.evolve({
         url: (url) =>
           signer.signResource({

--- a/catalog/package-lock.json
+++ b/catalog/package-lock.json
@@ -14304,9 +14304,9 @@
       }
     },
     "vega-lite": {
-      "version": "3.2.1",
-      "resolved": "https://registry.npmjs.org/vega-lite/-/vega-lite-3.2.1.tgz",
-      "integrity": "sha512-Q8ZWodSo5Q3ovLrtqHt9nR7ooRnN9rJzT74JKDPcyGTwqV6kpqFApQxyHYfIj4s4CAZs4pGdpBQaa2M4pKVeyw==",
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/vega-lite/-/vega-lite-3.3.0.tgz",
+      "integrity": "sha512-LEfyuJK9EhnbLcs8FuSXbVl/Ks5mm/jjRY+s4zogxSv89Z7yiCNl/HTtGklJ7q0vHT8ffEsrnonIgEQxVzZegA==",
       "requires": {
         "@types/clone": "~0.1.30",
         "@types/fast-json-stable-stringify": "^2.0.0",
@@ -14317,19 +14317,9 @@
         "tslib": "~1.9.3",
         "vega-event-selector": "~2.0.0",
         "vega-expression": "~2.6.0",
-        "vega-typings": "0.6.2",
+        "vega-typings": "0.7.1",
         "vega-util": "~1.10.0",
-        "yargs": "~13.2.2"
-      },
-      "dependencies": {
-        "vega-typings": {
-          "version": "0.6.2",
-          "resolved": "https://registry.npmjs.org/vega-typings/-/vega-typings-0.6.2.tgz",
-          "integrity": "sha512-k1VBtlj+Ls8cgl1zvdUD6iX7YGsxkHSWmeG0C8DGOxKU7Q3imOCb7uUytexVjVKuWqwCrMnmNTYspelgLBMO+Q==",
-          "requires": {
-            "vega-util": "^1.10.0"
-          }
-        }
+        "yargs": "~13.2.4"
       }
     },
     "vega-loader": {

--- a/catalog/package.json
+++ b/catalog/package.json
@@ -111,7 +111,7 @@
     "uuid": "^3.3.2",
     "vega": "^5.4.0",
     "vega-embed": "^4.2.0",
-    "vega-lite": "^3.2.1",
+    "vega-lite": "^3.3.0",
     "warning": "^4.0.3"
   },
   "devDependencies": {


### PR DESCRIPTION
bump `vega-lite` to `3.3.0` (used in @ResidentMario's specs) and fix signing vega-lite data sources (vega-lite and vega specs have different constraints for the `data` field: vega expects an array and vega-lite -- just a single object, so we should support both)