### PR TITLE
Remove parso from preview lambda

### DIFF
--- a/lambdas/preview/requirements.txt
+++ b/lambdas/preview/requirements.txt
@@ -20,7 +20,6 @@ nbformat==4.4.0
 numpy==1.16.1
 pandas==0.24.1
 pandocfilters==1.4.2
-parso==0.3.4
 pexpect==4.6.0
 pickleshare==0.7.5
 prompt-toolkit==2.0.9


### PR DESCRIPTION
## Description
Removing unneeded library from the preview lambda (also avoids a security vulnerability).
