### PR TITLE
fix selector function documentation bug

### DIFF
--- a/api/python/quilt3/packages.py
+++ b/api/python/quilt3/packages.py
@@ -1202,7 +1202,7 @@ class Package(object):
 
 
     @ApiTelemetry("package.push")
-    def push(self, name, registry=None, dest=None, message=None, selector_fn=lambda logical_key, package_entry: True):
+    def push(self, name, registry=None, dest=None, message=None, selector_fn=None):
         """
         Copies objects to path, then creates a new package that points to those objects.
         Copies each object in this package to path according to logical key structure,
@@ -1239,6 +1239,8 @@ class Package(object):
         Returns:
             A new package that points to the copied objects.
         """
+        selector_fn = lambda *args: True if selector_fn is None else selector_fn
+
         validate_package_name(name)
 
         if registry is None:

--- a/docs/API Reference/Package.md
+++ b/docs/API Reference/Package.md
@@ -259,7 +259,7 @@ __Raises__
 * `KeyError`:  when logical_key is not present to be deleted
 
 
-## Package.push(self, name, registry=None, dest=None, message=None, selector\_fn=<function Package.<lambda> at 0x10d02aa70>)  {#Package.push}
+## Package.push(self, name, registry=None, dest=None, message=None, selector\_fn=None)  {#Package.push}
 
 Copies objects to path, then creates a new package that points to those objects.
 Copies each object in this package to path according to logical key structure,


### PR DESCRIPTION
## Description
Error in the documentation for quilt push selector_fxn=x
see - https://docs.quiltdata.com/api-reference/package#Package.push
<img width="816" alt="Screenshot 2020-02-26 at 10 59 10 AM" src="https://user-images.githubusercontent.com/30266850/75333860-2999dc80-5887-11ea-8053-55570c1900a8.png">
