### PR TITLE
Remove useless compression logic

### DIFF
--- a/api/python/setup.py
+++ b/api/python/setup.py
@@ -57,7 +57,7 @@ setup(
         'numpy>=1.14.0',                    # required by pandas, but missing from its dependencies.
         'packaging>=16.8',
         'pandas>=0.19.2',
-        'pyarrow==0.14.1',                  # as of 7/5/19: linux/circleci bugs on 0.14.0
+        'pyarrow>=0.14.1',                  # as of 7/5/19: linux/circleci bugs on 0.14.0
         'requests>=2.12.4',
         'ruamel.yaml<=0.15.70',
         'tqdm>=4.26.0',


### PR DESCRIPTION
No point in setting compression for each column individually - that's what pyarrow does already.

Fixes pyarrow 0.15