### PR TITLE
add required registry

### DIFF
--- a/api/python/quilt3/imports.py
+++ b/api/python/quilt3/imports.py
@@ -3,7 +3,7 @@
 from importlib.machinery import ModuleSpec
 import sys
 
-from quilt3.util import get_from_config
+from quilt3.util import get_from_config, PhysicalKey
 from quilt3.api import _list_packages
 from quilt3 import Package
 
@@ -41,9 +41,10 @@ class DataPackageImporter:
 
         elif len(name_parts) == 3:  # e.g. module.__name__ == quilt3.data.foo
             namespace = name_parts[2]
+            registry_passed = PhysicalKey.from_url(registry)
 
             # we do not know the name the user will ask for, so populate all valid names
-            for pkg in _list_packages():
+            for pkg in _list_packages(registry_passed):
                 pkg_user, pkg_name = pkg.split('/')
                 if pkg_user == namespace:
                     module.__dict__[pkg_name] = Package._browse(pkg, registry=registry)

--- a/api/python/quilt3/imports.py
+++ b/api/python/quilt3/imports.py
@@ -41,10 +41,10 @@ class DataPackageImporter:
 
         elif len(name_parts) == 3:  # e.g. module.__name__ == quilt3.data.foo
             namespace = name_parts[2]
-            registry_passed = PhysicalKey.from_url(registry)
+            registry_parsed = PhysicalKey.from_url(registry)
 
             # we do not know the name the user will ask for, so populate all valid names
-            for pkg in _list_packages(registry_passed):
+            for pkg in _list_packages(registry_parsed):
                 pkg_user, pkg_name = pkg.split('/')
                 if pkg_user == namespace:
                     module.__dict__[pkg_name] = Package._browse(pkg, registry=registry)

--- a/api/python/quilt3/packages.py
+++ b/api/python/quilt3/packages.py
@@ -521,7 +521,7 @@ class Package(object):
         return cls._browse(name=name, registry=registry, top_hash=top_hash)
 
     @classmethod
-    def _browse(cls, name, registry, top_hash):
+    def _browse(cls, name, registry=None, top_hash=None):
         validate_package_name(name)
         if registry is None:
             registry = get_from_config('default_local_registry')


### PR DESCRIPTION
## Description
**Problem** - import fails for missing argument in `_list_packages` private function.

<img width="882" alt="Screenshot 2020-02-19 at 12 42 07 PM" src="https://user-images.githubusercontent.com/30266850/74866796-bad2f580-5353-11ea-88c3-b69732193222.png"> 

**Solution** - Add default registry to `_list_packages` usage [here](https://github.com/quiltdata/quilt/blob/a764778d029713e235296b3c7d1e62f3678afcfd/api/python/quilt3/imports.py#L46)


