### PR TITLE
Don't ask the user to set a password in SIGN_IN_ONLY mode

### DIFF
--- a/catalog/app/containers/Auth/SSOSignUp.js
+++ b/catalog/app/containers/Auth/SSOSignUp.js
@@ -113,7 +113,7 @@ export default ({ location: { search } }) => {
                 invalid: <FM {...msg.signUpUsernameInvalid} />,
               }}
             />
-            {!!cfg.passwordAuth && (
+            {cfg.passwordAuth === true && (
               <>
                 <Field
                   component={Layout.Field}


### PR DESCRIPTION
If SSO is enabled with password sign-in but not password sign-up, don't ask the user to set a password.

(This particular combination has never come up before.)