### PR TITLE
Fix a key error caused by switching text to content

### DIFF
--- a/lambdas/es/indexer/index.py
+++ b/lambdas/es/indexer/index.py
@@ -128,7 +128,7 @@ class DocumentQueue:
 
     def append_document(self, doc):
         """append well-formed documents (used for retry or by append())"""
-        if doc["text"]:
+        if doc["content"]:
             # document text dominates memory footprint; OK to neglect the
             # small fixed size for the JSON metadata
             self.size += min(doc["size"], DOC_LIMIT_BYTES)


### PR DESCRIPTION
Probably a strong signal not to use dicts and keys instead of a namedtuple/class.
