### PR TITLE
Clean up config handling

### DIFF
--- a/api/python/quilt3/api.py
+++ b/api/python/quilt3/api.py
@@ -190,7 +190,7 @@ def _config(*catalog_url, **config_values):
     if catalog_url:
         catalog_url = catalog_url[0]
 
-        # If catalog_url is empty, reset to the default config.
+        # If catalog_url is empty, reset to an empty config.
         if catalog_url:
             config_template = configure_from_url(catalog_url)
         else:

--- a/api/python/quilt3/api.py
+++ b/api/python/quilt3/api.py
@@ -5,7 +5,8 @@ from .packages import Package
 from .search_util import search_api
 from .util import (QuiltConfig, QuiltException, CONFIG_PATH,
                    CONFIG_TEMPLATE, configure_from_url, fix_url,
-                   get_package_registry, read_yaml, validate_package_name, write_yaml)
+                   get_package_registry, load_config, read_yaml,
+                   validate_package_name, write_yaml)
 from .telemetry import ApiTelemetry
 
 
@@ -190,7 +191,6 @@ def _config(*catalog_url, **config_values):
         catalog_url = catalog_url[0]
 
         # If catalog_url is empty, reset to the default config.
-
         if catalog_url:
             config_template = configure_from_url(catalog_url)
         else:
@@ -199,10 +199,7 @@ def _config(*catalog_url, **config_values):
         return QuiltConfig(CONFIG_PATH, config_template)
 
     # Use local configuration (or defaults)
-    if CONFIG_PATH.exists():
-        local_config = read_yaml(CONFIG_PATH)
-    else:
-        local_config = read_yaml(CONFIG_TEMPLATE)
+    local_config = load_config()
 
     # Write to config if needed
     if config_values:

--- a/api/python/quilt3/telemetry.py
+++ b/api/python/quilt3/telemetry.py
@@ -8,7 +8,7 @@ import sys
 from threading import Lock
 import uuid
 
-from .util import load_config, set_config_value
+from .util import get_from_config, set_config_value
 from . import __version__ as quilt3_version
 
 TELEMETRY_URL = "https://telemetry.quiltdata.cloud/Prod/metrics"
@@ -53,7 +53,7 @@ class ApiTelemetry:
         Check if 'telemetry_disabled' field exists in quilt3 config. If it does, return it. If it does not exist, set
         it to default value of 'false' (to handle case of current users who predate this config field).
         """
-        config_value = load_config().get("telemetry_disabled")
+        config_value = get_from_config("telemetry_disabled")
         if config_value is not None:
             return config_value
         else:

--- a/api/python/quilt3/util.py
+++ b/api/python/quilt3/util.py
@@ -368,8 +368,9 @@ def load_config():
     if CONFIG_PATH.exists():
         local_config = read_yaml(CONFIG_PATH)
     else:
-        # This should only happen if a user deletes their local config
-        raise QuiltException("Local config not found. Run quilt3 config <URL>")
+        # This should only happen if a user deletes their local config and
+        # during test setup
+        local_config = read_yaml(CONFIG_TEMPLATE)
     return local_config
 
 def get_from_config(key):

--- a/api/python/quilt3/util.py
+++ b/api/python/quilt3/util.py
@@ -368,7 +368,8 @@ def load_config():
     if CONFIG_PATH.exists():
         local_config = read_yaml(CONFIG_PATH)
     else:
-        local_config = configure_from_url(OPEN_DATA_URL)
+        # This should only happen if a user deletes their local config
+        raise QuiltException("Local config not found. Run quilt3 config <URL>")
     return local_config
 
 def get_from_config(key):

--- a/api/python/quilt3/util.py
+++ b/api/python/quilt3/util.py
@@ -360,10 +360,23 @@ def configure_from_url(catalog_url):
     write_yaml(config_template, CONFIG_PATH, keep_backup=True)
     return config_template
 
+def configure_from_default():
+    """
+    Configure to the default (public) Quilt stack if no
+    current config exists. If reading the public stack fails,
+    warn the user and save an empty template.
+    """
+    if not CONFIG_PATH.exists():
+        try:
+            configure_from_url(OPEN_DATA_URL)
+        except requests.exceptions.ConnectionError:
+            config_template = read_yaml(CONFIG_TEMPLATE)
+            write_yaml(config_template, CONFIG_PATH, keep_backup=True)
+
 def load_config():
     """
-    Read the local config if one exists, else build one from
-    the default stack (OPEN_DATA_URL)
+    Read the local config if one exists, else return an
+    empty config based on CONFIG_TEMPLATE.
     """
     if CONFIG_PATH.exists():
         local_config = read_yaml(CONFIG_PATH)
@@ -384,14 +397,9 @@ def get_install_location():
 
 def set_config_value(key, value):
     # Use local configuration (or defaults)
-    if CONFIG_PATH.exists():
-        local_config = read_yaml(CONFIG_PATH)
-    else:
-        local_config = read_yaml(CONFIG_TEMPLATE)
-
+    local_config = load_config()
     local_config[key] = value
     write_yaml(local_config, CONFIG_PATH)
-
 
 def quiltignore_filter(paths, ignore, url_scheme):
     """Given a list of paths, filter out the paths which are captured by the 

--- a/api/python/setup.py
+++ b/api/python/setup.py
@@ -22,9 +22,8 @@ def readme():
 
 def default_config():
     """Configure to the default (public) Quilt stack"""
-    from quilt3 import api
-    from quilt3.util import OPEN_DATA_URL
-    api.config(OPEN_DATA_URL)
+    from quilt3.util import configure_from_default
+    configure_from_default()
 
 
 class PostDevelopCommand(develop):
@@ -34,7 +33,7 @@ class PostDevelopCommand(develop):
     def run(self):
         default_config()
         develop.run(self)
-        
+
 
 class PostInstallCommand(install):
     """ Post install hook """

--- a/api/python/setup.py
+++ b/api/python/setup.py
@@ -5,6 +5,7 @@ from pathlib import Path
 
 from setuptools import setup, find_packages
 from setuptools.command.install import install
+from setuptools.command.develop import develop
 
 VERSION = Path(Path(__file__).parent, "quilt3", "VERSION").read_text()
 
@@ -18,6 +19,31 @@ def readme():
 
     """
     return readme_short
+
+def default_config():
+    """Configure to the default (public) Quilt stack"""
+    from quilt3 import api
+    from quilt3.util import OPEN_DATA_URL
+    api.config(OPEN_DATA_URL)
+
+
+class PostDevelopCommand(develop):
+    """ Post install hook for development installs """
+    description = 'Setup default configuration'
+
+    def run(self):
+        default_config()
+        develop.run(self)
+        
+
+class PostInstallCommand(install):
+    """ Post install hook """
+    description = 'Setup default configuration'
+
+    def run(self):
+        default_config()
+        install.run(self)
+
 
 class VerifyVersionCommand(install):
     """Custom command to verify that the git tag matches our version"""
@@ -69,15 +95,15 @@ setup(
     ],
     extras_require={
         'pyarrow': [
-            'numpy>=1.14.0',                    # required by pandas, but missing from its dependencies.
+            'numpy>=1.14.0',                # required by pandas, but missing from its dependencies.
             'pandas>=0.19.2',
-            'pyarrow>=0.14.1',                  # as of 7/5/19: linux/circleci bugs on 0.14.0
+            'pyarrow>=0.14.1',              # as of 7/5/19: linux/circleci bugs on 0.14.0
         ],
         'tests': [
             'codecov',
-            'numpy>=1.14.0',                    # required by pandas, but missing from its dependencies.
+            'numpy>=1.14.0',                # required by pandas, but missing from its dependencies.
             'pandas>=0.19.2',
-            'pyarrow>=0.14.1',                  # as of 7/5/19: linux/circleci bugs on 0.14.0
+            'pyarrow>=0.14.1',              # as of 7/5/19: linux/circleci bugs on 0.14.0
             'pytest<5.1.0',  # TODO: Fix pytest.ensuretemp in conftest.py
             'pytest-cov',
             'responses',
@@ -92,5 +118,7 @@ setup(
     },
     cmdclass={
         'verify': VerifyVersionCommand,
+        'install': PostInstallCommand,
+        'develop': PostDevelopCommand,
     }
 )

--- a/api/python/tests/test_api.py
+++ b/api/python/tests/test_api.py
@@ -17,9 +17,10 @@ class TestAPI(QuiltTestCase):
     def test_config(self):
         content = {
             'navigator_url': 'https://foo.bar',
-            'elastic_search_url': 'https://es.foo',
-            'accept_invalid_config_keys': 'yup',
-            'telemetry_disabled': False
+            'telemetry_disabled': False,
+            's3Proxy': None,
+            'apiGatewayEndpoint': None,
+            'binaryApiGatewayEndpoint': None
         }
         self.requests_mock.add(responses.GET, 'https://foo.bar/config.json', json=content, status=200)
 

--- a/api/python/tests/utils.py
+++ b/api/python/tests/utils.py
@@ -27,13 +27,14 @@ class QuiltTestCase(TestCase):
 
         quilt3.config(
             navigator_url='https://example.com',
-            elastic_search_url='https://es.example.com/',
             apiGatewayEndpoint='https://xyz.execute-api.us-east-1.amazonaws.com/prod',
+            binaryApiGatewayEndpoint='https://xyz.execute-api.us-east-1.amazonaws.com/prod',
             default_local_registry=pathlib.Path('.').resolve().as_uri() + '/local_registry',
             default_remote_registry='s3://example/',
             default_install_location=None,
             defaultBucket='test-bucket',
-            registryUrl='https://registry.example.com'
+            registryUrl='https://registry.example.com',
+            s3Proxy='open-s3-proxy.quiltdata.com'
         )
 
         self.requests_mock = responses.RequestsMock(assert_all_requests_are_fired=False)


### PR DESCRIPTION
## Clean up config handling
Use CONFIG_TEMPLATE as a config-field whitelist (and remove the blacklist).

Create a default config from the OPEN_DATA_REGISTRY as a post-install step. Config loading is now side-effect free and won't risk overwriting user options.
