### PR TITLE
print package url to catalog after push

### DIFF
--- a/api/python/quilt3/main.py
+++ b/api/python/quilt3/main.py
@@ -218,7 +218,6 @@ def cmd_push(name, dir, registry, dest, message):
     pkg = api.Package()
     pkg.set_dir('.', dir)
     pkg.push(name, registry=registry, dest=dest, message=message)
-    print("Successfully pushed the new package")
 
 
 def create_parser():

--- a/api/python/quilt3/packages.py
+++ b/api/python/quilt3/packages.py
@@ -1316,12 +1316,14 @@ class Package:
         if user_is_configured_to_custom_stack():
             navigator_url = get_from_config("navigator_url")
 
-            print(f"Visit {catalog_package_url(navigator_url, dest_parsed.bucket, name)}")
+            print(f"Successfully pushed the new package to "
+                  f"{catalog_package_url(navigator_url, dest_parsed.bucket, name)}")
         else:
             dest_s3_url = str(dest_parsed)
             if not dest_s3_url.endswith("/"):
                 dest_s3_url += "/"
             print(f"Run `quilt3 catalog {dest_s3_url}` to browse.")
+            print("Successfully pushed the new package")
 
         return pkg
 

--- a/api/python/quilt3/util.py
+++ b/api/python/quilt3/util.py
@@ -386,11 +386,9 @@ def config_exists():
 
 
 def user_is_configured_to_custom_stack():
-    """Look at the users stack to see if they have configured to their own stack. There is currently no way to
-    distinguish between someone who has not configured their stack and someone who has intentionally configured
-    their stack to use open.quiltdata.com"""
+    """Look at the users stack to see if they have configured to their own stack."""
     configured_nav_url = get_from_config("navigator_url")
-    return configured_nav_url is not None and configured_nav_url != OPEN_DATA_URL
+    return configured_nav_url is not None
 
 
 def configure_from_default():


### PR DESCRIPTION
## Description
Print Package url in the bucket after push. Desired (if the user has a `navigator_url` configured)

## Result
```
(.venv) python$ quilt3 config https://quilt-t4-staging.quiltdata.com/
(.venv) python$ quilt3 push greg/test-3 --dir test3/ --message "test cat url" --registry s3://quilt-t4-staging
Hashing: 100%|███████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 86.8k/86.8k [00:00<00:00, 68.9MB/s]
Copying objects: 100%|███████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 86.8k/86.8k [00:01<00:00, 47.7kB/s]
Package greg/test-3@60f6979 pushed to s3://quilt-t4-staging
Successfully pushed the new package to https://quilt-t4-staging.quiltdata.com/b/quilt-t4-staging/packages/greg/test-3/tree/latest
```