### PR TITLE
Use the binary API endpoint for thumbnails

### DIFF
--- a/catalog/app/components/Thumbnail/Thumbnail.js
+++ b/catalog/app/components/Thumbnail/Thumbnail.js
@@ -35,7 +35,7 @@ export default RT.composeComponent(
     size: 'sm',
   }),
   ({ handle, size, alt = '', ...props }) => {
-    const api = useConfig().apiGatewayEndpoint
+    const api = useConfig().binaryApiGatewayEndpoint
     const sign = AWS.Signer.useS3Signer()
     const url = React.useMemo(() => sign(handle), [handle])
     const search = mkSearch({ url, size: sizeStr(size), output: 'raw' })

--- a/catalog/config-schema.json
+++ b/catalog/config-schema.json
@@ -11,7 +11,11 @@
     },
     "apiGatewayEndpoint": {
       "type": "string",
-      "description": "Endpoint to use for previews. Should be auto-populated by your stack."
+      "description": "Endpoint to use for previews and other things. Should be auto-populated by your stack."
+    },
+    "binaryApiGatewayEndpoint": {
+      "type": "string",
+      "description": "Endpoint to use for thumbnails. Should be auto-populated by your stack."
     },
     "defaultBucket": {
       "type": "string",
@@ -79,6 +83,7 @@
   "required": [
     "alwaysRequiresAuth",
     "apiGatewayEndpoint",
+    "binaryApiGatewayEndpoint",
     "defaultBucket",
     "mixpanelToken",
     "passwordAuth",

--- a/catalog/config.json.tmpl
+++ b/catalog/config.json.tmpl
@@ -1,5 +1,6 @@
 {
     "apiGatewayEndpoint": "${API_GATEWAY}",
+    "binaryApiGatewayEndpoint": "${BINARY_API_GATEWAY}",
     "alwaysRequiresAuth": false,
     "defaultBucket": "${BUCKET_NAME}",
     "s3Proxy": "${S3_PROXY_URL}",


### PR DESCRIPTION
Binary support in API Gateway comes with too many bugs - so we will now have two API Gateways, a normal one and a binary one.