### PR TITLE
Handle gzip'ed files in the indexer. Fix misc bugs.

### DIFF
--- a/lambdas/es/indexer/index.py
+++ b/lambdas/es/indexer/index.py
@@ -8,6 +8,7 @@ from datetime import datetime
 from math import floor
 import json
 import os
+import pathlib
 from urllib.parse import unquote, unquote_plus
 
 from aws_requests_auth.aws_auth import AWSRequestsAuth
@@ -18,7 +19,7 @@ from elasticsearch.helpers import bulk
 import nbformat
 from tenacity import retry, retry_if_exception, stop_after_attempt, wait_exponential
 
-from t4_lambda_shared.preview import get_preview_lines, MAX_BYTES, MAX_LINES
+from t4_lambda_shared.preview import get_bytes, get_preview_lines, MAX_BYTES, MAX_LINES
 
 
 CONTENT_INDEX_EXTS = [
@@ -200,6 +201,12 @@ class DocumentQueue:
 
 def get_contents(bucket, key, ext, *, etag, version_id, s3_client, size):
     """get the byte contents of a file"""
+    if ext == '.gz':
+        compression = 'gz'
+        ext = pathlib.PurePosixPath(key[:-len(ext)]).suffix.lower()
+    else:
+        compression = None
+
     content = ""
     if ext in CONTENT_INDEX_EXTS:
         if ext == ".ipynb":
@@ -211,17 +218,18 @@ def get_contents(bucket, key, ext, *, etag, version_id, s3_client, size):
                     bucket,
                     key,
                     size,
+                    compression,
                     etag=etag,
                     s3_client=s3_client,
                     version_id=version_id
                 )
             )
-            content = trim_to_bytes(content)
         else:
             content = get_plain_text(
                 bucket,
                 key,
                 size,
+                compression,
                 etag=etag,
                 s3_client=s3_client,
                 version_id=version_id
@@ -259,7 +267,7 @@ def extract_text(notebook_str):
 
     return "\n".join(text)
 
-def get_notebook_cells(bucket, key, size, *, etag, s3_client, version_id):
+def get_notebook_cells(bucket, key, size, compression, *, etag, s3_client, version_id):
     """extract cells for ipynb notebooks for indexing"""
     text = ""
     try:
@@ -272,22 +280,24 @@ def get_notebook_cells(bucket, key, size, *, etag, s3_client, version_id):
             s3_client=s3_client,
             version_id=version_id
         )
-        notebook = obj["Body"].read().decode("utf-8")
-        text = extract_text(notebook)
+        data = get_bytes(obj["Body"], compression)
+        notebook = data.getvalue().decode("utf-8")
+        try:
+            text = extract_text(notebook)
+        except (json.JSONDecodeError, nbformat.reader.NotJSONError):
+            print(f"Invalid JSON in {key}.")
+        except (KeyError, AttributeError)  as err:
+            print(f"Missing key in {key}: {err}")
+        # there might be more errors than covered by test_read_notebook
+        # better not to fail altogether
+        except Exception as exc:#pylint: disable=broad-except
+            print(f"Exception in file {key}: {exc}")
     except UnicodeDecodeError as uni:
         print(f"Unicode decode error in {key}: {uni}")
-    except (json.JSONDecodeError, nbformat.reader.NotJSONError):
-        print(f"Invalid JSON in {key}.")
-    except (KeyError, AttributeError)  as err:
-        print(f"Missing key in {key}: {err}")
-    # there might be more errors than covered by test_read_notebook
-    # better not to fail altogether
-    except Exception as exc:#pylint: disable=broad-except
-        print(f"Exception in file {key}: {exc}")
 
     return text
 
-def get_plain_text(bucket, key, size, *, etag, s3_client, version_id):
+def get_plain_text(bucket, key, size, compression, *, etag, s3_client, version_id):
     """get plain text object contents"""
     text = ""
     try:
@@ -301,7 +311,7 @@ def get_plain_text(bucket, key, size, *, etag, s3_client, version_id):
             limit=MAX_BYTES,
             version_id=version_id
         )
-        lines = get_preview_lines(obj["Body"], None, MAX_LINES, MAX_BYTES)
+        lines = get_preview_lines(obj["Body"], compression, MAX_LINES, MAX_BYTES)
         text = ''.join(lines)
     except UnicodeDecodeError as ex:
         print(f"Unicode decode error in {key}", ex)
@@ -378,8 +388,8 @@ def handler(event, context):
                 version_id = event_["s3"]["object"].get("versionId")
                 version_id = unquote(version_id) if version_id else None
                 etag = unquote(event_["s3"]["object"]["eTag"])
-                _, ext = os.path.splitext(key)
-                ext = ext.lower()
+
+                ext = pathlib.PurePosixPath(key).suffix.lower()
 
                 head = retry_s3(
                     "head",
@@ -408,8 +418,6 @@ def handler(event, context):
                     )
                     continue
 
-                _, ext = os.path.splitext(key)
-                ext = ext.lower()
                 text = get_contents(
                     bucket,
                     key,
@@ -473,7 +481,7 @@ def retry_s3(
         "Bucket": bucket,
         "Key": key
     }
-    if operation == 'get' and size:
+    if operation == 'get' and size and limit:
         # can only request range if file is not empty
         arguments['Range'] = f"bytes=0-{limit}"
     if version_id:

--- a/lambdas/shared/tests/test_preview.py
+++ b/lambdas/shared/tests/test_preview.py
@@ -6,7 +6,7 @@ import os
 import pathlib
 from unittest import TestCase
 
-from t4_lambda_shared.preview import get_preview_lines
+from t4_lambda_shared.preview import get_bytes, get_preview_lines
 
 BASE_DIR = pathlib.Path(__file__).parent / 'data'
 
@@ -62,3 +62,11 @@ class TestPreview(TestCase):
             lines = get_preview_lines(iterate_chunks(file_obj, chunk_size), None, max_lines, max_bytes)
         assert len(lines) == 1, 'failed to truncate bytes'
         assert lines[0] == '🚷🚯', 'failed to truncate bytes'
+
+    def test_bytes(self):
+        txt = BASE_DIR / 'long.txt.gz'
+        with open(txt, 'rb') as file_obj:
+            buffer = get_bytes(file_obj, 'gz')
+        lines = buffer.getvalue().splitlines()
+        assert lines[0] == b'Line 1'
+        assert lines[-1] == b'Line 999'


### PR DESCRIPTION
- Refactor preview lambda's ungzip'ing code and move it into the shared preview code.
- Do a streaming decompression even if we're reading the whole file.
- Use pathlib.PurePosixPath to get file extensions.
- Remove a duplicate trim_to_bytes.
- Don't send 'Range: bytes=0-None'.
- Catch notebook exceptions only while parsing the notebook - otherwise, we can catch unrelated things.