### PR TITLE
Fix S3ClientProvider bug in _upload_or_copy_file (bug in 3.1.9 release)

### DIFF
--- a/api/python/quilt3/data_transfer.py
+++ b/api/python/quilt3/data_transfer.py
@@ -396,7 +396,7 @@ def _upload_or_copy_file(ctx, size, src_path, dest_bucket, dest_path):
             params = dict(Bucket=dest_bucket, Key=dest_path)
             s3_client = ctx.s3_client_provider.find_correct_client(S3Api.HEAD_OBJECT, dest_bucket, params)
             resp = s3_client.head_object(**params)
-        except S3NoValidClientError:
+        except ClientError:
             # Destination doesn't exist, so fall through to the normal upload.
             pass
         else:


### PR DESCRIPTION
We need to catch when the head_object call fails, not when the S3ClientProvider is getting AccessDenied