### PR TITLE
Fix some Windows bugs

### DIFF
--- a/api/python/quilt3/data_transfer.py
+++ b/api/python/quilt3/data_transfer.py
@@ -480,7 +480,7 @@ def delete_url(src):
         src_path = parse_file_url(src_url)
         src_file = pathlib.Path(src_path)
 
-        if _looks_like_dir(src_path):
+        if src_file.is_dir():
             try:
                 src_file.rmdir()
             except OSError:

--- a/api/python/quilt3/formats.py
+++ b/api/python/quilt3/formats.py
@@ -779,6 +779,10 @@ class CSVPandasFormatHandler(BaseFormatHandler):
 
         default_opts = copy.deepcopy(self.defaults)
 
+        # CSVs should be the same regardless of the OS.
+        # This can't be in self.defaults, though, because we don't want it when deserializing.
+        default_opts['linesep'] = '\n'
+
         # Use the default delimiter for the given extension, if no fieldsep was specified.
         if ext and 'fieldsep' not in opts:
             ext = ext.strip().lstrip('.').lower()


### PR DESCRIPTION
- Don't check if file paths end with '/'; it's only ok for URLs.
- Use '\n' when serializing to .csv, to be consistent