### PR TITLE
Fix config read+support tests on Windows

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,10 +1,14 @@
-version: 2
+version: 2.1
+
+orbs:
+  win: circleci/windows@2.4.0
 
 workflows:
   version: 2
   test:
     jobs:
-      - test-3.6
+      - test-36
+      - test-windows
       - test-lambdas-indexer
       - test-lambdas-preview
       - test-lambdas-s3select
@@ -25,7 +29,7 @@ workflows:
             branches:
               ignore: /.*/
 jobs:
-  test-3.6: &test-template
+  test-36: &test-template
     docker:
       - image: circleci/python:3.6-jessie
     environment:
@@ -43,6 +47,28 @@ jobs:
           command: |
             . venv/bin/activate
             cd api/python && pytest --cov=./
+            codecov
+
+  test-windows:
+    executor:
+      name: win/default
+      size: "medium"
+    environment:
+      QUILT_DISABLE_USAGE_METRICS: true
+    steps:
+      - checkout
+      - run:
+          name: Setup
+          command: |
+            pip install virtualenv
+            virtualenv venv
+            venv\Scripts\activate.bat
+            pip install -e api\python[tests]
+      - run:
+          name: Run Pytest
+          command: |
+            venv\Scripts\activate.bat
+            cd api\python; pytest --cov=.
             codecov
 
   test-lambdas-indexer:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -62,13 +62,14 @@ jobs:
           command: |
             pip install virtualenv
             virtualenv venv
-            venv/Scripts/activate.bat
+            source venv/Scripts/activate
             pip install -e api/python[tests]
           shell: bash.exe
       - run:
           name: Run Pytest
           command: |
-            venv/Scripts/activate.bat
+            set -e
+            source venv/Scripts/activate
             cd api/python; pytest --cov=.
             codecov
           shell: bash.exe

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -28,51 +28,44 @@ workflows:
               only: /[0-9]+(\.[0-9]+)*([abrc]+[0-9]+)?$/
             branches:
               ignore: /.*/
+
+test-base: &test-base
+  environment:
+    QUILT_DISABLE_USAGE_METRICS: true
+  steps:
+    - run: git config --global core.autocrlf false # for Windows
+    - checkout
+    - run:
+        name: Setup venv
+        command: |
+          pip install virtualenv
+          virtualenv venv
+          if [ -e venv/bin/activate ]; then
+            echo ". venv/bin/activate" >> $BASH_ENV
+          else
+            echo ". venv/Scripts/activate" >> $BASH_ENV # for Windows
+          fi
+    - run:
+        name: Install dependencies
+        command: |
+          pip install -e api/python[tests]
+    - run:
+        name: Run Pytest
+        command: |
+          cd api/python && pytest --cov=./
+          codecov
+
 jobs:
-  test-36: &test-template
+  test-36:
     docker:
       - image: circleci/python:3.6-jessie
-    environment:
-      QUILT_DISABLE_USAGE_METRICS: true
-    steps:
-      - checkout
-      - run:
-          name: Setup
-          command: |
-            virtualenv venv
-            . venv/bin/activate
-            pip install -e api/python[tests]
-      - run:
-          name: Run Pytest
-          command: |
-            . venv/bin/activate
-            cd api/python && pytest --cov=./
-            codecov
+    <<: *test-base
 
   test-windows:
     executor:
       name: win/default
-      size: "medium"
-    environment:
-      QUILT_DISABLE_USAGE_METRICS: true
-    steps:
-      - checkout
-      - run:
-          name: Setup
-          command: |
-            pip install virtualenv
-            virtualenv venv
-            source venv/Scripts/activate
-            pip install -e api/python[tests]
-          shell: bash.exe
-      - run:
-          name: Run Pytest
-          command: |
-            set -e
-            source venv/Scripts/activate
-            cd api/python; pytest --cov=.
-            codecov
-          shell: bash.exe
+      shell: bash --login -eo pipefail
+    <<: *test-base
 
   test-lambdas-indexer:
     docker:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -33,7 +33,6 @@ test-base: &test-base
   environment:
     QUILT_DISABLE_USAGE_METRICS: true
   steps:
-    - run: git config --global core.autocrlf false # for Windows
     - checkout
     - run:
         name: Setup venv

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -62,14 +62,16 @@ jobs:
           command: |
             pip install virtualenv
             virtualenv venv
-            venv\Scripts\activate.bat
-            pip install -e api\python[tests]
+            venv/Scripts/activate.bat
+            pip install -e api/python[tests]
+          shell: bash.exe
       - run:
           name: Run Pytest
           command: |
-            venv\Scripts\activate.bat
-            cd api\python; pytest --cov=.
+            venv/Scripts/activate.bat
+            cd api/python; pytest --cov=.
             codecov
+          shell: bash.exe
 
   test-lambdas-indexer:
     docker:

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,5 @@
+api/python/tests/data/*.csv text eol=lf
+api/python/tests/data/dir/foo.txt text eol=lf
+api/python/tests/data/dir/x/blah.txt text eol=lf
+api/python/tests/integration/data/foo.txt text eol=lf
+api/python/tests/integration/data/foo.unrecognized.ext text eol=lf

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,5 +1,0 @@
-api/python/tests/data/*.csv text eol=lf
-api/python/tests/data/dir/foo.txt text eol=lf
-api/python/tests/data/dir/x/blah.txt text eol=lf
-api/python/tests/integration/data/foo.txt text eol=lf
-api/python/tests/integration/data/foo.unrecognized.ext text eol=lf

--- a/api/python/quilt3/util.py
+++ b/api/python/quilt3/util.py
@@ -235,7 +235,7 @@ def extract_file_extension(file_path_or_url):
 
 def read_yaml(yaml_stream):
     try:
-        if isinstance(yaml_stream, pathlib.PosixPath):
+        if isinstance(yaml_stream, pathlib.Path):
             with yaml_stream.open(mode='r') as stream:
                 return yaml.safe_load(stream)
         return yaml.safe_load(yaml_stream)

--- a/api/python/tests/integration/test_packages.py
+++ b/api/python/tests/integration/test_packages.py
@@ -1348,7 +1348,7 @@ class PackageTest(QuiltTestCase):
         path = pathlib.Path.cwd() / dest / 'bat'
         mocked_cache_set.assert_called_once_with(
             entry_url,
-            str(path),
+            PhysicalKey.from_path(path).path,
         )
         assert path.read_bytes() == entry_content
 
@@ -1372,7 +1372,7 @@ class PackageTest(QuiltTestCase):
         path = pathlib.Path.cwd() / dest / 'bat'
         mocked_cache_set.assert_called_once_with(
             entry_url,
-            str(path),
+            PhysicalKey.from_path(path).path,
         )
         assert path.read_bytes() == entry_content
 


### PR DESCRIPTION
## Description

`quilt3` fails to load config on Windows as of `3.1.12`, giving me this error on `import quilt3`:

```
AttributeError: 'WindowsPath' object has no attribute 'read'
```

from inside the `yaml` code. Tracing around, I believe the root is that [this check](https://github.com/NathanDeMaria/quilt/blob/2fe625d9717a2098ae40c087086d28bebd7ea7e5/api/python/quilt3/util.py#L238) should accept all `pathlib.Path`s, not just `pathlib.PosixPath`. Without that check, `quilt3` passes a `pathlib` object instead of a stream into `yaml.safe_load`, which triggers the above error.

Changing this worked for me locally.