### PR TITLE
Only use IPv4 nameservers on Mac

### DIFF
--- a/api/python/quilt3/main.py
+++ b/api/python/quilt3/main.py
@@ -66,7 +66,11 @@ def _launch_local_s3proxy():
 
     # Workaround for a Docker-for-Mac bug in which the container
     # ends up with a different DNS server than the host.
-    command += ["--dns", dns_resolver.nameservers[0]]
+    # Workaround #2: use only IPv4 addresses.
+    if sys.platform == 'darwin':
+        nameservers = [ip for ip in dns_resolver.nameservers if ip.count('.') == 3]
+        command += ["--dns", nameservers[0]]
+
     command += ["-p", "5002:80", "quiltdata/s3proxy"]
     subprocess.Popen(command)
 


### PR DESCRIPTION
Workaround for a Docker bug: https://github.com/docker/for-mac/issues/1432