### PR TITLE
Fix listing objects in the s3 proxy

### DIFF
--- a/s3-proxy/nginx.conf
+++ b/s3-proxy/nginx.conf
@@ -58,7 +58,7 @@ http {
 
             # Proxy everything else to S3.
             # Use $request_uri rather than $s3_path because it needs to stay encoded.
-            if ($request_uri ~ "^/[^/]+/(.*)") {
+            if ($request_uri ~ "^/[^/?]+/?(.*)") {
                 proxy_pass 'https://$s3_bucket.s3.amazonaws.com/$1';
             }
 


### PR DESCRIPTION
AWS SDK does not include a `/` after the bucket name when listing objects.
Fix the regex to not require `/`, and also stop at `?` so we don't drop the query string.

S3 server does not seem to care if the `/` is present or not. The following produce the same result:
- `https://s3.amazonaws.com/quilt-example?list-type=2`
- `https://s3.amazonaws.com/quilt-example/?list-type=2`

But of course we can't just proxy everything starting with the `/` because these are NOT the same:
- `https://s3.amazonaws.com/quilt-example/dima/q/foo%3F.txt`
- `https://s3.amazonaws.com/quilt-example//dima/q/foo%3F.txt`

Sigh.