### PR TITLE
Remove some unnecessary parsing and copying

### DIFF
--- a/api/python/quilt3/packages.py
+++ b/api/python/quilt3/packages.py
@@ -131,7 +131,7 @@ class PackageEntry(object):
         Returns:
             a PackageEntry
         """
-        self.physical_keys = [fix_url(x) for x in physical_keys]
+        self.physical_keys = physical_keys
         self.size = size
         self.hash = hash_obj
         self._meta = meta or {}


### PR DESCRIPTION
PackageEntry is more or less private API; we can assume it will be called with valid URLs.

Parsing URLs unnecessary adds quite a bit of overhead for large manifests.