### PR TITLE
Catch and retry timeouts during hashing

### DIFF
--- a/api/python/quilt3/data_transfer.py
+++ b/api/python/quilt3/data_transfer.py
@@ -11,7 +11,7 @@ import warnings
 
 from botocore import UNSIGNED
 from botocore.client import Config
-from botocore.exceptions import ClientError, ReadTimeoutError
+from botocore.exceptions import ClientError, ConnectionError, HTTPClientError, ReadTimeoutError
 import boto3
 from boto3.s3.transfer import TransferConfig
 from s3transfer.utils import ChunksizeAdjuster, OSUtils, signal_transferring, signal_not_transferring
@@ -805,15 +805,16 @@ def calculate_sha256(src_list: List[PhysicalKey], sizes: List[int]):
                 params = dict(Bucket=src.bucket, Key=src.path)
                 if src.version_id is not None:
                     params.update(dict(VersionId=src.version_id))
-                s3_client = S3ClientProvider().find_correct_client(S3Api.GET_OBJECT, src.bucket, params)
                 try:
+                    s3_client = S3ClientProvider().find_correct_client(S3Api.GET_OBJECT, src.bucket, params)
+
                     resp = s3_client.get_object(**params)
                     body = resp['Body']
                     for chunk in body:
                         hash_obj.update(chunk)
                         with lock:
                             progress.update(len(chunk))
-                except ReadTimeoutError:
+                except (ConnectionError, HTTPClientError, ReadTimeoutError):
                     # TODO: Find a better way to warn users that we failed to compute this hash
                     return None
             return hash_obj.hexdigest()

--- a/api/python/quilt3/packages.py
+++ b/api/python/quilt3/packages.py
@@ -869,7 +869,7 @@ class Package(object):
                 if obj_hash is None:
                     entries_w_missing_hash.append(entry)
                 else:
-                    entry.hash = dict(type='SHA256', value=obj_hash) if obj_hash is not None else None
+                    entry.hash = dict(type='SHA256', value=obj_hash)
             return entries_w_missing_hash
 
         entries = [entry for key, entry in self.walk() if entry.hash is None]

--- a/api/python/quilt3/packages.py
+++ b/api/python/quilt3/packages.py
@@ -879,7 +879,7 @@ class Package(object):
         self._incomplete_entries = entries_w_missing_hash
         if self._incomplete_entries:
             incomplete_manifest_path = self._dump_manifest_to_scratch()
-            msg = "Could not compute all hash values. Incomplete manifest saved to: {path}"
+            msg = "Unable to reach S3 for some hash values. Incomplete manifest saved to {path}."
             raise PackageException(msg.format(path=incomplete_manifest_path))
 
     def _set_commit_message(self, msg):

--- a/api/python/quilt3/packages.py
+++ b/api/python/quilt3/packages.py
@@ -29,7 +29,7 @@ from .util import (
 from .util import CACHE_PATH, TEMPFILE_DIR_PATH as APP_DIR_TEMPFILE_DIR, PhysicalKey, get_from_config, \
     user_is_configured_to_custom_stack, catalog_package_url
 
-MAX_FIX_HASH_RETRIES = 0
+MAX_FIX_HASH_RETRIES = 3
 
 
 def hash_file(readable_file):

--- a/api/python/setup.py
+++ b/api/python/setup.py
@@ -65,6 +65,7 @@ setup(
         'python-dateutil<=2.8.0',           # 2.8.1 conflicts with botocore
         'requests>=2.12.4',
         'ruamel.yaml>=0.15.78',
+        'tenacity>=5.1.1',
         'tqdm>=4.26.0',
         'urllib3<1.25,>=1.21.1',            # required by requests
         'requests_futures==1.0.0',

--- a/api/python/tests/test_data_transfer.py
+++ b/api/python/tests/test_data_transfer.py
@@ -444,6 +444,5 @@ class DataTransferTest(QuiltTestCase):
         pk = PhysicalKey(bucket, key, vid)
         with mock.patch('botocore.client.BaseClient._make_api_call',
                         side_effect=ReadTimeoutError('Error Uploading', endpoint_url="s3://foobar")):
-            results = [r for r in data_transfer.calculate_sha256([pk], [len(a_contents)])]
-            assert len(results) == 1
-            assert results[0] is None
+            results = data_transfer.calculate_sha256([pk], [len(a_contents)])
+            assert list(results) == [None]

--- a/api/python/tests/test_data_transfer.py
+++ b/api/python/tests/test_data_transfer.py
@@ -1,7 +1,6 @@
 """ Testing for data_transfer.py """
 
 ### Python imports
-from io import BytesIO
 import pathlib
 
 from unittest import mock
@@ -433,8 +432,7 @@ class DataTransferTest(QuiltTestCase):
         with mock.patch('quilt3.data_transfer.s3_transfer_config.max_request_concurrency', 1):
             data_transfer.copy_file_list([
                 (PhysicalKey.from_url('s3://example1/large_file1.npy'), PhysicalKey.from_url('s3://example2/large_file2.npy'), size),
-            ])
-
+                ])
 
     def test_calculate_sha256_read_timeout(self):
         bucket = 'test-bucket'
@@ -443,11 +441,9 @@ class DataTransferTest(QuiltTestCase):
 
         a_contents = b'a' * 10
 
-        def raise_read_timeout():
-            raise botocore.ReadTimeout("Test Timeout")
-
         pk = PhysicalKey(bucket, key, vid)
-        with mock.patch('botocore.client.BaseClient._make_api_call', side_effect=ReadTimeoutError('Error Uploading', endpoint_url="s3://foobar")):
+        with mock.patch('botocore.client.BaseClient._make_api_call',
+                        side_effect=ReadTimeoutError('Error Uploading', endpoint_url="s3://foobar")):
             results = [r for r in data_transfer.calculate_sha256([pk], [len(a_contents)])]
             assert len(results) == 1
             assert results[0] is None

--- a/api/python/tests/test_data_transfer.py
+++ b/api/python/tests/test_data_transfer.py
@@ -1,12 +1,14 @@
 """ Testing for data_transfer.py """
 
 ### Python imports
+from io import BytesIO
 import pathlib
 
 from unittest import mock
 
 ### Third-party imports
 from botocore.stub import ANY
+from botocore.exceptions import ReadTimeoutError
 import pandas as pd
 import pytest
 
@@ -432,3 +434,20 @@ class DataTransferTest(QuiltTestCase):
             data_transfer.copy_file_list([
                 (PhysicalKey.from_url('s3://example1/large_file1.npy'), PhysicalKey.from_url('s3://example2/large_file2.npy'), size),
             ])
+
+
+    def test_calculate_sha256_read_timeout(self):
+        bucket = 'test-bucket'
+        key = 'dir/a'
+        vid = 'a1234'
+
+        a_contents = b'a' * 10
+
+        def raise_read_timeout():
+            raise botocore.ReadTimeout("Test Timeout")
+
+        pk = PhysicalKey(bucket, key, vid)
+        with mock.patch('botocore.client.BaseClient._make_api_call', side_effect=ReadTimeoutError('Error Uploading', endpoint_url="s3://foobar")):
+            results = [r for r in data_transfer.calculate_sha256([pk], [len(a_contents)])]
+            assert len(results) == 1
+            assert results[0] is None

--- a/api/python/tests/test_data_transfer.py
+++ b/api/python/tests/test_data_transfer.py
@@ -432,7 +432,7 @@ class DataTransferTest(QuiltTestCase):
         with mock.patch('quilt3.data_transfer.s3_transfer_config.max_request_concurrency', 1):
             data_transfer.copy_file_list([
                 (PhysicalKey.from_url('s3://example1/large_file1.npy'), PhysicalKey.from_url('s3://example2/large_file2.npy'), size),
-                ])
+            ])
 
     def test_calculate_sha256_read_timeout(self):
         bucket = 'test-bucket'


### PR DESCRIPTION
## Description

Fixing a bug where building a package failed due to a timeout during hashing. Instead of failing if one file fails to hash, catch the exception and retry.

## TODO
- parameterize number of retries
- add unit test
- look for other hashing uses (other than build)
