### PR TITLE
AWS/S3: adjust signing logic

### DIFF
--- a/catalog/app/utils/BucketConfig.js
+++ b/catalog/app/utils/BucketConfig.js
@@ -57,17 +57,7 @@ export const useCurrentBucketConfig = () => {
 
 export function useInStackBuckets() {
   const bucketConfigs = useBucketConfigs()
-  const cfg = Config.use()
-  return React.useMemo(
-    () =>
-      R.pipe(
-        R.pluck('name'),
-        R.append(cfg.analyticsBucket),
-        R.reject((b) => !b),
-        R.uniq,
-      )(bucketConfigs),
-    [bucketConfigs, cfg.analyticsBucket],
-  )
+  return React.useMemo(() => R.pluck('name', bucketConfigs), [bucketConfigs])
 }
 
 export function useIsInStack() {


### PR DESCRIPTION
dont count analyticsBucket as in-stack, but sign requests to it if authenticated, otherwise use s3 select proxy