### PR TITLE
Fix some version ID bugs

### DIFF
--- a/api/python/quilt3/data_transfer.py
+++ b/api/python/quilt3/data_transfer.py
@@ -242,7 +242,7 @@ def _upload_or_copy_file(ctx, size, src_path, dest_bucket, dest_path):
             # Check the ETag.
             dest_size = resp['ContentLength']
             dest_etag = resp['ETag']
-            dest_version_id = resp['VersionId']
+            dest_version_id = resp.get('VersionId')
             if size == dest_size:
                 src_etag = _calculate_etag(src_path)
                 if src_etag == dest_etag:
@@ -633,8 +633,7 @@ def get_size_and_version(src):
         s3_client = create_s3_client()
         resp = s3_client.head_object(**params)
         size = resp['ContentLength']
-        if resp.get('VersionId', 'null') != 'null':  # Yes, 'null'
-            version = resp['VersionId']
+        version = resp.get('VersionId')
     else:
         raise NotImplementedError
     return size, version

--- a/api/python/quilt3/util.py
+++ b/api/python/quilt3/util.py
@@ -147,7 +147,7 @@ def parse_s3_url(s3_url):
 
 def make_s3_url(bucket, path, version_id=None):
     params = {}
-    if version_id not in (None, 'null'):
+    if version_id is not None:
         params = {'versionId': version_id}
 
     return urlunparse(('s3', bucket, quote(path), None, urlencode(params), None))

--- a/api/python/tests/integration/test_packages.py
+++ b/api/python/tests/integration/test_packages.py
@@ -628,7 +628,7 @@ class PackageTest(QuiltTestCase):
             pkg.set_dir('', 's3://bucket/foo/', meta='test_meta')
 
             assert pkg['a.txt'].physical_key == 's3://bucket/foo/a.txt?versionId=xyz'
-            assert pkg['x']['y.txt'].physical_key == 's3://bucket/foo/x/y.txt'
+            assert pkg['x']['y.txt'].physical_key == 's3://bucket/foo/x/y.txt?versionId=null'
             assert pkg.meta == "test_meta"
             assert pkg['x']['y.txt'].size == 10  # GH368
 
@@ -639,7 +639,7 @@ class PackageTest(QuiltTestCase):
             pkg.set_dir('bar', 's3://bucket/foo')
 
             assert pkg['bar']['a.txt'].physical_key == 's3://bucket/foo/a.txt?versionId=xyz'
-            assert pkg['bar']['x']['y.txt'].physical_key == 's3://bucket/foo/x/y.txt'
+            assert pkg['bar']['x']['y.txt'].physical_key == 's3://bucket/foo/x/y.txt?versionId=null'
             assert pkg['bar']['a.txt'].size == 10 # GH368
 
             list_object_versions_mock.assert_called_with('bucket', 'foo/')

--- a/api/python/tests/test_data_transfer.py
+++ b/api/python/tests/test_data_transfer.py
@@ -157,7 +157,6 @@ class DataTransferTest(QuiltTestCase):
         self.s3_stubber.add_response(
             method='put_object',
             service_response={
-                'VersionId': 'null'
             },
             expected_params={
                 'Body': ANY,
@@ -176,7 +175,6 @@ class DataTransferTest(QuiltTestCase):
         self.s3_stubber.add_response(
             method='put_object',
             service_response={
-                'VersionId': 'null'
             },
             expected_params={
                 'Body': ANY,


### PR DESCRIPTION
- Fix an exception when overwriting a file in an unversioned bucket: call `.get()` to get the version ID
- Don't treat `null` the same as no version: it is technically different. In particular, `s3://bucket/foo` and `s3://bucket/foo?versionId=null` can return different values