### PR TITLE
Use ChunksizeAdjuster to adjust chunk size

### DIFF
--- a/api/python/tests/test_data_transfer.py
+++ b/api/python/tests/test_data_transfer.py
@@ -443,10 +443,16 @@ class DataTransferTest(QuiltTestCase):
 
 
     def test_multipart_copy(self):
-        size = 20 * 1024 * 1024
+        size = 100 * 1024 * 1024 * 1024
+
+        # size / 8MB would give us 12501 chunks - but the maximum allowed is 10000,
+        # so we should end with 16MB chunks instead.
         chunksize = 8 * 1024 * 1024
+        assert size / chunksize > 10000
+        chunksize *= 2
 
         chunks = -(-size // chunksize)
+        assert chunks <= 10000
 
         self.s3_stubber.add_response(
             method='head_object',


### PR DESCRIPTION
...because of course it's a thing.

S3 allows a maximum of 10,000 chunks - and with the default chunk size of 8MB,
we would go over that if the file is bigger than 80GB.

Boto adjusts chunk sizes to deal with that, so let's do the same.

Also adjust unit tests to use realistic file sizes (because there's also
a minimum allowed chunk size).