### PR TITLE
Ignore errors when looking up objects in the cache

### DIFF
--- a/api/python/quilt3/packages.py
+++ b/api/python/quilt3/packages.py
@@ -64,7 +64,7 @@ class ObjectPathCache(object):
         try:
             with open(cache_path) as fd:
                 path, dev, ino, mtime = json.load(fd)
-        except FileNotFoundError:
+        except (FileNotFoundError, ValueError):
             return None
 
         try:


### PR DESCRIPTION
Cache file can get corrupted if the `set` call is interrupted, etc.