### PR TITLE
Remove "federations" from config.json and hard-code the registry endpoint

### DIFF
--- a/catalog/config-schema.json
+++ b/catalog/config-schema.json
@@ -17,11 +17,6 @@
       "type": "string",
       "description": "Default bucket users will see upon navigating to the catalog."
     },
-    "federations": {
-      "type": "array",
-      "description": "List of links to federations you want your catalog to be aware of.",
-      "items": { "$ref": "#/definitions/Url" }
-    },
     "googleClientId": {
       "type": "string",
       "description": "Client ID for Google Sign-In"
@@ -76,7 +71,6 @@
     "alwaysRequiresAuth",
     "apiGatewayEndpoint",
     "defaultBucket",
-    "federations",
     "mixpanelToken",
     "passwordAuth",
     "registryUrl",

--- a/catalog/config.json.example
+++ b/catalog/config.json.example
@@ -10,9 +10,6 @@
     "quilt-example",
     "quilt-aics"
   ],
-  "federations": [
-    "/federation.json"
-  ],
   "passwordAuth": "ENABLED",
   "ssoAuth": "SIGN_IN_ONLY",
   "ssoProviders": "google",


### PR DESCRIPTION
We're not planning on supporting any federations besides the registry endpoint, so remove the config option.