### PR TITLE
Speed up hashing by using bigger chunks

### DIFF
--- a/api/python/quilt3/data_transfer.py
+++ b/api/python/quilt3/data_transfer.py
@@ -654,7 +654,7 @@ def calculate_sha256(src_list, sizes):
 
                 with open(path, 'rb') as fd:
                     while True:
-                        chunk = fd.read(1024)
+                        chunk = fd.read(64 * 1024)
                         if not chunk:
                             break
                         hash_obj.update(chunk)


### PR DESCRIPTION
Turns out, 1KB chunks are _really_ inefficient.

64KB appears to work pretty well. Tested two packages on my laptop:
- 1.8GB, 50170 files: 40s -> 16s
- 11GB, 1383 files: 180s -> 28s

Chunks bigger than 64KB don't make much difference.