### PR TITLE
Remove needed fields from blacklist

### DIFF
--- a/api/python/quilt3/util.py
+++ b/api/python/quilt3/util.py
@@ -64,11 +64,8 @@ telemetry_disabled: false
 
 # When pulling the config from the catalog, don't keep fields that are not relevant for the python client
 CONFIG_FIELD_BLACKLIST = [
-    "apiGatewayEndpoint",
-    "binaryApiGatewayEndpoint",
     "alwaysRequiresAuth",
     "defaultBucket",
-    "s3Proxy",
     "intercomAppId",
     "signInRedirect",
     "signOutRedirect",


### PR DESCRIPTION
## Description

The `quilt3 catalog` command needs info from Quilt config that was recently added to the config field blacklist. Removing those fields from the blacklist to fix catalog.