### PR TITLE
Adjust preview note & warnings display, tweak package truncation warning display

### DIFF
--- a/catalog/app/components/Preview/renderers/DataFrame.js
+++ b/catalog/app/components/Preview/renderers/DataFrame.js
@@ -2,7 +2,7 @@ import cx from 'classnames'
 import * as React from 'react'
 import * as M from '@material-ui/core'
 
-import { renderPreviewStatus } from './util'
+import { renderWarnings } from './util'
 
 const useStyles = M.makeStyles((t) => ({
   root: {
@@ -39,8 +39,9 @@ function DataFrame({ children, className, note, warnings, ...props } = {}) {
   const classes = useStyles()
   return (
     <div className={cx(className, classes.root)} {...props}>
-      {renderPreviewStatus({ note, warnings })}
+      {renderWarnings(warnings)}
       <div
+        title={note}
         className={classes.wrapper}
         // eslint-disable-next-line react/no-danger
         dangerouslySetInnerHTML={{ __html: children }}

--- a/catalog/app/components/Preview/renderers/Notebook.js
+++ b/catalog/app/components/Preview/renderers/Notebook.js
@@ -5,7 +5,7 @@ import * as M from '@material-ui/core'
 
 import 'katex/dist/katex.css'
 
-import { renderPreviewStatus } from './util'
+import { renderWarnings } from './util'
 
 const MATH_DELIMITERS = [
   { left: '$$', right: '$$', display: true },
@@ -36,8 +36,9 @@ function Notebook({ children, className, note, warnings, ...props } = {}) {
   const classes = useStyles()
   return (
     <div className={cx(classes.root, className)} {...props}>
-      {renderPreviewStatus({ note, warnings })}
+      {renderWarnings(warnings)}
       <div
+        title={note}
         className={cx(classes.contents, 'ipynb-preview')}
         // eslint-disable-next-line react/no-danger
         dangerouslySetInnerHTML={{ __html: children }}

--- a/catalog/app/components/Preview/renderers/Parquet.js
+++ b/catalog/app/components/Preview/renderers/Parquet.js
@@ -5,7 +5,7 @@ import * as M from '@material-ui/core'
 
 import JsonDisplay from 'components/JsonDisplay'
 
-import { renderPreviewStatus } from './util'
+import { renderWarnings } from './util'
 
 const useStyles = M.makeStyles((t) => ({
   root: {
@@ -72,7 +72,7 @@ function Parquet({
 
   return (
     <div className={cx(className, classes.root)} {...props}>
-      {renderPreviewStatus({ note, warnings })}
+      {renderWarnings(warnings)}
       <table className={classes.meta}>
         <tbody>
           {renderMeta('Created by:', createdBy, (c) => (
@@ -97,6 +97,7 @@ function Parquet({
         </tbody>
       </table>
       <div
+        title={note}
         className={classes.dataframe}
         // eslint-disable-next-line react/no-danger
         dangerouslySetInnerHTML={{ __html: preview }}

--- a/catalog/app/components/Preview/renderers/Text.js
+++ b/catalog/app/components/Preview/renderers/Text.js
@@ -2,7 +2,7 @@ import cx from 'classnames'
 import * as React from 'react'
 import * as M from '@material-ui/core'
 
-import { renderPreviewStatus } from './util'
+import { renderWarnings } from './util'
 
 const useStyles = M.makeStyles((t) => ({
   root: {
@@ -19,8 +19,10 @@ function Text({ className, children, note, warnings, ...props }) {
   const classes = useStyles()
   return (
     <div className={cx(className, classes.root)} {...props}>
-      {renderPreviewStatus({ note, warnings })}
-      <div className={classes.text}>{children}</div>
+      {renderWarnings(warnings)}
+      <div title={note} className={classes.text}>
+        {children}
+      </div>
     </div>
   )
 }

--- a/catalog/app/components/Preview/renderers/Vcf.js
+++ b/catalog/app/components/Preview/renderers/Vcf.js
@@ -2,7 +2,7 @@ import cx from 'classnames'
 import * as React from 'react'
 import * as M from '@material-ui/core'
 
-import { renderPreviewStatus } from './util'
+import { renderWarnings } from './util'
 
 const useStyles = M.makeStyles((t) => ({
   root: {
@@ -59,7 +59,7 @@ function Vcf({ meta, header, data, variants, note, warnings }) {
 
   return (
     <div className={classes.root}>
-      {renderPreviewStatus({ note, warnings })}
+      {renderWarnings(warnings)}
       <div className={classes.tableWrapper}>
         <M.Table className={classes.table}>
           <M.TableHead>
@@ -77,7 +77,7 @@ function Vcf({ meta, header, data, variants, note, warnings }) {
           </M.TableHead>
         </M.Table>
       </div>
-      <div className={classes.tableWrapper}>
+      <div title={note} className={classes.tableWrapper}>
         <M.Table className={classes.table}>
           {!!header && (
             <M.TableHead>

--- a/catalog/app/components/Preview/renderers/util.js
+++ b/catalog/app/components/Preview/renderers/util.js
@@ -32,10 +32,13 @@ export function Msg({ type = 'info', className, children, ...props }) {
   )
 }
 
-export const renderPreviewStatus = ({ note, warnings }) => (
-  <Msg type="warning" mb={2}>
-    {!!note && note}
-    {!!note && !!warnings && '\n\n'}
-    {!!warnings && warnings}
-  </Msg>
-)
+export const renderWarnings = (warnings) =>
+  !!warnings && (
+    <Msg type="warning" mb={2}>
+      <M.Box component="span" fontWeight="fontWeightMedium">
+        Preview encountered parsing errors:
+      </M.Box>
+      {'\n'}
+      {warnings}
+    </Msg>
+  )

--- a/catalog/app/containers/Bucket/PackageTree.js
+++ b/catalog/app/containers/Bucket/PackageTree.js
@@ -443,11 +443,23 @@ export default function PackageTree({
               )}
             </div>
 
-            <M.Box className={classes.warning} mb={2}>
-              <M.Icon className={classes.warningIcon}>warning</M.Icon>
-              The Packages tab shows only the first 1,000 files. Use the Files tab (above)
-              or Python code (below) to view all files. This is a temporary limitation.
-            </M.Box>
+            {AsyncResult.case(
+              {
+                Ok: TreeDisplay.case({
+                  Dir: () => (
+                    <M.Box className={classes.warning} mb={2}>
+                      <M.Icon className={classes.warningIcon}>warning</M.Icon>
+                      The Packages tab shows only the first 1,000 files. Use the Files tab
+                      (above) or Python code (below) to view all files. This is a
+                      temporary limitation.
+                    </M.Box>
+                  ),
+                  _: () => null,
+                }),
+                _: () => null,
+              },
+              result,
+            )}
 
             <Section icon="code" heading="Code">
               <Code>{code}</Code>


### PR DESCRIPTION
Follow-up for #1477 & #1492 
- only show package truncation warning when browsing a directory
- show preview `.note` as a title hover text
- show prefix text for `.warnings`