### PR TITLE
Fix a typo in the credentials logic

### DIFF
--- a/api/python/quilt3/session.py
+++ b/api/python/quilt3/session.py
@@ -34,7 +34,7 @@ def _save_auth(cfg):
         json.dump(cfg, fd)
 
 def _load_credentials():
-    if AUTH_PATH.exists():
+    if CREDENTIALS_PATH.exists():
         with open(CREDENTIALS_PATH) as fd:
             return json.load(fd)
     return {}


### PR DESCRIPTION
Causes an exception when accessing S3 if the user has never logged into the registry.