### PR TITLE
Drop irrelevant config fields when pulling from catalog

### DIFF
--- a/api/python/quilt3/util.py
+++ b/api/python/quilt3/util.py
@@ -62,6 +62,25 @@ registryUrl:
 telemetry_disabled: false
 """.format(BASE_PATH.as_uri() + '/packages')
 
+# When pulling the config from the catalog, don't keep fields that are not relevant for the python client
+CONFIG_FIELD_BLACKLIST = [
+    "apiGatewayEndpoint",
+    "binaryApiGatewayEndpoint",
+    "alwaysRequiresAuth",
+    "defaultBucket",
+    "s3Proxy",
+    "intercomAppId",
+    "signInRedirect",
+    "signOutRedirect",
+    "passwordAuth",
+    "ssoAuth",
+    "ssoProviders",
+    "googleClientId",
+    "sentryDSN",
+    "mixpanelToken",
+    "analyticsBucket",
+    "mode"
+]
 
 class QuiltException(Exception):
     def __init__(self, message, **kwargs):
@@ -348,12 +367,9 @@ def configure_from_url(catalog_url):
     if not new_config.get('navigator_url'):
         new_config['navigator_url'] = catalog_url
 
-    # Discard some keys that are only relevant for the catalog
-    config_keys_to_ignore = ["mixpanelToken", "sentryDSN"] # TODO: discard more
-
     # Use our template + their configured values, keeping our comments.
     for key, value in new_config.items():
-        if key in config_keys_to_ignore:
+        if key in CONFIG_FIELD_BLACKLIST:
             continue
         config_template[key] = value
     write_yaml(config_template, CONFIG_PATH, keep_backup=True)

--- a/api/python/quilt3/util.py
+++ b/api/python/quilt3/util.py
@@ -348,8 +348,13 @@ def configure_from_url(catalog_url):
     if not new_config.get('navigator_url'):
         new_config['navigator_url'] = catalog_url
 
+    # Discard some keys that are only relevant for the catalog
+    config_keys_to_ignore = ["mixpanelToken", "sentryDSN"] # TODO: discard more
+
     # Use our template + their configured values, keeping our comments.
     for key, value in new_config.items():
+        if key in config_keys_to_ignore:
+            continue
         config_template[key] = value
     write_yaml(config_template, CONFIG_PATH, keep_backup=True)
     return config_template


### PR DESCRIPTION
## TODO:

Figure out which other fields we should discard. Below are list of fields:

```
apiGatewayEndpoint: 
binaryApiGatewayEndpoint: 
alwaysRequiresAuth: 
defaultBucket: 
s3Proxy: 
intercomAppId: 
signInRedirect: 
signOutRedirect: 
passwordAuth: 
ssoAuth: 
ssoProviders: 
googleClientId: 
sentryDSN: 
mixpanelToken: 
analyticsBucket:
mode: 
```