### PR TITLE
Fix description of quilt3 verify --extra-files-ok

### DIFF
--- a/api/python/quilt3/main.py
+++ b/api/python/quilt3/main.py
@@ -310,7 +310,7 @@ def create_parser():
     )
     verify_p.add_argument(
         "--extra-files-ok",
-        help="Directory to verify",
+        help="Whether extra files in the directory should cause a failure",
         action="store_true"
     )
     verify_p.set_defaults(func=cmd_verify)

--- a/docs/API Reference/cli.md
+++ b/docs/API Reference/cli.md
@@ -78,7 +78,8 @@ optional arguments:
                        BUCKET
   --top-hash TOP_HASH  Hash of package to verify
   --dir DIR            Directory to verify
-  --extra-files-ok     Directory to verify
+  --extra-files-ok     Whether extra files in the directory should cause a
+                       failure
 ```
 ## `login`
 ```


### PR DESCRIPTION
Currently descriptions of `--extra-files-ok` and `--dir` parameters of `verify` are the same:

```
$ quilt3 verify -h
usage: quilt3 verify [-h] --registry REGISTRY --top-hash TOP_HASH --dir DIR
                     [--extra-files-ok]
                     name

Verify that package contents matches a given directory

positional arguments:
  name                 Name of package, in the USER/PKG format

optional arguments:
  -h, --help           show this help message and exit
  --registry REGISTRY  Registry where package is located, usually s3://MY-
                       BUCKET
  --top-hash TOP_HASH  Hash of package to verify
  --dir DIR            Directory to verify
  --extra-files-ok     Directory to verify
```