### PR TITLE
Use a single physical key in PackageEntry

### DIFF
--- a/api/python/quilt3/packages.py
+++ b/api/python/quilt3/packages.py
@@ -294,6 +294,13 @@ class PackageEntry(object):
     def with_physical_key(self, key):
         return self.__class__(key, self.size, self.hash, self._meta)
 
+    @property
+    def physical_keys(self):
+        """
+        Deprecated
+        """
+        return [self.physical_key]
+
 
 class Package(object):
     """ In-memory representation of a package """

--- a/api/python/quilt3/packages.py
+++ b/api/python/quilt3/packages.py
@@ -38,27 +38,6 @@ def hash_file(readable_file):
 
     return hasher.hexdigest()
 
-def _to_singleton(physical_keys):
-    """
-    Ensure that there is a single physical key, throw otherwise.
-    Temporary utility method to avoid repeated, identical checks.
-
-    Args:
-        pkeys (list): list of physical keys
-    Returns:
-        A physical key
-
-    Throws:
-        NotImplementedError
-
-    TODO:
-        support multiple physical keys
-    """
-    if len(physical_keys) > 1:
-        raise NotImplementedError("Multiple physical keys not supported")
-
-    return physical_keys[0]
-
 
 def _delete_local_physical_key(pk):
     assert file_is_local(pk), "This function only works on files that live on a local disk"
@@ -115,13 +94,13 @@ class PackageEntry(object):
     """
     Represents an entry at a logical key inside a package.
     """
-    __slots__ = ['physical_keys', 'size', 'hash', '_meta']
-    def __init__(self, physical_keys, size, hash_obj, meta):
+    __slots__ = ['physical_key', 'size', 'hash', '_meta']
+    def __init__(self, physical_key, size, hash_obj, meta):
         """
         Creates an entry.
 
         Args:
-            physical_keys: a nonempty list of URIs (either `s3://` or `file://`)
+            physical_key: a URI (either `s3://` or `file://`)
             size(number): size of object in bytes
             hash({'type': string, 'value': string}): hash object
                 for example: {'type': 'SHA256', 'value': 'bb08a...'}
@@ -130,7 +109,7 @@ class PackageEntry(object):
         Returns:
             a PackageEntry
         """
-        self.physical_keys = physical_keys
+        self.physical_key = physical_key
         self.size = size
         self.hash = hash_obj
         self._meta = meta or {}
@@ -144,14 +123,14 @@ class PackageEntry(object):
         )
 
     def __repr__(self):
-        return f"PackageEntry('{self.physical_keys[0]}')"
+        return f"PackageEntry('{self.physical_key}')"
 
     def as_dict(self):
         """
         Returns dict representation of entry.
         """
         return {
-            'physical_keys': self.physical_keys,
+            'physical_keys': [self.physical_key],
             'size': self.size,
             'hash': self.hash,
             'meta': self._meta
@@ -195,7 +174,7 @@ class PackageEntry(object):
             self
         """
         if path is not None:
-            self.physical_keys = [fix_url(path)]
+            self.physical_key = fix_url(path)
             self.size = None
             self.hash = None
         elif meta is not None:
@@ -207,15 +186,14 @@ class PackageEntry(object):
         """
         Returns the physical key of this PackageEntry.
         """
-        return _to_singleton(self.physical_keys)
+        return self.physical_key
 
     def get_cached_path(self):
         """
         Returns a locally cached physical key, if available.
         """
-        physical_key = _to_singleton(self.physical_keys)
-        if not file_is_local(physical_key):
-            return ObjectPathCache.get(physical_key)
+        if not file_is_local(self.physical_key):
+            return ObjectPathCache.get(self.physical_key)
         return None
 
     def get_bytes(self, use_cache_if_available=True):
@@ -228,8 +206,7 @@ class PackageEntry(object):
             if cached_path is not None:
                 return get_bytes(pathlib.Path(cached_path).as_uri())
 
-        physical_key = _to_singleton(self.physical_keys)
-        data = get_bytes(physical_key)
+        data = get_bytes(self.physical_key)
         return data
 
     def get_as_json(self, use_cache_if_available=True):
@@ -269,13 +246,12 @@ class PackageEntry(object):
             hash verification fail
             when deserialization metadata is not present
         """
-        physical_key = _to_singleton(self.physical_keys)
-        data = get_bytes(physical_key)
+        data = get_bytes(self.physical_key)
 
         if func is not None:
             return func(data)
 
-        pkey_ext = pathlib.PurePosixPath(unquote(urlparse(physical_key).path)).suffix
+        pkey_ext = pathlib.PurePosixPath(unquote(urlparse(self.physical_key).path)).suffix
 
         # Verify format can be handled before checking hash.  Raises if none found.
         formats = FormatRegistry.search(None, self._meta, pkey_ext)
@@ -296,19 +272,17 @@ class PackageEntry(object):
         Returns:
             None
         """
-        physical_key = _to_singleton(self.physical_keys)
-
         if dest is None:
-            name = pathlib.PurePosixPath(unquote(urlparse(physical_key).path)).name
+            name = pathlib.PurePosixPath(unquote(urlparse(self.physical_key).path)).name
             dest = (pathlib.Path().resolve() / name).as_uri()
         else:
             dest = fix_url(dest)
 
-        copy_file(physical_key, dest)
+        copy_file(self.physical_key, dest)
 
         # return a package reroot package physical keys after the copy operation succeeds
         # see GH#388 for context
-        return self.with_physical_keys([dest])
+        return self.with_physical_key(dest)
 
 
     def __call__(self, func=None, **kwargs):
@@ -317,8 +291,8 @@ class PackageEntry(object):
         """
         return self.deserialize(func=func, **kwargs)
 
-    def with_physical_keys(self, keys):
-        return self.__class__(keys, self.size, self.hash, self._meta)
+    def with_physical_key(self, key):
+        return self.__class__(key, self.size, self.hash, self._meta)
 
 
 class Package(object):
@@ -346,7 +320,7 @@ class Package(object):
                 has_remote_entries = any(
                     self._map(
                         lambda lk, entry: urlparse(
-                            fix_url(_to_singleton(entry.physical_keys))
+                            fix_url(entry.physical_key)
                         ).scheme != 'file'
                     )
                 )
@@ -594,14 +568,14 @@ class Package(object):
         pkg = Package()
 
         for logical_key, entry in self.walk():
-            physical_key = _to_singleton(entry.physical_keys)
+            physical_key = entry.physical_key
             new_physical_key = f'{nice_dest}/{quote(logical_key)}'
 
             file_list.append((physical_key, new_physical_key, entry.size))
 
             # return a package reroot package physical keys after the copy operation succeeds
             # see GH#388 for context
-            new_entry = entry.with_physical_keys([new_physical_key])
+            new_entry = entry.with_physical_key(new_physical_key)
             pkg._set(logical_key, new_entry)
 
         copy_file_list(file_list)
@@ -684,7 +658,7 @@ class Package(object):
             if key in subpkg._children:
                 raise PackageException("Duplicate logical key while loading package")
             subpkg._children[key] = PackageEntry(
-                obj['physical_keys'],
+                obj['physical_keys'][0],
                 obj['size'],
                 obj['hash'],
                 obj['meta']
@@ -742,7 +716,7 @@ class Package(object):
             for f in files:
                 if not f.is_file():
                     continue
-                entry = PackageEntry([f.as_uri()], f.stat().st_size, None, None)
+                entry = PackageEntry(f.as_uri(), f.stat().st_size, None, None)
                 logical_key = f.relative_to(src_path).as_posix()
                 root._set(logical_key, entry)
         elif url.scheme == 's3':
@@ -761,7 +735,7 @@ class Package(object):
                         warnings.warn(f'Logical keys cannot end in "/", skipping: {obj["Key"]}')
                     continue
                 obj_url = make_s3_url(src_bucket, obj['Key'], obj.get('VersionId'))
-                entry = PackageEntry([obj_url], obj['Size'], None, None)
+                entry = PackageEntry(obj_url, obj['Size'], None, None)
                 logical_key = obj['Key'][len(src_key):]
                 root._set(logical_key, entry)
         else:
@@ -822,7 +796,7 @@ class Package(object):
         physical_keys = []
         sizes = []
         for entry in entries:
-            physical_keys.append(entry.physical_keys[0])
+            physical_keys.append(entry.physical_key)
             sizes.append(entry.size)
 
         results = calculate_sha256(physical_keys, sizes)
@@ -991,7 +965,7 @@ class Package(object):
                 bucket, key, current_version = parse_s3_url(parsed_url)
                 if not current_version and version:
                     url = make_s3_url(bucket, key, version)
-            entry = PackageEntry([url], size, None, None)
+            entry = PackageEntry(url, size, None, None)
         elif isinstance(entry, PackageEntry):
             assert meta is None
 
@@ -1044,7 +1018,7 @@ class Package(object):
 
             size = serialization_path.stat().st_size
             write_url = serialization_path.as_uri()
-            entry = PackageEntry([write_url], size, hash_obj=None, meta=new_meta)
+            entry = PackageEntry(write_url, size, hash_obj=None, meta=new_meta)
 
         else:
             raise TypeError(f"Expected a string for entry, but got an instance of {type(entry)}.")
@@ -1114,7 +1088,7 @@ class Package(object):
         for logical_key, entry in self.walk():
             if entry.hash is None or entry.size is None:
                 raise QuiltException(
-                    "PackageEntry missing hash and/or size: %s" % entry.physical_keys[0]
+                    "PackageEntry missing hash and/or size: %s" % entry.physical_key
                 )
             entry_dict = entry.as_dict()
             entry_dict['logical_key'] = logical_key
@@ -1147,7 +1121,7 @@ class Package(object):
 
 
                          Note that push is careful to not push data unnecessarily. To illustrate, imagine you have a
-                         PackageEntry: `pkg["entry_1"].physical_keys = ["/tmp/package_entry_1.json"]`
+                         PackageEntry: `pkg["entry_1"].physical_key = "/tmp/package_entry_1.json"`
 
                          If that entry would be pushed to s3://bucket/prefix/entry_1.json, but
                          s3://bucket/prefix/entry_1.json already contains the exact same bytes as
@@ -1223,7 +1197,7 @@ class Package(object):
                 return False
             return pathlib.Path(parse_file_url(urlparse(pk))).parent == APP_DIR_TEMPFILE_DIR
 
-        temp_file_logical_keys = [lk for lk, entry in self.walk() if physical_key_is_temp_file(entry.physical_keys[0])]
+        temp_file_logical_keys = [lk for lk, entry in self.walk() if physical_key_is_temp_file(entry.physical_key)]
         temp_file_physical_keys = [self.get(lk) for lk in temp_file_logical_keys]
 
         # Now that data has been pushed, delete tmp files created by pkg.set('KEY', obj)
@@ -1306,7 +1280,7 @@ class Package(object):
                 continue
 
             # Copy the datafiles in the package.
-            physical_key = _to_singleton(entry.physical_keys)
+            physical_key = entry.physical_key
 
             if local_dest:
                 # Try a local cache.
@@ -1330,7 +1304,7 @@ class Package(object):
             self._maybe_add_to_cache(old_physical_key, versioned_key)
             # Create a new package entry pointing to the new remote key.
             assert versioned_key is not None
-            new_entry = entry.with_physical_keys([versioned_key])
+            new_entry = entry.with_physical_key(versioned_key)
             pkg._set(logical_key, new_entry)
         return pkg
 

--- a/api/python/tests/integration/test_packages.py
+++ b/api/python/tests/integration/test_packages.py
@@ -77,7 +77,7 @@ class PackageTest(QuiltTestCase):
         out_path = LOCAL_REGISTRY / ".quilt/packages" / top_hash
         with open(out_path) as fd:
             pkg = Package.load(fd)
-            assert test_file.resolve().as_uri() == pkg['foo'].physical_keys[0]
+            assert test_file.resolve().as_uri() == pkg['foo'].physical_key
 
         # Verify latest points to the new location.
         named_pointer_path = LOCAL_REGISTRY / ".quilt/named_packages/Quilt/Test/latest"
@@ -91,7 +91,7 @@ class PackageTest(QuiltTestCase):
         out_path = LOCAL_REGISTRY / ".quilt/packages" / top_hash
         with open(out_path) as fd:
             pkg = Package.load(fd)
-            assert test_file.resolve().as_uri() == pkg['bar'].physical_keys[0]
+            assert test_file.resolve().as_uri() == pkg['bar'].physical_key
 
     def test_default_registry(self):
         new_pkg = Package()
@@ -110,7 +110,7 @@ class PackageTest(QuiltTestCase):
         out_path = LOCAL_REGISTRY / ".quilt/packages" / top_hash
         with open(out_path) as fd:
             pkg = Package.load(fd)
-            assert test_file.resolve().as_uri() == pkg['foo'].physical_keys[0]
+            assert test_file.resolve().as_uri() == pkg['foo'].physical_key
 
         # Verify latest points to the new location.
         named_pointer_path = LOCAL_REGISTRY / ".quilt/named_packages/Quilt/Test/latest"
@@ -124,7 +124,7 @@ class PackageTest(QuiltTestCase):
         out_path = LOCAL_REGISTRY / ".quilt/packages" / top_hash
         with open(out_path) as fd:
             pkg = Package.load(fd)
-            assert test_file.resolve().as_uri() == pkg['bar'].physical_keys[0]
+            assert test_file.resolve().as_uri() == pkg['bar'].physical_key
 
     @patch('quilt3.Package._browse', lambda name, registry, top_hash: Package())
     def test_default_install_location(self):
@@ -341,7 +341,7 @@ class PackageTest(QuiltTestCase):
         # test that package re-rooting works as expected
         out_dir_abs_path = pathlib.Path(out_dir).resolve().as_uri()
         assert all(
-            entry.physical_keys[0].startswith(out_dir_abs_path) for _, entry in new_package_.walk()
+            entry.physical_key.startswith(out_dir_abs_path) for _, entry in new_package_.walk()
         )
 
     def test_package_fetch_default_dest(self):
@@ -376,7 +376,7 @@ class PackageTest(QuiltTestCase):
         pkg = quilt3.Package().set('foo', DATA_DIR / 'foo.txt')
         new_pkg_entry = pkg['foo'].fetch('bar.txt')
         out_abs_path = pathlib.Path("bar.txt").resolve().as_uri()
-        assert new_pkg_entry.physical_keys[0] == out_abs_path
+        assert new_pkg_entry.physical_key == out_abs_path
 
     def test_fetch_default_dest(tmpdir):
         """Verify fetching a package entry to a default destination."""
@@ -560,21 +560,21 @@ class PackageTest(QuiltTestCase):
 
         pkg = pkg.set_dir("/", ".", meta="test_meta")
 
-        assert pathlib.Path('foo').resolve().as_uri() == pkg['foo'].physical_keys[0]
-        assert pathlib.Path('bar').resolve().as_uri() == pkg['bar'].physical_keys[0]
-        assert (bazdir / 'baz').resolve().as_uri() == pkg['foo_dir/baz_dir/baz'].physical_keys[0]
-        assert (foodir / 'bar').resolve().as_uri() == pkg['foo_dir/bar'].physical_keys[0]
+        assert pathlib.Path('foo').resolve().as_uri() == pkg['foo'].physical_key
+        assert pathlib.Path('bar').resolve().as_uri() == pkg['bar'].physical_key
+        assert (bazdir / 'baz').resolve().as_uri() == pkg['foo_dir/baz_dir/baz'].physical_key
+        assert (foodir / 'bar').resolve().as_uri() == pkg['foo_dir/bar'].physical_key
         assert pkg.meta == "test_meta"
 
         pkg = Package()
         pkg = pkg.set_dir('/','foo_dir/baz_dir/')
         # todo nested at set_dir site or relative to set_dir path.
-        assert (bazdir / 'baz').resolve().as_uri() == pkg['baz'].physical_keys[0]
+        assert (bazdir / 'baz').resolve().as_uri() == pkg['baz'].physical_key
 
         pkg = Package()
         pkg = pkg.set_dir('my_keys', 'foo_dir/baz_dir/')
         # todo nested at set_dir site or relative to set_dir path.
-        assert (bazdir / 'baz').resolve().as_uri() == pkg['my_keys/baz'].physical_keys[0]
+        assert (bazdir / 'baz').resolve().as_uri() == pkg['my_keys/baz'].physical_key
 
         # Verify ignoring files in the presence of a dot-quiltignore
         with open('.quiltignore', 'w') as fd:
@@ -603,15 +603,15 @@ class PackageTest(QuiltTestCase):
 
         pkg = pkg.set_dir("new_dir", ".", meta="new_test_meta")
 
-        assert pathlib.Path('foo').resolve().as_uri() == pkg['new_dir/foo'].physical_keys[0]
-        assert pathlib.Path('bar').resolve().as_uri() == pkg['new_dir/bar'].physical_keys[0]
+        assert pathlib.Path('foo').resolve().as_uri() == pkg['new_dir/foo'].physical_key
+        assert pathlib.Path('bar').resolve().as_uri() == pkg['new_dir/bar'].physical_key
         assert pkg['new_dir'].meta == "new_test_meta"
 
         # verify set_dir logical key shortcut
         pkg = Package()
         pkg.set_dir("/")
-        assert pathlib.Path('foo').resolve().as_uri() == pkg['foo'].physical_keys[0]
-        assert pathlib.Path('bar').resolve().as_uri() == pkg['bar'].physical_keys[0]
+        assert pathlib.Path('foo').resolve().as_uri() == pkg['foo'].physical_key
+        assert pathlib.Path('bar').resolve().as_uri() == pkg['bar'].physical_key
 
 
     def test_s3_set_dir(self):
@@ -627,8 +627,8 @@ class PackageTest(QuiltTestCase):
 
             pkg.set_dir('', 's3://bucket/foo/', meta='test_meta')
 
-            assert pkg['a.txt'].physical_keys[0] == 's3://bucket/foo/a.txt?versionId=xyz'
-            assert pkg['x']['y.txt'].physical_keys[0] == 's3://bucket/foo/x/y.txt'
+            assert pkg['a.txt'].physical_key == 's3://bucket/foo/a.txt?versionId=xyz'
+            assert pkg['x']['y.txt'].physical_key == 's3://bucket/foo/x/y.txt'
             assert pkg.meta == "test_meta"
             assert pkg['x']['y.txt'].size == 10  # GH368
 
@@ -638,8 +638,8 @@ class PackageTest(QuiltTestCase):
 
             pkg.set_dir('bar', 's3://bucket/foo')
 
-            assert pkg['bar']['a.txt'].physical_keys[0] == 's3://bucket/foo/a.txt?versionId=xyz'
-            assert pkg['bar']['x']['y.txt'].physical_keys[0] == 's3://bucket/foo/x/y.txt'
+            assert pkg['bar']['a.txt'].physical_key == 's3://bucket/foo/a.txt?versionId=xyz'
+            assert pkg['bar']['x']['y.txt'].physical_key == 's3://bucket/foo/x/y.txt'
             assert pkg['bar']['a.txt'].size == 10 # GH368
 
             list_object_versions_mock.assert_called_with('bucket', 'foo/')
@@ -705,11 +705,11 @@ class PackageTest(QuiltTestCase):
             test_file = Path(fd.name)
         pkg['bar'].set('bar.txt')
 
-        assert test_file.resolve().as_uri() == pkg['bar'].physical_keys[0]
+        assert test_file.resolve().as_uri() == pkg['bar'].physical_key
 
         # Test shortcut codepath
         pkg = Package().set('bar.txt')
-        assert test_file.resolve().as_uri() == pkg['bar.txt'].physical_keys[0]
+        assert test_file.resolve().as_uri() == pkg['bar.txt'].physical_key
 
     def test_set_package_entry_as_object(self):
         pkg = Package()


### PR DESCRIPTION
Calling `_to_singleton(self.physical_keys)` all over the place is not helping anyone. Just make it a single value.

The manifest is still using a list, so the format is staying the same.