### PR TITLE
[WIP] Alternative package.set('KEY', object) approach with early serialization

### DIFF
--- a/api/python/tst_lspe.py
+++ b/api/python/tst_lspe.py
@@ -1,0 +1,24 @@
+import pandas as pd
+import numpy as np
+import quilt3
+
+def gen_large_dataframe(rows=1_000_000, cols=1_000_000):
+    df = pd.DataFrame(np.random.randint(0, 100, size=(rows, cols)))
+    return df
+
+if __name__ == '__main__':
+    quilt3.config("https://armand-staging.quiltdata.com")
+    # quilt3.login()
+
+    pkg = quilt3.Package()
+
+    pkg.set("myLSPEdataframe1.parquet", gen_large_dataframe(100_000, 100), write_dir="~/code/quilt/api/python/")
+    pkg.set("myLSPEdataframe2.parquet", gen_large_dataframe(100_000, 100), write_dir="~/code/quilt/api/python/")
+    pkg.set("myLSPEdataframe3.parquet", gen_large_dataframe(100_000, 100), write_dir="~/code/quilt/api/python/")
+    pkg.set("myLSPEdataframe4.parquet", gen_large_dataframe(100_000, 100), write_dir="~/code/quilt/api/python/")
+    pkg.set("myLSPEdataframe5.parquet", gen_large_dataframe(100_000, 100), write_dir="~/code/quilt/api/python/")
+
+
+    pkg.push("armand/test",
+             "s3://armand-staging-t4",
+             message="Test2")


### PR DESCRIPTION
## Description

Alternative implementation where serialization happens immediately. Trades off slower `package.set()` for a guarantee that data will not be lost between `package.set()` and `package.build()`/`package.push()`

Any discussion should take place in #1221 