### PR TITLE
Doc'd quilt3.login() and quilt3.logout()

### DIFF
--- a/api/python/quilt3/session.py
+++ b/api/python/quilt3/session.py
@@ -165,7 +165,8 @@ def open_url(url):
 
 def login():
     """
-    Authenticate.
+    Authenticate to your Quilt stack and assume the role assigned to you by
+    your stack administrator. Not required if you have existing AWS credentials.
 
     Launches a web browser and asks the user for a token.
     """
@@ -208,7 +209,7 @@ def login_with_token(refresh_token):
 
 def logout():
     """
-    Become anonymous. Useful for testing.
+    Do not use Quilt credentials. Useful if you have existing AWS credentials.
     """
     # TODO revoke refresh token (without logging out of web sessions)
     if _load_auth() or _load_credentials():

--- a/docs/API Reference/api.md
+++ b/docs/API Reference/api.md
@@ -110,3 +110,15 @@ a list of objects with the following structure:
 }, ...]
 ```
 
+
+## login()  {#login}
+
+Authenticate.
+
+Launches a web browser and asks the user for a token.
+
+
+## logout()  {#logout}
+
+Become anonymous. Useful for testing.
+

--- a/docs/API Reference/api.md
+++ b/docs/API Reference/api.md
@@ -113,12 +113,13 @@ a list of objects with the following structure:
 
 ## login()  {#login}
 
-Authenticate.
+Authenticate to your Quilt stack and assume the role assigned to you by
+your stack administrator. Not required if you have existing AWS credentials.
 
 Launches a web browser and asks the user for a token.
 
 
 ## logout()  {#logout}
 
-Become anonymous. Useful for testing.
+Do not use Quilt credentials. Useful if you have existing AWS credentials.
 

--- a/docs/API Reference/api.md
+++ b/docs/API Reference/api.md
@@ -78,6 +78,19 @@ __Returns__
 A sequence of strings containing the names of the packages
 
 
+## login()  {#login}
+
+Authenticate to your Quilt stack and assume the role assigned to you by
+your stack administrator. Not required if you have existing AWS credentials.
+
+Launches a web browser and asks the user for a token.
+
+
+## logout()  {#logout}
+
+Do not use Quilt credentials. Useful if you have existing AWS credentials.
+
+
 ## search(query, limit=10)  {#search}
 
 Execute a search against the configured search endpoint.
@@ -109,17 +122,4 @@ a list of objects with the following structure:
 `"_type"`: <document type>
 }, ...]
 ```
-
-
-## login()  {#login}
-
-Authenticate to your Quilt stack and assume the role assigned to you by
-your stack administrator. Not required if you have existing AWS credentials.
-
-Launches a web browser and asks the user for a token.
-
-
-## logout()  {#logout}
-
-Do not use Quilt credentials. Useful if you have existing AWS credentials.
 

--- a/gendocs/pydocmd.yml
+++ b/gendocs/pydocmd.yml
@@ -15,9 +15,9 @@ generate:
     - quilt3.delete_package
     - quilt3.list_package_versions
     - quilt3.list_packages
-    - quilt3.search
     - quilt3.login
     - quilt3.logout
+    - quilt3.search
 # Uncomment the following two lines in include these classes directly in api.md
 #    - Bucket+
 #    - Package+

--- a/gendocs/pydocmd.yml
+++ b/gendocs/pydocmd.yml
@@ -16,6 +16,8 @@ generate:
     - quilt3.list_package_versions
     - quilt3.list_packages
     - quilt3.search
+    - quilt3.login
+    - quilt3.logout
 # Uncomment the following two lines in include these classes directly in api.md
 #    - Bucket+
 #    - Package+


### PR DESCRIPTION
## Description

Probably docstrings can be improved, but I think `quilt3.login()` and `quilt3.logout()` should be documented somehow (considering that we're adding `is_logged()`).