### PR TITLE
Make Athena CloudTrail queries more efficient

### DIFF
--- a/lambdas/access_counts/index.py
+++ b/lambdas/access_counts/index.py
@@ -15,13 +15,16 @@ ATHENA_DATABASE = os.environ['ATHENA_DATABASE']
 CLOUDTRAIL_BUCKET = os.environ['CLOUDTRAIL_BUCKET']
 # Bucket where query results will be stored.
 QUERY_RESULT_BUCKET = os.environ['QUERY_RESULT_BUCKET']
-# A temporary directory where Athena query results will be written.
-QUERY_TEMP_DIR = os.environ['QUERY_TEMP_DIR']
 # Directory where the summary files will be stored.
 ACCESS_COUNTS_OUTPUT_DIR = os.environ['ACCESS_COUNTS_OUTPUT_DIR']
 
+# A temporary directory where Athena query results will be written.
+QUERY_TEMP_DIR = 'AthenaQueryResults'
+
+# Pre-processed CloudTrail logs, persistent across different runs of the lambda.
 OBJECT_ACCESS_LOG_DIR = 'ObjectAccessLog'
 
+# Timestamp for the dir above.
 LAST_UPDATE_KEY = f'{OBJECT_ACCESS_LOG_DIR}.last_updated_ts.txt'
 
 

--- a/lambdas/access_counts/tests/test_access_counts.py
+++ b/lambdas/access_counts/tests/test_access_counts.py
@@ -138,6 +138,15 @@ class TestAccessCounts(TestCase):
             index.ADD_CLOUDTRAIL_PARTITION.format(account='123456', region='ng-north-1', year=2009, month=2, day=13),
         ])
 
+        self.s3_stubber.add_response(
+            method='delete_object',
+            expected_params={
+                'Bucket': 'results-bucket',
+                'Key': 'ObjectAccessLog.last_updated_ts.txt',
+            },
+            service_response={}
+        )
+
         self._run_queries([index.INSERT_INTO_OBJECT_ACCESS_LOG.format(start_ts=start_ts.timestamp(), end_ts=end_ts.timestamp())])
 
         self.s3_stubber.add_response(

--- a/lambdas/access_counts/tests/test_access_counts.py
+++ b/lambdas/access_counts/tests/test_access_counts.py
@@ -17,7 +17,6 @@ class TestAccessCounts(TestCase):
             'ATHENA_DATABASE': 'athena-db',
             'CLOUDTRAIL_BUCKET': 'cloudtrail-bucket',
             'QUERY_RESULT_BUCKET': 'results-bucket',
-            'QUERY_TEMP_DIR': 'AthenaQueryResults',
             'ACCESS_COUNTS_OUTPUT_DIR': 'AccessCounts',
         })
         self.env_patcher.start()

--- a/lambdas/access_counts/tests/test_access_counts.py
+++ b/lambdas/access_counts/tests/test_access_counts.py
@@ -1,0 +1,197 @@
+from datetime import datetime, timedelta
+from io import BytesIO
+import os
+from unittest import TestCase
+from unittest.mock import Mock, patch
+
+from botocore.stub import Stubber
+
+
+class TestAccessCounts(TestCase):
+    """Tests S3 Select"""
+    def setUp(self):
+        self.env_patcher = patch.dict(os.environ, {
+            'AWS_ACCESS_KEY_ID': 'test_key',
+            'AWS_SECRET_ACCESS_KEY': 'test_secret',
+            'AWS_DEFAULT_REGION': 'ng-north-1',
+            'ATHENA_DATABASE': 'athena-db',
+            'CLOUDTRAIL_BUCKET': 'cloudtrail-bucket',
+            'QUERY_RESULT_BUCKET': 'results-bucket',
+            'QUERY_TEMP_DIR': 'AthenaQueryResults',
+            'ACCESS_COUNTS_OUTPUT_DIR': 'AccessCounts',
+        })
+        self.env_patcher.start()
+
+        import index
+
+        self.s3_stubber = Stubber(index.s3)
+        self.s3_stubber.activate()
+
+        self.athena_stubber = Stubber(index.athena)
+        self.athena_stubber.activate()
+
+    def tearDown(self):
+        self.athena_stubber.deactivate()
+        self.s3_stubber.deactivate()
+        self.env_patcher.stop()
+
+    def _start_query(self, query, execution_id):
+        self.athena_stubber.add_response(
+            method='start_query_execution',
+            expected_params={
+                'QueryExecutionContext': {
+                    'Database': 'athena-db'
+                },
+                'QueryString': query,
+                'ResultConfiguration': {'OutputLocation': 's3://results-bucket/AthenaQueryResults/'}
+            },
+            service_response={
+                'QueryExecutionId': execution_id
+            },
+        )
+
+    def _end_query(self, execution_id=None):
+        self.athena_stubber.add_response(
+            method='get_query_execution',
+            expected_params={
+                'QueryExecutionId': execution_id
+            } if execution_id is not None else None,
+            service_response={
+                'QueryExecution': {
+                    'Status': {
+                        'State': 'SUCCEEDED'
+                    }
+                }
+            }
+        )
+
+    def test_access_counts(self):
+        import index
+
+        now = datetime.fromtimestamp(1234567890)
+        end_ts = now - timedelta(minutes=15)
+        start_ts = now - timedelta(days=1)
+
+        self.s3_stubber.add_response(
+            method='get_object',
+            expected_params={
+                'Bucket': 'results-bucket',
+                'Key': 'ObjectAccessLog.last_updated_ts.txt',
+            },
+            service_response={
+                'Body': BytesIO(str(start_ts.timestamp()).encode()),
+            }
+        )
+
+        self.s3_stubber.add_response(
+            method='list_objects_v2',
+            expected_params={
+                'Bucket': 'results-bucket',
+                'Prefix': 'AthenaQueryResults',
+                'MaxKeys': 1000,
+            },
+            service_response={}
+        )
+
+        self.s3_stubber.add_response(
+            method='list_objects_v2',
+            expected_params={
+                'Bucket': 'cloudtrail-bucket',
+                'Prefix': 'AWSLogs/',
+                'Delimiter': '/',
+            },
+            service_response={
+                'CommonPrefixes': [{
+                    'Prefix': 'AWSLogs/123456/'
+                }]
+            }
+        )
+
+        self.s3_stubber.add_response(
+            method='list_objects_v2',
+            expected_params={
+                'Bucket': 'cloudtrail-bucket',
+                'Prefix': 'AWSLogs/123456/CloudTrail/',
+                'Delimiter': '/',
+            },
+            service_response={
+                'CommonPrefixes': [{
+                    'Prefix': 'AWSLogs/123456/CloudTrail/ng-north-1/'
+                }]
+            }
+        )
+
+        for idx, table in enumerate(['cloudtrail', 'object_access_log', 'package_hashes']):
+            self._start_query(f'DROP TABLE IF EXISTS {table}', str(idx))
+
+        for _ in range(3):
+            self._end_query()
+
+        for idx, query in enumerate([index.CREATE_CLOUDTRAIL, index.CREATE_OBJECT_ACCESS_LOG, index.CREATE_PACKAGE_HASHES]):
+            self._start_query(query, str(idx))
+
+        for _ in range(3):
+            self._end_query()
+
+        for idx, query in enumerate([
+            index.REPAIR_OBJECT_ACCESS_LOG,
+            index.ADD_CLOUDTRAIL_PARTITION.format(account='123456', region='ng-north-1', year=2009, month=2, day=12),
+            index.ADD_CLOUDTRAIL_PARTITION.format(account='123456', region='ng-north-1', year=2009, month=2, day=13),
+        ]):
+            self._start_query(query, str(idx))
+
+        for _ in range(3):
+            self._end_query()
+
+        self._start_query(
+            index.INSERT_INTO_OBJECT_ACCESS_LOG.format(start_ts=start_ts.timestamp(), end_ts=end_ts.timestamp()),
+            'blah'
+        )
+
+        self._end_query('blah')
+
+        self.s3_stubber.add_response(
+            method='put_object',
+            expected_params={
+                'Bucket': 'results-bucket',
+                'Key': 'ObjectAccessLog.last_updated_ts.txt',
+                'ContentType': 'text/plain',
+                'Body': str(end_ts.timestamp()),
+            },
+            service_response={}
+        )
+
+        for idx, query in enumerate([index.OBJECT_ACCESS_COUNTS, index.PACKAGE_ACCESS_COUNTS, index.PACKAGE_VERSION_ACCESS_COUNTS,
+                                     index.BUCKET_ACCESS_COUNTS, index.EXTS_ACCESS_COUNTS]):
+            self._start_query(query, str(idx))
+
+        for _ in range(5):
+            self._end_query()
+
+        for idx, name in enumerate(['Objects', 'Packages', 'PackageVersions', 'Bucket', 'Exts']):
+            self.s3_stubber.add_response(
+                method='head_object',
+                expected_params={
+                    'Bucket': 'results-bucket',
+                    'Key': f'AthenaQueryResults/{idx}.csv',
+                },
+                service_response={
+                    'ContentLength': 123
+                }
+            )
+            self.s3_stubber.add_response(
+                method='copy_object',
+                expected_params={
+                    'CopySource': {
+                        'Bucket': 'results-bucket',
+                        'Key': f'AthenaQueryResults/{idx}.csv',
+                    },
+                    'Bucket': 'results-bucket',
+                    'Key': f'AccessCounts/{name}.csv',
+                },
+                service_response={}
+            )
+
+        with patch('index.now', return_value=now), \
+             patch('time.sleep', return_value=None):
+            index.handler(None, None)


### PR DESCRIPTION
Only scan the last 7 days of CloudTrail logs, and keep a persistent table of processed data in S3.