### PR TITLE
Use a PhysicalKey class instead of strings with URLs

### DIFF
--- a/api/python/quilt3/data_transfer.py
+++ b/api/python/quilt3/data_transfer.py
@@ -1,11 +1,10 @@
 from codecs import iterdecode
 from concurrent.futures import ThreadPoolExecutor
 import hashlib
-import json
 import pathlib
 import shutil
 from threading import Lock
-from urllib.parse import quote, unquote, urlparse
+from typing import List, Tuple
 import warnings
 
 from botocore import UNSIGNED
@@ -19,7 +18,7 @@ import jsonlines
 from tqdm import tqdm
 
 from .session import create_botocore_session
-from .util import QuiltException, make_s3_url, parse_file_url, parse_s3_url
+from .util import PhysicalKey, QuiltException
 
 
 def create_s3_client():
@@ -62,7 +61,7 @@ def _copy_local_file(ctx, size, src_path, dest_path):
     ctx.progress(size)
     shutil.copymode(src_path, dest_path)
 
-    ctx.done(pathlib.Path(dest_path).as_uri())
+    ctx.done(PhysicalKey(None, dest_path, None))
 
 
 def _upload_file(ctx, size, src_path, dest_bucket, dest_key):
@@ -77,7 +76,7 @@ def _upload_file(ctx, size, src_path, dest_bucket, dest_key):
             )
 
         version_id = resp.get('VersionId')  # Absent in unversioned buckets.
-        ctx.done(make_s3_url(dest_bucket, dest_key, version_id))
+        ctx.done(PhysicalKey(dest_bucket, dest_key, version_id))
     else:
         resp = s3_client.create_multipart_upload(
             Bucket=dest_bucket,
@@ -118,7 +117,7 @@ def _upload_file(ctx, size, src_path, dest_bucket, dest_key):
                     MultipartUpload={"Parts": parts}
                 )
                 version_id = resp.get('VersionId')  # Absent in unversioned buckets.
-                ctx.done(make_s3_url(dest_bucket, dest_key, version_id))
+                ctx.done(PhysicalKey(dest_bucket, dest_key, version_id))
 
         for i, start in enumerate(chunk_offsets):
             end = min(start + chunksize, size)
@@ -148,7 +147,7 @@ def _download_file(ctx, src_bucket, src_key, src_version, dest_path):
             fd.write(chunk)
             ctx.progress(len(chunk))
 
-    ctx.done(pathlib.Path(dest_path).as_uri())
+    ctx.done(PhysicalKey(None, dest_path, None))
 
 
 def _copy_remote_file(ctx, size, src_bucket, src_key, src_version,
@@ -177,7 +176,7 @@ def _copy_remote_file(ctx, size, src_bucket, src_key, src_version,
         resp = s3_client.copy_object(**params)
         ctx.progress(size)
         version_id = resp.get('VersionId')  # Absent in unversioned buckets.
-        ctx.done(make_s3_url(dest_bucket, dest_key, version_id))
+        ctx.done(PhysicalKey(dest_bucket, dest_key, version_id))
     else:
         resp = s3_client.create_multipart_upload(
             Bucket=dest_bucket,
@@ -220,7 +219,7 @@ def _copy_remote_file(ctx, size, src_bucket, src_key, src_version,
                     MultipartUpload={"Parts": parts}
                 )
                 version_id = resp.get('VersionId')  # Absent in unversioned buckets.
-                ctx.done(make_s3_url(dest_bucket, dest_key, version_id))
+                ctx.done(PhysicalKey(dest_bucket, dest_key, version_id))
 
         for i, start in enumerate(chunk_offsets):
             end = min(start + chunksize, size)
@@ -249,7 +248,7 @@ def _upload_or_copy_file(ctx, size, src_path, dest_bucket, dest_path):
                     # Nothing more to do. We should not attempt to copy the object because
                     # that would cause the "copy object to itself" error.
                     ctx.progress(size)
-                    ctx.done(make_s3_url(dest_bucket, dest_path, dest_version_id))
+                    ctx.done(PhysicalKey(dest_bucket, dest_path, dest_version_id))
                     return  # Optimization succeeded.
 
     # If the optimization didn't happen, do the normal upload.
@@ -287,7 +286,7 @@ def _copy_file_list_internal(s3_client, file_list):
             with lock:
                 futures.append(future)
 
-        def worker(idx, src_url, dest_url, size):
+        def worker(idx, src, dest, size):
             def done_callback(value):
                 assert value is not None
                 with lock:
@@ -296,33 +295,22 @@ def _copy_file_list_internal(s3_client, file_list):
 
             ctx = WorkerContext(s3_client=s3_client, progress=progress_callback, done=done_callback, run=run_task)
 
-            if src_url.scheme == 'file':
-                src_path = parse_file_url(src_url)
-                if dest_url.scheme == 'file':
-                    dest_path = parse_file_url(dest_url)
-                    _copy_local_file(ctx, size, src_path, dest_path)
-                elif dest_url.scheme == 's3':
-                    dest_bucket, dest_path, dest_version_id = parse_s3_url(dest_url)
-                    if dest_version_id:
-                        raise ValueError("Cannot set VersionId on destination")
-                    _upload_or_copy_file(ctx, size, src_path, dest_bucket, dest_path)
+            if dest.version_id:
+                raise ValueError("Cannot set VersionId on destination")
+
+            if src.is_local():
+                if dest.is_local():
+                    _copy_local_file(ctx, size, src.path, dest.path)
                 else:
-                    raise NotImplementedError
-            elif src_url.scheme == 's3':
-                src_bucket, src_path, src_version_id = parse_s3_url(src_url)
-                if dest_url.scheme == 'file':
-                    dest_path = parse_file_url(dest_url)
-                    _download_file(ctx, src_bucket, src_path, src_version_id, dest_path)
-                elif dest_url.scheme == 's3':
-                    dest_bucket, dest_path, dest_version_id = parse_s3_url(dest_url)
-                    if dest_version_id:
+                    if dest.version_id:
                         raise ValueError("Cannot set VersionId on destination")
-                    _copy_remote_file(ctx, size, src_bucket, src_path, src_version_id,
-                                      dest_bucket, dest_path)
-                else:
-                    raise NotImplementedError
+                    _upload_or_copy_file(ctx, size, src.path, dest.bucket, dest.path)
             else:
-                raise NotImplementedError
+                if dest.is_local():
+                    _download_file(ctx, src.bucket, src.path, src.version_id, dest.path)
+                else:
+                    _copy_remote_file(ctx, size, src.bucket, src.path, src.version_id,
+                                      dest.bucket, dest.path)
 
         for idx, args in enumerate(file_list):
             run_task(worker, idx, *args)
@@ -432,15 +420,13 @@ def list_objects(bucket, prefix, recursive=True):
         return prefixes, objects
 
 
-def _looks_like_dir(s):
-    return not s or s.endswith('/')
+def _looks_like_dir(pk: PhysicalKey):
+    return pk.basename() == ''
 
 
-def list_url(src):
-    src_url = urlparse(src)
-    if src_url.scheme == 'file':
-        src_path = parse_file_url(src_url)
-        src_file = pathlib.Path(src_path)
+def list_url(src: PhysicalKey):
+    if src.is_local():
+        src_file = pathlib.Path(src.path)
 
         for f in src_file.rglob('*'):
             try:
@@ -450,34 +436,30 @@ def list_url(src):
             except FileNotFoundError:
                 # If a file does not exist, is it really a file?
                 pass
-    elif src_url.scheme == 's3':
-        src_bucket, src_path, src_version_id = parse_s3_url(src_url)
-        if src_version_id is not None:
-            raise ValueError(f"Directories cannot have version IDs: {src_url!r}")
-        if not _looks_like_dir(src_path):
+    else:
+        if src.version_id is not None:
+            raise ValueError(f"Directories cannot have version IDs: {src}")
+        src_path = src.path
+        if not _looks_like_dir(src):
             src_path += '/'
         s3_client = create_s3_client()
         paginator = s3_client.get_paginator('list_objects_v2')
-        for response in paginator.paginate(Bucket=src_bucket, Prefix=src_path):
+        for response in paginator.paginate(Bucket=src.bucket, Prefix=src_path):
             for obj in response.get('Contents', []):
                 key = obj['Key']
                 if not key.startswith(src_path):
                     raise ValueError("Unexpected key: %r" % key)
                 yield key[len(src_path):], obj['Size']
-    else:
-        raise NotImplementedError
 
 
-def delete_url(src):
+def delete_url(src: PhysicalKey):
     """Deletes the given URL.
     Follows S3 semantics even for local files:
     - If the URL does not exist, it's a no-op.
     - If it's a non-empty directory, it's also a no-op.
     """
-    src_url = urlparse(src)
-    if src_url.scheme == 'file':
-        src_path = parse_file_url(src_url)
-        src_file = pathlib.Path(src_path)
+    if src.is_local():
+        src_file = pathlib.Path(src.path)
 
         if src_file.is_dir():
             try:
@@ -490,12 +472,9 @@ def delete_url(src):
                 src_file.unlink()
             except FileExistsError:
                 pass
-    elif src_url.scheme == 's3':
-        src_bucket, src_path, src_version_id = parse_s3_url(src_url)
-        s3_client = create_s3_client()
-        s3_client.delete_object(Bucket=src_bucket, Key=src_path)
     else:
-        raise NotImplementedError
+        s3_client = create_s3_client()
+        s3_client.delete_object(Bucket=src.bucket, Key=src.path)
 
 
 def copy_file_list(file_list):
@@ -504,23 +483,15 @@ def copy_file_list(file_list):
     URLs must be regular files, not directories.
     Returns versioned URLs for S3 destinations and regular file URLs for files.
     """
-    processed_file_list = []
-    for src, dest, size in file_list:
-        src_url = urlparse(src)
-        src_path = unquote(src_url.path)
-        dest_url = urlparse(dest)
-        dest_path = unquote(dest_url.path)
-
-        if _looks_like_dir(src_path) or _looks_like_dir(dest_path):
+    for src, dest, _ in file_list:
+        if _looks_like_dir(src) or _looks_like_dir(dest):
             raise ValueError("Directories are not allowed")
 
-        processed_file_list.append((src_url, dest_url, size))
-
     s3_client = create_s3_client()
-    return _copy_file_list_internal(s3_client, processed_file_list)
+    return _copy_file_list_internal(s3_client, file_list)
 
 
-def copy_file(src, dest, size=None):
+def copy_file(src: PhysicalKey, dest: PhysicalKey, size=None):
     """
     Copies a single file or directory.
     If src is a file, dest can be a file or a directory.
@@ -531,114 +502,90 @@ def copy_file(src, dest, size=None):
             if part in ('', '.', '..'):
                 raise ValueError("Invalid relative path: %r" % rel_path)
 
-    def url_append(url, path):
-        return url._replace(path=url.path + quote(path))
-
-    src_url = urlparse(src)
-    dest_url = urlparse(dest)
-    src_path = unquote(src_url.path)
-    dest_path = unquote(dest_url.path)
-
     url_list = []
-    if _looks_like_dir(src_path):
-        if not _looks_like_dir(dest_path):
+    if _looks_like_dir(src):
+        if not _looks_like_dir(dest):
             raise ValueError("Destination path must end in /")
         if size is not None:
             raise ValueError("`size` does not make sense for directories")
 
         for rel_path, size in list_url(src):
             sanity_check(rel_path)
-            new_src_url = url_append(src_url, rel_path)
-            new_dest_url = url_append(dest_url, rel_path)
-            url_list.append((new_src_url, new_dest_url, size))
+            url_list.append((src.join(rel_path), dest.join(rel_path), size))
         if not url_list:
             raise QuiltException("No objects to download.")
     else:
-        if _looks_like_dir(dest_path):
-            name = src_path.rsplit('/', 1)[1]
-            dest_url = url_append(dest_url, name)
+        if _looks_like_dir(dest):
+            dest = dest.join(src.basename())
         if size is None:
             size, _ = get_size_and_version(src)
-        url_list.append((src_url, dest_url, size))
+        url_list.append((src, dest, size))
 
     s3_client = create_s3_client()
     _copy_file_list_internal(s3_client, url_list)
 
 
-def put_bytes(data, dest):
-    dest_url = urlparse(dest)
-    if dest_url.scheme == 'file':
-        dest_path = pathlib.Path(parse_file_url(dest_url))
-        dest_path.parent.mkdir(parents=True, exist_ok=True)
-        dest_path.write_bytes(data)
-    elif dest_url.scheme == 's3':
-        dest_bucket, dest_path, dest_version_id = parse_s3_url(dest_url)
-        if not dest_path or dest_path.endswith('/'):
-            raise ValueError("Invalid path: %r" % dest_path)
-        if dest_version_id:
+def put_bytes(data: bytes, dest: PhysicalKey):
+    if _looks_like_dir(dest):
+        raise ValueError("Invalid path: %r" % dest.path)
+
+    if dest.is_local():
+        dest_file = pathlib.Path(dest.path)
+        dest_file.parent.mkdir(parents=True, exist_ok=True)
+        dest_file.write_bytes(data)
+    else:
+        if dest.version_id is not None:
             raise ValueError("Cannot set VersionId on destination")
         s3_client = create_s3_client()
         s3_client.put_object(
-            Bucket=dest_bucket,
-            Key=dest_path,
+            Bucket=dest.bucket,
+            Key=dest.path,
             Body=data,
         )
-    else:
-        raise NotImplementedError
 
-def get_bytes(src):
-    src_url = urlparse(src)
-    if src_url.scheme == 'file':
-        src_path = pathlib.Path(parse_file_url(src_url))
-        data = src_path.read_bytes()
-    elif src_url.scheme == 's3':
-        src_bucket, src_path, src_version_id = parse_s3_url(src_url)
-        params = dict(Bucket=src_bucket, Key=src_path)
-        if src_version_id is not None:
-            params.update(dict(VersionId=src_version_id))
+def get_bytes(src: PhysicalKey):
+    if src.is_local():
+        src_file = pathlib.Path(src.path)
+        data = src_file.read_bytes()
+    else:
+        params = dict(Bucket=src.bucket, Key=src.path)
+        if src.version_id is not None:
+            params.update(dict(VersionId=src.version_id))
         s3_client = create_s3_client()
         resp = s3_client.get_object(**params)
         data = resp['Body'].read()
-    else:
-        raise NotImplementedError
     return data
 
-def get_size_and_version(src):
+def get_size_and_version(src: PhysicalKey):
     """
     Gets size and version for the object at a given URL.
 
     Returns:
         size, version(str)
     """
-    src_url = urlparse(src)
-    path = unquote(src_url.path)
-
-    if not path or path.endswith('/'):
-        raise QuiltException("Invalid path: %r; cannot be a directory" % path)
+    if _looks_like_dir(src):
+        raise QuiltException("Invalid path: %r; cannot be a directory" % src.path)
 
     version = None
-    if src_url.scheme == 'file':
-        src_path = pathlib.Path(parse_file_url(src_url))
-        if not src_path.is_file():
-            raise QuiltException("Not a file: %r" % str(src_path))
-        size = src_path.stat().st_size
-    elif src_url.scheme == 's3':
-        bucket, key, version_id = parse_s3_url(src_url)
+    if src.is_local():
+        src_file = pathlib.Path(src.path)
+        if not src_file.is_file():
+            raise QuiltException("Not a file: %r" % str(src_file))
+        size = src_file.stat().st_size
+    else:
         params = dict(
-            Bucket=bucket,
-            Key=key
+            Bucket=src.bucket,
+            Key=src.path
         )
-        if version_id:
-            params.update(dict(VersionId=version_id))
+        if src.version_id is not None:
+            params.update(dict(VersionId=src.version_id))
         s3_client = create_s3_client()
         resp = s3_client.head_object(**params)
         size = resp['ContentLength']
         version = resp.get('VersionId')
-    else:
-        raise NotImplementedError
     return size, version
 
-def calculate_sha256(src_list, sizes):
+def calculate_sha256(src_list: List[PhysicalKey], sizes: List[int]):
     assert len(src_list) == len(sizes)
 
     total_size = sum(sizes)
@@ -646,12 +593,9 @@ def calculate_sha256(src_list, sizes):
 
     with tqdm(desc="Hashing", total=total_size, unit='B', unit_scale=True) as progress:
         def _process_url(src, size):
-            src_url = urlparse(src)
             hash_obj = hashlib.sha256()
-            if src_url.scheme == 'file':
-                path = pathlib.Path(parse_file_url(src_url))
-
-                with open(path, 'rb') as fd:
+            if src.is_local():
+                with open(src.path, 'rb') as fd:
                     while True:
                         chunk = fd.read(64 * 1024)
                         if not chunk:
@@ -670,11 +614,10 @@ def calculate_sha256(src_list, sizes):
                             f"This should be avoided if possible."
                         )
 
-            elif src_url.scheme == 's3':
-                src_bucket, src_path, src_version_id = parse_s3_url(src_url)
-                params = dict(Bucket=src_bucket, Key=src_path)
-                if src_version_id is not None:
-                    params.update(dict(VersionId=src_version_id))
+            else:
+                params = dict(Bucket=src.bucket, Key=src.path)
+                if src.version_id is not None:
+                    params.update(dict(VersionId=src.version_id))
                 s3_client = create_s3_client()
                 resp = s3_client.get_object(**params)
                 body = resp['Body']
@@ -682,8 +625,6 @@ def calculate_sha256(src_list, sizes):
                     hash_obj.update(chunk)
                     with lock:
                         progress.update(len(chunk))
-            else:
-                raise NotImplementedError
             return hash_obj.hexdigest()
 
         with ThreadPoolExecutor() as executor:
@@ -692,7 +633,7 @@ def calculate_sha256(src_list, sizes):
     return results
 
 
-def select(url, query, meta=None, raw=False, **kwargs):
+def select(src, query, meta=None, raw=False, **kwargs):
     """Perform an S3 Select SQL query, return results as a Pandas DataFrame
 
     The data returned by Boto3 for S3 Select is fairly convoluted, to say the
@@ -712,7 +653,7 @@ def select(url, query, meta=None, raw=False, **kwargs):
         transparently supported.
 
     Args:
-        url(str):  S3 URL of the object to query
+        src(PhysicalKey):  S3 URL of the object to query
         query(str): An SQL query using the 'SELECT' directive. See examples at
             https://docs.aws.amazon.com/AmazonS3/latest/API/RESTObjectSELECTContent.html
         meta: Quilt Object Metadata
@@ -764,8 +705,9 @@ def select(url, query, meta=None, raw=False, **kwargs):
         }
     delims = {'.tsv': '\t', '.ssv': ';'}
 
-    parsed_url = urlparse(url)
-    bucket, path, version_id = parse_s3_url(parsed_url)
+    assert not src.is_local(), "src must be an S3 URL"
+
+    # TODO: what about version_id???
 
     # TODO: Use formats lib for this stuff
     # use metadata to get format and compression
@@ -778,7 +720,7 @@ def select(url, query, meta=None, raw=False, **kwargs):
             format = meta.get('format', {}).get('contained_format', {}).get('name')
 
     # use file extensions to get compression info, if none is present
-    exts = pathlib.Path(path).suffixes  # last of e.g. ['.periods', '.in', '.name', '.json', '.gz']
+    exts = pathlib.Path(src.path).suffixes  # last of e.g. ['.periods', '.in', '.name', '.json', '.gz']
     if exts and not compression:
         if exts[-1].lower() in accepted_compression:
             compression = accepted_compression[exts.pop(-1)]   # remove e.g. '.gz'
@@ -797,7 +739,7 @@ def select(url, query, meta=None, raw=False, **kwargs):
                 raise QuiltException("Compression {!r} not valid for select on format {!r}: "
                                      "Expected {!r}".format(compression, s3_format, ok_compression))
     if not format:
-        raise QuiltException("Unable to discover format for select on {!r}".format(url))
+        raise QuiltException("Unable to discover format for select on {}".format(src))
 
     # At this point, we have a known format and enough information to use it.
     s3_format = valid_s3_select_formats[format]
@@ -816,8 +758,8 @@ def select(url, query, meta=None, raw=False, **kwargs):
 
     # These are processed and/or default args.
     select_kwargs = dict(
-        Bucket=bucket,
-        Key=path,
+        Bucket=src.bucket,
+        Key=src.path,
         Expression=query,
         ExpressionType=query_type,
         InputSerialization=input_serialization,

--- a/api/python/quilt3/data_transfer.py
+++ b/api/python/quilt3/data_transfer.py
@@ -61,7 +61,7 @@ def _copy_local_file(ctx, size, src_path, dest_path):
     ctx.progress(size)
     shutil.copymode(src_path, dest_path)
 
-    ctx.done(PhysicalKey(None, dest_path, None))
+    ctx.done(PhysicalKey.from_path(dest_path))
 
 
 def _upload_file(ctx, size, src_path, dest_bucket, dest_key):
@@ -147,7 +147,7 @@ def _download_file(ctx, src_bucket, src_key, src_version, dest_path):
             fd.write(chunk)
             ctx.progress(len(chunk))
 
-    ctx.done(PhysicalKey(None, dest_path, None))
+    ctx.done(PhysicalKey.from_path(dest_path))
 
 
 def _copy_remote_file(ctx, size, src_bucket, src_key, src_version,
@@ -653,7 +653,7 @@ def select(src, query, meta=None, raw=False, **kwargs):
         transparently supported.
 
     Args:
-        src(PhysicalKey):  S3 URL of the object to query
+        src(PhysicalKey):  S3 PhysicalKey of the object to query
         query(str): An SQL query using the 'SELECT' directive. See examples at
             https://docs.aws.amazon.com/AmazonS3/latest/API/RESTObjectSELECTContent.html
         meta: Quilt Object Metadata

--- a/api/python/quilt3/packages.py
+++ b/api/python/quilt3/packages.py
@@ -8,7 +8,6 @@ import os
 import shutil
 import time
 from multiprocessing import Pool
-from urllib.parse import quote, urlparse, unquote
 import uuid
 import warnings
 
@@ -23,10 +22,10 @@ from .exceptions import PackageException
 from .formats import FormatRegistry
 from .telemetry import ApiTelemetry
 from .util import (
-    QuiltException, fix_url, get_from_config, get_install_location, make_s3_url, parse_file_url,
-    parse_s3_url, validate_package_name, quiltignore_filter, validate_key, extract_file_extension, file_is_local
+    QuiltException, fix_url, get_from_config, get_install_location,
+    validate_package_name, quiltignore_filter, validate_key, extract_file_extension
 )
-from .util import CACHE_PATH, TEMPFILE_DIR_PATH as APP_DIR_TEMPFILE_DIR
+from .util import CACHE_PATH, TEMPFILE_DIR_PATH as APP_DIR_TEMPFILE_DIR, PhysicalKey
 
 
 
@@ -42,8 +41,8 @@ def hash_file(readable_file):
 
 
 def _delete_local_physical_key(pk):
-    assert file_is_local(pk), "This function only works on files that live on a local disk"
-    pathlib.Path(parse_file_url(urlparse(pk))).unlink()
+    assert pk.is_local(), "This function only works on files that live on a local disk"
+    pathlib.Path(pk.path).unlink()
 
 
 def _filesystem_safe_encode(key):
@@ -111,6 +110,7 @@ class PackageEntry(object):
         Returns:
             a PackageEntry
         """
+        assert isinstance(physical_key, PhysicalKey)
         self.physical_key = physical_key
         self.size = size
         self.hash = hash_obj
@@ -132,7 +132,7 @@ class PackageEntry(object):
         Returns dict representation of entry.
         """
         return {
-            'physical_keys': [self.physical_key],
+            'physical_keys': [str(self.physical_key)],
             'size': self.size,
             'hash': self.hash,
             'meta': self._meta
@@ -176,7 +176,7 @@ class PackageEntry(object):
             self
         """
         if path is not None:
-            self.physical_key = fix_url(path)
+            self.physical_key = PhysicalKey.from_url(fix_url(path))
             self.size = None
             self.hash = None
         elif meta is not None:
@@ -188,14 +188,14 @@ class PackageEntry(object):
         """
         Returns the physical key of this PackageEntry.
         """
-        return self.physical_key
+        return str(self.physical_key)
 
     def get_cached_path(self):
         """
         Returns a locally cached physical key, if available.
         """
-        if not file_is_local(self.physical_key):
-            return ObjectPathCache.get(self.physical_key)
+        if not self.physical_key.is_local():
+            return ObjectPathCache.get(str(self.physical_key))
         return None
 
     def get_bytes(self, use_cache_if_available=True):
@@ -206,7 +206,7 @@ class PackageEntry(object):
         if use_cache_if_available:
             cached_path = self.get_cached_path()
             if cached_path is not None:
-                return get_bytes(pathlib.Path(cached_path).as_uri())
+                return get_bytes(PhysicalKey(None, cached_path, None))
 
         data = get_bytes(self.physical_key)
         return data
@@ -253,7 +253,7 @@ class PackageEntry(object):
         if func is not None:
             return func(data)
 
-        pkey_ext = pathlib.PurePosixPath(unquote(urlparse(self.physical_key).path)).suffix
+        pkey_ext = pathlib.PurePosixPath(self.physical_key.path).suffix
 
         # Verify format can be handled before checking hash.  Raises if none found.
         formats = FormatRegistry.search(None, self._meta, pkey_ext)
@@ -275,10 +275,10 @@ class PackageEntry(object):
             None
         """
         if dest is None:
-            name = pathlib.PurePosixPath(unquote(urlparse(self.physical_key).path)).name
-            dest = (pathlib.Path().resolve() / name).as_uri()
+            name = self.physical_key.basename()
+            dest = PhysicalKey.from_path('.').join(name)
         else:
-            dest = fix_url(dest)
+            dest = PhysicalKey.from_url(fix_url(dest))
 
         copy_file(self.physical_key, dest)
 
@@ -328,9 +328,7 @@ class Package(object):
             if parent:
                 has_remote_entries = any(
                     self._map(
-                        lambda lk, entry: urlparse(
-                            fix_url(entry.physical_key)
-                        ).scheme != 'file'
+                        lambda lk, entry: not entry.physical_key.is_local()
                     )
                 )
                 pkg_type = 'remote' if has_remote_entries else 'local'
@@ -408,38 +406,43 @@ class Package(object):
                     "No registry specified and no default_remote_registry configured. Please "
                     "specify a registry or configure a default remote registry with quilt3.config"
                 )
+        else:
+            registry = fix_url(registry)
+
+        registry_parsed = PhysicalKey.from_url(registry)
 
         if dest_registry is None:
             dest_registry = get_from_config('default_local_registry')
         else:
-            dest_registry_parsed = urlparse(fix_url(dest_registry))
-            if dest_registry_parsed.scheme != 'file':
-                raise QuiltException(
-                    f"Can only 'install' to a local registry, but 'dest_registry' "
-                    f"{dest_registry!r} is a remote path. To store a package in a remote "
-                    f"registry, use 'push' or 'build' instead."
-                )
+            dest_registry = fix_url(dest_registry)
+
+        dest_registry_parsed = PhysicalKey.from_url(dest_registry)
+        if not dest_registry_parsed.is_local():
+            raise QuiltException(
+                f"Can only 'install' to a local registry, but 'dest_registry' "
+                f"{dest_registry!r} is a remote path. To store a package in a remote "
+                f"registry, use 'push' or 'build' instead."
+            )
 
         if dest is None:
-            dest = get_install_location().rstrip('/') + '/' + quote(name)
+            dest_parsed = PhysicalKey.from_url(get_install_location()).join(name)
         else:
-            dest_parsed = urlparse(fix_url(dest))
-            if dest_parsed.scheme != 'file':
+            dest_parsed = PhysicalKey.from_url(fix_url(dest))
+            if not dest_parsed.is_local():
                 raise QuiltException(
                     f"Invalid package destination path {dest!r}. 'dest', if set, must point at "
                     f"the local filesystem. To copy a package to a remote registry use 'push' or "
                     f"'build' instead."
                 )
 
-        pkg = cls._browse(name=name, registry=registry, top_hash=top_hash)
-        dest = fix_url(dest)
+        pkg = cls._browse(name=name, registry=registry_parsed, top_hash=top_hash)
         message = pkg._meta.get('message', None)  # propagate the package message
 
-        pkg._materialize(dest)
-        pkg._build(name, registry=dest_registry, message=message)
+        pkg._materialize(dest_parsed)
+        pkg._build(name, registry=dest_registry_parsed, message=message)
         if top_hash is None:
             top_hash = pkg.top_hash
-        short_tophash = Package.shorten_tophash(name, registry, top_hash)
+        short_tophash = Package._shorten_tophash(name, dest_registry_parsed, top_hash)
         print(f"Successfully installed package '{name}', tophash={short_tophash} from {registry}")
 
 
@@ -451,11 +454,12 @@ class Package(object):
             registry(string): location of registry
             hash_prefix(string): hash prefix with length between 6 and 64 characters
         """
+        assert isinstance(registry, PhysicalKey)
         if len(hash_prefix) == 64:
             top_hash = hash_prefix
         elif 6 <= len(hash_prefix) < 64:
             matching_hashes = [h for h, _
-                               in list_url(f'{registry}/.quilt/packages/')
+                               in list_url(registry.join('.quilt/packages/'))
                                if h.startswith(hash_prefix)]
             if not matching_hashes:
                 raise QuiltException("Found zero matches for %r" % hash_prefix)
@@ -468,9 +472,9 @@ class Package(object):
         return top_hash
 
     @classmethod
-    def shorten_tophash(cls, package_name, registry, top_hash):
+    def _shorten_tophash(cls, package_name, registry, top_hash):
         min_shorthash_len = 7
-        matches = [h for h, _ in list_url(f'{registry}/.quilt/packages/') if h.startswith(top_hash[:min_shorthash_len])]
+        matches = [h for h, _ in list_url(registry.join('.quilt/packages/')) if h.startswith(top_hash[:min_shorthash_len])]
         if len(matches) == 0:
             raise ValueError(f"Tophash {top_hash} was not found in registry {registry}")
         for prefix_length in range(min_shorthash_len, 64):
@@ -482,7 +486,7 @@ class Package(object):
 
     @classmethod
     @ApiTelemetry("package.browse")
-    def browse(cls, name=None, registry=None, top_hash=None):
+    def browse(cls, name, registry=None, top_hash=None):
         """
         Load a package into memory from a registry without making a local copy of
         the manifest.
@@ -491,37 +495,34 @@ class Package(object):
             registry(string): location of registry to load package from
             top_hash(string): top hash of package version to load
         """
-        return cls._browse(name=name, registry=registry, top_hash=top_hash)
-
-    @classmethod
-    def _browse(cls, name=None, registry=None, top_hash=None):
+        validate_package_name(name)
         if registry is None:
             registry = get_from_config('default_local_registry')
         else:
             registry = fix_url(registry)
+        registry_parsed = PhysicalKey.from_url(registry)
+        return cls._browse(name=name, registry=registry_parsed, top_hash=top_hash)
 
-        registry = registry.rstrip('/')
-        validate_package_name(name)
-
+    @classmethod
+    def _browse(cls, name, registry, top_hash):
         if top_hash is None:
-            top_hash_url = f'{registry}/.quilt/named_packages/{quote(name)}/latest'
-            top_hash = get_bytes(top_hash_url).decode('utf-8').strip()
+            top_hash_file = registry.join(f'.quilt/named_packages/{name}/latest')
+            top_hash = get_bytes(top_hash_file).decode('utf-8').strip()
         else:
             top_hash = cls.resolve_hash(registry, top_hash)
 
         # TODO: verify that name is correct with respect to this top_hash
-        # TODO: allow partial hashes (e.g. first six alphanumeric)
-        pkg_manifest_uri = f'{registry}/.quilt/packages/{quote(top_hash)}'
+        pkg_manifest = registry.join(f'.quilt/packages/{top_hash}')
 
-        if file_is_local(pkg_manifest_uri):
-            local_pkg_manifest = parse_file_url(urlparse(pkg_manifest_uri))
+        if pkg_manifest.is_local():
+            local_pkg_manifest = pkg_manifest.path
         else:
-            local_pkg_manifest = CACHE_PATH / "manifest" / _filesystem_safe_encode(pkg_manifest_uri)
+            local_pkg_manifest = CACHE_PATH / "manifest" / _filesystem_safe_encode(str(pkg_manifest))
             if not local_pkg_manifest.exists():
                 # Copy to a temporary file first, to make sure we don't cache a truncated file
                 # if the download gets interrupted.
                 tmp_path = local_pkg_manifest.with_suffix('.tmp')
-                copy_file(pkg_manifest_uri, tmp_path.as_uri())
+                copy_file(pkg_manifest, PhysicalKey.from_path(tmp_path))
                 tmp_path.rename(local_pkg_manifest)
 
         return cls._from_path(local_pkg_manifest)
@@ -590,13 +591,13 @@ class Package(object):
         Returns:
             None
         """
-        nice_dest = fix_url(dest).rstrip('/')
+        nice_dest = PhysicalKey.from_url(fix_url(dest))
         file_list = []
         pkg = Package()
 
         for logical_key, entry in self.walk():
             physical_key = entry.physical_key
-            new_physical_key = f'{nice_dest}/{quote(logical_key)}'
+            new_physical_key = nice_dest.join(logical_key)
 
             file_list.append((physical_key, new_physical_key, entry.size))
 
@@ -696,10 +697,10 @@ class Package(object):
                     if key in subpkg._children:
                         raise PackageException("Duplicate logical key while loading package")
                     subpkg._children[key] = PackageEntry(
-                            obj['physical_keys'][0],
-                            obj['size'],
-                            obj['hash'],
-                            obj['meta']
+                        PhysicalKey.from_url(obj['physical_keys'][0]),
+                        obj['size'],
+                        obj['hash'],
+                        obj['meta']
                     )
                     tqdm_progress.update(1)
         finally:
@@ -736,15 +737,14 @@ class Package(object):
 
         root.set_meta(meta)
 
-        if not path:
-            current_working_dir = pathlib.Path.cwd()
-            logical_key_abs_path = pathlib.Path(lkey).absolute()
-            path = logical_key_abs_path.relative_to(current_working_dir)
+        if path:
+            src = PhysicalKey.from_url(fix_url(path))
+        else:
+            src = PhysicalKey.from_path(lkey)
 
         # TODO: deserialization metadata
-        url = urlparse(fix_url(path).strip('/'))
-        if url.scheme == 'file':
-            src_path = pathlib.Path(parse_file_url(url))
+        if src.is_local():
+            src_path = pathlib.Path(src.path)
             if not src_path.is_dir():
                 raise PackageException("The specified directory doesn't exist")
 
@@ -756,16 +756,16 @@ class Package(object):
             for f in files:
                 if not f.is_file():
                     continue
-                entry = PackageEntry(f.as_uri(), f.stat().st_size, None, None)
+                entry = PackageEntry(PhysicalKey.from_path(f), f.stat().st_size, None, None)
                 logical_key = f.relative_to(src_path).as_posix()
                 root._set(logical_key, entry)
-        elif url.scheme == 's3':
-            src_bucket, src_key, src_version = parse_s3_url(url)
-            if src_version:
+        else:
+            if src.version_id is not None:
                 raise PackageException("Directories cannot have versions")
-            if src_key and not src_key.endswith('/'):
-                src_key += '/'
-            objects, _ = list_object_versions(src_bucket, src_key)
+            src_path = src.path
+            if src.basename() != '':
+                src_path += '/'
+            objects, _ = list_object_versions(src.bucket, src_path)
             for obj in objects:
                 if not obj['IsLatest']:
                     continue
@@ -774,12 +774,10 @@ class Package(object):
                     if obj['Size'] != 0:
                         warnings.warn(f'Logical keys cannot end in "/", skipping: {obj["Key"]}')
                     continue
-                obj_url = make_s3_url(src_bucket, obj['Key'], obj.get('VersionId'))
-                entry = PackageEntry(obj_url, obj['Size'], None, None)
-                logical_key = obj['Key'][len(src_key):]
+                obj_pk = PhysicalKey(src.bucket, obj['Key'], obj.get('VersionId'))
+                entry = PackageEntry(obj_pk, obj['Size'], None, None)
+                logical_key = obj['Key'][len(src_path):]
                 root._set(logical_key, entry)
-        else:
-            raise NotImplementedError
 
         return self
 
@@ -867,7 +865,7 @@ class Package(object):
 
 
     @ApiTelemetry("package.build")
-    def build(self, name=None, registry=None, message=None):
+    def build(self, name, registry=None, message=None):
         """
         Serializes this package to a registry.
 
@@ -880,35 +878,35 @@ class Package(object):
         Returns:
             The top hash as a string.
         """
-        return self._build(name=name, registry=registry, message=message)
-
-
-    def _build(self, name=None, registry=None, message=None):
-        self._set_commit_message(message)
+        validate_package_name(name)
 
         if registry is None:
             registry = get_from_config('default_local_registry')
         else:
             registry = fix_url(registry)
 
-        registry = registry.rstrip('/')
-        validate_package_name(name)
+        registry_parsed = PhysicalKey.from_url(registry)
+
+        return self._build(name=name, registry=registry_parsed, message=message)
+
+    def _build(self, name, registry, message):
+        self._set_commit_message(message)
 
         self._fix_sha256()
         manifest = io.BytesIO()
         self._dump(manifest)
 
-        pkg_manifest_file = f'{registry}/.quilt/packages/{quote(self.top_hash)}'
+        pkg_manifest_file = registry.join(f'.quilt/packages/{self.top_hash}')
         put_bytes(
             manifest.getvalue(),
             pkg_manifest_file
         )
 
-        named_path = f'{registry}/.quilt/named_packages/{quote(name)}/'
-        # TODO: use a float to string formater instead of double casting
+        named_path = registry.join(f'.quilt/named_packages/{name}')
         hash_bytes = self.top_hash.encode('utf-8')
-        timestamp_path = named_path + str(int(time.time()))
-        latest_path = named_path + "latest"
+        # TODO: use a float to string formater instead of double casting
+        timestamp_path = named_path.join(str(int(time.time())))
+        latest_path = named_path.join("latest")
         put_bytes(hash_bytes, timestamp_path)
         put_bytes(hash_bytes, latest_path)
 
@@ -991,21 +989,18 @@ class Package(object):
         validate_key(logical_key)
 
         if entry is None:
-            current_working_dir = pathlib.Path.cwd()
-            logical_key_abs_path = pathlib.Path(logical_key).absolute()
-            entry = logical_key_abs_path.relative_to(current_working_dir)
+            entry = pathlib.Path(logical_key).resolve().as_uri()
+            print('entry1: %r' % entry)
 
         if isinstance(entry, (str, os.PathLike)):
-            url = fix_url(str(entry))
-            size, version = get_size_and_version(url)
+            src = PhysicalKey.from_url(fix_url(str(entry)))
+            size, version_id = get_size_and_version(src)
 
             # Determine if a new version needs to be appended.
-            parsed_url = urlparse(url)
-            if parsed_url.scheme == 's3':
-                bucket, key, current_version = parse_s3_url(parsed_url)
-                if not current_version and version:
-                    url = make_s3_url(bucket, key, version)
-            entry = PackageEntry(url, size, None, None)
+            if not src.is_local() and src.version_id is None and version_id is not None:
+                src.version_id = version_id
+            entry = PackageEntry(src, size, None, None)
+            print('entry2: %r' % entry)
         elif isinstance(entry, PackageEntry):
             assert meta is None
 
@@ -1057,8 +1052,8 @@ class Package(object):
             serialization_path.write_bytes(serialized_object_bytes)
 
             size = serialization_path.stat().st_size
-            write_url = serialization_path.as_uri()
-            entry = PackageEntry(write_url, size, hash_obj=None, meta=new_meta)
+            write_pk = PhysicalKey.from_path(serialization_path)
+            entry = PackageEntry(write_pk, size, hash_obj=None, meta=new_meta)
 
         else:
             raise TypeError(f"Expected a string for entry, but got an instance of {type(entry)}.")
@@ -1188,57 +1183,44 @@ class Package(object):
                     "No registry specified and no default remote registry configured. Please "
                     "specify a registry or configure a default remote registry with quilt3.config"
                 )
-            registry_parsed = urlparse(fix_url(registry))
+            registry_parsed = PhysicalKey.from_url(fix_url(registry))
         else:
-            registry_parsed = urlparse(fix_url(registry))
-            if registry_parsed.scheme == 's3':
-                bucket, path, _ = parse_s3_url(registry_parsed)
-                if path != '':  # parse_s3_url returns path == '' if input is pathless
+            registry_parsed = PhysicalKey.from_url(fix_url(registry))
+            if not registry_parsed.is_local():
+                if registry_parsed.path != '':
                     raise QuiltException(
                         f"The 'registry' argument expects an S3 bucket but the S3 object path "
                         f"{registry!r} was provided instead. You probably wanted to set "
-                        f"'registry' to {'s3://' + bucket!r} instead. To specify that package "
+                        f"'registry' to {'s3://' + registry_parsed.bucket!r} instead. To specify that package "
                         f"data land in a specific directory use 'dest'."
                     )
-                registry = 's3://' + bucket
-            elif registry_parsed.scheme == 'file':
+            else:
                 raise QuiltException(
                     f"Can only 'push' to remote registries in S3, but {registry!r} "
                     f"is a local file. To store a package in the local registry, use "
                     f"'build' instead."
                 )
-            else:
-                raise NotImplementedError
 
         if dest is None:
-            dest = registry.rstrip('/') + '/' + quote(name)
+            dest_parsed = registry_parsed.join(name)
         else:
-            dest_parsed = urlparse(fix_url(dest))
-            if dest_parsed.scheme != registry_parsed.scheme:
-                raise QuiltException(
-                    f"Invalid package destination path {dest!r}. 'dest', if set, must be a path "
-                    f"in the {registry!r} package registry specified by 'registry'."
-                )
-
-            assert dest_parsed.scheme == 's3'
-            registry_bucket, _, _ = parse_s3_url(registry_parsed)
-            dest_bucket, _, _ = parse_s3_url(dest_parsed)
-            if registry_bucket != dest_bucket:
+            dest_parsed = PhysicalKey.from_url(fix_url(dest))
+            if dest_parsed.bucket != registry_parsed.bucket:
                 raise QuiltException(
                     f"Invalid package destination path {dest!r}. 'dest', if set, must be a path "
                     f"in the {registry!r} package registry specified by 'registry'."
                 )
 
         self._fix_sha256()
-        pkg = self._materialize(dest, selector_fn=selector_fn)
+        pkg = self._materialize(dest_parsed, selector_fn=selector_fn)
 
         def physical_key_is_temp_file(pk):
-            if not file_is_local(pk):
+            if not pk.is_local():
                 return False
-            return pathlib.Path(parse_file_url(urlparse(pk))).parent == APP_DIR_TEMPFILE_DIR
+            return pathlib.Path(pk.path).parent == APP_DIR_TEMPFILE_DIR
 
         temp_file_logical_keys = [lk for lk, entry in self.walk() if physical_key_is_temp_file(entry.physical_key)]
-        temp_file_physical_keys = [self.get(lk) for lk in temp_file_logical_keys]
+        temp_file_physical_keys = [self[lk].physical_key for lk in temp_file_logical_keys]
 
         # Now that data has been pushed, delete tmp files created by pkg.set('KEY', obj)
         with Pool(10) as p:
@@ -1248,7 +1230,7 @@ class Package(object):
         for lk in temp_file_logical_keys:
             self._set(lk, pkg[lk])
 
-        pkg._build(name, registry=registry, message=message)
+        pkg._build(name, registry=registry_parsed, message=message)
         return pkg
 
     @classmethod
@@ -1261,13 +1243,13 @@ class Package(object):
             registry(str): Registry where package is located.
             top_hash(str): Hash to rollback to.
         """
-        registry = fix_url(registry).rstrip('/')
+        registry = PhysicalKey.from_url(fix_url(registry))
         validate_package_name(name)
 
         top_hash = cls.resolve_hash(registry, top_hash)
 
-        hash_path = f'{registry}/.quilt/packages/{quote(top_hash)}'
-        latest_path = f'{registry}/.quilt/named_packages/{quote(name)}/latest'
+        hash_path = registry.join(f'.quilt/packages/{top_hash}')
+        latest_path = registry.join(f'.quilt/named_packages/{name}/latest')
 
         # Check that both latest and top_hash actually exist.
         get_size_and_version(hash_path)
@@ -1276,14 +1258,11 @@ class Package(object):
         put_bytes(top_hash.encode('utf-8'), latest_path)
 
     @classmethod
-    def _maybe_add_to_cache(cls, old_url, new_url):
-        old_parsed_url = urlparse(old_url)
-        new_parsed_url = urlparse(new_url)
-        if old_parsed_url.scheme == 's3' and new_parsed_url.scheme == 'file':
-            path = parse_file_url(new_parsed_url)
-            ObjectPathCache.set(old_url, path)
+    def _maybe_add_to_cache(cls, old: PhysicalKey, new: PhysicalKey):
+        if not old.is_local() and new.is_local():
+            ObjectPathCache.set(str(old), new.path)
 
-    def _materialize(self, dest_url, selector_fn=lambda logical_key, pkg_entry: True):
+    def _materialize(self, dest: PhysicalKey, selector_fn=lambda logical_key, pkg_entry: True):
         """
         Copies all Package entries to the destination, then creates a new package that points to those objects.
 
@@ -1310,10 +1289,6 @@ class Package(object):
         file_list = []
         entries = []
 
-        dest_url = dest_url.rstrip('/')
-
-        local_dest = file_is_local(dest_url)
-
         for logical_key, entry in self.walk():
             if not selector_fn(logical_key, entry):
                 pkg._set(logical_key, entry)
@@ -1322,15 +1297,15 @@ class Package(object):
             # Copy the datafiles in the package.
             physical_key = entry.physical_key
 
-            if local_dest:
+            if dest.is_local():
                 # Try a local cache.
-                cached_file = ObjectPathCache.get(physical_key)
+                cached_file = ObjectPathCache.get(str(physical_key))
                 if cached_file is not None:
-                    physical_key = pathlib.Path(cached_file).as_uri()
+                    physical_key = PhysicalKey.from_path(cached_file)
 
-            unversioned_physical_key = physical_key.split('?', 1)[0]
-            new_physical_key = dest_url + "/" + quote(logical_key)
-            if unversioned_physical_key == new_physical_key:
+            new_physical_key = dest.join(logical_key)
+            if (physical_key.bucket == new_physical_key.bucket and
+                physical_key.path == new_physical_key.path):
                 # No need to copy - re-use the original physical key.
                 pkg._set(logical_key, entry)
             else:
@@ -1340,7 +1315,7 @@ class Package(object):
         results = copy_file_list(file_list)
 
         for (logical_key, entry), versioned_key in zip(entries, results):
-            old_physical_key = entry.get()
+            old_physical_key = entry.physical_key
             self._maybe_add_to_cache(old_physical_key, versioned_key)
             # Create a new package entry pointing to the new remote key.
             assert versioned_key is not None
@@ -1454,7 +1429,7 @@ class Package(object):
         Returns:
             True if the package matches the directory; False otherwise.
         """
-        src = fix_url(src).rstrip('/') + '/'
+        src = PhysicalKey.from_url(fix_url(src))
         src_dict = dict(list_url(src))
         url_list = []
         size_list = []
@@ -1464,7 +1439,7 @@ class Package(object):
                 return False
             if entry.size != src_size:
                 return False
-            entry_url = src + quote(logical_key)
+            entry_url = src.join(logical_key)
             url_list.append(entry_url)
             size_list.append(src_size)
 

--- a/api/python/quilt3/util.py
+++ b/api/python/quilt3/util.py
@@ -6,7 +6,7 @@ import json
 import os
 import pathlib
 from urllib.parse import parse_qs, quote, unquote, urlencode, urlparse, urlunparse
-from urllib.request import url2pathname
+from urllib.request import pathname2url, url2pathname
 import warnings
 
 # Third-Party
@@ -79,6 +79,116 @@ class QuiltException(Exception):
             setattr(self, k, v)
 
 
+class PhysicalKey(object):
+    __slots__ = ['bucket', 'path', 'version_id']
+
+    def __init__(self, bucket, path, version_id):
+        """
+        """
+        assert bucket is None or isinstance(bucket, str)
+        assert isinstance(path, str)
+        assert version_id is None or isinstance(version_id, str)
+
+        if bucket is None:
+            assert path is not None, "Local keys must have a path"
+            assert version_id is None, "Local keys cannot have a version ID"
+            if os.name == 'nt':
+                assert '\\' not in path, "Paths must use / as a separator"
+        else:
+            assert not path.startswith('/'), "S3 paths must not start with '/'"
+
+        self.bucket = bucket
+        self.path = path
+        self.version_id = version_id
+
+    @classmethod
+    def from_url(cls, url):
+        parsed = urlparse(url)
+
+        if parsed.scheme == 's3':
+            if not parsed.netloc:
+                raise ValueError("Missing bucket")
+            bucket = parsed.netloc
+            assert not parsed.path or parsed.path.startswith('/')
+            path = unquote(parsed.path)[1:]
+            # Parse the version ID the way the Java SDK does:
+            # https://github.com/aws/aws-sdk-java/blob/master/aws-java-sdk-s3/src/main/java/com/amazonaws/services/s3/AmazonS3URI.java#L192
+            query = parse_qs(parsed.query)
+            version_id = query.pop('versionId', [None])[0]
+            if query:
+                raise ValueError(f"Unexpected S3 query string: {parsed.query!r}")
+            return cls(bucket, path, version_id)
+        elif parsed.scheme == 'file':
+            if parsed.netloc not in ('', 'localhost'):
+                raise ValueError("Unexpected hostname")
+            if not parsed.path:
+                raise ValueError("Missing path")
+            if not parsed.path.startswith('/'):
+                raise ValueError("Relative paths are not allowed")
+            if parsed.query:
+                raise ValueError("Unexpected query")
+            path = url2pathname(parsed.path)
+            if parsed.path.endswith('/') and not path.endswith(os.path.sep):
+                # On Windows, url2pathname loses the trailing `/`.
+                path += os.path.sep
+            return cls.from_path(path)
+        else:
+            raise ValueError(f"Unexpected scheme: {parsed.scheme!r}")
+
+    @classmethod
+    def from_path(cls, path):
+        path = os.fspath(path)
+        new_path = os.path.realpath(path)
+        # Use '/' as the path separator.
+        if os.path.sep != '/':
+            new_path = new_path.replace(os.path.sep, '/')
+        # Add back a trailing '/' if the original path has it.
+        if (path.endswith(os.path.sep) or
+            (os.path.altsep is not None and path.endswith(os.path.altsep))):
+            new_path += '/'
+        return cls(None, new_path, None)
+
+    def is_local(self):
+        return self.bucket is None
+
+    def join(self, rel_path):
+        if self.version_id is not None:
+            raise ValueError('Cannot append paths to URLs with a version ID')
+
+        if os.name == 'nt' and '\\' in rel_path:
+            raise ValueError("Paths must use / as a separator")
+
+        if self.path:
+            new_path = self.path.rstrip('/') + '/' + rel_path.lstrip('/')
+        else:
+            new_path = rel_path.lstrip('/')
+        return PhysicalKey(self.bucket, new_path, None)
+
+    def basename(self):
+        return self.path.rsplit('/', 1)[-1]
+
+    def __eq__(self, other):
+        return (
+            isinstance(other, self.__class__) and
+            self.bucket == other.bucket and
+            self.path == other.path and
+            self.version_id == other.version_id
+        )
+
+    def __repr__(self):
+        return f'{self.__class__.__name__}({self.bucket!r}, {self.path!r}, {self.version_id!r})'
+
+    def __str__(self):
+        if self.bucket is None:
+            return urlunparse(('file', '', pathname2url(self.path.replace('/', os.path.sep)), None, None, None))
+        else:
+            if self.version_id is None:
+                params = {}
+            else:
+                params = {'versionId': self.version_id}
+            return urlunparse(('s3', self.bucket, quote(self.path), None, urlencode(params), None))
+
+
 def fix_url(url):
     """Convert non-URL paths to file:// URLs"""
     # If it has a scheme, we assume it's a URL.
@@ -121,50 +231,6 @@ def extract_file_extension(file_path_or_url):
     else:
         return None
 
-
-EXAMPLE = "Example: 's3://my-bucket/path/'."
-def parse_s3_url(s3_url):
-    """
-    Takes in the result of urlparse, and returns a tuple (bucket, path, version_id)
-    """
-    if s3_url.scheme != 's3':
-        raise ValueError("Expected URI scheme 's3', not '{}'. {}".format(s3_url.scheme, EXAMPLE))
-    if not s3_url.netloc:
-        raise ValueError("Expected non-empty URI location. {}".format(EXAMPLE))
-    # based on testing, the next case can never happen; TODO: remove this case
-    if (s3_url.path and not s3_url.path.startswith('/')):
-        raise ValueError("Expected URI path to start with '/', not '{}'. {}".format(s3_url.scheme, EXAMPLE))
-    bucket = s3_url.netloc
-    path = unquote(s3_url.path)[1:]
-    # Parse the version ID the way the Java SDK does:
-    # https://github.com/aws/aws-sdk-java/blob/master/aws-java-sdk-s3/src/main/java/com/amazonaws/services/s3/AmazonS3URI.java#L192
-    query = parse_qs(s3_url.query)
-    version_id = query.pop('versionId', [None])[0]
-    if query:
-        raise ValueError("Unexpected S3 query string: %r" % s3_url.query)
-    return bucket, path, version_id
-
-
-def make_s3_url(bucket, path, version_id=None):
-    params = {}
-    if version_id is not None:
-        params = {'versionId': version_id}
-
-    return urlunparse(('s3', bucket, quote(path), None, urlencode(params), None))
-
-
-def parse_file_url(file_url):
-    if file_url.scheme != 'file':
-        raise ValueError("Invalid file URI")
-    path = url2pathname(file_url.path)
-    if file_url.netloc not in ('', 'localhost'):
-        # Windows file share
-        # TODO: Can't do anything useful on non-Windows... Return an error?
-        path = '\\\\%s%s' % (file_url.netloc, path)
-    return path
-
-def file_is_local(file_url_or_path):
-    return urlparse(fix_url(file_url_or_path)).scheme == 'file'
 
 def read_yaml(yaml_stream):
     yaml = ruamel.yaml.YAML()
@@ -441,14 +507,17 @@ def catalog_s3_url(catalog_url, s3_url):
     if s3_url is None:
         return catalog_url
 
-    bucket, path, version_id = parse_s3_url(urlparse(s3_url))
-    catalog_s3_url = f"{catalog_url}/b/{quote(bucket)}"
+    pk = PhysicalKey.from_url(s3_url)
+    if pk.is_local():
+        raise QuiltException("Not an S3 URL")
 
-    if path:
-        catalog_s3_url += f"/tree/{quote(path)}"
+    url = f"{catalog_url}/b/{quote(pk.bucket)}"
+
+    if pk.path:
+        url += f"/tree/{quote(pk.path)}"
 
         # Ignore version_id if path is empty (e.g., s3://<bucket>)
-        if version_id is not None:
-            params = {'version': version_id}
-            catalog_s3_url += f"?{urlencode(params)}"
-    return catalog_s3_url
+        if pk.version_id is not None:
+            params = {'version': pk.version_id}
+            url += f"?{urlencode(params)}"
+    return url

--- a/api/python/quilt3/util.py
+++ b/api/python/quilt3/util.py
@@ -84,6 +84,7 @@ class PhysicalKey(object):
 
     def __init__(self, bucket, path, version_id):
         """
+        For internal use only; call from_path or from_url instead.
         """
         assert bucket is None or isinstance(bucket, str)
         assert isinstance(path, str)

--- a/api/python/tests/integration/test_packages.py
+++ b/api/python/tests/integration/test_packages.py
@@ -296,7 +296,7 @@ class PackageTest(QuiltTestCase):
 
                 materialize_mock.assert_called_once_with(PhysicalKey.from_path('./'))
                 build_mock.assert_called_once_with(
-                    'Quilt/nice-name', message=None, registry=PhysicalKey.from_url(dest_registry)
+                    'Quilt/nice-name', message=None, registry=dest_registry
                 )
 
     def test_install_restrictions(self):
@@ -1017,7 +1017,7 @@ class PackageTest(QuiltTestCase):
 
             pkg.push('Quilt/test_pkg_name', 's3://test-bucket', message='test_message')
             build_mock.assert_called_once_with(
-                'Quilt/test_pkg_name', registry=PhysicalKey.from_url('s3://test-bucket'), message='test_message'
+                'Quilt/test_pkg_name', registry='s3://test-bucket', message='test_message'
             )
 
     def test_overwrite_dir_fails(self):

--- a/api/python/tests/integration/test_packages.py
+++ b/api/python/tests/integration/test_packages.py
@@ -5,7 +5,6 @@ import pathlib
 from pathlib import Path
 import pandas as pd
 import shutil
-from urllib.parse import urlparse
 
 import jsonlines
 from unittest.mock import patch, call, ANY
@@ -13,7 +12,7 @@ import pytest
 
 import quilt3
 from quilt3 import Package
-from quilt3.util import QuiltException, validate_package_name, parse_file_url, fix_url
+from quilt3.util import PhysicalKey, QuiltException, validate_package_name, fix_url
 
 from ..utils import QuiltTestCase
 
@@ -64,7 +63,7 @@ class PackageTest(QuiltTestCase):
         out_path = LOCAL_REGISTRY / ".quilt/packages" / top_hash
         with open(out_path) as fd:
             pkg = Package.load(fd)
-            assert test_file.resolve().as_uri() == pkg['foo'].physical_key
+            assert PhysicalKey.from_path(test_file) == pkg['foo'].physical_key
 
         # Verify latest points to the new location.
         named_pointer_path = LOCAL_REGISTRY / ".quilt/named_packages/Quilt/Test/latest"
@@ -78,7 +77,7 @@ class PackageTest(QuiltTestCase):
         out_path = LOCAL_REGISTRY / ".quilt/packages" / top_hash
         with open(out_path) as fd:
             pkg = Package.load(fd)
-            assert test_file.resolve().as_uri() == pkg['bar'].physical_key
+            assert PhysicalKey.from_path(test_file) == pkg['bar'].physical_key
 
     def test_default_registry(self):
         new_pkg = Package()
@@ -97,7 +96,7 @@ class PackageTest(QuiltTestCase):
         out_path = LOCAL_REGISTRY / ".quilt/packages" / top_hash
         with open(out_path) as fd:
             pkg = Package.load(fd)
-            assert test_file.resolve().as_uri() == pkg['foo'].physical_key
+            assert PhysicalKey.from_path(test_file) == pkg['foo'].physical_key
 
         # Verify latest points to the new location.
         named_pointer_path = LOCAL_REGISTRY / ".quilt/named_packages/Quilt/Test/latest"
@@ -111,10 +110,10 @@ class PackageTest(QuiltTestCase):
         out_path = LOCAL_REGISTRY / ".quilt/packages" / top_hash
         with open(out_path) as fd:
             pkg = Package.load(fd)
-            assert test_file.resolve().as_uri() == pkg['bar'].physical_key
+            assert PhysicalKey.from_path(test_file) == pkg['bar'].physical_key
 
     @patch('quilt3.Package._browse', lambda name, registry, top_hash: Package())
-    @patch('quilt3.Package.shorten_tophash', lambda package_name, registry, top_hash: "7a67ff4")
+    @patch('quilt3.Package._shorten_tophash', lambda package_name, registry, top_hash: "7a67ff4")
     def test_default_install_location(self):
         """Verify that pushes to the default local install location work as expected"""
         with patch('quilt3.Package._materialize') as materialize_mock:
@@ -122,7 +121,7 @@ class PackageTest(QuiltTestCase):
             Package.install(pkg_name, registry='s3://my-test-bucket')
 
             materialize_mock.assert_called_once_with(
-                quilt3.util.get_install_location().rstrip('/') + '/' + pkg_name,
+                PhysicalKey.from_url(quilt3.util.get_install_location()).join(pkg_name),
             )
 
     def test_read_manifest(self):
@@ -142,8 +141,12 @@ class PackageTest(QuiltTestCase):
         with open(out_path) as fd:
             written_set = list(jsonlines.Reader(fd))
         assert len(original_set) == len(written_set)
-        assert sorted(original_set, key=lambda k: k.get('logical_key', 'manifest')) \
-            == sorted(written_set, key=lambda k: k.get('logical_key', 'manifest'))
+
+        if os.name != 'nt':
+            # TODO: LOCAL_MANIFEST contains paths like file:///foo -
+            # but they're not valid absolute paths on Windows. What do we do?
+            assert sorted(original_set, key=lambda k: k.get('logical_key', 'manifest')) \
+                == sorted(written_set, key=lambda k: k.get('logical_key', 'manifest'))
 
     def test_remote_browse(self):
         """ Verify loading manifest from s3 """
@@ -291,9 +294,9 @@ class PackageTest(QuiltTestCase):
 
                 quilt3.Package.install('Quilt/nice-name', dest='./')
 
-                materialize_mock.assert_called_once_with(fix_url('./'))
+                materialize_mock.assert_called_once_with(PhysicalKey.from_path('./'))
                 build_mock.assert_called_once_with(
-                    'Quilt/nice-name', message=None, registry=dest_registry
+                    'Quilt/nice-name', message=None, registry=PhysicalKey.from_url(dest_registry)
                 )
 
     def test_install_restrictions(self):
@@ -327,10 +330,10 @@ class PackageTest(QuiltTestCase):
             'fetch wrote {} files; expected: {}'.format(file_count, expected)
 
         # test that package re-rooting works as expected
-        out_dir_abs_path = pathlib.Path(out_dir).resolve().as_uri()
-        assert all(
-            entry.physical_key.startswith(out_dir_abs_path) for _, entry in new_package_.walk()
-        )
+        out_dir_abs_path = pathlib.Path(out_dir).resolve()
+        for _, entry in new_package_.walk():
+            # relative_to will raise an exception if the first path is not inside the second path.
+            pathlib.Path(entry.physical_key.path).relative_to(out_dir_abs_path)
 
     def test_package_fetch_default_dest(self):
         """Verify fetching a package to the default local destination."""
@@ -363,8 +366,7 @@ class PackageTest(QuiltTestCase):
         # The key gets re-rooted correctly.
         pkg = quilt3.Package().set('foo', DATA_DIR / 'foo.txt')
         new_pkg_entry = pkg['foo'].fetch('bar.txt')
-        out_abs_path = pathlib.Path("bar.txt").resolve().as_uri()
-        assert new_pkg_entry.physical_key == out_abs_path
+        assert new_pkg_entry.physical_key == PhysicalKey.from_path('bar.txt')
 
     def test_fetch_default_dest(tmpdir):
         """Verify fetching a package entry to a default destination."""
@@ -372,8 +374,11 @@ class PackageTest(QuiltTestCase):
             (Package()
              .set('foo', os.path.join(os.path.dirname(__file__), 'data', 'foo.txt'))['foo']
              .fetch())
-            filepath = fix_url(os.path.join(os.path.dirname(__file__), 'data', 'foo.txt'))
-            copy_mock.assert_called_once_with(filepath, ANY)
+            filepath = os.path.join(os.path.dirname(__file__), 'data', 'foo.txt')
+            copy_mock.assert_called_once_with(
+                PhysicalKey.from_path(filepath),
+                PhysicalKey.from_path('foo.txt')
+            )
 
     def test_load_into_quilt(self):
         """ Verify loading local manifest and data into S3. """
@@ -548,21 +553,21 @@ class PackageTest(QuiltTestCase):
 
         pkg = pkg.set_dir("/", ".", meta="test_meta")
 
-        assert pathlib.Path('foo').resolve().as_uri() == pkg['foo'].physical_key
-        assert pathlib.Path('bar').resolve().as_uri() == pkg['bar'].physical_key
-        assert (bazdir / 'baz').resolve().as_uri() == pkg['foo_dir/baz_dir/baz'].physical_key
-        assert (foodir / 'bar').resolve().as_uri() == pkg['foo_dir/bar'].physical_key
+        assert PhysicalKey.from_path('foo') == pkg['foo'].physical_key
+        assert PhysicalKey.from_path('bar') == pkg['bar'].physical_key
+        assert PhysicalKey.from_path(bazdir / 'baz') == pkg['foo_dir/baz_dir/baz'].physical_key
+        assert PhysicalKey.from_path(foodir / 'bar') == pkg['foo_dir/bar'].physical_key
         assert pkg.meta == "test_meta"
 
         pkg = Package()
         pkg = pkg.set_dir('/','foo_dir/baz_dir/')
         # todo nested at set_dir site or relative to set_dir path.
-        assert (bazdir / 'baz').resolve().as_uri() == pkg['baz'].physical_key
+        assert PhysicalKey.from_path(bazdir / 'baz') == pkg['baz'].physical_key
 
         pkg = Package()
         pkg = pkg.set_dir('my_keys', 'foo_dir/baz_dir/')
         # todo nested at set_dir site or relative to set_dir path.
-        assert (bazdir / 'baz').resolve().as_uri() == pkg['my_keys/baz'].physical_key
+        assert PhysicalKey.from_path(bazdir / 'baz') == pkg['my_keys/baz'].physical_key
 
         # Verify ignoring files in the presence of a dot-quiltignore
         with open('.quiltignore', 'w') as fd:
@@ -591,15 +596,15 @@ class PackageTest(QuiltTestCase):
 
         pkg = pkg.set_dir("new_dir", ".", meta="new_test_meta")
 
-        assert pathlib.Path('foo').resolve().as_uri() == pkg['new_dir/foo'].physical_key
-        assert pathlib.Path('bar').resolve().as_uri() == pkg['new_dir/bar'].physical_key
+        assert PhysicalKey.from_path('foo') == pkg['new_dir/foo'].physical_key
+        assert PhysicalKey.from_path('bar') == pkg['new_dir/bar'].physical_key
         assert pkg['new_dir'].meta == "new_test_meta"
 
         # verify set_dir logical key shortcut
         pkg = Package()
         pkg.set_dir("/")
-        assert pathlib.Path('foo').resolve().as_uri() == pkg['foo'].physical_key
-        assert pathlib.Path('bar').resolve().as_uri() == pkg['bar'].physical_key
+        assert PhysicalKey.from_path('foo') == pkg['foo'].physical_key
+        assert PhysicalKey.from_path('bar') == pkg['bar'].physical_key
 
 
     def test_s3_set_dir(self):
@@ -615,8 +620,8 @@ class PackageTest(QuiltTestCase):
 
             pkg.set_dir('', 's3://bucket/foo/', meta='test_meta')
 
-            assert pkg['a.txt'].physical_key == 's3://bucket/foo/a.txt?versionId=xyz'
-            assert pkg['x']['y.txt'].physical_key == 's3://bucket/foo/x/y.txt?versionId=null'
+            assert pkg['a.txt'].get() == 's3://bucket/foo/a.txt?versionId=xyz'
+            assert pkg['x']['y.txt'].get() == 's3://bucket/foo/x/y.txt?versionId=null'
             assert pkg.meta == "test_meta"
             assert pkg['x']['y.txt'].size == 10  # GH368
 
@@ -626,8 +631,8 @@ class PackageTest(QuiltTestCase):
 
             pkg.set_dir('bar', 's3://bucket/foo')
 
-            assert pkg['bar']['a.txt'].physical_key == 's3://bucket/foo/a.txt?versionId=xyz'
-            assert pkg['bar']['x']['y.txt'].physical_key == 's3://bucket/foo/x/y.txt?versionId=null'
+            assert pkg['bar']['a.txt'].get() == 's3://bucket/foo/a.txt?versionId=xyz'
+            assert pkg['bar']['x']['y.txt'].get() == 's3://bucket/foo/x/y.txt?versionId=null'
             assert pkg['bar']['a.txt'].size == 10 # GH368
 
             list_object_versions_mock.assert_called_with('bucket', 'foo/')
@@ -688,16 +693,15 @@ class PackageTest(QuiltTestCase):
         pkg['bar'].meta['target'] = 'unicode'
 
         # Build a dummy file to add to the map.
-        with open('bar.txt', "w") as fd:
-            fd.write('test_file_content_string')
-            test_file = Path(fd.name)
+        test_file = Path('bar.txt')
+        test_file.write_text('test_file_content_string')
         pkg['bar'].set('bar.txt')
 
-        assert test_file.resolve().as_uri() == pkg['bar'].physical_key
+        assert PhysicalKey.from_path(test_file) == pkg['bar'].physical_key
 
         # Test shortcut codepath
         pkg = Package().set('bar.txt')
-        assert test_file.resolve().as_uri() == pkg['bar.txt'].physical_key
+        assert PhysicalKey.from_path(test_file) == pkg['bar.txt'].physical_key
 
     def test_set_package_entry_as_object(self):
         pkg = Package()
@@ -720,7 +724,7 @@ class PackageTest(QuiltTestCase):
         pkg.set("mydataframe6.tsv", df, meta={'user_meta': 'blah6'})
 
         for lk, entry in pkg.walk():
-            file_path = parse_file_url(urlparse(entry.get()))
+            file_path = entry.physical_key.path
             assert pathlib.Path(file_path).exists(), "The serialization files should exist"
 
         pkg._fix_sha256()
@@ -737,11 +741,11 @@ class PackageTest(QuiltTestCase):
             pkg.push('Quilt/test_pkg_name', 's3://test-bucket')
 
         for lk in ["mydataframe1.parquet", "mydataframe2.csv", "mydataframe3.tsv"]:
-            file_path = parse_file_url(urlparse(pkg.get(lk)))
+            file_path = pkg[lk].physical_key.path
             assert pathlib.Path(file_path).exists(), "These files should not have been deleted during push()"
 
         for lk in ["mydataframe4.parquet", "mydataframe5.csv", "mydataframe6.tsv"]:
-            file_path = parse_file_url(urlparse(pkg.get(lk)))
+            file_path = pkg[lk].physical_key.path
             assert not pathlib.Path(file_path).exists(), "These temp files should have been deleted during push()"
 
 
@@ -1013,7 +1017,7 @@ class PackageTest(QuiltTestCase):
 
             pkg.push('Quilt/test_pkg_name', 's3://test-bucket', message='test_message')
             build_mock.assert_called_once_with(
-                'Quilt/test_pkg_name', registry='s3://test-bucket', message='test_message'
+                'Quilt/test_pkg_name', registry=PhysicalKey.from_url('s3://test-bucket'), message='test_message'
             )
 
     def test_overwrite_dir_fails(self):
@@ -1176,7 +1180,7 @@ class PackageTest(QuiltTestCase):
         with pytest.raises(QuiltException):
             pkg.set('s3://foo/..', LOCAL_MANIFEST)
 
-    @patch('quilt3.Package.shorten_tophash', lambda package_name, registry, top_hash: "7a67ff4")
+    @patch('quilt3.Package._shorten_tophash', lambda package_name, registry, top_hash: "7a67ff4")
     def test_install(self):
         # Manifest
 
@@ -1277,7 +1281,7 @@ class PackageTest(QuiltTestCase):
 
         # ...but moving it back fixes it.
         pathlib.Path('foo2').rename(local_path)
-        assert p['foo'].get_cached_path() == str(local_path)
+        assert pathlib.Path(p['foo'].get_cached_path()) == local_path
 
         # Check that changing the contents invalidates the cache.
         local_path.write_text('omg')
@@ -1334,7 +1338,7 @@ class PackageTest(QuiltTestCase):
         with self.assertRaises(QuiltException):
             Package.rollback('quilt/blah', LOCAL_REGISTRY, good_hash)
 
-    @patch('quilt3.Package.shorten_tophash', lambda package_name, registry, top_hash: "7a67ff4")
+    @patch('quilt3.Package._shorten_tophash', lambda package_name, registry, top_hash: "7a67ff4")
     def test_verify(self):
         pkg = Package()
 


### PR DESCRIPTION
Parse the URLs only once, when we get them from the user or from the manifest, and store the parsed values.

All user-visible APIs continue to use URLs as input and output.