### PR TITLE
Don't show progress bar when there's nothing to hash

### DIFF
--- a/api/python/quilt3/data_transfer.py
+++ b/api/python/quilt3/data_transfer.py
@@ -805,6 +805,8 @@ def get_size_and_version(src: PhysicalKey):
 def calculate_sha256(src_list: List[PhysicalKey], sizes: List[int]):
     assert len(src_list) == len(sizes)
 
+    if not src_list:
+        return []
     return _calculate_sha256_internal(src_list, sizes, [None] * len(src_list))
 
 


### PR DESCRIPTION
## Description

Before:
```python
In [2]: p = quilt3.Package()                         
In [3]: p.push('sergey/test-push', registry="s3://quilt-t4-staging")                                      
Hashing: 0.00B [00:00, ?B/s]
Hashing: 0.00B [00:00, ?B/s]
Package sergey/test-push@2a5a671 pushed to s3://quilt-t4-staging
Visit https://quilt-t4-staging.quiltdata.com/b/quilt-t4-staging/packages/sergey/test-push/tree/latest

In [4]: p = quilt3.Package()                         
In [5]: p.set('test', 'empty')                       
In [6]: p.push('sergey/test-push', registry="s3://quilt-t4-staging")                                      
Hashing: 0.00B [00:00, ?B/s]
Copying objects: 0.00B [00:00, ?B/s]
Hashing: 0.00B [00:00, ?B/s]
Package sergey/test-push@0a48560 pushed to s3://quilt-t4-staging
Visit https://quilt-t4-staging.quiltdata.com/b/quilt-t4-staging/packages/sergey/test-push/tree/latest
```

After:
```python
In [5]: p = quilt3.Package()                         
In [6]: p.push('sergey/test-push', registry="s3://quilt-t4-staging")                                      
Package sergey/test-push@2a5a671 pushed to s3://quilt-t4-staging
Visit https://quilt-t4-staging.quiltdata.com/b/quilt-t4-staging/packages/sergey/test-push/tree/latest

In [7]: p = quilt3.Package()                         
In [8]: p.set('test', 'empty')                       
In [9]: p.push('sergey/test-push', registry="s3://quilt-t4-staging")                                      
Hashing: 0.00B [00:00, ?B/s]
Copying objects: 0.00B [00:01, ?B/s]
Package sergey/test-push@0a48560 pushed to s3://quilt-t4-staging
Visit https://quilt-t4-staging.quiltdata.com/b/quilt-t4-staging/packages/sergey/test-push/tree/latest
```