### PR TITLE
Expose linked data (JSON-LD) for packages

### DIFF
--- a/catalog/app/containers/Bucket/Overview.js
+++ b/catalog/app/containers/Bucket/Overview.js
@@ -1165,7 +1165,7 @@ export default function Overview({
       {AsyncResult.case({
         Ok: () => (
           <M.Box pb={{ xs: 0, sm: 4 }} mx={{ xs: -2, sm: 0 }}>
-            {!!cfg && cfg.relevance >= 0 && (
+            {!!cfg && (
               <React.Suspense fallback={null}>
                 <LinkedData.BucketData bucket={cfg} />
               </React.Suspense>

--- a/catalog/app/containers/Bucket/PackageTree.js
+++ b/catalog/app/containers/Bucket/PackageTree.js
@@ -12,8 +12,10 @@ import { Crumb, copyWithoutSpaces, render as renderCrumbs } from 'components/Bre
 import Skeleton from 'components/Skeleton'
 import AsyncResult from 'utils/AsyncResult'
 import * as AWS from 'utils/AWS'
+import * as BucketConfig from 'utils/BucketConfig'
 import * as Config from 'utils/Config'
 import Data from 'utils/Data'
+import * as LinkedData from 'utils/LinkedData'
 import * as NamedRoutes from 'utils/NamedRoutes'
 import Link, { linkStyle } from 'utils/StyledLink'
 import { getBreadCrumbs, getPrefix, isDir, parseS3Url, up, decode } from 'utils/s3paths'
@@ -361,6 +363,7 @@ export default function PackageTree({
   const { urls } = NamedRoutes.use()
   const getSignedS3URL = AWS.Signer.useS3Signer()
   const { apiGatewayEndpoint: endpoint } = Config.useConfig()
+  const bucketCfg = BucketConfig.useCurrentBucketConfig()
   const t = M.useTheme()
   const xs = M.useMediaQuery(t.breakpoints.down('xs'))
 
@@ -391,6 +394,31 @@ export default function PackageTree({
 
   return (
     <M.Box pt={2} pb={4}>
+      {!!bucketCfg && (
+        <Data
+          fetch={requests.getRevisionData}
+          params={{
+            s3req,
+            sign: getSignedS3URL,
+            endpoint,
+            bucket,
+            name,
+            id: revision,
+            maxKeys: 0,
+          }}
+        >
+          {AsyncResult.case({
+            _: () => null,
+            Ok: ({ hash, modified, header }) => (
+              <React.Suspense fallback={null}>
+                <LinkedData.PackageData
+                  {...{ bucket: bucketCfg, name, revision, hash, modified, header }}
+                />
+              </React.Suspense>
+            ),
+          })}
+        </Data>
+      )}
       <Data
         fetch={requests.fetchPackageTree}
         params={{ s3req, sign: getSignedS3URL, endpoint, bucket, name, revision }}


### PR DESCRIPTION
To be merged after #1462 

### TODO
- [x] package detail
- [x] package list
- [x] package revision list

### Notes

Currently structured data is being looked up under the `['user_meta']['json-ld']` path (as I discovered in some existing packages) in the manifest header (first line). The props used are:
- `name`
- `description`
- `sameAs`
- `identifier`
- `keywords`
- `creator`
- `license`

Moving forward, I think we should optimize and standardize structured data lookup for packages: make `name` (human-readable) and `description` top-level keys, bc they seem to be usable outside of the SEO / JSON-LD cases (btw `description` is required by Google). The rest of the props may live somewhere under the `structured_data` or `linked_data` top-level key, for example (no need for the schema.org boilerplate like `@context` and `@type`, just the actual data is required).