### PR TITLE
Raise exceptions on potential S3 and Elastic calls from Indexer lambda

### DIFF
--- a/lambdas/es/indexer/index.py
+++ b/lambdas/es/indexer/index.py
@@ -185,7 +185,7 @@ class DocumentQueue:
                     # that, but if there's an error without an id we need to assume it applies to
                     # the batch.
                     send_again = self.queue
-                    print("unhandled indexer error:", error)
+                    print("unhandled indexer error (missing index field):", error)
 
             # we won't retry after this (elasticsearch might retry 429s tho)
             if send_again:


### PR DESCRIPTION
This will allow SQS/lambda to properly handle message failures.