### PR TITLE
Install now shows tophash in output

### DIFF
--- a/api/python/quilt3/packages.py
+++ b/api/python/quilt3/packages.py
@@ -471,23 +471,31 @@ class Package(object):
         if len(hash_prefix) == 64:
             top_hash = hash_prefix
         elif 6 <= len(hash_prefix) < 64:
-            all_hashes = list_url(f'{registry}/.quilt/packages/')
-            matches = [h for h, _ in all_hashes if h.startswith(hash_prefix)]
-            if not matches:
+            matching_hashes = [h for h, _
+                               in list_url(f'{registry}/.quilt/packages/')
+                               if h.startswith(hash_prefix)]
+            if not matching_hashes:
                 raise QuiltException("Found zero matches for %r" % hash_prefix)
-            elif len(matches) > 1:
+            elif len(matching_hashes) > 1:
                 raise QuiltException("Found multiple matches: %r" % hash_prefix)
             else:
-                top_hash = matches[0]
+                top_hash = matching_hashes[0]
         else:
             raise QuiltException("Invalid hash: %r" % hash_prefix)
         return top_hash
 
     @classmethod
     def shorten_tophash(cls, package_name, registry, top_hash):
-        # TODO: Eventually we should check that we aren't giving a short hash that has a conflict. Not easy to do with
-        #       current .quilt layout
-        return top_hash[:6]
+        min_shorthash_len = 7
+        matches = [h for h, _ in list_url(f'{registry}/.quilt/packages/') if h.startswith(top_hash[:min_shorthash_len])]
+        if len(matches) == 0:
+            raise ValueError(f"Tophash {top_hash} was not found in registry {registry}")
+        for prefix_length in range(min_shorthash_len, 64):
+            potential_shorthash = top_hash[:prefix_length]
+            matches = [h for h in matches if h.startswith(potential_shorthash)]
+            if len(matches) == 1:
+                return potential_shorthash
+
 
     @classmethod
     @ApiTelemetry("package.browse")

--- a/api/python/quilt3/packages.py
+++ b/api/python/quilt3/packages.py
@@ -454,6 +454,10 @@ class Package(object):
 
         pkg._materialize(dest)
         pkg._build(name, registry=dest_registry, message=message)
+        if top_hash is None:
+            top_hash = pkg.top_hash
+        short_tophash = Package.shorten_tophash(name, registry, top_hash)
+        print(f"Successfully installed package {name}@{short_tophash} from {registry}")
 
 
     @classmethod
@@ -478,6 +482,12 @@ class Package(object):
         else:
             raise QuiltException("Invalid hash: %r" % hash_prefix)
         return top_hash
+
+    @classmethod
+    def shorten_tophash(cls, package_name, registry, top_hash):
+        # TODO: Eventually we should check that we aren't giving a short hash that has a conflict. Not easy to do with
+        #       current .quilt layout
+        return top_hash[:6]
 
     @classmethod
     @ApiTelemetry("package.browse")

--- a/api/python/quilt3/packages.py
+++ b/api/python/quilt3/packages.py
@@ -457,7 +457,7 @@ class Package(object):
         if top_hash is None:
             top_hash = pkg.top_hash
         short_tophash = Package.shorten_tophash(name, registry, top_hash)
-        print(f"Successfully installed package {name}@{short_tophash} from {registry}")
+        print(f"Successfully installed package '{name}', tophash={short_tophash} from {registry}")
 
 
     @classmethod

--- a/api/python/tests/integration/test_packages.py
+++ b/api/python/tests/integration/test_packages.py
@@ -130,8 +130,6 @@ class PackageTest(QuiltTestCase):
     @patch('quilt3.Package.shorten_tophash', lambda package_name, registry, top_hash: "7a67ff4")
     def test_default_install_location(self):
         """Verify that pushes to the default local install location work as expected"""
-
-
         with patch('quilt3.Package._materialize') as materialize_mock:
             pkg_name = 'Quilt/nice-name'
             Package.install(pkg_name, registry='s3://my-test-bucket')

--- a/api/python/tests/integration/test_packages.py
+++ b/api/python/tests/integration/test_packages.py
@@ -127,8 +127,11 @@ class PackageTest(QuiltTestCase):
             assert test_file.resolve().as_uri() == pkg['bar'].physical_keys[0]
 
     @patch('quilt3.Package._browse', lambda name, registry, top_hash: Package())
+    @patch('quilt3.Package.shorten_tophash', lambda package_name, registry, top_hash: "7a67ff4")
     def test_default_install_location(self):
         """Verify that pushes to the default local install location work as expected"""
+
+
         with patch('quilt3.Package._materialize') as materialize_mock:
             pkg_name = 'Quilt/nice-name'
             Package.install(pkg_name, registry='s3://my-test-bucket')
@@ -1190,6 +1193,7 @@ class PackageTest(QuiltTestCase):
         with pytest.raises(QuiltException):
             pkg.set('s3://foo/..', LOCAL_MANIFEST)
 
+    @patch('quilt3.Package.shorten_tophash', lambda package_name, registry, top_hash: "7a67ff4")
     def test_install(self):
         # Manifest
 
@@ -1347,7 +1351,7 @@ class PackageTest(QuiltTestCase):
         with self.assertRaises(QuiltException):
             Package.rollback('quilt/blah', LOCAL_REGISTRY, good_hash)
 
-
+    @patch('quilt3.Package.shorten_tophash', lambda package_name, registry, top_hash: "7a67ff4")
     def test_verify(self):
         pkg = Package()
 


### PR DESCRIPTION
```
$ quilt3 install test/tiny-pkg --registry="s3://quilt-ml-data" --dest=./tiny-pkg
Copying: 0.00B [00:00, ?B/s]
Successfully installed package 'test/tiny-pkg', tophash=b19dd2 from s3://quilt-ml-data
```