### PR TITLE
Expand JSON schemas to permit variable substitution at template-time

### DIFF
--- a/catalog/config-schema.json
+++ b/catalog/config-schema.json
@@ -96,7 +96,7 @@
     "AuthMethodConfig": {
       "type": "string",
 	  "description": "must work for actual values AND template substitution",
-      "pattern": "^((ENABLED)|(DISABLED)|(SIGN_IN_ONLY)|(\$\{\w+\}))$"
+      "pattern": "^((ENABLED)|(DISABLED)|(SIGN_IN_ONLY)|(\\$\\{\\w+\\}))$"
     }
   }
 }

--- a/catalog/config-schema.json
+++ b/catalog/config-schema.json
@@ -64,7 +64,7 @@
     },
     "ssoProviders": {
       "type": "string",
-      "pattern": "^(google)|(\\$\\{\\w+\\}))$",
+      "pattern": "^(google)|(\\$\\{\\w+\\})$",
       "description": "Space-separated list of SSO providers (must support template substitution)."
     },
     "suggestedBuckets": {
@@ -95,7 +95,7 @@
     },
     "AuthMethodConfig": {
       "type": "string",
-	  "description": "must work for actual values AND template substitution",
+	    "description": "must work for actual values AND template substitution",
       "pattern": "^((ENABLED)|(DISABLED)|(SIGN_IN_ONLY)|(\\$\\{\\w+\\}))$"
     }
   }

--- a/catalog/config-schema.json
+++ b/catalog/config-schema.json
@@ -64,8 +64,8 @@
     },
     "ssoProviders": {
       "type": "string",
-      "pattern": "^(google)?$",
-      "description": "Space-separated list of Single Sign-On providers (just 'google' for now)."
+      "pattern": "^(google)|(\\$\\{\\w+\\}))$",
+      "description": "Space-separated list of SSO providers (must support template substitution)."
     },
     "suggestedBuckets": {
       "type": "array",

--- a/catalog/config-schema.json
+++ b/catalog/config-schema.json
@@ -95,7 +95,8 @@
     },
     "AuthMethodConfig": {
       "type": "string",
-      "pattern": "^((ENABLED)|(DISABLED)|(SIGN_IN_ONLY))$"
+	  "description": "must work for actual values AND template substitution",
+      "pattern": "^((ENABLED)|(DISABLED)|(SIGN_IN_ONLY)|(\$\{\w+\}))$"
     }
   }
 }


### PR DESCRIPTION
`passwordAuth`, `ssoAuth`, and `ssoProviders` are runtime-bound, and therefore the validation expressions for these fields must support template variables of the form `${VARIABLE_NAME}`.