### PR TITLE
Catalog: expose structured data (JSON-LD)

### DIFF
--- a/catalog/app/containers/Bucket/Bucket.js
+++ b/catalog/app/containers/Bucket/Bucket.js
@@ -1,4 +1,3 @@
-import PT from 'prop-types'
 import * as R from 'ramda'
 import * as React from 'react'
 import { Link, Route, Switch, matchPath } from 'react-router-dom'
@@ -8,7 +7,7 @@ import * as M from '@material-ui/core'
 import Layout from 'components/Layout'
 import Placeholder from 'components/Placeholder'
 import { ThrowNotFound } from 'containers/NotFoundPage'
-import * as S3 from 'utils/AWS/S3'
+import * as AWS from 'utils/AWS'
 import { useCurrentBucketConfig } from 'utils/BucketConfig'
 import * as NamedRoutes from 'utils/NamedRoutes'
 import * as RT from 'utils/reactTools'
@@ -65,20 +64,17 @@ const NavTab = RT.composeComponent(
   M.Tab,
 )
 
-const BucketLayout = RT.composeComponent(
-  'Bucket.Layout',
-  RC.setPropTypes({
-    bucket: PT.string.isRequired,
-    section: PT.oneOf([...Object.keys(sections), false]),
-  }),
-  NamedRoutes.inject(),
-  M.withStyles(({ palette }) => ({
-    appBar: {
-      backgroundColor: palette.common.white,
-      color: palette.getContrastText(palette.common.white),
-    },
-  })),
-  ({ classes, bucket, section = false, children, urls }) => (
+const useStyles = M.makeStyles((t) => ({
+  appBar: {
+    backgroundColor: t.palette.common.white,
+    color: t.palette.getContrastText(t.palette.common.white),
+  },
+}))
+
+function BucketLayout({ bucket, section = false, children }) {
+  const { urls } = NamedRoutes.use()
+  const classes = useStyles()
+  return (
     <Layout
       pre={
         <>
@@ -104,8 +100,8 @@ const BucketLayout = RT.composeComponent(
         </>
       }
     />
-  ),
-)
+  )
+}
 
 export default ({
   location,
@@ -117,7 +113,7 @@ export default ({
   const bucketCfg = useCurrentBucketConfig()
   const s3Props = bucketCfg && bucketCfg.region && { region: bucketCfg.region }
   return (
-    <S3.Provider {...s3Props}>
+    <AWS.S3.Provider {...s3Props}>
       <BucketLayout bucket={bucket} section={getBucketSection(paths)(location.pathname)}>
         <Switch>
           <Route path={paths.bucketFile} component={File} exact strict />
@@ -130,6 +126,6 @@ export default ({
           <Route component={ThrowNotFound} />
         </Switch>
       </BucketLayout>
-    </S3.Provider>
+    </AWS.S3.Provider>
   )
 }

--- a/catalog/app/containers/Bucket/Overview.js
+++ b/catalog/app/containers/Bucket/Overview.js
@@ -18,6 +18,7 @@ import AsyncResult from 'utils/AsyncResult'
 import * as BucketConfig from 'utils/BucketConfig'
 import * as Config from 'utils/Config'
 import Data from 'utils/Data'
+import * as LinkedData from 'utils/LinkedData'
 import * as NamedRoutes from 'utils/NamedRoutes'
 import * as SVG from 'utils/SVG'
 import Link from 'utils/StyledLink'
@@ -1164,6 +1165,11 @@ export default function Overview({
       {AsyncResult.case({
         Ok: () => (
           <M.Box pb={{ xs: 0, sm: 4 }} mx={{ xs: -2, sm: 0 }}>
+            {!!cfg && cfg.relevance >= 0 && (
+              <React.Suspense fallback={null}>
+                <LinkedData.BucketData bucket={cfg} />
+              </React.Suspense>
+            )}
             {cfg ? (
               <Head {...{ es, s3req, bucket, overviewUrl, description }} />
             ) : (

--- a/catalog/app/containers/Bucket/requests.js
+++ b/catalog/app/containers/Bucket/requests.js
@@ -764,20 +764,27 @@ const loadRevisionHash = ({ s3req, bucket, key }) =>
     params: { Bucket: bucket, Key: key },
   }).then((res) => res.Body.toString('utf-8'))
 
-export const getRevisionData = async ({ s3req, endpoint, signer, bucket, key }) => {
+export const getRevisionData = async ({
+  s3req,
+  endpoint,
+  signer,
+  bucket,
+  key,
+  maxKeys = MAX_PACKAGE_ENTRIES,
+}) => {
   const hash = await loadRevisionHash({ s3req, bucket, key })
   const manifestKey = `${MANIFESTS_PREFIX}${hash}`
   const url = signer.getSignedS3URL({ bucket, key: manifestKey })
-  const maxLines = MAX_PACKAGE_ENTRIES + 2 // 1 for the meta and 1 for checking overflow
+  const maxLines = maxKeys + 2 // 1 for the meta and 1 for checking overflow
   const r = await fetch(
     `${endpoint}/preview?url=${encodeURIComponent(url)}&input=txt&line_count=${maxLines}`,
   )
   const [info, ...entries] = await r
     .json()
     .then((json) => json.info.data.head.map((l) => JSON.parse(l)))
-  const files = Math.min(MAX_PACKAGE_ENTRIES, entries.length)
-  const bytes = entries.slice(0, MAX_PACKAGE_ENTRIES).reduce((sum, i) => sum + i.size, 0)
-  const truncated = entries.length > MAX_PACKAGE_ENTRIES
+  const files = Math.min(maxKeys, entries.length)
+  const bytes = entries.slice(0, maxKeys).reduce((sum, i) => sum + i.size, 0)
+  const truncated = entries.length > maxKeys
   return {
     hash,
     stats: { files, bytes, truncated },

--- a/catalog/app/utils/BucketConfig.js
+++ b/catalog/app/utils/BucketConfig.js
@@ -14,10 +14,11 @@ const fetchBuckets = async ({ registryUrl }) => {
   }
   const json = JSON.parse(text)
   return json.buckets.map((b) => ({
-    ...R.omit(['icon_url', 'overview_url', 'relevance_score'], b),
+    ...R.omit(['icon_url', 'overview_url', 'relevance_score', 'schema_org'], b),
     iconUrl: b.icon_url,
     overviewUrl: b.overview_url,
     relevance: b.relevance_score,
+    linkedData: b.schema_org,
   }))
 }
 
@@ -34,6 +35,7 @@ export const useRelevantBucketConfigs = () => {
   return React.useMemo(
     () =>
       R.pipe(
+        // TODO: filter-out buckets with relevance == null?
         R.filter((b) => b.relevance == null || b.relevance >= 0),
         R.sortWith([R.descend(R.prop('relevance')), R.ascend(R.prop('name'))]),
       )(bs),

--- a/catalog/app/utils/LinkedData.js
+++ b/catalog/app/utils/LinkedData.js
@@ -1,0 +1,94 @@
+import * as React from 'react'
+import { Helmet } from 'react-helmet'
+
+import { useRelevantBucketConfigs } from 'utils/BucketConfig'
+import { useConfig } from 'utils/Config'
+import * as NamedRoutes from 'utils/NamedRoutes'
+
+const catalogRef = (name) => ({
+  '@type': 'DataCatalog',
+  name,
+  sameAs: window.location.origin,
+})
+
+const mkCatalogAnnotation = ({ name, description, buckets, urls }) => ({
+  '@context': 'https://schema.org/',
+  '@type': 'DataCatalog',
+  url: window.location.origin,
+  name,
+  description,
+  dataset: [
+    ...buckets.map((b) => ({
+      '@type': 'Dataset',
+      sameAs: window.location.origin + urls.bucketRoot(b.name),
+    })),
+    // TODO: expose packages as datasets
+  ],
+})
+
+function mkBucketAnnotation({ bucket, catalog, urls }) {
+  const ld = bucket.linkedData
+  return {
+    '@context': 'https://schema.org/',
+    '@type': 'Dataset',
+    name: (ld && ld.name) || bucket.title,
+    alternateName: bucket.name,
+    description: (ld && ld.description) || bucket.description || undefined,
+    url: window.location.origin + urls.bucketRoot(bucket.name),
+    sameAs: (ld && ld.sameAs) || undefined,
+    identifier: (ld && ld.identifier) || undefined,
+    keywords: (ld && ld.keyword) || bucket.tags || undefined,
+    creator: (ld && ld.creator) || undefined,
+    license: (ld && ld.license) || undefined,
+    // TODO: expose packages
+    // hasPart: [],
+    includedInDataCatalog: catalog ? catalogRef(catalog) : undefined,
+  }
+}
+
+/* TODO: expose packages as datasets
+// render on the package revision (tree) root page
+const mkPackageAnnotation = ({ }) => ({
+  '@context': 'https://schema.org/',
+  '@type': 'Dataset',
+  name: TODO,
+  description: TODO,
+  alternateName: 'package handle',
+  // TODO: use proper route
+  url: window.location.origin + urls.bucketPackageTree(bucket, handle, revision),
+  version: REVISION,
+  dateModified: TODO,
+  // sameAs: from rest
+  // identifier: from rest
+  keywords: [], // TODO: from dataset provider
+  // creator: from rest
+  isPartOf: {
+    '@type': 'Dataset',
+    sameAs: window.location.origin + urls.bucketRoot(bucket),
+  },
+  includedInDataCatalog: catalogRef,
+})
+*/
+
+const renderJsonLd = (ld) => (
+  <Helmet>
+    <script type="application/ld+json">{JSON.stringify(ld)}</script>
+  </Helmet>
+)
+
+export function CatalogData() {
+  const cfg = useConfig()
+  const buckets = useRelevantBucketConfigs()
+  const { urls } = NamedRoutes.use()
+  if (!cfg.linkedData || !cfg.linkedData.name) return null
+  const ld = mkCatalogAnnotation({ ...cfg.linkedData, buckets, urls })
+  return renderJsonLd(ld)
+}
+
+export function BucketData({ bucket }) {
+  const cfg = useConfig()
+  const { urls } = NamedRoutes.use()
+  if (!cfg.linkedData) return null
+  const ld = mkBucketAnnotation({ bucket, catalog: cfg.linkedData.name, urls })
+  return renderJsonLd(ld)
+}

--- a/catalog/app/website/pages/Landing/Landing.js
+++ b/catalog/app/website/pages/Landing/Landing.js
@@ -1,6 +1,7 @@
 import * as React from 'react'
 
 import * as Config from 'utils/Config'
+import * as LinkedData from 'utils/LinkedData'
 
 import Dots from 'website/components/Backgrounds/Dots'
 import Layout from 'website/components/Layout'
@@ -20,6 +21,9 @@ export default function Landing() {
   const cfg = Config.useConfig()
   return (
     <Layout>
+      <React.Suspense fallback={null}>
+        <LinkedData.CatalogData />
+      </React.Suspense>
       <Dots />
       {cfg.mode === 'PRODUCT' && <Buckets />}
       <Showcase />

--- a/catalog/app/website/pages/OpenLanding/OpenLanding.js
+++ b/catalog/app/website/pages/OpenLanding/OpenLanding.js
@@ -1,5 +1,7 @@
 import * as React from 'react'
 
+import * as LinkedData from 'utils/LinkedData'
+
 import Layout from 'website/components/Layout'
 import Contribute from 'website/components/Contribute'
 import Videos from 'website/components/Videos'
@@ -12,6 +14,9 @@ import QuiltIsDifferent from './QuiltIsDifferent'
 export default function OpenLanding() {
   return (
     <Layout>
+      <React.Suspense fallback={null}>
+        <LinkedData.CatalogData />
+      </React.Suspense>
       <Search />
       <Showcase />
       <Buckets />

--- a/catalog/config-schema.json
+++ b/catalog/config-schema.json
@@ -38,6 +38,18 @@
       "type": "string",
       "description": "Requests to /package/$owner/[$package/] will be redirected there (must not end in slash)."
     },
+    "linkedData": {
+      "description": "If present, expose structured data (JSON-LD) about the catalog and the datasets it contains",
+      "type": "object",
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "description": {
+          "type": "string"
+        }
+      }
+    },
     "mixpanelToken": {
       "type": "string",
       "description": "Token for Mixpanel analytics service"


### PR DESCRIPTION
Expose structured data (JSON-LD) for:
- catalog root (as `DataCatalog`)
- buckets (as `Dataset`s)

To enable this, add to `config.json`:
```json
  "linkedData": {
    "name": "DataCatalog name goes here",
    "description": "DataCatalog description goes here (optional)"
  },
``` 

Data for buckets is sourced from the bucket objects returned by `/api/buckets` endpoint