### PR TITLE
Preview: show note & warnings if present

### DIFF
--- a/catalog/app/components/Preview/loaders/Csv.js
+++ b/catalog/app/components/Preview/loaders/Csv.js
@@ -5,19 +5,19 @@ import AsyncResult from 'utils/AsyncResult'
 import { PreviewData } from '../types'
 import * as utils from './utils'
 
-export const detect = R.pipe(
-  utils.stripCompression,
-  utils.extIn(['.csv', '.tsv']),
-)
+export const detect = R.pipe(utils.stripCompression, utils.extIn(['.csv', '.tsv']))
 
 const fetcher = utils.previewFetcher('csv', (json) =>
-  AsyncResult.Ok(PreviewData.DataFrame({ preview: json.html })),
+  AsyncResult.Ok(
+    PreviewData.DataFrame({
+      preview: json.html,
+      note: json.info.note,
+      warnings: json.info.warnings,
+    }),
+  ),
 )
 
-const isTsv = R.pipe(
-  utils.stripCompression,
-  utils.extIs('.tsv'),
-)
+const isTsv = R.pipe(utils.stripCompression, utils.extIs('.tsv'))
 
 export const load = (handle, callback) =>
   fetcher(handle, callback, isTsv(handle.key) ? { query: { sep: '\t' } } : undefined)

--- a/catalog/app/components/Preview/loaders/Excel.js
+++ b/catalog/app/components/Preview/loaders/Excel.js
@@ -5,11 +5,14 @@ import AsyncResult from 'utils/AsyncResult'
 import { PreviewData } from '../types'
 import * as utils from './utils'
 
-export const detect = R.pipe(
-  utils.stripCompression,
-  utils.extIn(['.xls', '.xlsx']),
-)
+export const detect = R.pipe(utils.stripCompression, utils.extIn(['.xls', '.xlsx']))
 
 export const load = utils.previewFetcher('excel', (json) =>
-  AsyncResult.Ok(PreviewData.DataFrame({ preview: json.html })),
+  AsyncResult.Ok(
+    PreviewData.DataFrame({
+      preview: json.html,
+      note: json.info.note,
+      warnings: json.info.warnings,
+    }),
+  ),
 )

--- a/catalog/app/components/Preview/loaders/Notebook.js
+++ b/catalog/app/components/Preview/loaders/Notebook.js
@@ -5,11 +5,14 @@ import AsyncResult from 'utils/AsyncResult'
 import { PreviewData } from '../types'
 import * as utils from './utils'
 
-export const detect = R.pipe(
-  utils.stripCompression,
-  utils.extIs('.ipynb'),
-)
+export const detect = R.pipe(utils.stripCompression, utils.extIs('.ipynb'))
 
 export const load = utils.previewFetcher('ipynb', (json) =>
-  AsyncResult.Ok(PreviewData.Notebook({ preview: json.html })),
+  AsyncResult.Ok(
+    PreviewData.Notebook({
+      preview: json.html,
+      note: json.info.note,
+      warnings: json.info.warnings,
+    }),
+  ),
 )

--- a/catalog/app/components/Preview/loaders/Parquet.js
+++ b/catalog/app/components/Preview/loaders/Parquet.js
@@ -5,10 +5,7 @@ import AsyncResult from 'utils/AsyncResult'
 import { PreviewData } from '../types'
 import * as utils from './utils'
 
-export const detect = R.pipe(
-  utils.stripCompression,
-  utils.extIs('.parquet'),
-)
+export const detect = R.pipe(utils.stripCompression, utils.extIs('.parquet'))
 
 export const load = utils.previewFetcher(
   'parquet',
@@ -31,6 +28,8 @@ export const load = utils.previewFetcher(
       ),
       serializedSize: info.serialized_size,
       shape: { rows: info.shape[0], columns: info.shape[1] },
+      note: info.note,
+      warnings: info.warnings,
     }),
     PreviewData.Parquet,
     AsyncResult.Ok,

--- a/catalog/app/components/Preview/loaders/Text.js
+++ b/catalog/app/components/Preview/loaders/Text.js
@@ -61,12 +61,14 @@ const hl = (lang) => (contents) => hljs.highlight(lang, contents).value
 
 const fetcher = utils.previewFetcher(
   'txt',
-  ({ info: { data } }, { handle, forceLang }) => {
+  ({ info: { data, note, warnings } }, { handle, forceLang }) => {
     const head = data.head.join('\n')
     const tail = data.tail.join('\n')
     const lang = forceLang || getLang(handle.key)
     const highlighted = R.map(hl(lang), { head, tail })
-    return AsyncResult.Ok(PreviewData.Text({ head, tail, lang, highlighted }))
+    return AsyncResult.Ok(
+      PreviewData.Text({ head, tail, lang, highlighted, note, warnings }),
+    )
   },
 )
 

--- a/catalog/app/components/Preview/loaders/Vcf.js
+++ b/catalog/app/components/Preview/loaders/Vcf.js
@@ -5,10 +5,7 @@ import AsyncResult from 'utils/AsyncResult'
 import { PreviewData } from '../types'
 import * as utils from './utils'
 
-export const detect = R.pipe(
-  utils.stripCompression,
-  utils.extIs('.vcf'),
-)
+export const detect = R.pipe(utils.stripCompression, utils.extIs('.vcf'))
 
 export const load = utils.previewFetcher(
   'vcf',
@@ -17,8 +14,10 @@ export const load = utils.previewFetcher(
       info: {
         data: { meta, header, data },
         metadata: { variants },
+        note,
+        warnings,
       },
-    }) => ({ meta, header, data, variants }),
+    }) => ({ meta, header, data, variants, note, warnings }),
     PreviewData.Vcf,
     AsyncResult.Ok,
   ),

--- a/catalog/app/components/Preview/loaders/utils.js
+++ b/catalog/app/components/Preview/loaders/utils.js
@@ -177,16 +177,9 @@ const fetchPreview = async ({ endpoint, type, handle, signer, query }) => {
 const withGatewayEndpoint = (callback) => (
   <Config.Inject>
     {AsyncResult.case({
-      Err: R.pipe(
-        AsyncResult.Err,
-        callback,
-      ),
+      Err: R.pipe(AsyncResult.Err, callback),
       _: callback,
-      Ok: R.pipe(
-        R.prop('apiGatewayEndpoint'),
-        AsyncResult.Ok,
-        callback,
-      ),
+      Ok: R.pipe(R.prop('apiGatewayEndpoint'), AsyncResult.Ok, callback),
     })}
   </Config.Inject>
 )

--- a/catalog/app/components/Preview/renderers/DataFrame.js
+++ b/catalog/app/components/Preview/renderers/DataFrame.js
@@ -1,56 +1,56 @@
 import cx from 'classnames'
-import PT from 'prop-types'
 import * as React from 'react'
-import * as RC from 'recompose'
-import { withStyles } from '@material-ui/styles'
+import * as M from '@material-ui/core'
 
-import * as RT from 'utils/reactTools'
+import { renderPreviewStatus } from './util'
 
-const DataFrame = RT.composeComponent(
-  'Preview.renderers.DataFrame',
-  RC.setPropTypes({
-    children: PT.string,
-    className: PT.string,
-  }),
-  withStyles(({ palette, spacing: { unit } }) => ({
-    root: {
-      width: '100%',
-    },
-    wrapper: {
-      overflow: 'auto',
+const useStyles = M.makeStyles((t) => ({
+  root: {
+    width: '100%',
+  },
+  wrapper: {
+    overflow: 'auto',
 
-      '& table.dataframe': {
+    '& table.dataframe': {
+      border: 'none',
+      minWidth: '100%',
+      width: 'auto',
+
+      '& tr:nth-child(even)': {
+        backgroundColor: t.palette.grey[100],
+      },
+
+      '& th, & td': {
         border: 'none',
-        minWidth: '100%',
-        width: 'auto',
+        fontSize: 'small',
+        height: t.spacing(3),
+        paddingLeft: t.spacing(1),
+        paddingRight: t.spacing(1),
+      },
 
-        '& tr:nth-child(even)': {
-          backgroundColor: palette.grey[100],
-        },
-
-        '& th, & td': {
-          border: 'none',
-          fontSize: 'small',
-          height: 3 * unit,
-          paddingLeft: unit,
-          paddingRight: unit,
-        },
-
-        '& td': {
-          whiteSpace: 'nowrap',
-        },
+      '& td': {
+        whiteSpace: 'nowrap',
       },
     },
-  })),
-  ({ classes, children, className, ...props } = {}) => (
+  },
+}))
+
+function DataFrame({ children, className, note, warnings, ...props } = {}) {
+  const classes = useStyles()
+  return (
     <div className={cx(className, classes.root)} {...props}>
+      {renderPreviewStatus({ note, warnings })}
       <div
         className={classes.wrapper}
         // eslint-disable-next-line react/no-danger
         dangerouslySetInnerHTML={{ __html: children }}
       />
     </div>
-  ),
-)
+  )
+}
 
-export default ({ preview }, props) => <DataFrame {...props}>{preview}</DataFrame>
+export default ({ preview, note, warnings }, props) => (
+  <DataFrame {...{ note, warnings }} {...props}>
+    {preview}
+  </DataFrame>
+)

--- a/catalog/app/components/Preview/renderers/Notebook.js
+++ b/catalog/app/components/Preview/renderers/Notebook.js
@@ -1,13 +1,11 @@
 import cx from 'classnames'
 import renderMathInEl from 'katex/contrib/auto-render/auto-render'
-import PT from 'prop-types'
 import * as React from 'react'
-import * as RC from 'recompose'
-import { makeStyles } from '@material-ui/styles'
+import * as M from '@material-ui/core'
 
 import 'katex/dist/katex.css'
 
-import * as RT from 'utils/reactTools'
+import { renderPreviewStatus } from './util'
 
 const MATH_DELIMITERS = [
   { left: '$$', right: '$$', display: true },
@@ -21,9 +19,11 @@ const renderMath = (el) => {
   renderMathInEl(el, { delimiters: MATH_DELIMITERS })
 }
 
-const useStyles = makeStyles({
+const useStyles = M.makeStyles({
   root: {
     width: '100%',
+  },
+  contents: {
     // workaround to speed-up browser rendering / compositing
     '& pre': {
       overflow: 'hidden',
@@ -32,24 +32,23 @@ const useStyles = makeStyles({
   },
 })
 
-const Notebook = RT.composeComponent(
-  'Preview.renderers.Notebook',
-  RC.setPropTypes({
-    children: PT.string,
-    className: PT.string,
-  }),
-  ({ children, className, ...props } = {}) => {
-    const classes = useStyles()
-    return (
+function Notebook({ children, className, note, warnings, ...props } = {}) {
+  const classes = useStyles()
+  return (
+    <div className={cx(classes.root, className)} {...props}>
+      {renderPreviewStatus({ note, warnings })}
       <div
-        className={cx(classes.root, className, 'ipynb-preview')}
+        className={cx(classes.contents, 'ipynb-preview')}
         // eslint-disable-next-line react/no-danger
         dangerouslySetInnerHTML={{ __html: children }}
         ref={renderMath}
-        {...props}
       />
-    )
-  },
-)
+    </div>
+  )
+}
 
-export default ({ preview }, props) => <Notebook {...props}>{preview}</Notebook>
+export default ({ preview, note, warnings }, props) => (
+  <Notebook {...{ note, warnings }} {...props}>
+    {preview}
+  </Notebook>
+)

--- a/catalog/app/components/Preview/renderers/Parquet.js
+++ b/catalog/app/components/Preview/renderers/Parquet.js
@@ -1,121 +1,108 @@
 import cx from 'classnames'
-import PT from 'prop-types'
 import * as R from 'ramda'
 import * as React from 'react'
-import * as RC from 'recompose'
-import { styled, withStyles } from '@material-ui/styles'
+import * as M from '@material-ui/core'
 
 import JsonDisplay from 'components/JsonDisplay'
-import * as RT from 'utils/reactTools'
 
-const Mono = styled('span')(({ theme: t }) => ({
-  fontFamily: t.typography.monospace.fontFamily,
-}))
+import { renderPreviewStatus } from './util'
 
-const Parquet = RT.composeComponent(
-  'Preview.renderers.Parquet',
-  RC.setPropTypes({
-    className: PT.string,
-    preview: PT.string.isRequired,
-    createdBy: PT.string,
-    formatVersion: PT.string,
-    metadata: PT.object,
-    numRowGroups: PT.number,
-    // { path, logicalType, physicalType, maxDefinitionLevel, maxRepetitionLevel }
-    schema: PT.object.isRequired,
-    serializedSize: PT.number,
-    shape: PT.object, // { rows, columns }
-  }),
-  withStyles(({ palette, spacing: { unit } }) => ({
-    root: {
-      width: '100%',
-    },
-    meta: {},
-    metaName: {
-      paddingRight: unit,
-      textAlign: 'left',
-      verticalAlign: 'top',
-    },
-    dataframe: {
-      overflow: 'auto',
-      paddingTop: 2 * unit,
+const useStyles = M.makeStyles((t) => ({
+  root: {
+    width: '100%',
+  },
+  meta: {},
+  mono: {
+    fontFamily: t.typography.monospace.fontFamily,
+  },
+  metaName: {
+    paddingRight: t.spacing(1),
+    textAlign: 'left',
+    verticalAlign: 'top',
+  },
+  dataframe: {
+    overflow: 'auto',
+    paddingTop: t.spacing(2),
 
-      '& table.dataframe': {
+    '& table.dataframe': {
+      border: 'none',
+      width: 'auto',
+
+      '& tr:nth-child(even)': {
+        backgroundColor: t.palette.grey[100],
+      },
+
+      '& th, & td': {
         border: 'none',
-        width: 'auto',
+        fontSize: 'small',
+        height: t.spacing(3),
+        paddingLeft: t.spacing(1),
+        paddingRight: t.spacing(1),
+      },
 
-        '& tr:nth-child(even)': {
-          backgroundColor: palette.grey[100],
-        },
-
-        '& th, & td': {
-          border: 'none',
-          fontSize: 'small',
-          height: 3 * unit,
-          paddingLeft: unit,
-          paddingRight: unit,
-        },
-
-        '& td': {
-          whiteSpace: 'nowrap',
-        },
+      '& td': {
+        whiteSpace: 'nowrap',
       },
     },
-  })),
-  ({
-    classes,
-    className,
-    preview,
-    createdBy,
-    formatVersion,
-    metadata,
-    numRowGroups,
-    schema,
-    serializedSize,
-    shape,
-    ...props
-  }) => {
-    const renderMeta = (name, value, render = R.identity) =>
-      !!value && (
-        <tr>
-          <th className={classes.metaName}>{name}</th>
-          <td>{render(value)}</td>
-        </tr>
-      )
-
-    return (
-      <div className={cx(className, classes.root)} {...props}>
-        <table className={classes.meta}>
-          <tbody>
-            {renderMeta('Created by:', createdBy, (c) => (
-              <Mono>{c}</Mono>
-            ))}
-            {renderMeta('Format version:', formatVersion, (v) => (
-              <Mono>{v}</Mono>
-            ))}
-            {renderMeta('# row groups:', numRowGroups)}
-            {renderMeta('Serialized size:', serializedSize)}
-            {renderMeta('Shape:', shape, ({ rows, columns }) => (
-              <span>
-                {rows} rows &times; {columns} columns
-              </span>
-            ))}
-            {renderMeta('Metadata:', metadata, (m) => (
-              <JsonDisplay value={m} />
-            ))}
-            {renderMeta('Schema:', schema, (s) => (
-              <JsonDisplay value={s} />
-            ))}
-          </tbody>
-        </table>
-        <div
-          className={classes.dataframe}
-          // eslint-disable-next-line react/no-danger
-          dangerouslySetInnerHTML={{ __html: preview }}
-        />
-      </div>
-    )
   },
-)
+}))
+
+function Parquet({
+  className,
+  preview,
+  createdBy,
+  formatVersion,
+  metadata,
+  numRowGroups,
+  schema, // { path, logicalType, physicalType, maxDefinitionLevel, maxRepetitionLevel }
+  serializedSize,
+  shape, // { rows, columns }
+  note,
+  warnings,
+  ...props
+}) {
+  const classes = useStyles()
+  const renderMeta = (name, value, render = R.identity) =>
+    !!value && (
+      <tr>
+        <th className={classes.metaName}>{name}</th>
+        <td>{render(value)}</td>
+      </tr>
+    )
+
+  return (
+    <div className={cx(className, classes.root)} {...props}>
+      {renderPreviewStatus({ note, warnings })}
+      <table className={classes.meta}>
+        <tbody>
+          {renderMeta('Created by:', createdBy, (c) => (
+            <span className={classes.mono}>{c}</span>
+          ))}
+          {renderMeta('Format version:', formatVersion, (v) => (
+            <span className={classes.mono}>{v}</span>
+          ))}
+          {renderMeta('# row groups:', numRowGroups)}
+          {renderMeta('Serialized size:', serializedSize)}
+          {renderMeta('Shape:', shape, ({ rows, columns }) => (
+            <span>
+              {rows} rows &times; {columns} columns
+            </span>
+          ))}
+          {renderMeta('Metadata:', metadata, (m) => (
+            <JsonDisplay value={m} />
+          ))}
+          {renderMeta('Schema:', schema, (s) => (
+            <JsonDisplay value={s} />
+          ))}
+        </tbody>
+      </table>
+      <div
+        className={classes.dataframe}
+        // eslint-disable-next-line react/no-danger
+        dangerouslySetInnerHTML={{ __html: preview }}
+      />
+    </div>
+  )
+}
 
 export default (data, props) => <Parquet {...data} {...props} />

--- a/catalog/app/components/Preview/renderers/Text.js
+++ b/catalog/app/components/Preview/renderers/Text.js
@@ -1,28 +1,29 @@
 import cx from 'classnames'
-import PT from 'prop-types'
 import * as React from 'react'
-import * as RC from 'recompose'
-import { withStyles } from '@material-ui/styles'
+import * as M from '@material-ui/core'
 
-import * as RT from 'utils/reactTools'
+import { renderPreviewStatus } from './util'
 
-const Text = RT.composeComponent(
-  'Preview.renderers.Text',
-  RC.setPropTypes({
-    className: PT.string,
-    children: PT.node,
-  }),
-  withStyles((t) => ({
-    root: {
-      fontFamily: t.typography.monospace.fontFamily,
-      overflow: 'auto',
-      whiteSpace: 'pre',
-    },
-  })),
-  ({ classes, className, ...props }) => (
-    <div className={cx(className, classes.root)} {...props} />
-  ),
-)
+const useStyles = M.makeStyles((t) => ({
+  root: {
+    width: '100%',
+  },
+  text: {
+    fontFamily: t.typography.monospace.fontFamily,
+    overflow: 'auto',
+    whiteSpace: 'pre',
+  },
+}))
+
+function Text({ className, children, note, warnings, ...props }) {
+  const classes = useStyles()
+  return (
+    <div className={cx(className, classes.root)} {...props}>
+      {renderPreviewStatus({ note, warnings })}
+      <div className={classes.text}>{children}</div>
+    </div>
+  )
+}
 
 const html = (contents) => (
   // eslint-disable-next-line react/no-danger
@@ -31,8 +32,8 @@ const html = (contents) => (
 
 const Skip = () => <div>&hellip;</div>
 
-export default ({ highlighted: { head, tail } }, props) => (
-  <Text {...props}>
+export default ({ highlighted: { head, tail }, note, warnings }, props) => (
+  <Text {...{ note, warnings }} {...props}>
     {html(head)}
     {!!tail && <Skip />}
     {!!tail && html(tail)}

--- a/catalog/app/components/Preview/renderers/Vcf.js
+++ b/catalog/app/components/Preview/renderers/Vcf.js
@@ -1,17 +1,10 @@
 import cx from 'classnames'
 import * as React from 'react'
-import {
-  Box,
-  Table,
-  TableBody,
-  TableCell,
-  TableHead,
-  TableRow,
-  Typography,
-} from '@material-ui/core'
-import { makeStyles } from '@material-ui/styles'
+import * as M from '@material-ui/core'
 
-const useStyles = makeStyles((t) => ({
+import { renderPreviewStatus } from './util'
+
+const useStyles = M.makeStyles((t) => ({
   root: {
     width: '100%',
   },
@@ -51,64 +44,65 @@ const useStyles = makeStyles((t) => ({
   },
 }))
 
-const Vcf = ({ meta, header, data, variants }) => {
+function Vcf({ meta, header, data, variants, note, warnings }) {
   const classes = useStyles()
 
   const renderCell = (type, i = '') => (col, j) => (
-    <TableCell
+    <M.TableCell
       // eslint-disable-next-line react/no-array-index-key
       key={`${type}:${i}:${j}`}
       className={cx(classes.cell, classes[type])}
     >
       {col}
-    </TableCell>
+    </M.TableCell>
   )
 
   return (
     <div className={classes.root}>
+      {renderPreviewStatus({ note, warnings })}
       <div className={classes.tableWrapper}>
-        <Table className={classes.table}>
-          <TableHead>
+        <M.Table className={classes.table}>
+          <M.TableHead>
             {meta.map((l, i) => (
               // eslint-disable-next-line react/no-array-index-key
-              <TableRow key={`meta:${i}`} className={classes.row}>
-                <TableCell
+              <M.TableRow key={`meta:${i}`} className={classes.row}>
+                <M.TableCell
                   colSpan={header ? header[0].length : undefined}
                   className={cx(classes.cell, classes.meta)}
                 >
                   {l}
-                </TableCell>
-              </TableRow>
+                </M.TableCell>
+              </M.TableRow>
             ))}
-          </TableHead>
-        </Table>
+          </M.TableHead>
+        </M.Table>
       </div>
       <div className={classes.tableWrapper}>
-        <Table className={classes.table}>
+        <M.Table className={classes.table}>
           {!!header && (
-            <TableHead>
-              <TableRow className={classes.row}>
+            <M.TableHead>
+              <M.TableRow className={classes.row}>
                 {header.map(renderCell('header'))}
-              </TableRow>
-            </TableHead>
+              </M.TableRow>
+            </M.TableHead>
           )}
-          <TableBody>
+          <M.TableBody>
             {data.map((row, i) => (
               // eslint-disable-next-line react/no-array-index-key
-              <TableRow key={`data:${i}`} className={classes.row}>
+              <M.TableRow key={`data:${i}`} className={classes.row}>
                 {row.map(renderCell('data', i))}
-              </TableRow>
+              </M.TableRow>
             ))}
-          </TableBody>
-        </Table>
+          </M.TableBody>
+        </M.Table>
       </div>
       {!!variants.length && (
-        <Box mt={2}>
-          <Typography variant="h6" gutterBottom>
+        <M.Box mt={2}>
+          <M.Typography variant="h6" gutterBottom>
             Variants ({variants.length})
-          </Typography>
+          </M.Typography>
           <div className={classes.variants}>{variants.join(' ')}</div>
-        </Box>
+        </M.Box>
       )}
     </div>
   )

--- a/catalog/app/components/Preview/renderers/util.js
+++ b/catalog/app/components/Preview/renderers/util.js
@@ -6,7 +6,12 @@ const useMsgStyles = M.makeStyles((t) => ({
   root: {
     borderRadius: t.shape.borderRadius,
     padding: t.spacing(1.5),
+    whiteSpace: 'pre-wrap',
     ...t.typography.body2,
+  },
+  inner: {
+    maxHeight: 100,
+    overflow: 'auto',
   },
   info: {
     background: t.palette.info.light,
@@ -18,22 +23,19 @@ const useMsgStyles = M.makeStyles((t) => ({
   },
 }))
 
-export function Msg({ type = 'info', className, ...props }) {
+export function Msg({ type = 'info', className, children, ...props }) {
   const classes = useMsgStyles()
-  return <M.Box className={cx(classes.root, classes[type], className)} {...props} />
+  return (
+    <M.Box className={cx(classes.root, classes[type], className)} {...props}>
+      <div className={classes.inner}>{children}</div>
+    </M.Box>
+  )
 }
 
 export const renderPreviewStatus = ({ note, warnings }) => (
-  <>
-    {!!note && (
-      <Msg type="info" mb={2}>
-        {note}
-      </Msg>
-    )}
-    {!!warnings && (
-      <Msg type="warning" mb={2}>
-        {warnings}
-      </Msg>
-    )}
-  </>
+  <Msg type="warning" mb={2}>
+    {!!note && note}
+    {!!note && !!warnings && '\n\n'}
+    {!!warnings && warnings}
+  </Msg>
 )

--- a/catalog/app/components/Preview/renderers/util.js
+++ b/catalog/app/components/Preview/renderers/util.js
@@ -1,0 +1,39 @@
+import cx from 'classnames'
+import * as React from 'react'
+import * as M from '@material-ui/core'
+
+const useMsgStyles = M.makeStyles((t) => ({
+  root: {
+    borderRadius: t.shape.borderRadius,
+    padding: t.spacing(1.5),
+    ...t.typography.body2,
+  },
+  info: {
+    background: t.palette.info.light,
+    color: t.palette.info.contrastText,
+  },
+  warning: {
+    background: t.palette.warning.light,
+    color: t.palette.warning.contrastText,
+  },
+}))
+
+export function Msg({ type = 'info', className, ...props }) {
+  const classes = useMsgStyles()
+  return <M.Box className={cx(classes.root, classes[type], className)} {...props} />
+}
+
+export const renderPreviewStatus = ({ note, warnings }) => (
+  <>
+    {!!note && (
+      <Msg type="info" mb={2}>
+        {note}
+      </Msg>
+    )}
+    {!!warnings && (
+      <Msg type="warning" mb={2}>
+        {warnings}
+      </Msg>
+    )}
+  </>
+)

--- a/catalog/app/components/Preview/types.js
+++ b/catalog/app/components/Preview/types.js
@@ -16,17 +16,22 @@ ParquetMeta: {
   serializedSize: number,
   shape: { rows: number, columns: number },
 }
+
+PreviewStatus: {
+  note: string?,
+  warnings: string?,
+}
 */
 
 export const PreviewData = tagged([
-  'DataFrame', // { preview: string }
+  'DataFrame', // { preview: string, ...PreviewStatus }
   'Image', // { handle: object }
   'IFrame', // { src: string }
   'Markdown', // { rendered: string }
-  'Notebook', // { preview: string }
-  'Parquet', // { preview: string, ...ParquetMeta }
-  'Text', // { contents: string, lang: string }
-  'Vcf', // { meta: string[], header: string[], body: string[][], variants: string[] }
+  'Notebook', // { preview: string, ...PreviewStatus }
+  'Parquet', // { preview: string, ...ParquetMeta, ...PreviewStatus }
+  'Text', // { head: string, tail: string, lang: string, highlighted: { head: string, tail: string }, ...PreviewStatus }
+  'Vcf', // { meta: string[], header: string[], body: string[][], variants: string[], ...PreviewStatus }
   'Vega', // { spec: Object }
 ])
 

--- a/catalog/app/constants/style.js
+++ b/catalog/app/constants/style.js
@@ -11,6 +11,12 @@ const appPalette = {
   secondary: {
     main: colors.orange[600],
   },
+  info: {
+    main: colors.lightBlue[50],
+  },
+  warning: {
+    main: colors.yellow[200],
+  },
 }
 
 const websitePalette = {


### PR DESCRIPTION
Looks like this:
![warnings](https://user-images.githubusercontent.com/122294/71558077-e4b51d80-2a70-11ea-95ad-10686d398579.png)

Tho there was no testing using the real warnings returned by the backend, bc I couldn't find a deployed preview endpoint running the new code and proper broken files causing warnings, so I wasn't sure what format to expect.
