### PR TITLE
Reuse top hash in Package.build() and Package.push() for better performance

### DIFF
--- a/api/python/quilt3/packages.py
+++ b/api/python/quilt3/packages.py
@@ -947,21 +947,22 @@ class Package:
         manifest = io.BytesIO()
         self._dump(manifest)
 
-        pkg_manifest_file = registry_parsed.join(f'.quilt/packages/{self.top_hash}')
+        top_hash = self.top_hash
+        pkg_manifest_file = registry_parsed.join(f'.quilt/packages/{top_hash}')
         put_bytes(
             manifest.getvalue(),
             pkg_manifest_file
         )
 
         named_path = registry_parsed.join(f'.quilt/named_packages/{name}')
-        hash_bytes = self.top_hash.encode('utf-8')
+        hash_bytes = top_hash.encode()
         # TODO: use a float to string formater instead of double casting
         timestamp_path = named_path.join(str(int(time.time())))
         latest_path = named_path.join("latest")
         put_bytes(hash_bytes, timestamp_path)
         put_bytes(hash_bytes, latest_path)
 
-        return self
+        return top_hash
 
     @ApiTelemetry("package.dump")
     def dump(self, writable_file):
@@ -1308,9 +1309,9 @@ class Package:
         for lk in temp_file_logical_keys:
             self._set(lk, pkg[lk])
 
-        pkg._build(name, registry=registry, message=message)
+        top_hash = pkg._build(name, registry=registry, message=message)
 
-        shorthash = Package._shorten_tophash(name, PhysicalKey.from_url(registry), pkg.top_hash)
+        shorthash = Package._shorten_tophash(name, PhysicalKey.from_url(registry), top_hash)
         print(f"Package {name}@{shorthash} pushed to s3://{dest_parsed.bucket}")
 
         if user_is_configured_to_custom_stack():

--- a/api/python/tests/integration/test_packages.py
+++ b/api/python/tests/integration/test_packages.py
@@ -101,7 +101,7 @@ class PackageTest(QuiltTestCase):
 
         # Build a new package into the local registry.
         new_pkg = new_pkg.set('foo', test_file_name)
-        top_hash = new_pkg.build("Quilt/Test").top_hash
+        top_hash = new_pkg.build("Quilt/Test")
 
         # Verify manifest is registered by hash.
         out_path = LOCAL_REGISTRY / ".quilt/packages" / top_hash
@@ -117,7 +117,7 @@ class PackageTest(QuiltTestCase):
         # Test unnamed packages.
         new_pkg = Package()
         new_pkg = new_pkg.set('bar', test_file_name)
-        top_hash = new_pkg.build('Quilt/Test').top_hash
+        top_hash = new_pkg.build('Quilt/Test')
         out_path = LOCAL_REGISTRY / ".quilt/packages" / top_hash
         with open(out_path) as fd:
             pkg = Package.load(fd)
@@ -134,7 +134,7 @@ class PackageTest(QuiltTestCase):
 
         # Build a new package into the local registry.
         new_pkg = new_pkg.set('foo', test_file_name)
-        top_hash = new_pkg.build("Quilt/Test").top_hash
+        top_hash = new_pkg.build("Quilt/Test")
 
         # Verify manifest is registered by hash.
         out_path = LOCAL_REGISTRY / ".quilt/packages" / top_hash
@@ -150,7 +150,7 @@ class PackageTest(QuiltTestCase):
         # Test unnamed packages.
         new_pkg = Package()
         new_pkg = new_pkg.set('bar', test_file_name)
-        top_hash = new_pkg.build("Quilt/Test").top_hash
+        top_hash = new_pkg.build("Quilt/Test")
         out_path = LOCAL_REGISTRY / ".quilt/packages" / top_hash
         with open(out_path) as fd:
             pkg = Package.load(fd)
@@ -957,7 +957,7 @@ class PackageTest(QuiltTestCase):
 
     def test_local_package_delete(self):
         """Verify local package delete works."""
-        top_hash = Package().build("Quilt/Test").top_hash
+        top_hash = Package().build("Quilt/Test")
         assert 'Quilt/Test' in quilt3.list_packages()
 
         quilt3.delete_package('Quilt/Test')
@@ -1098,7 +1098,7 @@ class PackageTest(QuiltTestCase):
         pkg = Package()
         pkg.set('as/df', LOCAL_MANIFEST)
         pkg.set('as/qw', LOCAL_MANIFEST)
-        top_hash = pkg.build('foo/bar').top_hash
+        top_hash = pkg.build('foo/bar')
         manifest = list(pkg.manifest)
 
         pkg2 = Package.browse('foo/bar', top_hash=top_hash)


### PR DESCRIPTION
This also makes `Package.build()` return top hash instead of (as docstring says)

For 1M entries manifest this speed up `Package.build()` from 42.1s to 27.7s.