### PR TITLE
Only consider second file extension if primary ends with '.gz'

### DIFF
--- a/lambdas/access_counts/index.py
+++ b/lambdas/access_counts/index.py
@@ -210,7 +210,7 @@ EXTS_ACCESS_COUNTS = textwrap.dedent("""\
             eventname,
             bucket,
             lower(CASE
-                WHEN cardinality(parts) > 2 THEN concat(element_at(parts, -2), '.', element_at(parts, -1))
+                WHEN cardinality(parts) > 2 AND lower(element_at(parts, -1)) = 'gz' THEN concat(element_at(parts, -2), '.', element_at(parts, -1))
                 WHEN cardinality(parts) = 2 THEN element_at(parts, -1)
                 ELSE ''
                 END

--- a/lambdas/access_counts/index.py
+++ b/lambdas/access_counts/index.py
@@ -210,8 +210,8 @@ EXTS_ACCESS_COUNTS = textwrap.dedent("""\
             eventname,
             bucket,
             lower(CASE
-                WHEN cardinality(parts) > 2
-                    AND lower(element_at(parts, -1)) = 'gz' THEN concat(element_at(parts, -2), '.', element_at(parts, -1))
+                WHEN cardinality(parts) > 2 AND lower(element_at(parts, -1)) = 'gz'
+                    THEN concat(element_at(parts, -2), '.', element_at(parts, -1))
                 WHEN cardinality(parts) >= 2 THEN element_at(parts, -1)
                 ELSE ''
                 END

--- a/lambdas/access_counts/index.py
+++ b/lambdas/access_counts/index.py
@@ -210,7 +210,8 @@ EXTS_ACCESS_COUNTS = textwrap.dedent("""\
             eventname,
             bucket,
             lower(CASE
-                WHEN cardinality(parts) > 2 AND lower(element_at(parts, -1)) = 'gz' THEN concat(element_at(parts, -2), '.', element_at(parts, -1))
+                WHEN cardinality(parts) > 2
+                    AND lower(element_at(parts, -1)) = 'gz' THEN concat(element_at(parts, -2), '.', element_at(parts, -1))
                 WHEN cardinality(parts) = 2 THEN element_at(parts, -1)
                 ELSE ''
                 END


### PR DESCRIPTION
Customer stacks with lot of *.blah.png, *.boo.png, *.baz.png extensions actually wanted all of those file stats to roll up under .png in the overview. Now we only consider the secondary extension if the primary is .gz.