### PR TITLE
Handle null helium metadata

### DIFF
--- a/lambdas/es/indexer/index.py
+++ b/lambdas/es/indexer/index.py
@@ -427,7 +427,7 @@ def handler(event, context):
                 if meta and "helium" in meta:
                     try:
                         decoded_helium = json.loads(meta["helium"])
-                        meta["helium"] = decoded_helium if decoded_helium else {}
+                        meta["helium"] = decoded_helium or {}
                     except (KeyError, json.JSONDecodeError):
                         print("Unable to parse Quilt 'helium' metadata", meta)
 

--- a/lambdas/es/indexer/index.py
+++ b/lambdas/es/indexer/index.py
@@ -424,11 +424,12 @@ def handler(event, context):
                     size=size
                 )
                 # decode Quilt-specific metadata
-                try:
-                    if "helium" in meta:
-                        meta["helium"] = json.loads(meta["helium"])
-                except (KeyError, json.JSONDecodeError):
-                    print("Unable to parse Quilt 'helium' metadata", meta)
+                if meta and "helium" in meta:
+                    try:
+                        decoded_helium = json.loads(meta["helium"])
+                        meta["helium"] = decoded_helium if decoded_helium else {}
+                    except (KeyError, json.JSONDecodeError):
+                        print("Unable to parse Quilt 'helium' metadata", meta)
 
                 batch_processor.append(
                     event_name,


### PR DESCRIPTION
Also only log helium errors when the helium header is present. Right now this produced ~55 million unnecessary log events