### PR TITLE
Fix exception handling when copying files

### DIFF
--- a/api/python/quilt3/data_transfer.py
+++ b/api/python/quilt3/data_transfer.py
@@ -1,3 +1,4 @@
+from collections import deque
 from codecs import iterdecode
 from concurrent.futures import ThreadPoolExecutor
 import hashlib
@@ -271,7 +272,7 @@ def _copy_file_list_internal(s3_client, file_list):
     total_size = sum(size for _, _, size in file_list)
 
     lock = Lock()
-    futures = []
+    futures = deque()
     results = [None] * len(file_list)
 
     stopped = False
@@ -331,7 +332,7 @@ def _copy_file_list_internal(s3_client, file_list):
                 with lock:
                     if not futures:
                         break
-                    future = futures.pop()
+                    future = futures.popleft()
                 future.result()
         finally:
             # Make sure all tasks exit quickly if the main thread exits before they're done.


### PR DESCRIPTION
Currently, the code creates a list of futures, then waits for them in _reverse_ order. That's fine as long as they all succeed.

But if they all fail (access denied, out of disk, etc.), we will keep trying every single object, and only the last exception will propagate to the main thread.