### PR TITLE
Fix install-page-related issues

### DIFF
--- a/catalog/app/containers/App/App.js
+++ b/catalog/app/containers/App/App.js
@@ -75,7 +75,7 @@ export default function App() {
       <Switch>
         <Route path={paths.home} component={Home} exact />
 
-        <Route path={paths.install} component={Install} exact />
+        {cfg.mode !== 'OPEN' && <Route path={paths.install} component={Install} exact />}
 
         {!!cfg.legacyPackagesRedirect && (
           <Route path={paths.legacyPackages} component={LegacyPackages} />

--- a/catalog/app/website/pages/Landing/Pricing/Pricing.js
+++ b/catalog/app/website/pages/Landing/Pricing/Pricing.js
@@ -1,7 +1,9 @@
 import cx from 'classnames'
 import * as React from 'react'
+import { Link } from 'react-router-dom'
 import * as M from '@material-ui/core'
 
+import * as NamedRoutes from 'utils/NamedRoutes'
 import img2x from 'utils/img2x'
 import scrollIntoView from 'utils/scrollIntoView'
 import { useTracker } from 'utils/tracking'
@@ -32,7 +34,7 @@ const PLANS = [
     price: 600,
     features: ['Unlimited data', 'Unlimited users', 'One S3 bucket', '30-day free trial'],
     cta: 'Try Now',
-    href: '/install',
+    to: ({ urls }) => urls.install(),
     variant: 'primary',
     featured: true,
   },
@@ -54,6 +56,18 @@ const PLANS = [
     variant: 'secondary',
   },
 ]
+
+function Btn({ to, trackingName, ...rest }) {
+  const { urls } = NamedRoutes.use()
+  const t = useTracker()
+  const trackingArgs = ['WEB', { type: 'action', location: `/#${trackingName}` }]
+  const track = React.useMemo(
+    () => (to ? () => t.track(...trackingArgs) : t.trackLink(...trackingArgs)),
+    [t, to, trackingName],
+  )
+  const props = to ? { component: Link, to: to({ urls }), ...rest } : rest
+  return <M.Button onClick={track} {...props} />
+}
 
 const useStyles = M.makeStyles((t) => ({
   root: {},
@@ -157,7 +171,6 @@ const useStyles = M.makeStyles((t) => ({
 
 export default function Pricing() {
   const classes = useStyles()
-  const t = useTracker()
   return (
     <M.Box position="relative">
       <Backlight top={-320} />
@@ -203,18 +216,16 @@ export default function Pricing() {
                 ))}
               </div>
 
-              <M.Button
+              <Btn
                 variant="contained"
                 className={classes.btn}
                 color={p.variant !== 'tertiary' ? p.variant : undefined}
                 href={p.href}
-                onClick={t.trackLink('WEB', {
-                  type: 'action',
-                  location: `/#${p.trackingName}`,
-                })}
+                to={p.to}
+                trackingName={p.trackingName}
               >
                 {p.cta}
-              </M.Button>
+              </Btn>
             </div>
           ))}
         </div>

--- a/catalog/app/website/pages/Landing/Showcase/Showcase.js
+++ b/catalog/app/website/pages/Landing/Showcase/Showcase.js
@@ -1,6 +1,9 @@
 import * as React from 'react'
 import * as M from '@material-ui/core'
 
+import HashLink from 'utils/HashLink'
+import * as NamedRoutes from 'utils/NamedRoutes'
+
 import Bar from 'website/components/Bar'
 import ChevronLink from 'website/components/ChevronLink'
 import Overlay1Full from 'website/components/Backgrounds/Overlay1Full'
@@ -51,6 +54,7 @@ const useStyles = M.makeStyles((t) => ({
 
 export default function Showcase() {
   const classes = useStyles()
+  const { urls } = NamedRoutes.use()
   return (
     <div className={classes.root}>
       <Overlay2 />
@@ -84,7 +88,12 @@ export default function Showcase() {
                 Book demo
               </M.Button>
               <M.Box display="inline-block" ml={2} />
-              <M.Button variant="contained" color="secondary" href="/#pricing">
+              <M.Button
+                variant="contained"
+                color="secondary"
+                to={`${urls.home()}#pricing`}
+                component={HashLink}
+              >
                 Try now
               </M.Button>
             </M.Box>


### PR DESCRIPTION
Fix some leftover issues from #1329:

- dont show install page when in "OPEN" mode

- use react-router Link for navigating inside the app

- use HashLink for the "try now" (#pricing) btn on the landing page