### PR TITLE
Per-bucket search

### DIFF
--- a/api/python/quilt3/__init__.py
+++ b/api/python/quilt3/__init__.py
@@ -10,7 +10,8 @@ from .api import (
     get,
     list_packages,
     config,
-    delete_package
+    delete_package,
+    search
 )
 
 from .session import login, logout

--- a/api/python/quilt3/api.py
+++ b/api/python/quilt3/api.py
@@ -511,9 +511,8 @@ def search(query, limit=10):
     default_bucket = get_from_config('defaultBucket')
     navigator_url = get_from_config('navigator_url')
     config_url = navigator_url + '/config.json'
-    search_endpoint = get_from_config('elastic_search_url')
-
-    # TODO: we can maybe get this from searchEndpoint or apiGatewayEndpoint
-    region = get_from_config('region')
+    default_config = find_bucket_config(default_bucket, config_url)
+    search_endpoint = default_config['searchEndpoint']
+    region = default_config['region']
 
     return util_search(query, search_endpoint, limit=limit, aws_region=region)

--- a/api/python/quilt3/bucket.py
+++ b/api/python/quilt3/bucket.py
@@ -69,7 +69,7 @@ class Bucket(object):
         schema = get_search_schema(self._search_endpoint, self._region)
         return schema['user_meta']
 
-    def search(self, query, limit=10, bucket=self._bucket):
+    def search(self, query, limit=10):
         """
         Execute a search against the configured search endpoint.
 
@@ -103,8 +103,8 @@ class Bucket(object):
             self.config()
         if self._region:
             return search(
-                query, self._search_endpoint, limit=limit, aws_region=self._region)
-        return search(query, self._search_endpoint, limit=limit)
+                query, self._search_endpoint, limit=limit, aws_region=self._region, bucket=self._bucket)
+        return search(query, self._search_endpoint, limit=limit, bucket=self._bucket)
 
     def deserialize(self, key):
         """

--- a/api/python/quilt3/bucket.py
+++ b/api/python/quilt3/bucket.py
@@ -69,7 +69,7 @@ class Bucket(object):
         schema = get_search_schema(self._search_endpoint, self._region)
         return schema['user_meta']
 
-    def search(self, query, limit=10):
+    def search(self, query, limit=10, bucket=self._bucket):
         """
         Execute a search against the configured search endpoint.
 

--- a/api/python/quilt3/search_util.py
+++ b/api/python/quilt3/search_util.py
@@ -13,8 +13,6 @@ from elasticsearch import Elasticsearch, RequestsHttpConnection
 from .session import create_botocore_session
 from .util import QuiltException
 
-ES_INDEX = 'drive'
-
 def _create_es(search_endpoint, aws_region):
     """
     search_endpoint: url for search endpoint
@@ -50,7 +48,11 @@ def _create_es(search_endpoint, aws_region):
 
     return es_client
 
-def search(query, search_endpoint, limit, aws_region='us-east-1'):
+def _bucket_index_name(bucket_name):
+    es_index = bucket_name if bucket_name is not None else '_all'
+    return es_index
+
+def search(query, search_endpoint, limit, aws_region='us-east-1', bucket=None):
     """
     Searches your bucket. Query may contain plaintext and clauses of the 
         form $key:"$value" that search for exact matches on specific keys.
@@ -87,7 +89,7 @@ def search(query, search_endpoint, limit, aws_region='us-east-1'):
     if limit:
         payload['size'] = limit
 
-    raw_response = es_client.search(index=ES_INDEX, body=payload)
+    raw_response = es_client.search(index=_bucket_index_name(bucket), body=payload)
 
     try:
         results = []
@@ -118,7 +120,7 @@ def search(query, search_endpoint, limit, aws_region='us-east-1'):
         setattr(exception, 'raw_response', raw_response)
         raise exception
 
-def get_raw_mapping_unpacked(endpoint, aws_region, return_full_response=False):
+def get_raw_mapping_unpacked(endpoint, aws_region, return_full_response=False, bucket=None):
     """
     Gets raw mapping from Elasticsearch
 
@@ -142,7 +144,7 @@ def get_raw_mapping_unpacked(endpoint, aws_region, return_full_response=False):
     type is one of 'long', 'text', 'keyword', etc.
     """
     es_client = _create_es(endpoint, aws_region)
-    raw_response = es_client.indices.get_mapping(index=ES_INDEX)
+    raw_response = es_client.indices.get_mapping(index=_bucket_index_name(bucket))
     if return_full_response:
         return raw_response
     return raw_response['drive']['mappings']['_doc']

--- a/api/python/quilt3/search_util.py
+++ b/api/python/quilt3/search_util.py
@@ -100,7 +100,7 @@ def search(query, search_endpoint, limit, aws_region='us-east-1', bucket=None):
             results.append({
                 'key': result['_source']['key'],
                 'version_id': result['_source']['version_id'],
-                'operation': result['_source']['type'],
+                'operation': result['_source'].get('event'),
                 'meta': json.dumps(result['_source']['user_meta']),
                 'size': str(result['_source']['size']),
                 'text': result['_source']['text'],

--- a/api/python/quilt3/search_util.py
+++ b/api/python/quilt3/search_util.py
@@ -95,18 +95,16 @@ def search(query, search_endpoint, limit, aws_region='us-east-1', bucket=None):
     raw_response = es_client.search(index=_bucket_index_name(bucket), body=payload)
 
     try:
-        results = []
-        for result in raw_response['hits']['hits']:
-            results.append({
-                'key': result['_source']['key'],
-                'version_id': result['_source']['version_id'],
-                'operation': result['_source'].get('event'),
-                'meta': json.dumps(result['_source']['user_meta']),
-                'size': str(result['_source']['size']),
-                'text': result['_source']['text'],
-                'source': result['_source'],
-                'time': str(result['_source']['updated'])
-            })
+        results = [{
+            'key': result['_source']['key'],
+            'version_id': result['_source']['version_id'],
+            'operation': result['_source'].get('event'),
+            'meta': json.dumps(result['_source']['user_meta']),
+            'size': str(result['_source']['size']),
+            'text': result['_source']['text'],
+            'source': result['_source'],
+            'time': str(result['_source']['updated'])
+            } for result in raw_response['hits']['hits']]
         results = list(sorted(results, key=lambda x: x['time'], reverse=True))
         return results
     except KeyError:

--- a/api/python/tests/test_bucket.py
+++ b/api/python/tests/test_bucket.py
@@ -314,7 +314,11 @@ class TestBucket(QuiltTestCase):
         b.search('blah', limit=1)
 
         config_mock.assert_called_once_with('navigator_url')
-        search_mock.assert_called_once_with('blah', 'https://es-fake.endpoint', limit=1, aws_region='us-meow')
+        search_mock.assert_called_once_with('blah',
+                                            'https://es-fake.endpoint',
+                                            limit=1,
+                                            aws_region='us-meow',
+                                            bucket='quilt-testing-fake')
 
     @patch('quilt3.bucket.put_bytes')
     def test_bucket_put_ext(self, put_bytes):

--- a/api/python/tests/test_search.py
+++ b/api/python/tests/test_search.py
@@ -1,9 +1,11 @@
 import json
 from unittest.mock import patch, MagicMock
 
-from quilt3 import Bucket
+from quilt3 import Bucket, search
 
 from quilt3.search_util import get_search_schema
+
+from .utils import QuiltTestCase
 
 @patch('quilt3.search_util.get_raw_mapping_unpacked')
 def test_search_schema_transform(get_raw_mapping_unpacked):
@@ -120,3 +122,43 @@ def test_bucket_search():
         results = bucket.search(query)
         assert es_mock.search.called_with('*', 'test')
         assert len(results) == 1
+
+def mock_find_bucket_config(bucket_name, catalog_config_url):
+    return dict(searchEndpoint='test',
+                region='us-east-1')
+
+class SearchTestCase(QuiltTestCase):
+
+    def test_all_bucket_search(self):
+        with patch('quilt3.search_util._create_es') as create_es_mock:
+            es_mock = MagicMock()
+            es_mock.search.return_value = {
+                'hits': {
+                    'hits': [{
+                        '_source': {
+                            'key': 'asdf',
+                            'version_id': 'asdf',
+                            'type': 'asdf',
+                            'user_meta': {},
+                            'size': 0,
+                            'text': '',
+                            'updated': '0'
+                        }
+                    }]
+                }
+            }
+            create_es_mock.return_value = es_mock
+            results = search('*')
+            assert es_mock.search.called_with('*', 'test')
+            assert len(results) == 1
+
+            query = {
+                'query': {
+                    'term': {
+                        'key': '*'
+                    }
+                }
+            }
+            results = search(query)
+            assert es_mock.search.called_with('*', 'test')
+            assert len(results) == 1

--- a/api/python/tests/utils.py
+++ b/api/python/tests/utils.py
@@ -31,6 +31,7 @@ class QuiltTestCase(TestCase):
             default_local_registry=pathlib.Path('.').resolve().as_uri() + '/local_registry',
             default_remote_registry='s3://example/',
             default_install_location=None,
+            defaultBucket='test-bucket',
             registryUrl='https://registry.example.com'
         )
 


### PR DESCRIPTION
## Description

This PR supports separate indexing for each bucket in the elastic cluster. Bucket::search is now scoped to a single bucket and there is a new top-level API function to search across all buckets indexed by the search cluster.