### PR TITLE
Fix IPv6 addresses in nginx config

### DIFF
--- a/s3-proxy/run-nginx.sh
+++ b/s3-proxy/run-nginx.sh
@@ -3,6 +3,12 @@
 # Get the DNS server from /etc/resolv.conf
 nameserver=$(awk '{if ($1 == "nameserver") { print $2; exit;}}' < /etc/resolv.conf)
 
+if [[ "$nameserver" == *:*:* ]]
+then
+   # IPv6; put brackets around it.
+   nameserver="[$nameserver]"
+fi
+
 # Add it to the NGINX config
 echo "resolver $nameserver;" > /etc/nginx/conf.d/resolver.conf
 


### PR DESCRIPTION
nginx gets confused by IPv6 addresses without brackets.