### PR TITLE
Add pylint git pre-commit hook

### DIFF
--- a/api/python/.pylintrc
+++ b/api/python/.pylintrc
@@ -1,2 +1,5 @@
 [TYPECHECK]
 generated-members=requests.codes.*,responses.*
+
+[pre-commit-hook]
+limit=8.0

--- a/api/python/setup.py
+++ b/api/python/setup.py
@@ -71,7 +71,6 @@ setup(
         'tqdm>=4.26.0',
         'urllib3<1.25,>=1.21.1',            # required by requests
         'requests_futures==1.0.0',
-        'git-pylint-commit-hook',
     ],
     extras_require={
         'pyarrow': [
@@ -91,6 +90,7 @@ setup(
             'tox',
             'detox',
             'tox-pytest-summary',
+            'git-pylint-commit-hook',
         ],
     },
     include_package_data=True,

--- a/api/python/setup.py
+++ b/api/python/setup.py
@@ -71,6 +71,7 @@ setup(
         'tqdm>=4.26.0',
         'urllib3<1.25,>=1.21.1',            # required by requests
         'requests_futures==1.0.0',
+        'git-pylint-commit-hook',
     ],
     extras_require={
         'pyarrow': [


### PR DESCRIPTION
## Description
Add to quiltdata/quilt: pylint pre-commit git hook for *.py

If commit hook doesn't work automatically after applying this PR changes,  create a new file `quilt/.git/hooks/pre-commit` and add the following to that file:

```
#!/usr/bin/env bash
git-pylint-commit-hook
```
Save the file and make it executable:

```
chmod +x .git/hooks/pre-commit
```