### PR TITLE
remove-ipywidgets-dep

### DIFF
--- a/api/python/quilt3/data_transfer.py
+++ b/api/python/quilt3/data_transfer.py
@@ -15,12 +15,8 @@ import boto3
 from boto3.s3.transfer import TransferConfig
 from s3transfer.utils import OSUtils, signal_transferring, signal_not_transferring
 
-import warnings
-with warnings.catch_warnings():
-    warnings.simplefilter("ignore")
-    from tqdm.autonotebook import tqdm
-
 import jsonlines
+from tqdm import tqdm
 
 from .session import create_botocore_session
 from .util import QuiltException, make_s3_url, parse_file_url, parse_s3_url

--- a/api/python/setup.py
+++ b/api/python/setup.py
@@ -64,8 +64,7 @@ setup(
         'tqdm>=4.26.0',
         'urllib3<1.25,>=1.21.1',            # required by requests
         'xattr>=0.9.6; platform_system!="Windows"',
-        'humanize',
-        'ipywidgets>=0.6.0'                 # required by tqdm.autonotebook
+        'humanize'
     ],
     extras_require={
         'tests': [


### PR DESCRIPTION
After conversations with @akarve and my frustrations with how, even though Quilt3 has `ipywidgets` as a dependency, progress bars aren't being rendered in JupyterLab (which I would say is the now-a-days, standard workbench). Additionally, having it as a dependency, leads to a fair bit of bloat as it causes `jupyter-core`, `ipykernals`, and etc, to be installed when you install `quilt3` which to me shouldn't really be the case imo.

This is what progress bars look like on current master / `quilt3` version `3.0.4` while using JupyterLab:
![image](https://user-images.githubusercontent.com/17132317/60612918-addea300-9d7e-11e9-8a73-73e84c4ca084.png)

This is what they will look like after this PR:
![image](https://user-images.githubusercontent.com/17132317/60612947-bcc55580-9d7e-11e9-8f24-53e15f58863e.png)