### PR TITLE
Mock the cache directory in unit tests

### DIFF
--- a/api/python/tests/conftest.py
+++ b/api/python/tests/conftest.py
@@ -29,12 +29,15 @@ def pytest_sessionstart(session):
     # Figuring out how to use the pytest tmpdir fixture externally was kinda awful.
     Vars.tmpdir_home = pytest.ensuretemp('fake_home')
     Vars.tmpdir_data = Vars.tmpdir_home.mkdir('appdirs_datadir')
+    Vars.tmpdir_cache = Vars.tmpdir_home.mkdir('appdirs_cachedir')
 
     user_data_dir = lambda *x: str(Vars.tmpdir_data / x[0] if x else Vars.tmpdir_data)
+    user_cache_dir = lambda *x: str(Vars.tmpdir_cache / x[0] if x else Vars.tmpdir_cache)
 
     # Mockers that need to be loaded before any of our code
     Vars.extrasession_mockers.extend([
-        mock.patch('appdirs.user_data_dir', user_data_dir)
+        mock.patch('appdirs.user_data_dir', user_data_dir),
+        mock.patch('appdirs.user_cache_dir', user_cache_dir),
     ])
 
     for mocker in Vars.extrasession_mockers:


### PR DESCRIPTION
Tests broke when the object cache got moved from data dir to cache dir.