### PR TITLE
Release v3.1.2

### DIFF
--- a/api/python/setup.py
+++ b/api/python/setup.py
@@ -4,7 +4,7 @@ import sys
 from setuptools import setup, find_packages
 from setuptools.command.install import install
 
-VERSION = "3.1.1"
+VERSION = "3.1.2"
 
 def readme():
     readme_short = """


### PR DESCRIPTION
Release Notes for 3.1.1 and 3.1.2

- Added support for adding an in-memory object (such as a pandas.DataFrame) to a package via package.set()
- Fix to work with pyarrow 0.15.0
- Performance improvements for list_packages and delete_package
- Added list_package_versions function


