### PR TITLE
Better package list ux pt. 2: new package routes + some more

### DIFF
--- a/catalog/app/components/Preview/renderers/Vcf.js
+++ b/catalog/app/components/Preview/renderers/Vcf.js
@@ -73,7 +73,7 @@ const Vcf = ({ meta, header, data, variants }) => {
               // eslint-disable-next-line react/no-array-index-key
               <TableRow key={`meta:${i}`} className={classes.row}>
                 <TableCell
-                  colSpan={header[0].length}
+                  colSpan={header ? header[0].length : undefined}
                   className={cx(classes.cell, classes.meta)}
                 >
                   {l}
@@ -85,11 +85,13 @@ const Vcf = ({ meta, header, data, variants }) => {
       </div>
       <div className={classes.tableWrapper}>
         <Table className={classes.table}>
-          <TableHead>
-            <TableRow className={classes.row}>
-              {header.map(renderCell('header'))}
-            </TableRow>
-          </TableHead>
+          {!!header && (
+            <TableHead>
+              <TableRow className={classes.row}>
+                {header.map(renderCell('header'))}
+              </TableRow>
+            </TableHead>
+          )}
           <TableBody>
             {data.map((row, i) => (
               // eslint-disable-next-line react/no-array-index-key

--- a/catalog/app/constants/routes.js
+++ b/catalog/app/constants/routes.js
@@ -100,12 +100,19 @@ export const bucketPackageList = {
 }
 export const bucketPackageDetail = {
   path: `/b/:bucket/packages/:name(${PACKAGE_PATTERN})`,
-  url: (bucket, name, { p } = {}) => `/b/${bucket}/packages/${name}${mkSearch({ p })}`,
+  url: (bucket, name) => `/b/${bucket}/packages/${name}`,
 }
 export const bucketPackageTree = {
   path: `/b/:bucket/packages/:name(${PACKAGE_PATTERN})/tree/:revision/:path(.*)?`,
   url: (bucket, name, revision, path = '') =>
-    `/b/${bucket}/packages/${name}/tree/${revision}/${encode(path)}`,
+    revision === 'latest' && !path
+      ? bucketPackageDetail.url(bucket, name)
+      : `/b/${bucket}/packages/${name}/tree/${revision}/${encode(path)}`,
+}
+export const bucketPackageRevisions = {
+  path: `/b/:bucket/packages/:name(${PACKAGE_PATTERN})/revisions`,
+  url: (bucket, name, { p } = {}) =>
+    `/b/${bucket}/packages/${name}/revisions${mkSearch({ p })}`,
 }
 
 // legacy stuff

--- a/catalog/app/containers/Bucket/Bucket.js
+++ b/catalog/app/containers/Bucket/Bucket.js
@@ -18,9 +18,9 @@ const mkLazy = (load) =>
 const Dir = mkLazy(() => import('./Dir'))
 const File = mkLazy(() => import('./File'))
 const Overview = mkLazy(() => import('./Overview'))
-const PackageDetail = mkLazy(() => import('./PackageDetail'))
 const PackageList = mkLazy(() => import('./PackageList'))
 const PackageTree = mkLazy(() => import('./PackageTree'))
+const PackageRevisions = mkLazy(() => import('./PackageRevisions'))
 const Search = mkLazy(() => import('./Search'))
 
 const match = (cases) => (pathname) => {
@@ -121,8 +121,9 @@ export default ({
           <Route path={paths.bucketOverview} component={Overview} exact />
           <Route path={paths.bucketSearch} component={Search} exact />
           <Route path={paths.bucketPackageList} component={PackageList} exact />
-          <Route path={paths.bucketPackageDetail} component={PackageDetail} exact />
+          <Route path={paths.bucketPackageDetail} component={PackageTree} exact />
           <Route path={paths.bucketPackageTree} component={PackageTree} exact />
+          <Route path={paths.bucketPackageRevisions} component={PackageRevisions} exact />
           <Route component={ThrowNotFound} />
         </Switch>
       </BucketLayout>

--- a/catalog/app/containers/Bucket/PackageRevisions.js
+++ b/catalog/app/containers/Bucket/PackageRevisions.js
@@ -65,7 +65,7 @@ const SparklineSkel = ({ width, height }) => {
   )
 }
 
-const Counts = ({ counts, total, sparklineW, sparklineH }) => {
+function Counts({ counts, total, sparklineW, sparklineH }) {
   const [cursor, setCursor] = React.useState(null)
   return (
     <>
@@ -377,7 +377,7 @@ function Revisions({ revisions, isTruncated, counts, bucket, name, page }) {
   const actualPage = page || 1
 
   const makePageUrl = React.useCallback(
-    (p) => urls.bucketPackageDetail(bucket, name, { p: p !== 1 ? p : undefined }),
+    (p) => urls.bucketPackageRevisions(bucket, name, { p: p !== 1 ? p : undefined }),
     [bucket, name],
   )
 
@@ -433,12 +433,12 @@ const pendingProps = AsyncResult.props(
   AsyncResult.Pending(),
 )
 
-export default ({
+export default function PackageRevisions({
   match: {
     params: { bucket, name },
   },
   location,
-}) => {
+}) {
   const { p } = parseSearch(location.search)
   const page = p && parseInt(p, 10)
   const s3req = AWS.S3.useRequest()

--- a/catalog/app/containers/Bucket/PackageRevisions.js
+++ b/catalog/app/containers/Bucket/PackageRevisions.js
@@ -191,7 +191,7 @@ function Revision({ bucket, name, id, hash, stats, message, counts }) {
                   className={classes.time}
                   to={urls.bucketPackageTree(bucket, name, v)}
                 >
-                  {dateFns.format(modified, dateFmt)}
+                  {v === 'latest' ? 'LATEST' : dateFns.format(modified, dateFmt)}
                 </Link>
               )
             },

--- a/catalog/app/containers/Bucket/PackageTree.js
+++ b/catalog/app/containers/Bucket/PackageTree.js
@@ -116,6 +116,13 @@ const useStyles = M.makeStyles((t) => ({
   name: {
     wordBreak: 'break-all',
   },
+  revision: {
+    alignItems: 'center',
+    display: 'inline-flex',
+  },
+  mono: {
+    fontFamily: t.typography.monospace.fontFamily,
+  },
   spacer: {
     flexGrow: 1,
   },
@@ -128,7 +135,7 @@ const useStyles = M.makeStyles((t) => ({
 
 export default function PackageTree({
   match: {
-    params: { bucket, name, revision, path: encodedPath = '' },
+    params: { bucket, name, revision = 'latest', path: encodedPath = '' },
   },
 }) {
   const classes = useStyles()
@@ -151,16 +158,18 @@ export default function PackageTree({
     () =>
       R.intersperse(
         Crumb.Sep(<>&nbsp;/ </>),
-        getBreadCrumbs(path).map(({ label, path: segPath }) =>
-          Crumb.Segment({
-            label,
-            to:
-              path === segPath
-                ? undefined
-                : urls.bucketPackageTree(bucket, name, revision, segPath),
-          }),
-        ),
-      ),
+        [{ label: 'ROOT', path: '' }]
+          .concat(getBreadCrumbs(path))
+          .map(({ label, path: segPath }) =>
+            Crumb.Segment({
+              label,
+              to:
+                path === segPath
+                  ? undefined
+                  : urls.bucketPackageTree(bucket, name, revision, segPath),
+            }),
+          ),
+      ).concat(path === '' || path.endsWith('/') ? Crumb.Sep(<>&nbsp;/</>) : []),
     [bucket, name, revision, path, urls],
   )
 
@@ -177,7 +186,17 @@ export default function PackageTree({
                 {name}
               </Link>
               {' @ '}
-              <Link to={urls.bucketPackageTree(bucket, name, revision)}>{revision}</Link>:
+              <Link
+                to={urls.bucketPackageRevisions(bucket, name)}
+                className={classes.revision}
+              >
+                {revision === 'latest' ? (
+                  'latest'
+                ) : (
+                  <span className={classes.mono}>{revision}</span>
+                )}{' '}
+                <M.Icon>expand_more</M.Icon>
+              </Link>
             </M.Typography>
             <div className={classes.topBar}>
               <div className={classes.crumbs} onCopy={copyWithoutSpaces}>

--- a/catalog/app/containers/Bucket/PackageTree.js
+++ b/catalog/app/containers/Bucket/PackageTree.js
@@ -102,11 +102,15 @@ function RevisionInfo({ revision, bucket, name, path }) {
                       >
                         <M.ListItemText
                           primary={
-                            <span>
-                              {dateFns.format(modified, 'MMMM Do YYYY - h:mmA')}
-                              {' | '}
-                              <span className={classes.mono}>{r.id}</span>
-                            </span>
+                            r.id === 'latest' ? (
+                              'LATEST'
+                            ) : (
+                              <span>
+                                {dateFns.format(modified, 'MMMM Do YYYY - h:mmA')}
+                                {' | '}
+                                <span className={classes.mono}>{r.id}</span>
+                              </span>
+                            )
                           }
                           secondary={
                             <span className={classes.secondaryText}>

--- a/catalog/app/containers/Bucket/PackageTree.js
+++ b/catalog/app/containers/Bucket/PackageTree.js
@@ -1,18 +1,21 @@
 import { basename } from 'path'
 
+import cx from 'classnames'
+import * as dateFns from 'date-fns'
 import dedent from 'dedent'
 import * as R from 'ramda'
 import * as React from 'react'
+import { Link as RRLink } from 'react-router-dom'
 import * as M from '@material-ui/core'
 
 import { Crumb, copyWithoutSpaces, render as renderCrumbs } from 'components/BreadCrumbs'
-import { ThrowNotFound } from 'containers/NotFoundPage'
+import Skeleton from 'components/Skeleton'
 import AsyncResult from 'utils/AsyncResult'
 import * as AWS from 'utils/AWS'
 import * as Config from 'utils/Config'
 import Data from 'utils/Data'
 import * as NamedRoutes from 'utils/NamedRoutes'
-import Link from 'utils/StyledLink'
+import Link, { linkStyle } from 'utils/StyledLink'
 import { getBreadCrumbs, getPrefix, isDir, parseS3Url, up, decode } from 'utils/s3paths'
 import tagged from 'utils/tagged'
 
@@ -23,6 +26,198 @@ import Section from './Section'
 import Summary from './Summary'
 import { displayError } from './errors'
 import * as requests from './requests'
+
+const MAX_REVISIONS = 5
+
+const useRevisionInfoStyles = M.makeStyles((t) => ({
+  revision: {
+    ...linkStyle,
+    alignItems: 'center',
+    display: 'inline-flex',
+  },
+  mono: {
+    fontFamily: t.typography.monospace.fontFamily,
+  },
+  line: {
+    whiteSpace: 'nowrap',
+  },
+  secondaryText: {
+    display: 'block',
+    height: 40,
+    overflow: 'hidden',
+    textOverflow: 'ellipsis',
+  },
+  list: {
+    width: 420,
+  },
+}))
+
+function RevisionInfo({ revision, bucket, name, path }) {
+  const s3req = AWS.S3.useRequest()
+  const signer = AWS.Signer.use()
+  const { apiGatewayEndpoint: endpoint } = Config.useConfig()
+  const { urls } = NamedRoutes.use()
+  const today = React.useMemo(() => new Date(), [])
+
+  const [anchor, setAnchor] = React.useState()
+  const [opened, setOpened] = React.useState(false)
+  const open = React.useCallback(() => setOpened(true), [])
+  const close = React.useCallback(() => setOpened(false), [])
+
+  const classes = useRevisionInfoStyles()
+
+  return (
+    <>
+      {/* eslint-disable-next-line jsx-a11y/click-events-have-key-events, jsx-a11y/no-static-element-interactions */}
+      <span className={classes.revision} onClick={open} ref={setAnchor}>
+        {revision === 'latest' ? (
+          'latest'
+        ) : (
+          <span className={classes.mono}>{revision}</span>
+        )}{' '}
+        <M.Icon>expand_more</M.Icon>
+      </span>
+      <Data fetch={requests.getPackageRevisions} params={{ s3req, bucket, name, today }}>
+        {R.pipe(
+          AsyncResult.case({
+            Ok: ({ revisions, isTruncated }) => {
+              const revList = revisions.slice(0, MAX_REVISIONS).map((r) => (
+                <Data
+                  key={r.id}
+                  fetch={requests.getRevisionData}
+                  params={{ s3req, signer, endpoint, bucket, key: r.key, maxKeys: 0 }}
+                >
+                  {(res) => {
+                    const modified = new Date(parseInt(r.id, 10) * 1000)
+                    const hash = AsyncResult.prop('hash', res)
+                    const msg = AsyncResult.prop('message', res)
+                    return (
+                      <M.ListItem
+                        key={r.id}
+                        button
+                        onClick={close}
+                        selected={r.id === revision}
+                        component={RRLink}
+                        to={urls.bucketPackageTree(bucket, name, r.id, path)}
+                      >
+                        <M.ListItemText
+                          primary={
+                            <span>
+                              {dateFns.format(modified, 'MMMM Do YYYY - h:mmA')}
+                              {' | '}
+                              <span className={classes.mono}>{r.id}</span>
+                            </span>
+                          }
+                          secondary={
+                            <span className={classes.secondaryText}>
+                              {AsyncResult.case(
+                                {
+                                  Ok: (v) => (
+                                    <span className={classes.line}>
+                                      {v || <i>No message</i>}
+                                    </span>
+                                  ),
+                                  _: () => (
+                                    <Skeleton
+                                      component="span"
+                                      display="inline-block"
+                                      borderRadius="borderRadius"
+                                      height={16}
+                                      width="90%"
+                                    />
+                                  ),
+                                },
+                                msg,
+                              )}
+                              <br />
+                              {AsyncResult.case(
+                                {
+                                  Ok: (v) => (
+                                    <span className={cx(classes.line, classes.mono)}>
+                                      {v}
+                                    </span>
+                                  ),
+                                  _: () => (
+                                    <Skeleton
+                                      component="span"
+                                      display="inline-block"
+                                      borderRadius="borderRadius"
+                                      height={16}
+                                      width="95%"
+                                    />
+                                  ),
+                                },
+                                hash,
+                              )}
+                            </span>
+                          }
+                        />
+                      </M.ListItem>
+                    )
+                  }}
+                </Data>
+              ))
+              if (isTruncated) {
+                revList.unshift(
+                  <M.ListItem key="__truncated">
+                    <M.ListItemText
+                      primary="Revision list is truncated"
+                      secondary="Latest revisions are not shown"
+                    />
+                    <M.ListItemSecondaryAction>
+                      <M.Icon>warning</M.Icon>
+                    </M.ListItemSecondaryAction>
+                  </M.ListItem>,
+                )
+              }
+              return revList
+            },
+            Err: () => (
+              <M.ListItem>
+                <M.ListItemIcon>
+                  <M.Icon>error</M.Icon>
+                </M.ListItemIcon>
+                <M.Typography variant="body1">Error fetching revisions</M.Typography>
+              </M.ListItem>
+            ),
+            _: () => (
+              <M.ListItem>
+                <M.ListItemIcon>
+                  <M.CircularProgress size={24} />
+                </M.ListItemIcon>
+                <M.Typography variant="body1">Fetching revisions</M.Typography>
+              </M.ListItem>
+            ),
+          }),
+          (children) => (
+            <M.Popover
+              open={opened && !!anchor}
+              anchorEl={anchor}
+              onClose={close}
+              anchorOrigin={{ vertical: 'bottom', horizontal: 'center' }}
+              transformOrigin={{ vertical: 'top', horizontal: 'center' }}
+            >
+              <M.List className={classes.list}>
+                {children}
+                <M.Divider />
+                <M.ListItem
+                  button
+                  onClick={close}
+                  component={RRLink}
+                  to={urls.bucketPackageRevisions(bucket, name)}
+                >
+                  <M.Box textAlign="center" width="100%">
+                    Show all revisions
+                  </M.Box>
+                </M.ListItem>
+              </M.List>
+            </M.Popover>
+          ),
+        )}
+      </Data>
+    </>
+  )
+}
 
 const TreeDisplay = tagged([
   'File', // S3Handle
@@ -116,13 +311,6 @@ const useStyles = M.makeStyles((t) => ({
   name: {
     wordBreak: 'break-all',
   },
-  revision: {
-    alignItems: 'center',
-    display: 'inline-flex',
-  },
-  mono: {
-    fontFamily: t.typography.monospace.fontFamily,
-  },
   spacer: {
     flexGrow: 1,
   },
@@ -154,24 +342,22 @@ export default function PackageTree({
     p = quilt3.Package.browse("${name}", registry="s3://${bucket}")
   `
 
-  const crumbs = React.useMemo(
-    () =>
-      R.intersperse(
-        Crumb.Sep(<>&nbsp;/ </>),
-        [{ label: 'ROOT', path: '' }]
-          .concat(getBreadCrumbs(path))
-          .map(({ label, path: segPath }) =>
-            Crumb.Segment({
-              label,
-              to:
-                path === segPath
-                  ? undefined
-                  : urls.bucketPackageTree(bucket, name, revision, segPath),
-            }),
-          ),
-      ).concat(path === '' || path.endsWith('/') ? Crumb.Sep(<>&nbsp;/</>) : []),
-    [bucket, name, revision, path, urls],
-  )
+  const crumbs = React.useMemo(() => {
+    const segments = getBreadCrumbs(path)
+    if (path !== '') segments.unshift({ label: 'ROOT', path: '' })
+    return R.intersperse(
+      Crumb.Sep(<>&nbsp;/ </>),
+      segments.map(({ label, path: segPath }) =>
+        Crumb.Segment({
+          label,
+          to:
+            path === segPath
+              ? undefined
+              : urls.bucketPackageTree(bucket, name, revision, segPath),
+        }),
+      ),
+    ).concat(path.endsWith('/') ? Crumb.Sep(<>&nbsp;/</>) : [])
+  }, [bucket, name, revision, path, urls])
 
   return (
     <M.Box pt={2} pb={4}>
@@ -186,17 +372,7 @@ export default function PackageTree({
                 {name}
               </Link>
               {' @ '}
-              <Link
-                to={urls.bucketPackageRevisions(bucket, name)}
-                className={classes.revision}
-              >
-                {revision === 'latest' ? (
-                  'latest'
-                ) : (
-                  <span className={classes.mono}>{revision}</span>
-                )}{' '}
-                <M.Icon>expand_more</M.Icon>
-              </Link>
+              <RevisionInfo {...{ revision, bucket, name, path }} />
             </M.Typography>
             <div className={classes.topBar}>
               <div className={classes.crumbs} onCopy={copyWithoutSpaces}>
@@ -259,10 +435,21 @@ export default function PackageTree({
                       <Summary files={dir.files} />
                     </M.Box>
                   ),
-                  NotFound: ThrowNotFound,
+                  NotFound: () => (
+                    <M.Box mt={4}>
+                      <M.Typography variant="h4" align="center">
+                        No such file
+                      </M.Typography>
+                    </M.Box>
+                  ),
                 }),
                 Err: displayError(),
-                _: () => <M.CircularProgress />,
+                _: () => (
+                  // TODO: skeleton placeholder
+                  <M.Box mt={2}>
+                    <M.CircularProgress />
+                  </M.Box>
+                ),
               },
               result,
             )}

--- a/catalog/app/containers/Bucket/requests.js
+++ b/catalog/app/containers/Bucket/requests.js
@@ -751,38 +751,42 @@ export const getPackageRevisions = withErrorHandling(
       revisions: r.Contents.reduce((acc, { Key: key }) => {
         const id = getRevisionIdFromKey(key)
         if (id === 'latest') return acc
-        return [{ id, key }].concat(acc)
+        return [id, ...acc]
       }, []),
       isTruncated: r.IsTruncated,
     }))
-    revisions.unshift({ id: 'latest', key: getRevisionKeyFromId(name, 'latest') })
+    revisions.unshift('latest')
     return { revisions, isTruncated, counts: await countsP }
   },
 )
 
-const loadRevisionHash = ({ s3req, bucket, key }) =>
+const loadRevisionHash = ({ s3req, bucket, name, id }) =>
   s3req({
     bucket,
     operation: 'getObject',
-    params: { Bucket: bucket, Key: key },
-  }).then((res) => res.Body.toString('utf-8'))
+    params: { Bucket: bucket, Key: getRevisionKeyFromId(name, id) },
+  }).then((res) => ({
+    modified: res.LastModified,
+    hash: res.Body.toString('utf-8'),
+  }))
 
 export const getRevisionData = async ({
   s3req,
   endpoint,
   signer,
   bucket,
-  key,
+  name,
+  id,
   maxKeys = MAX_PACKAGE_ENTRIES,
 }) => {
-  const hash = await loadRevisionHash({ s3req, bucket, key })
+  const { hash, modified } = await loadRevisionHash({ s3req, bucket, name, id })
   const manifestKey = `${MANIFESTS_PREFIX}${hash}`
   const url = signer.getSignedS3URL({ bucket, key: manifestKey })
   const maxLines = maxKeys + 2 // 1 for the meta and 1 for checking overflow
   const r = await fetch(
     `${endpoint}/preview?url=${encodeURIComponent(url)}&input=txt&line_count=${maxLines}`,
   )
-  const [info, ...entries] = await r
+  const [header, ...entries] = await r
     .json()
     .then((json) => json.info.data.head.map((l) => JSON.parse(l)))
   const files = Math.min(maxKeys, entries.length)
@@ -790,8 +794,10 @@ export const getRevisionData = async ({
   const truncated = entries.length > maxKeys
   return {
     hash,
+    modified,
     stats: { files, bytes, truncated },
-    ...info,
+    message: header.message,
+    header,
   }
 }
 
@@ -828,8 +834,7 @@ const MAX_PACKAGE_ENTRIES = 500
 
 export const fetchPackageTree = withErrorHandling(
   async ({ s3req, sign, endpoint, bucket, name, revision }) => {
-    const hashKey = getRevisionKeyFromId(name, revision)
-    const hash = await loadRevisionHash({ s3req, bucket, key: hashKey })
+    const { hash } = await loadRevisionHash({ s3req, bucket, name, id: revision })
     const manifestKey = `${MANIFESTS_PREFIX}${hash}`
 
     // We skip the first line - it contains the manifest version, etc.

--- a/catalog/app/containers/Bucket/requests.js
+++ b/catalog/app/containers/Bucket/requests.js
@@ -755,6 +755,7 @@ export const getPackageRevisions = withErrorHandling(
       }, []),
       isTruncated: r.IsTruncated,
     }))
+    revisions.unshift({ id: 'latest', key: getRevisionKeyFromId(name, 'latest') })
     return { revisions, isTruncated, counts: await countsP }
   },
 )

--- a/catalog/app/utils/StyledLink.js
+++ b/catalog/app/utils/StyledLink.js
@@ -1,26 +1,25 @@
 import cx from 'classnames'
 import * as React from 'react'
 import { Link } from 'react-router-dom'
-import * as colors from '@material-ui/core/colors'
-import { withStyles } from '@material-ui/styles'
-
-import * as RT from 'utils/reactTools'
+import * as M from '@material-ui/core'
 
 export const linkStyle = {
   '&, &:visited': {
-    color: colors.blue[900],
+    color: M.colors.blue[900],
     cursor: 'pointer',
   },
   '&:hover, &:focus': {
-    color: colors.blue[500],
+    color: M.colors.blue[500],
   },
 }
 
-export default RT.composeComponent(
-  'StyledLink',
-  withStyles(() => ({ root: linkStyle })),
-  ({ component, className, classes, ...props }) => {
-    const Component = component || props.to ? Link : 'a'
-    return <Component className={cx(className, classes.root)} {...props} />
-  },
-)
+const useStyles = M.makeStyles(() => ({ root: linkStyle }))
+
+export default React.forwardRef(function StyledLink(
+  { component, className, ...props },
+  ref,
+) {
+  const classes = useStyles()
+  const Component = component || props.to ? Link : 'a'
+  return <Component className={cx(className, classes.root)} {...props} ref={ref} />
+})


### PR DESCRIPTION
- render tree for the latest revision under the root package route
- show "ROOT /" in the breadcrumbs (maybe smth like "PACKAGE /" would be better? @akarve)
- show revision list under the new `$pkg/revisions` route
- link to the revision list from the revision label (is it obvious enough or do we need a proper "Revisions" link / button somewhere? @akarve)
- fix a crash while rendering VCF with null header
- show `latest` revision

![pkg-landing](https://user-images.githubusercontent.com/122294/71189966-7ec4db00-22a5-11ea-90e6-abd54f416ebb.png)