### PR TITLE
Proxy the query string to S3

### DIFF
--- a/s3-proxy/nginx.conf
+++ b/s3-proxy/nginx.conf
@@ -57,7 +57,7 @@ http {
             }
 
             # Proxy everything else to S3.
-            proxy_pass 'https://$s3_bucket.s3.amazonaws.com/$s3_path';
+            proxy_pass 'https://$s3_bucket.s3.amazonaws.com/$s3_path$is_args$args';
 
             # Remove the auth headers from the request.
             proxy_set_header Authorization '';


### PR DESCRIPTION
The path doesn't contain the `?` or the query parameters; need to pass those separately.