### PR TITLE
Fixed various problems with `quilt3 catalog`

### DIFF
--- a/api/python/quilt3/main.py
+++ b/api/python/quilt3/main.py
@@ -43,17 +43,14 @@ def cmd_catalog():
     command += ["-p", "3000:80", "quiltdata/catalog"]
     subprocess.Popen(command)
     print("Running a local version of the catalog at http://localhost:3000")
-    orig_stdout = sys.stdout
+
+    # app.run() generates misleading info to stderr ("Running on http://127.0.0.1:5000/") so disable stderr
     orig_stderr = sys.stderr
     try:
         f = open(os.devnull, 'w')
-        sys.stdout = f
         sys.stderr = f
         app.run()
-    except Exception:
-        pass
     finally:
-        sys.stdout = orig_stdout
         sys.stderr = orig_stderr
 
 def cmd_verify(name, registry, top_hash, dir, extra_files_ok):

--- a/api/python/quilt3/main.py
+++ b/api/python/quilt3/main.py
@@ -47,8 +47,7 @@ def cmd_catalog():
     # app.run() generates misleading info to stderr ("Running on http://127.0.0.1:5000/") so disable stderr
     orig_stderr = sys.stderr
     try:
-        f = open(os.devnull, 'w')
-        sys.stderr = f
+        sys.stderr = open(os.devnull, 'w')
         app.run()
     finally:
         sys.stderr = orig_stderr

--- a/api/python/quilt3/util.py
+++ b/api/python/quilt3/util.py
@@ -343,6 +343,20 @@ def get_package_registry(path=None):
 def configure_from_url(catalog_url):
     """ Read configuration settings from a Quilt catalog """
     config_template = read_yaml(CONFIG_TEMPLATE)
+
+    new_config = read_config_from_url(catalog_url)
+
+    # Use our template + their configured values, keeping our comments.
+    for key, value in new_config.items():
+        if key in CONFIG_FIELD_BLACKLIST:
+            continue
+        config_template[key] = value
+    write_yaml(config_template, CONFIG_PATH, keep_backup=True)
+    return config_template
+
+
+def read_config_from_url(catalog_url):
+    """ Read configuration settings from a Quilt catalog, but do not change the local config.yaml """
     # Clean up and validate catalog url
     catalog_url = catalog_url.rstrip('/')
     validate_url(catalog_url)
@@ -364,13 +378,8 @@ def configure_from_url(catalog_url):
     if not new_config.get('navigator_url'):
         new_config['navigator_url'] = catalog_url
 
-    # Use our template + their configured values, keeping our comments.
-    for key, value in new_config.items():
-        if key in CONFIG_FIELD_BLACKLIST:
-            continue
-        config_template[key] = value
-    write_yaml(config_template, CONFIG_PATH, keep_backup=True)
-    return config_template
+    return new_config
+
 
 def load_config():
     # For user-facing config, use api.config()


### PR DESCRIPTION
- Fixed bug where new users couldn't use `quilt3 catalog` because they do not have config fields such as `s3Proxy` that are relied on by catalog command.
- Added info about where the catalog will run
- Hid misleading flask output that says " Running on http://127.0.0.1:5000/ (Press CTRL+C to quit)"