### PR TITLE
Tweak renovate config

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,7 +1,6 @@
 {
   "extends": [
-    "config:base",
-    "schedule:earlyMondays"
+    "config:base"
   ],
   "enabledManagers": ["npm"],
   "rangeStrategy": "bump",


### PR DESCRIPTION
Because of rate limiting (2 PRs / hour AFAIR) and limited schedule (early Mondays), renovate only does ~8 PRs per week, so we're falling behind on updates and bug fixes.

We should probably figure out a better solution, but let's catch up first.