### PR TITLE
Improve S3 event tests, handle delete events properly (instead of failing)

### DIFF
--- a/lambdas/es/indexer/index.py
+++ b/lambdas/es/indexer/index.py
@@ -248,7 +248,9 @@ def handler(event, context):
                 key = unquote_plus(event_["s3"]["object"]["key"])
                 version_id = event_["s3"]["object"].get("versionId")
                 version_id = unquote(version_id) if version_id else None
-                etag = unquote(event_["s3"]["object"]["eTag"])
+                etag = "" # OBJECT_DELETE does not include eTag
+                if "eTag" in event_["s3"]["object"]:
+                    etag = unquote(event_["s3"]["object"]["eTag"])
 
                 # Get two levels of extensions to handle files like .csv.gz
                 path = pathlib.PurePosixPath(key)

--- a/lambdas/es/indexer/index.py
+++ b/lambdas/es/indexer/index.py
@@ -248,7 +248,7 @@ def handler(event, context):
                 key = unquote_plus(event_["s3"]["object"]["key"])
                 version_id = event_["s3"]["object"].get("versionId")
                 version_id = unquote(version_id) if version_id else None
-                etag = "" # OBJECT_DELETE does not include eTag
+                etag = ""  # OBJECT_DELETE does not include "eTag"
                 if "eTag" in event_["s3"]["object"]:
                     etag = unquote(event_["s3"]["object"]["eTag"])
 

--- a/lambdas/es/indexer/index.py
+++ b/lambdas/es/indexer/index.py
@@ -248,9 +248,8 @@ def handler(event, context):
                 key = unquote_plus(event_["s3"]["object"]["key"])
                 version_id = event_["s3"]["object"].get("versionId")
                 version_id = unquote(version_id) if version_id else None
-                etag = ""  # OBJECT_DELETE does not include "eTag"
-                if "eTag" in event_["s3"]["object"]:
-                    etag = unquote(event_["s3"]["object"]["eTag"])
+                # OBJECT_DELETE does not include "eTag"
+                etag = unquote(event_["s3"]["object"].get("eTag", ""))
 
                 # Get two levels of extensions to handle files like .csv.gz
                 path = pathlib.PurePosixPath(key)

--- a/lambdas/es/indexer/requirements.txt
+++ b/lambdas/es/indexer/requirements.txt
@@ -1,3 +1,4 @@
+attrs==19.1.0
 aws-requests-auth==0.4.2
 boto3==1.9.232
 botocore==1.12.232

--- a/lambdas/es/indexer/requirements.txt
+++ b/lambdas/es/indexer/requirements.txt
@@ -1,4 +1,3 @@
-attrs==19.1.0
 aws-requests-auth==0.4.2
 boto3==1.9.232
 botocore==1.12.232

--- a/lambdas/es/indexer/test-requirements.txt
+++ b/lambdas/es/indexer/test-requirements.txt
@@ -1,5 +1,4 @@
 atomicwrites==1.3.0
-attrs==18.2.0
 codecov==2.0.15
 coverage==4.5.2
 more-itertools==6.0.0

--- a/lambdas/es/indexer/test/test_index.py
+++ b/lambdas/es/indexer/test/test_index.py
@@ -87,14 +87,6 @@ RECORDS = {
                 "sequencer": "0A1B2C3D4E5F678901"
             }
         }
-    },
-    "s3:TestEvent": {
-        "Service":"Amazon S3",
-        "Event":"s3:TestEvent",
-        "Time":"2014-10-13T15:57:02.089Z",
-        "Bucket":"test-bucket",
-        "RequestId":"5582815E1AEA5ADF",
-        "HostId":"8cLeGAmw098X5cv4Zkwcmo8vvZa3eH3eKxsPzbB9wrR+YstdA6Knx4Ip8EXAMPLE"
     }
 }
 # No known docs the structure of delete markers. See also:
@@ -191,12 +183,16 @@ class TestIndex(TestCase):
             "Records": [{
                 "body": json.dumps({
                     "Message": json.dumps({
-                        "Event": "s3:TestEvent"
+                        "Service":"Amazon S3",
+                        "Event":"s3:TestEvent",
+                        "Time":"2014-10-13T15:57:02.089Z",
+                        "Bucket":"test-bucket",
+                        "RequestId":"5582815E1AEA5ADF",
+                        "HostId":"8cLeGAmw098X5cv4Zkwcmo8vvZa3eH3eKxsPzbB9wrR+YstdA6Knx4Ip8EXAMPLE"
                     })
                 })
             }]
         }
-
         index.handler(event, None)
 
     def test_index_file(self):

--- a/lambdas/es/indexer/test/test_index.py
+++ b/lambdas/es/indexer/test/test_index.py
@@ -76,7 +76,7 @@ RECORDS = {
             "bucket": {
                 "name": "test-bucket",
                 "ownerIdentity": {
-                "principalId": "EXAMPLE"
+                    "principalId": "EXAMPLE"
                 },
                 "arn": "arn:aws:s3:::test-bucket"
             },
@@ -185,12 +185,12 @@ class TestIndex(TestCase):
             "Records": [{
                 "body": json.dumps({
                     "Message": json.dumps({
-                        "Service":"Amazon S3",
-                        "Event":"s3:TestEvent",
-                        "Time":"2014-10-13T15:57:02.089Z",
-                        "Bucket":"test-bucket",
-                        "RequestId":"5582815E1AEA5ADF",
-                        "HostId":"8cLeGAmw098X5cv4Zkwcmo8vvZa3eH3eKxsPzbB9wrR+YstdA6Knx4Ip8EXAMPLE"
+                        "Service": "Amazon S3",
+                        "Event": "s3:TestEvent",
+                        "Time": "2014-10-13T15:57:02.089Z",
+                        "Bucket": "test-bucket",
+                        "RequestId": "5582815E1AEA5ADF",
+                        "HostId": "8cLeGAmw098X5cv4Zkwcmo8vvZa3eH3eKxsPzbB9wrR+YstdA6Knx4Ip8EXAMPLE"
                     })
                 })
             }]

--- a/lambdas/es/indexer/test/test_index.py
+++ b/lambdas/es/indexer/test/test_index.py
@@ -222,16 +222,16 @@ class TestIndex(TestCase):
         """
         Reusable helper function to test indexing a single text file.
         """
-        if event_name in RECORDS:
-            records = {
-                "Records": [{
-                    "body": json.dumps({
-                        "Message": json.dumps({
-                            "Records": [RECORDS[event_name]]
-                        })
+        assert event_name in RECORDS, f"unexpected event: {event_name}"
+        records = {
+            "Records": [{
+                "body": json.dumps({
+                    "Message": json.dumps({
+                        "Records": [RECORDS[event_name]]
                     })
-                }]
-            }
+                })
+            }]
+        }
 
         now = index.now_like_boto3()
 


### PR DESCRIPTION
Previous code looked for an "eTag" key which is not present in delete events.