### PR TITLE
Fix import syntax

### DIFF
--- a/api/python/quilt3/packages.py
+++ b/api/python/quilt3/packages.py
@@ -428,7 +428,8 @@ class Package(object):
             )
 
         if dest is None:
-            dest_parsed = PhysicalKey.from_url(get_install_location()).join(name)
+            dest = PhysicalKey.from_url(get_install_location()).join('named_packages')
+            dest_parsed = dest.join(name)
         else:
             dest_parsed = PhysicalKey.from_url(fix_url(dest))
             if not dest_parsed.is_local():

--- a/api/python/tests/integration/test_packages.py
+++ b/api/python/tests/integration/test_packages.py
@@ -1325,8 +1325,32 @@ class PackageTest(QuiltTestCase):
             }
         )
 
+        self.s3_stubber.add_response(
+            method='get_object',
+            service_response={
+                'VersionId': 'v1',
+                'Body': BytesIO(b'abcdef'),
+            },
+            expected_params={
+                'Bucket': 'my-test-bucket',
+                'Key': '.quilt/named_packages/Quilt/Foo/latest',
+            }
+        )
+
         with patch('quilt3.data_transfer.s3_transfer_config.max_request_concurrency', 1):
             Package.install('Quilt/Foo', registry='s3://my-test-bucket', dest='package/')
+
+        # make sure import works for an installed named package
+        with patch('quilt3.data_transfer.s3_transfer_config.max_request_concurrency', 1):
+            Package.install('Quilt/Foo', registry='s3://my-test-bucket')
+
+            with patch('quilt3.Package._browse') as browse_mock:
+                browse_mock.return_value = quilt3.Package()
+
+                from quilt3.data.Quilt import Foo
+
+                assert isinstance(Foo, Package)
+                browse_mock.assert_called_once()
 
     @pytest.mark.usefixtures('isolate_packages_cache')
     @patch('quilt3.data_transfer.s3_transfer_config.max_request_concurrency', 1)

--- a/api/python/tests/integration/test_packages.py
+++ b/api/python/tests/integration/test_packages.py
@@ -1333,23 +1333,30 @@ class PackageTest(QuiltTestCase):
             },
             expected_params={
                 'Bucket': 'my-test-bucket',
-                'Key': '.quilt/named_packages/Quilt/Foo/latest',
+                'Key': '.quilt/named_packages/test/foo/latest',
             }
         )
+
+        # import fails for installation outside named package directory
 
         with patch('quilt3.data_transfer.s3_transfer_config.max_request_concurrency', 1):
             Package.install('Quilt/Foo', registry='s3://my-test-bucket', dest='package/')
 
+            with patch('quilt3.Package._browse') as browse_mock, pytest.raises(ImportError) as exc_info:
+                browse_mock.return_value = quilt3.Package()
+                from quilt3.data.Quilt import Foo
+            assert "cannot import name 'Foo'" in str(exc_info.value)
+
         # make sure import works for an installed named package
+
         with patch('quilt3.data_transfer.s3_transfer_config.max_request_concurrency', 1):
-            Package.install('Quilt/Foo', registry='s3://my-test-bucket')
+            Package.install('test/foo', registry='s3://my-test-bucket')
 
             with patch('quilt3.Package._browse') as browse_mock:
                 browse_mock.return_value = quilt3.Package()
+                from quilt3.data.test import foo
 
-                from quilt3.data.Quilt import Foo
-
-                assert isinstance(Foo, Package)
+                assert isinstance(foo, Package)
                 browse_mock.assert_called_once()
 
     @pytest.mark.usefixtures('isolate_packages_cache')


### PR DESCRIPTION
## Description
Can't import installed named packages ie
```
from quilt3.data.username import package
```

### Solution
Make sure remote packages are installed in  `named packages` 

### Automated Test
```
pytest tests/integration/test_packages.py::PackageTest::test_install_named_package
```