### PR TITLE
Switch ruamel to PyYaml parser

### DIFF
--- a/api/python/quilt3/util.py
+++ b/api/python/quilt3/util.py
@@ -10,7 +10,7 @@ from urllib.request import pathname2url, url2pathname
 import warnings
 
 # Third-Party
-import ruamel.yaml
+import yaml
 from appdirs import user_cache_dir, user_data_dir
 import requests
 
@@ -234,10 +234,12 @@ def extract_file_extension(file_path_or_url):
 
 
 def read_yaml(yaml_stream):
-    yaml = ruamel.yaml.YAML()
     try:
-        return yaml.load(yaml_stream)
-    except ruamel.yaml.parser.ParserError as error:
+        if isinstance(yaml_stream, pathlib.PosixPath):
+            with yaml_stream.open(mode='r') as stream:
+                return yaml.safe_load(stream)
+        return yaml.safe_load(yaml_stream)
+    except yaml.YAMLError as error:
         raise QuiltException(str(error), original_error=error)
 
 
@@ -248,7 +250,6 @@ def write_yaml(data, yaml_path, keep_backup=False):
     :param yaml_path: Destination. Can be a string or pathlib path.
     :param keep_backup: If set, a timestamped backup will be kept in the same dir.
     """
-    yaml = ruamel.yaml.YAML()
     path = pathlib.Path(yaml_path)
     now = str(datetime.datetime.now())
 
@@ -274,36 +275,6 @@ def write_yaml(data, yaml_path, keep_backup=False):
 
     if backup_path.exists() and not keep_backup:
         backup_path.unlink()
-
-
-def yaml_has_comments(parsed):
-    """Determine if parsed YAML data has comments.
-
-    Any object can be given, but only objects based on `ruamel.yaml`'s
-    `CommentedBase` class can be True.
-
-    :returns: True if object has retained comments, False otherwise
-    """
-    # Is this even a parse result object that stores comments?
-    if not isinstance(parsed, ruamel.yaml.comments.CommentedBase):
-        return False
-
-    # Are there comments on this object?
-    if parsed.ca.items or parsed.ca.comment or parsed.ca.end:
-        return True
-
-    # Is this a container that might have values with comments?
-    values = ()
-    if isinstance(parsed, (Sequence, Set)):
-        values = parsed
-    if isinstance(parsed, Mapping):
-        values = parsed.values()
-    # If so, do any of them have comments?
-    for value in values:
-        if yaml_has_comments(value):
-            return True
-    # no comments found.
-    return False
 
 
 def validate_url(url):

--- a/api/python/setup.py
+++ b/api/python/setup.py
@@ -64,8 +64,8 @@ setup(
         'jsonlines==1.2.0',
         'packaging>=16.8',
         'python-dateutil<=2.8.0',           # 2.8.1 conflicts with botocore
+        'PyYAML>=5.3',
         'requests>=2.12.4',
-        'ruamel.yaml>=0.15.78',
         'tenacity>=5.1.1',
         'tqdm>=4.26.0',
         'urllib3<1.25,>=1.21.1',            # required by requests

--- a/api/python/tests/test_api.py
+++ b/api/python/tests/test_api.py
@@ -3,8 +3,7 @@ from datetime import datetime, timedelta, timezone
 import numpy as np
 import pytest
 import responses
-from ruamel.yaml import YAML
-
+import yaml
 import quilt3 as he
 from quilt3 import util
 
@@ -26,8 +25,8 @@ class TestAPI(QuiltTestCase):
 
         he.config('https://foo.bar')
 
-        yaml = YAML()
-        config = yaml.load(util.CONFIG_PATH)
+        with open(util.CONFIG_PATH, 'r') as stream:
+            config = yaml.safe_load(stream)
 
         # These come from CONFIG_TEMPLATE, not the mocked config file.
         content['default_local_registry'] = util.BASE_PATH.as_uri() + '/packages'

--- a/api/python/tests/test_util.py
+++ b/api/python/tests/test_util.py
@@ -55,13 +55,7 @@ def test_read_yaml(tmpdir):
     assert parsed_string == parsed_path_obj
 
 
-def test_yaml_has_comments(tmpdir):
-    no_comments_yaml = """blah: foo\nfizz: boop"""
-
-    assert not util.yaml_has_comments(util.read_yaml(no_comments_yaml))
-    assert util.yaml_has_comments(util.read_yaml(TEST_YAML))
-
-
+@pytest.mark.skip(reason="Broken due to yaml safe load")
 def test_read_yaml_exec_flaw(capfd):
     # We don't execute anything remote, but someone could give a bad build.yml..
     util.read_yaml("""!!python/object/apply:os.system\nargs: ['echo arbitrary code execution!']""")

--- a/api/python/tests/test_util.py
+++ b/api/python/tests/test_util.py
@@ -55,13 +55,11 @@ def test_read_yaml(tmpdir):
     assert parsed_string == parsed_path_obj
 
 
-@pytest.mark.skip(reason="Broken due to yaml safe load")
 def test_read_yaml_exec_flaw(capfd):
     # We don't execute anything remote, but someone could give a bad build.yml..
-    util.read_yaml("""!!python/object/apply:os.system\nargs: ['echo arbitrary code execution!']""")
-    out, err = capfd.readouterr()
-    assert not out
-    assert not err
+    with pytest.raises(util.QuiltException) as exc_info:
+        util.read_yaml("""!!python/object/apply:os.system\nargs: ['echo arbitrary code execution!']""")
+    assert "could not determine a constructor for the tag" in str(exc_info.value)
 
 
 def test_validate_url():

--- a/gendocs/build.py
+++ b/gendocs/build.py
@@ -9,8 +9,7 @@ try:
     from pip._internal import main as pipmain
 except ImportError:
     from pip import main as pipmain
-from ruamel import yaml
-
+import yaml
 
 
 # To push out and use a new version of pydocmd to people generating docs,


### PR DESCRIPTION
## Description
Ruamel is a hairy dependency. Can we take a simpler (or no?) yaml parser dependency with no regressions? I think we took Ruamel because it supports comments in Yaml which we don't use or care about.
