### PR TITLE
Fix a prop type warning

### DIFF
--- a/catalog/app/containers/Auth/Layout.js
+++ b/catalog/app/containers/Auth/Layout.js
@@ -36,7 +36,7 @@ export const Field = composeComponent(
     errors: PT.objectOf(PT.node),
   }),
   mapProps(({ input, meta, errors, floatingLabelText: label, ...rest }) => ({
-    error: meta.submitFailed && meta.error,
+    error: meta.submitFailed && !!meta.error,
     helperText:
       meta.submitFailed && meta.error
         ? errors[meta.error] || /* istanbul ignore next */ meta.error


### PR DESCRIPTION
The `error` property is supposed to be a boolean. Fixes:
```
Failed prop type: Invalid prop `error` of type `string` supplied to `FormControl`, expected `boolean`.
```