### PR TITLE
Don't send HTTP requests that are too large

### DIFF
--- a/lambdas/es/indexer/document_queue.py
+++ b/lambdas/es/indexer/document_queue.py
@@ -24,7 +24,7 @@ CONTENT_INDEX_EXTS = [
 ]
 
 # See https://amzn.to/2xJpngN for chunk size as a function of container size
-CHUNK_LIMIT_BYTES = 20_000_000
+CHUNK_LIMIT_BYTES = 9_500_000
 ELASTIC_TIMEOUT = 30
 MAX_BACKOFF = 360 #seconds
 MAX_RETRY = 4 # prevent long-running lambdas due to malformed calls


### PR DESCRIPTION
Per [AWS docs](https://docs.aws.amazon.com/elasticsearch-service/latest/developerguide/aes-limits.html#network-limits), requests to Elastic cannot exceed 10MiB for smaller containers. 