### PR TITLE
Add dnspython to setup.py requirements

### DIFF
--- a/api/python/setup.py
+++ b/api/python/setup.py
@@ -56,6 +56,7 @@ setup(
         'appdirs>=1.4.0',
         'aws-requests-auth>=0.4.2',
         'boto3>=1.8.0',
+        'dnspython>=1.16.0',
         'flask',
         'flask_cors',
         'flask_json',


### PR DESCRIPTION
## Description
The `dnspython` module is used to work around a Docker-for-Mac bug, but was previously not included in the install requirements in setup.py.