### PR TITLE
add warnings import to data_transfer.py

### DIFF
--- a/api/python/quilt3/data_transfer.py
+++ b/api/python/quilt3/data_transfer.py
@@ -7,6 +7,7 @@ import platform
 import shutil
 from threading import Lock
 from urllib.parse import quote, unquote, urlparse
+import warnings
 
 from botocore import UNSIGNED
 from botocore.client import Config


### PR DESCRIPTION
warnings was not imported in this file, which will raise an error if the warning in [this line](https://github.com/quiltdata/quilt/blob/16b3072933f3ef9fd92c57fdf4d4963749c5f322/api/python/quilt3/data_transfer.py#L196) gets triggered