### PR TITLE
lambdas/search: stats: rm obsolete aggregation

### DIFF
--- a/lambdas/search/index.py
+++ b/lambdas/search/index.py
@@ -71,7 +71,6 @@ def lambda_handler(request):
                     "terms": {"field": 'ext'},
                     "aggs": {"size": {"sum": {"field": 'size'}}},
                 },
-                "updated": {"max": {"field": 'updated'}},
             }
         }
         size = 0

--- a/lambdas/search/tests/test_search.py
+++ b/lambdas/search/tests/test_search.py
@@ -101,7 +101,6 @@ class TestS3Select(TestCase):
                         "terms": { "field": 'ext' },
                         "aggs": { "size": { "sum": { "field": 'size' } } },
                     },
-                    "updated": { "max": { "field": 'updated' } },
                 }
             }
             return 200, {}, json.dumps({'results': 'blah'})


### PR DESCRIPTION
Remove `updated` aggregation from the `stats` action -- it's not used by the catalog anymore (per #1324)