### PR TITLE
WIP feature/dask-support

### DIFF
--- a/api/python/quilt3/data_transfer.py
+++ b/api/python/quilt3/data_transfer.py
@@ -434,6 +434,7 @@ def _get_executor(maximum_concurrency: int = None):
     # only have a few cores / threads.
     # Instead of utilizing a single workers available resources we can call out to
     # the scheduler that we want to distribute our jobs to the available cluster.
+    # https://docs.dask.org/en/latest/futures.html#start-dask-client
 
     # Check if this function is running in a dask worker
     try:

--- a/api/python/setup.py
+++ b/api/python/setup.py
@@ -1,12 +1,12 @@
 import os
 import sys
-
 from pathlib import Path
 
-from setuptools import setup, find_packages
+from setuptools import find_packages, setup
 from setuptools.command.install import install
 
 VERSION = Path(Path(__file__).parent, "quilt3", "VERSION").read_text().strip()
+
 
 def readme():
     readme_short = """
@@ -32,6 +32,27 @@ class VerifyVersionCommand(install):
                 tag, VERSION
             )
             sys.exit(info)
+
+
+pyarrow_requires = [
+    'numpy>=1.14.0',  # required by pandas, but missing from its dependencies.
+    'pandas>=0.19.2',
+    'pyarrow>=0.14.1',  # as of 7/5/19: linux/circleci bugs on 0.14.0
+]
+
+test_requires = [
+    'codecov',
+    'numpy>=1.14.0',  # required by pandas, but missing from its dependencies.
+    'pandas>=0.19.2',
+    'pyarrow>=0.14.1',  # as of 7/5/19: linux/circleci bugs on 0.14.0
+    'pytest<5.1.0',  # TODO: Fix pytest.ensuretemp in conftest.py
+    'pytest-cov',
+    'pytest-env',
+    'responses',
+    'tox',
+    'detox',
+    'tox-pytest-summary',
+]
 
 setup(
     name="quilt3",
@@ -70,24 +91,12 @@ setup(
         'requests_futures==1.0.0',
     ],
     extras_require={
-        'pyarrow': [
-            'numpy>=1.14.0',                # required by pandas, but missing from its dependencies.
-            'pandas>=0.19.2',
-            'pyarrow>=0.14.1',              # as of 7/5/19: linux/circleci bugs on 0.14.0
-        ],
-        'tests': [
-            'codecov',
-            'numpy>=1.14.0',                # required by pandas, but missing from its dependencies.
-            'pandas>=0.19.2',
-            'pyarrow>=0.14.1',              # as of 7/5/19: linux/circleci bugs on 0.14.0
-            'pytest<5.1.0',  # TODO: Fix pytest.ensuretemp in conftest.py
-            'pytest-cov',
-            'pytest-env',
-            'responses',
-            'tox',
-            'detox',
-            'tox-pytest-summary',
-        ],
+        'pyarrow': pyarrow_requires,
+        'tests': test_requires,
+        'all': [
+            *pyarrow_requires,
+            *test_requires,
+        ]
     },
     include_package_data=True,
     entry_points={

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -31,7 +31,7 @@ Use `pip` to install `quilt` locally (including development dependencies):
 
 ```bash
 $ cd api/python
-$ pip install -e .[extra]
+$ pip install -e .[all]
 ```
 
 This will create an [editable install](https://pip.pypa.io/en/stable/reference/pip_install/#editable-installs) of `quilt`, allowing you to modify the code and test your changes right away.


### PR DESCRIPTION
## Description
Dask clients and concurrent futures executors have the same API of submit and map (Specifically designed to be that way). As more and more people are starting to use dask in data engineering and modeling workloads, the problem that arises is it is common for single dask workers to only have a few cores / threads. Instead of utilizing a single workers available resources we can call out to the scheduler that we want to distribute our jobs to the available cluster.

I wasn't able to fully get it working but would love eyes to see if I am missing something.

## TODO

Use this section for work-in-progress pull requests. If you're using this section,
please tag your PR "WIP". 

- [ ] Unit Tests
- [x] Documentation
- [ ] Fix conflict with #2