### PR TITLE
Sub-package install

### DIFF
--- a/api/python/quilt3/main.py
+++ b/api/python/quilt3/main.py
@@ -243,7 +243,7 @@ def create_parser():
     install_p = subparsers.add_parser("install", description=shorthelp, help=shorthelp, allow_abbrev=False)
     install_p.add_argument(
         "name",
-        help="Name of package, in the USER/PKG format",
+        help="Name of package, in the USER/PKG[/PATH] format",
         type=str,
     )
     install_p.add_argument(

--- a/api/python/tests/conftest.py
+++ b/api/python/tests/conftest.py
@@ -1,7 +1,6 @@
 
 ### stdlib
 import os
-import pathlib
 from unittest import mock
 
 # third party imports
@@ -84,6 +83,6 @@ def set_temporary_working_dir(request, tmpdir):
 
 
 @pytest.fixture
-def isolate_packages_cache(tmpdir):
-    with mock.patch('quilt3.packages.CACHE_PATH', pathlib.Path(tmpdir)):
+def isolate_packages_cache(tmp_path):
+    with mock.patch('quilt3.packages.CACHE_PATH', tmp_path):
         yield

--- a/api/python/tests/conftest.py
+++ b/api/python/tests/conftest.py
@@ -1,6 +1,7 @@
 
 ### stdlib
 import os
+import pathlib
 from unittest import mock
 
 # third party imports
@@ -80,3 +81,9 @@ def set_temporary_working_dir(request, tmpdir):
         os.chdir(orig_dir)
 
     request.addfinalizer(teardown)
+
+
+@pytest.fixture
+def isolate_packages_cache(tmpdir):
+    with mock.patch('quilt3.packages.CACHE_PATH', pathlib.Path(tmpdir)):
+        yield

--- a/api/python/tests/integration/test_packages.py
+++ b/api/python/tests/integration/test_packages.py
@@ -32,7 +32,7 @@ def _mock_copy_file_list(file_list, callback=None, message=None):
 
 class PackageTest(QuiltTestCase):
     def setup_s3_stubber(self, pkg_name, bucket, *, manifest=None, entries=()):
-        top_hash = 'abcde'
+        top_hash = 'abcdef'
 
         self.s3_stubber.add_response(
             method='get_object',
@@ -1327,6 +1327,7 @@ class PackageTest(QuiltTestCase):
         with patch('quilt3.data_transfer.s3_transfer_config.max_request_concurrency', 1):
             Package.install('Quilt/Foo', registry='s3://my-test-bucket', dest='package/')
 
+    @pytest.mark.usefixtures('isolate_packages_cache')
     def test_install_subpackage(self):
         pkg_name = 'Quilt/Foo'
         bucket = 'my-test-bucket'
@@ -1350,6 +1351,7 @@ class PackageTest(QuiltTestCase):
                 )
                 assert path.read_bytes() == entry_content
 
+    @pytest.mark.usefixtures('isolate_packages_cache')
     def test_install_entry(self):
         pkg_name = 'Quilt/Foo'
         bucket = 'my-test-bucket'

--- a/api/python/tests/integration/test_packages.py
+++ b/api/python/tests/integration/test_packages.py
@@ -31,6 +31,62 @@ def _mock_copy_file_list(file_list, callback=None, message=None):
 
 
 class PackageTest(QuiltTestCase):
+    def setup_s3_stubber(self, pkg_name, bucket, *, manifest=None, entries=()):
+        top_hash = 'abcde'
+
+        self.s3_stubber.add_response(
+            method='get_object',
+            service_response={
+                'VersionId': 'v1',
+                'Body': BytesIO(top_hash.encode()),
+            },
+            expected_params={
+                'Bucket': bucket,
+                'Key': f'.quilt/named_packages/{pkg_name}/latest',
+            }
+        )
+
+        if manifest:
+            self.s3_stubber.add_response(
+                method='head_object',
+                service_response={
+                    'VersionId': 'v1',
+                    'ContentLength': len(manifest),
+                },
+                expected_params={
+                    'Bucket': bucket,
+                    'Key': f'.quilt/packages/{top_hash}',
+                }
+            )
+
+            self.s3_stubber.add_response(
+                method='get_object',
+                service_response={
+                    'VersionId': 'v1',
+                    'Body': BytesIO(manifest),
+                    'ContentLength': len(manifest),
+                },
+                expected_params={
+                    'Bucket': bucket,
+                    'Key': f'.quilt/packages/{top_hash}',
+                }
+            )
+
+            for url, content in entries:
+                key = PhysicalKey.from_url(url)
+                self.s3_stubber.add_response(
+                    method='get_object',
+                    service_response={
+                        'VersionId': 'v1',
+                        'Body': BytesIO(content),
+                    },
+                    expected_params={
+                        'Bucket': key.bucket,
+                        'Key': key.path,
+                    }
+                )
+
+
     def test_build(self):
         """Verify that build dumps the manifest to appdirs directory."""
         new_pkg = Package()
@@ -1270,6 +1326,52 @@ class PackageTest(QuiltTestCase):
 
         with patch('quilt3.data_transfer.s3_transfer_config.max_request_concurrency', 1):
             Package.install('Quilt/Foo', registry='s3://my-test-bucket', dest='package/')
+
+    def test_install_subpackage(self):
+        pkg_name = 'Quilt/Foo'
+        bucket = 'my-test-bucket'
+        subpackage_path = 'baz'
+        entry_url = 's3://my_bucket/my_data_pkg/baz/bat'
+        entry_content = b'42'
+        entries = (
+            (entry_url, entry_content),
+        )
+        dest = 'package'
+
+        self.setup_s3_stubber(pkg_name, bucket, manifest=REMOTE_MANIFEST.read_bytes(), entries=entries)
+        with patch('quilt3.data_transfer.s3_transfer_config.max_request_concurrency', 1):
+            with patch('quilt3.packages.ObjectPathCache.set') as mocked_cache_set:
+                Package.install(f'{pkg_name}/{subpackage_path}', registry=f's3://{bucket}', dest=dest)
+
+                path = pathlib.Path.cwd() / dest / 'bat'
+                mocked_cache_set.assert_called_once_with(
+                    entry_url,
+                    str(path),
+                )
+                assert path.read_bytes() == entry_content
+
+    def test_install_entry(self):
+        pkg_name = 'Quilt/Foo'
+        bucket = 'my-test-bucket'
+        subpackage_path = 'baz/bat'
+        entry_url = 's3://my_bucket/my_data_pkg/baz/bat'
+        entry_content = b'42'
+        entries = (
+            (entry_url, entry_content),
+        )
+        dest = 'package'
+
+        self.setup_s3_stubber(pkg_name, bucket, manifest=REMOTE_MANIFEST.read_bytes(), entries=entries)
+        with patch('quilt3.data_transfer.s3_transfer_config.max_request_concurrency', 1):
+            with patch('quilt3.packages.ObjectPathCache.set') as mocked_cache_set:
+                Package.install(f'{pkg_name}/{subpackage_path}', registry=f's3://{bucket}', dest=dest)
+
+                path = pathlib.Path.cwd() / dest / 'bat'
+                mocked_cache_set.assert_called_once_with(
+                    entry_url,
+                    str(path),
+                )
+                assert path.read_bytes() == entry_content
 
     def test_rollback(self):
         p = Package()

--- a/api/python/tests/integration/test_packages.py
+++ b/api/python/tests/integration/test_packages.py
@@ -72,19 +72,19 @@ class PackageTest(QuiltTestCase):
                 }
             )
 
-            for url, content in entries:
-                key = PhysicalKey.from_url(url)
-                self.s3_stubber.add_response(
-                    method='get_object',
-                    service_response={
-                        'VersionId': 'v1',
-                        'Body': BytesIO(content),
-                    },
-                    expected_params={
-                        'Bucket': key.bucket,
-                        'Key': key.path,
-                    }
-                )
+        for url, content in entries:
+            key = PhysicalKey.from_url(url)
+            self.s3_stubber.add_response(
+                method='get_object',
+                service_response={
+                    'VersionId': 'v1',
+                    'Body': BytesIO(content),
+                },
+                expected_params={
+                    'Bucket': key.bucket,
+                    'Key': key.path,
+                }
+            )
 
 
     def test_build(self):

--- a/docs/API Reference/Package.md
+++ b/docs/API Reference/Package.md
@@ -30,7 +30,9 @@ Installs a named package to the local registry and downloads its files.
 
 __Arguments__
 
-* __name(str)__:  Name of package to install.
+* __name(str)__:  Name of package to install. It also can be passed as NAME/PATH,
+    in this case only the sub-package or the entry specified by PATH will
+    be downloaded.
 * __registry(str)__:  Registry where package is located.
     Defaults to the default remote registry.
 * __top_hash(str)__:  Hash of package to install. Defaults to latest.

--- a/docs/API Reference/cli.md
+++ b/docs/API Reference/cli.md
@@ -49,7 +49,7 @@ usage: quilt3 install [-h] [--registry REGISTRY] [--top-hash TOP_HASH]
 Install a package
 
 positional arguments:
-  name                  Name of package, in the USER/PKG format
+  name                  Name of package, in the USER/PKG[/PATH] format
 
 optional arguments:
   -h, --help            show this help message and exit


### PR DESCRIPTION
## Description

This allows to install only the part of the package. Example:

We have package `foo/bar`:
```
(remote Package)
 └─requirements.txt
 └─scripts/
   └─build.py
   └─demolish.py
```

```python
In [17]: import os, tempfile, quilt3                 

In [18]: with tempfile.TemporaryDirectory() as dest: 
    ...:     quilt3.Package.install('foo/bar/scripts', dest=dest) 
    ...:     print([os.path.relpath(os.path.join(top, f), dest) for top, dirs, files in os.walk(dest) for f in files]) 

['demolish.py', 'build.py', 'more_scripts/test.py']
```

```python
In [20]: with tempfile.TemporaryDirectory() as dest: 
    ...:     quilt3.Package.install('foo/bar/scripts/build.py', dest=dest) 
    ...:     print([os.path.relpath(os.path.join(top, f), dest) for top, dirs, files in os.walk(dest) for f in files]) 

['build.py']
```

