### PR TITLE
Speed-up Package.walk() by caching sub-package prefixes

### DIFF
--- a/api/python/quilt3/packages.py
+++ b/api/python/quilt3/packages.py
@@ -700,8 +700,14 @@ class Package:
             if isinstance(child, PackageEntry):
                 yield name, child
             else:
-                for key, value in child.walk():
-                    yield name + '/' + key, value
+                yield from child._walk(f'{name}/')
+
+    def _walk(self, prefix):
+        for name, child in sorted(self._children.items()):
+            if isinstance(child, PackageEntry):
+                yield f'{prefix}{name}', child
+            else:
+                yield from child._walk(f'{prefix}{name}/')
 
     def _walk_dir_meta(self):
         """


### PR DESCRIPTION
Benchmarked with:
```python
python -m timeit -r 1 -n 20 -s \
"
import quilt3
from collections import deque
consume = deque(maxlen=0).extend
pkg = quilt3.Package.browse('sergey/nasanex-dummy-obj-hashes', registry='s3://quilt-t4-staging')
" \
"consume(pkg.walk())"
```

Before:
```
20 loops, best of 1: 493 msec per loop
```
After:
```
20 loops, best of 1: 215 msec per loop
```