### PR TITLE
Remove config on install

### DIFF
--- a/api/python/quilt3/api.py
+++ b/api/python/quilt3/api.py
@@ -4,9 +4,10 @@ from .data_transfer import copy_file, get_bytes, delete_url, list_url
 from .packages import Package
 from .search_util import search_api
 from .util import (QuiltConfig, QuiltException, CONFIG_PATH,
-                   CONFIG_TEMPLATE, configure_from_url, fix_url,
-                   get_package_registry, load_config, read_yaml,
-                   validate_package_name, write_yaml)
+                   CONFIG_TEMPLATE, configure_from_default,
+                   configure_from_url, fix_url, get_package_registry,
+                   load_config, read_yaml, validate_package_name,
+                   write_yaml)
 from .telemetry import ApiTelemetry
 
 
@@ -250,6 +251,8 @@ def search(query, limit=10):
         }, ...]
         ```
     """
+    # force a call to configure_from_default if no config exists
+    _config()
     raw_results = search_api(query, '*', limit)
     return raw_results['hits']['hits']
 

--- a/api/python/quilt3/api.py
+++ b/api/python/quilt3/api.py
@@ -196,17 +196,17 @@ def _config(*catalog_url, **config_values):
         else:
             config_template = read_yaml(CONFIG_TEMPLATE)
             write_yaml(config_template, CONFIG_PATH, keep_backup=True)
-        return QuiltConfig(CONFIG_PATH, config_template)
-
-    # Use local configuration (or defaults)
-    local_config = load_config()
-
-    # Write to config if needed
-    if config_values:
+        local_config = config_template
+    # Create a custom config with the passed-in values only
+    elif config_values:
+        local_config = load_config()
         config_values = QuiltConfig('', config_values)  # Does some validation/scrubbing
         for key, value in config_values.items():
             local_config[key] = value
         write_yaml(local_config, CONFIG_PATH)
+    # Install the default configuration
+    else:
+        local_config = configure_from_default()
 
     # Return current config
     return QuiltConfig(CONFIG_PATH, local_config)

--- a/api/python/quilt3/main.py
+++ b/api/python/quilt3/main.py
@@ -27,7 +27,7 @@ def cmd_catalog():
     """
     Run the Quilt catalog locally
     """
-    open_config = api.config()
+    open_config = api._config()
     command = ["docker", "run", "--rm"]
     env = dict(REGISTRY_URL="http://localhost:5000",
                S3_PROXY_URL=open_config["s3Proxy"],

--- a/api/python/quilt3/util.py
+++ b/api/python/quilt3/util.py
@@ -330,12 +330,16 @@ def configure_from_default():
     current config exists. If reading the public stack fails,
     warn the user and save an empty template.
     """
-    if not CONFIG_PATH.exists():
+    if CONFIG_PATH.exists():
+        local_config = load_config()
+    else:
         try:
-            configure_from_url(OPEN_DATA_URL)
+            local_config = configure_from_url(OPEN_DATA_URL)
         except requests.exceptions.ConnectionError:
             config_template = read_yaml(CONFIG_TEMPLATE)
             write_yaml(config_template, CONFIG_PATH, keep_backup=True)
+            local_config = config_template
+    return local_config
 
 def load_config():
     """
@@ -366,7 +370,7 @@ def set_config_value(key, value):
     write_yaml(local_config, CONFIG_PATH)
 
 def quiltignore_filter(paths, ignore, url_scheme):
-    """Given a list of paths, filter out the paths which are captured by the 
+    """Given a list of paths, filter out the paths which are captured by the
     given ignore rules.
 
     Args:

--- a/api/python/setup.py
+++ b/api/python/setup.py
@@ -5,7 +5,6 @@ from pathlib import Path
 
 from setuptools import setup, find_packages
 from setuptools.command.install import install
-from setuptools.command.develop import develop
 
 VERSION = Path(Path(__file__).parent, "quilt3", "VERSION").read_text()
 
@@ -19,29 +18,6 @@ def readme():
 
     """
     return readme_short
-
-def default_config():
-    """Configure to the default (public) Quilt stack"""
-    from quilt3.util import configure_from_default
-    configure_from_default()
-
-
-class PostDevelopCommand(develop):
-    """ Post install hook for development installs """
-    description = 'Setup default configuration'
-
-    def run(self):
-        default_config()
-        develop.run(self)
-
-
-class PostInstallCommand(install):
-    """ Post install hook """
-    description = 'Setup default configuration'
-
-    def run(self):
-        default_config()
-        install.run(self)
 
 
 class VerifyVersionCommand(install):
@@ -117,7 +93,5 @@ setup(
     },
     cmdclass={
         'verify': VerifyVersionCommand,
-        'install': PostInstallCommand,
-        'develop': PostDevelopCommand,
     }
 )


### PR DESCRIPTION
## Description
Running `config` at install time doesn't work with wheel installs so this PR implements auto-configuration to the default stack on the first call to `api.config`.
