### PR TITLE
Add ~/.quilt/config.yml support

### DIFF
--- a/api/python/quilt3/api.py
+++ b/api/python/quilt3/api.py
@@ -10,7 +10,7 @@ from .data_transfer import copy_file, get_bytes, put_bytes, delete_object, list_
 from .formats import FormatRegistry
 from .packages import Package
 from .search_util import search as util_search
-from .util import (QuiltConfig, QuiltException, CONFIG_PATH,
+from .util import (QuiltConfig, QuiltException, CONFIG_PATH, load_config,
                    CONFIG_TEMPLATE, find_bucket_config, fix_url, get_from_config,
                    get_package_registry, parse_file_url, parse_s3_url, read_yaml,
                    validate_url, validate_package_name, write_yaml)
@@ -465,10 +465,7 @@ def config(*catalog_url, **config_values):
         return QuiltConfig(CONFIG_PATH, config_template)
 
     # Use local configuration (or defaults)
-    if CONFIG_PATH.exists():
-        local_config = read_yaml(CONFIG_PATH)
-    else:
-        local_config = read_yaml(CONFIG_TEMPLATE)
+    local_config = load_config()
 
     # Write to config if needed
     if config_values:

--- a/api/python/quilt3/util.py
+++ b/api/python/quilt3/util.py
@@ -19,6 +19,7 @@ APP_AUTHOR = "QuiltData"
 BASE_DIR = user_data_dir(APP_NAME, APP_AUTHOR)
 BASE_PATH = pathlib.Path(BASE_DIR)
 CONFIG_PATH = BASE_PATH / 'config.yml'
+USER_CONFIG_PATH = pathlib.Path.home() / '.quilt/config.yml'
 
 PACKAGE_NAME_FORMAT = r"[\w-]+/[\w-]+$"
 
@@ -303,11 +304,12 @@ def get_package_registry(path=None):
 
 def load_config():
     # For user-facing config, use api.config()
-    if CONFIG_PATH.exists():
-        local_config = read_yaml(CONFIG_PATH)
-    else:
-        config_template = read_yaml(CONFIG_TEMPLATE)
-        local_config = config_template
+    local_config = read_yaml(CONFIG_TEMPLATE)
+
+    for file in (CONFIG_PATH, USER_CONFIG_PATH):
+        if file.exists():
+            local_config.update(read_yaml(file))
+
     return local_config
 
 def get_from_config(key):
@@ -320,7 +322,7 @@ def get_install_location():
     return loc
 
 def quiltignore_filter(paths, ignore, url_scheme):
-    """Given a list of paths, filter out the paths which are captured by the 
+    """Given a list of paths, filter out the paths which are captured by the
     given ignore rules.
 
     Args:


### PR DESCRIPTION
This makes it possible for the user to define personal configuration in
$HOME/.quilt/config.yml that won't get overwritten by quilt3.config() and
makes it possible to save only a subset of the configuration options
with those not defined defaulting to their values in CONFIG_PATH or the
config template.
