### PR TITLE
Make pyarrow (along with pandas and numpy) optional

### DIFF
--- a/api/python/setup.py
+++ b/api/python/setup.py
@@ -54,20 +54,24 @@ setup(
         'aws-requests-auth>=0.4.2',
         'boto3>=1.8.0',
         'jsonlines==1.2.0',
-        'numpy>=1.14.0',                    # required by pandas, but missing from its dependencies.
         'packaging>=16.8',
-        'pandas>=0.19.2',
-        'pyarrow>=0.14.1',                  # as of 7/5/19: linux/circleci bugs on 0.14.0
         'requests>=2.12.4',
         'ruamel.yaml<=0.15.70',
         'tqdm>=4.26.0',
         'urllib3<1.25,>=1.21.1',            # required by requests
         'xattr>=0.9.6; platform_system!="Windows"',
-        'humanize'
     ],
     extras_require={
+        'pyarrow': [
+            'numpy>=1.14.0',                    # required by pandas, but missing from its dependencies.
+            'pandas>=0.19.2',
+            'pyarrow>=0.14.1',                  # as of 7/5/19: linux/circleci bugs on 0.14.0
+        ],
         'tests': [
             'codecov',
+            'numpy>=1.14.0',                    # required by pandas, but missing from its dependencies.
+            'pandas>=0.19.2',
+            'pyarrow>=0.14.1',                  # as of 7/5/19: linux/circleci bugs on 0.14.0
             'pytest<5.1.0',  # TODO: Fix pytest.ensuretemp in conftest.py
             'pytest-cov',
             'responses',


### PR DESCRIPTION
Make `all_supported_formats` return a dict, since pandas might not be installed.
    
Also remove `humanize` - no longer used.