### PR TITLE
Set NO_DOWNLOAD in local catalog

### DIFF
--- a/api/python/quilt3/main.py
+++ b/api/python/quilt3/main.py
@@ -77,6 +77,7 @@ def _launch_local_catalog():
     env = dict(REGISTRY_URL="http://localhost:5000",
                S3_PROXY_URL=open_config["s3Proxy"],
                ALWAYS_REQUIRE_AUTH="false",
+               NO_DOWNLOAD="false",
                CATALOG_MODE="LOCAL",
                SSO_AUTH="DISABLED",
                PASSWORD_AUTH="ENABLED",


### PR DESCRIPTION
## Description
A recent change to config.json (adding the NO_DOWNLOAD flag) requires that the catalog docker environment set `NO_DOWNLOAD` to produce a correct config.json.
