### PR TITLE
Clean up package unit tests

### DIFF
--- a/api/python/tests/integration/test_packages.py
+++ b/api/python/tests/integration/test_packages.py
@@ -26,24 +26,6 @@ SERIALIZATION_DIR = Path('serialization_dir')
 LOCAL_REGISTRY = Path('local_registry')  # Set by QuiltTestCase
 
 
-def mock_make_api_call(self, operation_name, kwarg):
-    """ Mock boto3's AWS API Calls for testing. """
-    if operation_name == 'GetObject':
-        parsed_response = {'Body': BytesIO(b'foo')}
-        return parsed_response
-    if operation_name == 'ListObjectsV2':
-        parsed_response = {'CommonPrefixes': ['foo']}
-        return parsed_response
-    if operation_name == 'HeadObject':
-        # TODO: mock this somehow
-        parsed_response = {
-            'ContentLength': 0
-        }
-        return parsed_response
-    raise NotImplementedError(operation_name)
-
-
-
 class PackageTest(QuiltTestCase):
     def test_build(self):
         """Verify that build dumps the manifest to appdirs directory."""
@@ -275,29 +257,6 @@ class PackageTest(QuiltTestCase):
         with self.assertRaises(QuiltException):
             Package.browse('Quilt/test', top_hash='123456', registry=registry)
 
-
-    def test_remote_install(self):
-        """Verify that installing from a local package works as expected."""
-        remote_registry = Path('.').resolve().as_uri()
-        quilt3.config(
-            default_local_registry=remote_registry,
-            default_remote_registry=remote_registry
-        )
-        with patch('quilt3.Package.push') as push_mock:
-            pkg = Package()
-            pkg.build('Quilt/nice-name')
-
-            with patch('quilt3.Package._materialize') as materialize_mock, \
-                patch('quilt3.Package._build') as build_mock:
-                materialize_mock.return_value = pkg
-                dest_registry = quilt3.util.get_from_config('default_local_registry')
-
-                quilt3.Package.install('Quilt/nice-name', dest='./')
-
-                materialize_mock.assert_called_once_with(PhysicalKey.from_path('./'))
-                build_mock.assert_called_once_with(
-                    'Quilt/nice-name', message=None, registry=dest_registry
-                )
 
     def test_install_restrictions(self):
         """Verify that install can only operate remote -> local."""
@@ -735,8 +694,7 @@ class PackageTest(QuiltTestCase):
                                                    "was serialized"
 
         # Test that push cleans up the temporary files, if and only if the serialization_location was not set
-        with patch('botocore.client.BaseClient._make_api_call', new=mock_make_api_call), \
-            patch('quilt3.Package._materialize') as materialize_mock, \
+        with patch('quilt3.Package._materialize') as materialize_mock, \
             patch('quilt3.Package._build') as build_mock:
             materialize_mock.return_value = pkg
 
@@ -1010,8 +968,7 @@ class PackageTest(QuiltTestCase):
     @patch('quilt3.Package._shorten_tophash', lambda package_name, registry, top_hash: "7a67ff4")
     def test_commit_message_on_push(self):
         """ Verify commit messages populate correctly on push."""
-        with patch('botocore.client.BaseClient._make_api_call', new=mock_make_api_call), \
-            patch('quilt3.Package._materialize') as materialize_mock, \
+        with patch('quilt3.Package._materialize') as materialize_mock, \
             patch('quilt3.Package._build') as build_mock:
             with open(REMOTE_MANIFEST) as fd:
                 pkg = Package.load(fd)


### PR DESCRIPTION
- Stop patching the boto client. We should be using S3 stubber, but turns out, everything is already mocked out so those API calls aren't even made.
- Delete test_remote_install - nothing about that test makes any sense at all.