### PR TITLE
Fix transient failure of test_formats_for_obj

### DIFF
--- a/api/python/tests/test_formats.py
+++ b/api/python/tests/test_formats.py
@@ -41,7 +41,7 @@ def test_formats_for_obj():
     assert found_string_fmt_names == expected_string_fmt_names
 
     bytes_obj = fmt.serialize(arr)[0]
-    assert np.array_equal(fmt.deserialize(bytes_obj, ), arr)
+    np.testing.assert_array_equal(fmt.deserialize(bytes_obj), arr)
 
 
 def test_formats_for_ext():


### PR DESCRIPTION
## Description

`test_formats_for_obj` transiently fails, see https://circleci.com/gh/quiltdata/quilt/23315. This happens because test data is random and sometimes it contains `NaN`s and `NaN` != `NaN`.
