### PR TITLE
send user to package url without tree path after push

### DIFF
--- a/api/python/quilt3/packages.py
+++ b/api/python/quilt3/packages.py
@@ -1318,7 +1318,7 @@ class Package:
             navigator_url = get_from_config("navigator_url")
 
             print(f"Successfully pushed the new package to "
-                  f"{catalog_package_url(navigator_url, dest_parsed.bucket, name)}")
+                  f"{catalog_package_url(navigator_url, dest_parsed.bucket, name, tree=False)}")
         else:
             dest_s3_url = str(dest_parsed)
             if not dest_s3_url.endswith("/"):

--- a/api/python/quilt3/util.py
+++ b/api/python/quilt3/util.py
@@ -520,10 +520,11 @@ def catalog_s3_url(catalog_url, s3_url):
     return url
 
 
-def catalog_package_url(catalog_url, bucket, package_name, package_timestamp="latest"):
+def catalog_package_url(catalog_url, bucket, package_name, package_timestamp="latest", tree=True):
     """
     Generate a URL to the Quilt catalog page of a package. By default will go to the latest version of the package,
     but the user can pass in the appropriate timestamp to go to a different version.
+    Disabling tree by passing `tree=False` will generate a package URL without tree path.
 
     Note: There is currently no good way to generate the URL given a specific tophash
     """
@@ -531,4 +532,7 @@ def catalog_package_url(catalog_url, bucket, package_name, package_timestamp="la
     assert package_name is not None, "The package_name parameter must not be None"
     validate_package_name(package_name)
 
-    return f"{catalog_url}/b/{bucket}/packages/{package_name}/tree/{package_timestamp}"
+    package_url = f"{catalog_url}/b/{bucket}/packages/{package_name}"
+    if tree:
+        package_url = package_url + f"/tree/{package_timestamp}"
+    return package_url


### PR DESCRIPTION
## Description
Send user to package url without tree path after push

### Result
```
(venv) python$ quilt3 push greg/test-4 --dir test4/ --message "test cat url" --registry s3://quilt-t4-staging
Hashing: 100%|█████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 13.0/13.0 [00:00<00:00, 26.2kB/s]
Copying objects: 100%|██████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 13.0/13.0 [00:02<00:00, 5.93B/s]
Package greg/test-4@e940c1f pushed to s3://quilt-t4-staging
Run `quilt3 catalog s3://quilt-t4-staging/greg/test-4/` to browse.
Successfully pushed the new package

(venv) python$ quilt3 config https://quilt-t4-staging.quiltdata.com/
(venv) python$ quilt3 push greg/test-4 --dir test4/ --message "test cat url" --registry s3://quilt-t4-staging
Hashing: 100%|█████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 13.0/13.0 [00:00<00:00, 5.31kB/s]
Copying objects: 100%|██████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 13.0/13.0 [00:02<00:00, 5.37B/s]
Package greg/test-4@e940c1f pushed to s3://quilt-t4-staging
Successfully pushed the new package to https://quilt-t4-staging.quiltdata.com/b/quilt-t4-staging/packages/greg/test-4
```

## Note

This should be merged AFTER the corresponding s3_select endpoint and catalog JS changes.
