### PR TITLE
Retry 403s when null, otherwise don't retry 403s

### DIFF
--- a/lambdas/es/indexer/index.py
+++ b/lambdas/es/indexer/index.py
@@ -49,7 +49,7 @@ TEST_EVENT = "s3:TestEvent"
 USER_AGENT_EXTRA = " quilt3-lambdas-es-indexer"
 
 # Key prefixes that can be ignored if 403 responses are returned when accessing
-FORBIDDEN_PREFIXES = tuple(filter(None, os.environ.get('FORBIDDEN_PREFIX', "").split(" ")))
+FORBIDDEN_PREFIXES = tuple(filter(None, os.environ.get('FORBIDDEN_PREFIXES', "").split(" ")))
 
 def bulk_send(elastic, list_):
     """make a bulk() call to elastic"""

--- a/lambdas/es/indexer/index.py
+++ b/lambdas/es/indexer/index.py
@@ -397,7 +397,7 @@ def handler(event, context):
 
                 ext = pathlib.PurePosixPath(key).suffix.lower()
 
-                try: 
+                try:
                     head = retry_s3(
                         "head",
                         bucket,
@@ -406,11 +406,10 @@ def handler(event, context):
                         version_id=version_id,
                         etag=etag
                     )
-                except botocore.exceptions.ClientError as exception: 
+                except botocore.exceptions.ClientError as exception:
                     # "null" version sometimes results in 403s for buckets
                     # that have changed versioning, retry without it
-
-                    if (exception.response.get('Error', {}).get('HTTPStatusCode') == 403 
+                    if (exception.response.get('Error', {}).get('HTTPStatusCode') == 403
                             and version_id == "null"):
                         head = retry_s3(
                             "head",


### PR DESCRIPTION
Not super excited about this, but would like a way to update the lambdas so we can flush the elevation tiles from the RODA queue. It's starting to backup a lot from the `log/` file 403s.