### PR TITLE
Use hosted s3proxy for local mode catalog

### DIFF
--- a/api/python/quilt3/main.py
+++ b/api/python/quilt3/main.py
@@ -69,7 +69,9 @@ def _launch_local_s3proxy():
     # Workaround for a Docker-for-Mac bug in which the container
     # ends up with a different DNS server than the host.
     # Workaround #2: use only IPv4 addresses.
-    # TODO: reintroduce this once Docker-for-Mac DNS works reliably
+    # Note: leaving this code in though it isn't called so that it
+    # can be reintroduced once Docker-for-Mac DNS works reliably.
+    # TODO: switch back to this local s3proxy or remove this function
     if sys.platform == 'darwin':
         nameservers = [ip for ip in dns_resolver.nameservers if ip.count('.') == 3]
         command += ["--dns", nameservers[0]]


### PR DESCRIPTION
## Description

Apparently due a bug in Docker on Mac, `quilt3 catalog` had been crashing on calls through the local s3 proxy. This change points local catalogs to the hosted s3proxy in users' config. The default is the s3proxy in the open.quiltdata.com stack.