### PR TITLE
Remove Package.delete_local_file

### DIFF
--- a/api/python/quilt3/packages.py
+++ b/api/python/quilt3/packages.py
@@ -62,9 +62,9 @@ def _to_singleton(physical_keys):
 def del_if_temp(physical_key):
     """ Delete a file if the physical key points to a local file in Quilt's APP_DIR_TEMPFILE_DIR folder """
     if file_is_local(physical_key):
-        key_parent_dir = pathlib.Path(parse_file_url(urlparse(physical_key))).parent
-        if key_parent_dir == APP_DIR_TEMPFILE_DIR:
-            Package.delete_local_file(physical_key)
+        path = pathlib.Path(parse_file_url(urlparse(physical_key)))
+        if path.parent == APP_DIR_TEMPFILE_DIR:
+            path.unlink()
 
 class PackageEntry(object):
     """
@@ -430,22 +430,6 @@ class Package(object):
         else:
             raise TypeError('Invalid logical_key: %r' % logical_key)
         return path
-
-    @classmethod
-    def delete_local_file(cls, physical_key):
-        """
-        Convenience method to delete a local file using the output of `Package.get()`, a file:// URL
-        e.g. `Package.delete_local_file(pkg.get('KEY'))
-        """
-        key_is_local = urlparse(fix_url(physical_key)).scheme == 'file'
-        if not key_is_local:
-            raise QuiltException("physical_key does not point to a local file")
-        physical_key_path = pathlib.Path(parse_file_url(urlparse(physical_key)))
-        if os.path.isdir(physical_key_path):
-            raise QuiltException("physical_key points to directory, not a file")
-        if not physical_key_path.exists():
-            raise QuiltException("physical_key points to a local file that does not exist")
-        os.remove(physical_key_path)
 
     def __contains__(self, logical_key):
         """

--- a/api/python/tests/integration/test_packages.py
+++ b/api/python/tests/integration/test_packages.py
@@ -601,15 +601,6 @@ class PackageTest(QuiltTestCase):
             file_path = parse_file_url(urlparse(pkg.get(lk)))
             assert not pathlib.Path(file_path).exists(), "These temp files should have been deleted during push()"
 
-        # Test file cleanup utility
-        Package.delete_local_file(pkg.get("mydataframe1.parquet"))
-        Package.delete_local_file(pkg.get("mydataframe2.csv"))
-        Package.delete_local_file(pkg.get("mydataframe3.tsv"))
-
-        for lk in ["mydataframe1.parquet", "mydataframe2.csv", "mydataframe3.tsv"]:
-            file_path = parse_file_url(urlparse(pkg.get(lk)))
-            assert not pathlib.Path(file_path).exists(), "File should have been deleted by Package.delete_local_file"
-
 
     def test_tophash_changes(self):
         test_file = Path('test.txt')


### PR DESCRIPTION
It doesn't really make sense for it to be a part of the user API.
In our own usecase, we have a physical key, so we can assume it's local, it's not a dir, it exists, etc.