### PR TITLE
Add test_patterns in .deepsource.toml

### DIFF
--- a/.deepsource.toml
+++ b/.deepsource.toml
@@ -1,9 +1,13 @@
 version = 1
 
-test_patterns = []
+test_patterns = [
+  '**/tests/**',
+]
 
 exclude_patterns = [
   'docs/**',
+  'gendocs/**',
+  
 ]
 
 [[ analyzers ]]


### PR DESCRIPTION
Adds `test_patterns` in `.deepsource.toml`, so false-positives related to test files are not raised.