### PR TITLE
PackageRegistry abstraction

### DIFF
--- a/api/python/quilt3/api.py
+++ b/api/python/quilt3/api.py
@@ -1,11 +1,11 @@
-from .data_transfer import copy_file, get_bytes, delete_url, list_url
-from .packages import Package
+from .backends import get_package_registry
+from .data_transfer import copy_file
 from .search_util import search_api
 from .util import (QuiltConfig, QuiltException, CONFIG_PATH,
                    CONFIG_TEMPLATE, configure_from_default, config_exists,
-                   configure_from_url, fix_url, get_package_registry,
+                   configure_from_url, fix_url,
                    load_config, PhysicalKey, read_yaml, validate_package_name,
-                   write_yaml, get_from_config)
+                   write_yaml)
 from .telemetry import ApiTelemetry
 
 
@@ -34,50 +34,7 @@ def delete_package(name, registry=None, top_hash=None):
         top_hash (str): Optional. A package hash to delete, instead of the whole package.
     """
     validate_package_name(name)
-    usr, pkg = name.split('/')
-
-    registry = (
-        get_from_config('default_local_registry')
-        if registry is None else
-        fix_url(registry)
-    )
-    registry_parsed = PhysicalKey.from_url(get_package_registry(registry))
-    named_packages = registry_parsed.join('named_packages')
-    package_path = named_packages.join(name)
-
-    paths = list(list_url(package_path))
-    if not paths:
-        raise QuiltException("No such package exists in the given directory.")
-
-    if top_hash is not None:
-        top_hash = Package.resolve_hash(name, PhysicalKey.from_url(registry), top_hash)
-        deleted = []
-        remaining = []
-        for path, _ in paths:
-            parts = path.split('/')
-            if len(parts) == 1:
-                pkg_hash = get_bytes(package_path.join(parts[0]))
-                if pkg_hash.decode().strip() == top_hash:
-                    deleted.append(parts[0])
-                else:
-                    remaining.append(parts[0])
-        if not deleted:
-            raise QuiltException("No such package version exists in the given directory.")
-        for path in deleted:
-            delete_url(package_path.join(path))
-        if 'latest' in deleted and remaining:
-            # Create a new "latest". Technically, we need to compare numerically,
-            # but string comparisons will be fine till year 2286.
-            new_latest = max(remaining)
-            copy_file(package_path.join(new_latest), package_path.join('latest'))
-    else:
-        for path, _ in paths:
-            delete_url(package_path.join(path))
-
-    # Will ignore non-empty dirs.
-    # TODO: .join('') adds a trailing slash - but need a better way.
-    delete_url(package_path.join(''))
-    delete_url(named_packages.join(usr).join(''))
+    get_package_registry(registry).delete_package(name, top_hash)
 
 
 @ApiTelemetry("api.list_packages")
@@ -93,31 +50,7 @@ def list_packages(registry=None):
     Returns:
         An iterable of strings containing the names of the packages
     """
-    registry_parsed = PhysicalKey.from_url(get_package_registry(fix_url(registry) if registry else None))
-
-    return _list_packages(registry_parsed)
-
-
-def _list_packages(registry):
-    """This differs from list_packages because it does not have
-
-    telemetry on it. If Quilt code needs the functionality to list
-    packages under a different customer-facing API, _list_packages()
-    is the function that should be used to prevent duplicate metrics
-    (each API call that the user makes should generate a single
-    telemetry event).
-    """
-
-    named_packages = registry.join('named_packages')
-    prev_pkg = None
-    for path, _ in list_url(named_packages):
-        parts = path.split('/')
-        if len(parts) == 3:
-            pkg = f'{parts[0]}/{parts[1]}'
-            # A package can have multiple versions, but we should only return the name once.
-            if pkg != prev_pkg:
-                prev_pkg = pkg
-                yield pkg
+    return get_package_registry(registry).list_packages()
 
 
 @ApiTelemetry("api.list_package_versions")
@@ -135,22 +68,7 @@ def list_package_versions(name, registry=None):
         An iterable of tuples containing the version and hash for the package.
     """
     validate_package_name(name)
-    registry_parsed = PhysicalKey.from_url(get_package_registry(fix_url(registry) if registry else None))
-
-    return _list_package_versions(name=name, registry=registry_parsed)
-
-
-def _list_package_versions(name, registry):
-    """Telemetry-free version of list_package_versions. Internal quilt
-    code should always use _list_package_versions.  See documentation
-    for _list_packages for why.
-    """
-    package = registry.join('named_packages').join(name)
-    for path, _ in list_url(package):
-        parts = path.split('/')
-        if len(parts) == 1:
-            pkg_hash = get_bytes(package.join(parts[0]))
-            yield parts[0], pkg_hash.decode().strip()
+    return get_package_registry(registry).list_package_versions(name)
 
 
 @ApiTelemetry("api.config")

--- a/api/python/quilt3/backends/__init__.py
+++ b/api/python/quilt3/backends/__init__.py
@@ -1,0 +1,19 @@
+from quilt3.util import PhysicalKey, get_from_config, fix_url
+
+from .base import PackageRegistry
+from .local import LocalPackageRegistryV1
+from .s3 import S3PackageRegistryV1
+
+
+def get_package_registry(path=None) -> PackageRegistry:
+    """ Returns the package registry for a given path """
+    # TODO: Don't check if it's PackageRegistry? Then we need better separation
+    #       to external functions that receive string and internal that receive
+    #       PackageRegistry.
+    if isinstance(path, PackageRegistry):
+        return path
+    if not isinstance(path, PhysicalKey):
+        path = PhysicalKey.from_url(
+            get_from_config('default_local_registry') if path is None else fix_url(path)
+        )
+    return (LocalPackageRegistryV1 if path.is_local() else S3PackageRegistryV1)(path)

--- a/api/python/quilt3/backends/base.py
+++ b/api/python/quilt3/backends/base.py
@@ -1,0 +1,204 @@
+import abc
+import time
+
+from quilt3.data_transfer import list_url, get_bytes, delete_url, copy_file, put_bytes
+from quilt3.util import PhysicalKey, QuiltException
+
+
+class PackageRegistry(abc.ABC):
+    latest_tag_name = 'latest'
+
+    def __init__(self, base: PhysicalKey):
+        self.base = base
+        self.root = self.base.join(self.root_path)
+
+    def __repr__(self):
+        return f'<{self.__class__.__name__}({self.base})>'
+
+    def __eq__(self, other):
+        return other.__class__ == self.__class__ and other.base == self.base
+
+    @property
+    def is_local(self) -> bool:
+        return self.base.is_local()
+
+    @property
+    @abc.abstractmethod
+    def root_path(self):
+        pass
+
+    @property
+    @abc.abstractmethod
+    def pointers_global_dir(self) -> PhysicalKey:
+        pass
+
+    @abc.abstractmethod
+    def pointers_dir(self, pkg_name: str) -> PhysicalKey:
+        pass
+
+    @abc.abstractmethod
+    def pointer_pk(self, pkg_name: str, pointer_name: str) -> PhysicalKey:
+        pass
+
+    @abc.abstractmethod
+    def pointer_latest_pk(self, pkg_name: str) -> PhysicalKey:
+        pass
+
+    @property
+    @abc.abstractmethod
+    def manifests_global_dir(self) -> PhysicalKey:
+        pass
+
+    @abc.abstractmethod
+    def manifests_package_dir(self, pkg_name: str) -> PhysicalKey:
+        pass
+
+    @abc.abstractmethod
+    def manifest_pk(self, pkg_name: str, top_hash: str) -> PhysicalKey:
+        pass
+
+    @abc.abstractmethod
+    def list_packages(self):
+        pass
+
+    @abc.abstractmethod
+    def list_package_versions(self, pkg_name: str):
+        pass
+
+    @abc.abstractmethod
+    def delete_package(self, pkg_name: str, top_hash: str = None):
+        pass
+
+    @abc.abstractmethod
+    def push_manifest(self, pkg_name: str, top_hash: str, manifest_data: bytes):
+        pass
+
+    @abc.abstractmethod
+    def resolve_top_hash(self, pkg_name: str, hash_prefix: str) -> str:
+        pass
+
+    @abc.abstractmethod
+    def shorten_top_hash(self, pkg_name: str, top_hash: str) -> str:
+        pass
+
+
+class PackageRegistryV1(PackageRegistry):
+    root_path = '.quilt'
+
+    @property
+    def pointers_global_dir(self) -> PhysicalKey:
+        return self.root.join('named_packages/')
+
+    def pointers_dir(self, pkg_name: str) -> PhysicalKey:
+        return self.root.join(f'named_packages/{pkg_name}/')
+
+    def pointer_pk(self, pkg_name: str, pointer_name: str) -> PhysicalKey:
+        return self.root.join(f'named_packages/{pkg_name}/{pointer_name}')
+
+    def pointer_latest_pk(self, pkg_name: str) -> PhysicalKey:
+        return self.pointer_pk(pkg_name, self.latest_tag_name)
+
+    @property
+    def manifests_global_dir(self) -> PhysicalKey:
+        return self.root.join('packages/')
+
+    def manifests_package_dir(self, pkg_name: str) -> PhysicalKey:
+        return self.manifests_global_dir  # TODO: does this make sense?
+
+    def manifest_pk(self, pkg_name: str, top_hash: str) -> PhysicalKey:
+        return self.root.join(f'packages/{top_hash}')
+
+    def list_packages(self):
+        prev_pkg = None
+        for path, _ in list_url(self.pointers_global_dir):
+            parts = path.split('/')
+            if len(parts) == 3:
+                pkg = f'{parts[0]}/{parts[1]}'
+                # A package can have multiple versions, but we should only return the name once.
+                if pkg != prev_pkg:
+                    prev_pkg = pkg
+                    yield pkg
+
+    def list_package_versions(self, pkg_name: str):
+        package_dir = self.pointers_dir(pkg_name)
+        for path, _ in list_url(package_dir):
+            parts = path.split('/')
+            if len(parts) == 1:
+                pkg_hash = get_bytes(package_dir.join(parts[0]))
+                yield parts[0], pkg_hash.decode().strip()
+
+    def delete_package(self, pkg_name: str, top_hash: str = None):
+        package_path = self.pointers_dir(pkg_name)
+        paths = list(list_url(package_path))
+        if not paths:
+            raise QuiltException("No such package exists in the given directory.")
+
+        if top_hash is not None:
+            top_hash = self.resolve_top_hash(pkg_name, top_hash)
+            deleted = []
+            remaining = []
+            for path, _ in paths:
+                parts = path.split('/')
+                if len(parts) == 1:
+                    pkg_hash = get_bytes(package_path.join(parts[0]))
+                    if pkg_hash.decode().strip() == top_hash:
+                        deleted.append(parts[0])
+                    else:
+                        remaining.append(parts[0])
+            if not deleted:
+                raise QuiltException("No such package version exists in the given directory.")
+            for path in deleted:
+                delete_url(package_path.join(path))
+            if 'latest' in deleted and remaining:
+                # Create a new "latest". Technically, we need to compare numerically,
+                # but string comparisons will be fine till year 2286.
+                new_latest = max(remaining)
+                copy_file(package_path.join(new_latest), package_path.join('latest'))
+        else:
+            for path, _ in paths:
+                delete_url(package_path.join(path))
+
+        # TODO: move to LocalRegistry?
+        # Will ignore non-empty dirs.
+        # TODO: .join('') adds a trailing slash - but need a better way.
+        delete_url(package_path.join(''))
+        usr = pkg_name.split('/')[0]
+        delete_url(self.pointers_global_dir.join(usr).join(''))
+
+    def push_manifest(self, pkg_name: str, top_hash: str, manifest_data: bytes):
+        put_bytes(manifest_data, self.manifest_pk(pkg_name, top_hash))
+        hash_bytes = top_hash.encode()
+        # TODO: use a float to string formatter instead of double casting
+        put_bytes(hash_bytes, self.pointer_pk(pkg_name, str(int(time.time()))))
+        put_bytes(hash_bytes, self.pointer_latest_pk(pkg_name))
+
+    def resolve_top_hash(self, pkg_name: str, hash_prefix: str) -> str:
+        if len(hash_prefix) == 64:
+            top_hash = hash_prefix
+        elif 6 <= len(hash_prefix) < 64:
+            matching_hashes = [h for h, _
+                               in list_url(self.manifests_package_dir(pkg_name))
+                               if h.startswith(hash_prefix)]
+            if not matching_hashes:
+                raise QuiltException("Found zero matches for %r" % hash_prefix)
+            elif len(matching_hashes) > 1:
+                raise QuiltException("Found multiple matches: %r" % hash_prefix)
+            else:
+                top_hash = matching_hashes[0]
+        else:
+            raise QuiltException("Invalid hash: %r" % hash_prefix)
+        # TODO: verify that name is correct with respect to this top_hash
+        return top_hash
+
+    def shorten_top_hash(self, pkg_name: str, top_hash: str) -> str:
+        min_shorthash_len = 7
+
+        matches = [h for h, _ in list_url(self.manifests_package_dir(pkg_name))
+                   if h.startswith(top_hash[:min_shorthash_len])]
+        if len(matches) == 0:
+            raise ValueError(f"Tophash {top_hash} was not found in registry {self.base}")
+        for prefix_length in range(min_shorthash_len, 64):
+            potential_shorthash = top_hash[:prefix_length]
+            matches = [h for h in matches if h.startswith(potential_shorthash)]
+            if len(matches) == 1:
+                return potential_shorthash

--- a/api/python/quilt3/backends/local.py
+++ b/api/python/quilt3/backends/local.py
@@ -1,5 +1,37 @@
+import os
+import shutil
+
+from quilt3.data_transfer import delete_url
+
 from .base import PackageRegistryV1
 
 
+def safe_listdir(path):
+    try:
+        return os.listdir(path)
+    except FileNotFoundError:
+        return ()
+
+
 class LocalPackageRegistryV1(PackageRegistryV1):
-    pass
+    def list_packages(self):
+        pointers_dir_path = self.pointers_global_dir.path
+        for usr in safe_listdir(pointers_dir_path):
+            for pkg in safe_listdir(os.path.join(pointers_dir_path, usr)):
+                yield f'{usr}/{pkg}'
+
+    def list_package_versions(self, pkg_name: str):
+        pointers_dir_path = self.pointers_dir(pkg_name).path
+        for path in safe_listdir(pointers_dir_path):
+            with open(os.path.join(pointers_dir_path, path)) as f:
+                yield path, f.read()
+
+    def delete_package(self, pkg_name: str, top_hash: str = None):
+        package_path = self.pointers_dir(pkg_name)
+        if top_hash is None:
+            shutil.rmtree(package_path.path)
+        else:
+            super().delete_package(pkg_name, top_hash)
+            delete_url(package_path)
+        usr = pkg_name.partition('/')[0]
+        delete_url(self.pointers_global_dir.join(usr))

--- a/api/python/quilt3/backends/local.py
+++ b/api/python/quilt3/backends/local.py
@@ -1,0 +1,5 @@
+from .base import PackageRegistryV1
+
+
+class LocalPackageRegistryV1(PackageRegistryV1):
+    pass

--- a/api/python/quilt3/backends/s3.py
+++ b/api/python/quilt3/backends/s3.py
@@ -1,5 +1,20 @@
+from quilt3.data_transfer import list_url, get_bytes
+
 from .base import PackageRegistryV1
 
 
 class S3PackageRegistryV1(PackageRegistryV1):
-    pass
+    def list_packages(self):
+        prev_pkg = None
+        for path, _ in list_url(self.pointers_global_dir):
+            pkg = path.rpartition('/')[0]
+            # A package can have multiple versions, but we should only return the name once.
+            if pkg != prev_pkg:
+                prev_pkg = pkg
+                yield pkg
+
+    def list_package_versions(self, pkg_name: str):
+        package_dir = self.pointers_dir(pkg_name)
+        for path, _ in list_url(package_dir):
+            pkg_hash = get_bytes(package_dir.join(path))
+            yield path, pkg_hash.decode().strip()

--- a/api/python/quilt3/backends/s3.py
+++ b/api/python/quilt3/backends/s3.py
@@ -1,0 +1,5 @@
+from .base import PackageRegistryV1
+
+
+class S3PackageRegistryV1(PackageRegistryV1):
+    pass

--- a/api/python/quilt3/imports.py
+++ b/api/python/quilt3/imports.py
@@ -3,9 +3,8 @@
 from importlib.machinery import ModuleSpec
 import sys
 
-from quilt3.util import get_from_config, PhysicalKey, get_package_registry
-from quilt3.api import _list_packages
 from quilt3 import Package
+from .backends import get_package_registry
 
 
 MODULE_PATH = []
@@ -30,8 +29,6 @@ class DataPackageImporter:
         Module executor.
         """
         name_parts = module.__name__.split('.')
-        registry = get_from_config('default_local_registry')
-
         if module.__name__ == 'quilt3.data':
             # __path__ must be set even if the package is virtual. Since __path__ will be
             # scanned by all other finders preceding this one in sys.meta_path order, make sure
@@ -42,7 +39,8 @@ class DataPackageImporter:
         elif len(name_parts) == 3:  # e.g. module.__name__ == quilt3.data.foo
             namespace = name_parts[2]
             # we do not know the name the user will ask for, so populate all valid names
-            for pkg in _list_packages(PhysicalKey.from_url(get_package_registry(registry))):
+            registry = get_package_registry()
+            for pkg in registry.list_packages():
                 pkg_user, pkg_name = pkg.split('/')
                 if pkg_user == namespace:
                     module.__dict__[pkg_name] = Package._browse(pkg, registry=registry)

--- a/api/python/quilt3/main.py
+++ b/api/python/quilt3/main.py
@@ -10,11 +10,11 @@ import sys
 import dns.resolver
 import requests
 
-from . import api, session
+from . import api, session, Package
 from . import __version__ as quilt3_version
+from .backends import get_package_registry
 from .session import open_url
-from .util import get_from_config, catalog_s3_url, catalog_package_url, QuiltException, PhysicalKey, \
-    fix_url, get_package_registry
+from .util import get_from_config, catalog_s3_url, catalog_package_url, QuiltException
 
 
 def cmd_config(catalog_url, **kwargs):
@@ -199,13 +199,12 @@ def cmd_disable_telemetry():
 
 
 def cmd_list_packages(registry):
-    registry_parsed = PhysicalKey.from_url(get_package_registry(fix_url(registry)))
-    for package_name in api._list_packages(registry=registry_parsed):
+    for package_name in get_package_registry(registry).list_packages:
         print(package_name)
 
 
 def cmd_verify(name, registry, top_hash, dir, extra_files_ok):
-    pkg = api.Package._browse(name, registry, top_hash)
+    pkg = Package._browse(name, registry, top_hash)
     if pkg.verify(dir, extra_files_ok):
         print("Verification succeeded")
         return 0
@@ -215,7 +214,7 @@ def cmd_verify(name, registry, top_hash, dir, extra_files_ok):
 
 
 def cmd_push(name, dir, registry, dest, message):
-    pkg = api.Package()
+    pkg = Package()
     pkg.set_dir('.', dir)
     pkg.push(name, registry=registry, dest=dest, message=message)
 
@@ -340,7 +339,7 @@ def create_parser():
         type=str,
         required=False,
     )
-    install_p.set_defaults(func=api.Package.install)
+    install_p.set_defaults(func=Package.install)
 
     # list-packages
     shorthelp = "List all packages in a registry"

--- a/api/python/quilt3/util.py
+++ b/api/python/quilt3/util.py
@@ -341,13 +341,6 @@ def validate_package_name(name):
         raise QuiltException(f"Invalid package name: {name}.")
 
 
-def get_package_registry(path=None):
-    """ Returns the package registry root for a given path """
-    if path is None:
-        path = get_from_config('default_local_registry')
-    return path.rstrip('/') + '/.quilt'
-
-
 def configure_from_url(catalog_url):
     """ Read configuration settings from a Quilt catalog """
     config_template = read_yaml(CONFIG_TEMPLATE)

--- a/api/python/tests/integration/test_packages.py
+++ b/api/python/tests/integration/test_packages.py
@@ -16,6 +16,7 @@ import pytest
 import quilt3
 from quilt3 import Package
 from quilt3.util import PhysicalKey, QuiltException, validate_package_name, RemovedInQuilt4Warning
+from quilt3.backends.local import LocalPackageRegistryV1
 
 from ..utils import QuiltTestCase
 
@@ -157,14 +158,20 @@ class PackageTest(QuiltTestCase):
             assert PhysicalKey.from_path(test_file) == pkg['bar'].physical_key
 
     @patch('quilt3.Package._browse', lambda name, registry, top_hash: Package())
-    @patch('quilt3.Package._shorten_tophash', lambda package_name, registry, top_hash: "7a67ff4")
+    @patch('quilt3.backends.base.PackageRegistryV1.shorten_top_hash', lambda self, pkg_name, top_hash: "7a67ff4")
     def test_default_install_location(self):
         """Verify that pushes to the default local install location work as expected"""
         with patch('quilt3.Package._build') as build_mock:
             pkg_name = 'Quilt/nice-name'
             Package.install(pkg_name, registry='s3://my-test-bucket')
 
-            build_mock.assert_called_once_with(pkg_name, registry=quilt3.util.get_install_location(), message=None)
+            build_mock.assert_called_once_with(
+                pkg_name,
+                registry=LocalPackageRegistryV1(
+                    PhysicalKey.from_url(quilt3.util.get_install_location())
+                ),
+                message=None
+            )
 
     def test_read_manifest(self):
         """ Verify reading serialized manifest from disk. """
@@ -398,7 +405,7 @@ class PackageTest(QuiltTestCase):
                 PhysicalKey.from_path('foo.txt')
             )
 
-    @patch('quilt3.Package._shorten_tophash', lambda package_name, registry, top_hash: "7a67ff4")
+    @patch('quilt3.backends.base.PackageRegistryV1.shorten_top_hash', lambda self, pkg_name, top_hash: "7a67ff4")
     def test_load_into_quilt(self):
         """ Verify loading local manifest and data into S3. """
         top_hash1 = 'abbf5f171cf20bfb2313ecd8684546958cd72ac4f3ec635e4510d9c771168226'
@@ -726,7 +733,7 @@ class PackageTest(QuiltTestCase):
         pkg = Package().set('bar.txt')
         assert PhysicalKey.from_path(test_file) == pkg['bar.txt'].physical_key
 
-    @patch('quilt3.Package._shorten_tophash', lambda package_name, registry, top_hash: "7a67ff4")
+    @patch('quilt3.backends.base.PackageRegistryV1.shorten_top_hash', lambda self, pkg_name, top_hash: "7a67ff4")
     def test_set_package_entry_as_object(self):
         pkg = Package()
         nasty_string = 'a,"\tb'
@@ -1043,7 +1050,7 @@ class PackageTest(QuiltTestCase):
         with pytest.raises(QuiltException):
             p.push('Quilt/Test', 's3://test-bucket', dest='s3://other-test-bucket')
 
-    @patch('quilt3.Package._shorten_tophash', lambda package_name, registry, top_hash: "7a67ff4")
+    @patch('quilt3.backends.base.PackageRegistryV1.shorten_top_hash', lambda self, pkg_name, top_hash: "7a67ff4")
     def test_commit_message_on_push(self):
         """ Verify commit messages populate correctly on push."""
         with patch('quilt3.packages.copy_file_list', _mock_copy_file_list), \
@@ -1165,7 +1172,7 @@ class PackageTest(QuiltTestCase):
 
     def test_import(self):
         with patch('quilt3.Package._browse') as browse_mock, \
-             patch('quilt3.imports._list_packages') as list_packages_mock:
+             patch('quilt3.backends.local.LocalPackageRegistryV1.list_packages') as list_packages_mock:
             browse_mock.return_value = quilt3.Package()
             list_packages_mock.return_value = ['foo/bar', 'foo/baz']
 
@@ -1212,7 +1219,7 @@ class PackageTest(QuiltTestCase):
         with pytest.raises(QuiltException):
             pkg.set('s3://foo/..', LOCAL_MANIFEST)
 
-    @patch('quilt3.Package._shorten_tophash', lambda package_name, registry, top_hash: "7a67ff4")
+    @patch('quilt3.backends.base.PackageRegistryV1.shorten_top_hash', lambda self, pkg_name, top_hash: "7a67ff4")
     def test_install(self):
         # Manifest
 
@@ -1529,7 +1536,7 @@ class PackageTest(QuiltTestCase):
         with self.assertRaises(QuiltException):
             Package.rollback('quilt/blah', LOCAL_REGISTRY, good_hash)
 
-    @patch('quilt3.Package._shorten_tophash', lambda package_name, registry, top_hash: "7a67ff4")
+    @patch('quilt3.backends.base.PackageRegistryV1.shorten_top_hash', lambda self, pkg_name, top_hash: "7a67ff4")
     def test_verify(self):
         pkg = Package()
 

--- a/api/python/tests/integration/test_packages.py
+++ b/api/python/tests/integration/test_packages.py
@@ -1019,7 +1019,7 @@ class PackageTest(QuiltTestCase):
             }
         )
 
-        for path in ['Quilt/Test/0', 'Quilt/Test/latest', 'Quilt/Test/', 'Quilt/']:
+        for path in ['Quilt/Test/0', 'Quilt/Test/latest']:
             self.s3_stubber.add_response(
                 method='delete_object',
                 service_response={},


### PR DESCRIPTION
## Description
The first commit adds `LocalPackage` abstraction layer, the second one reworks methods in a more backend specific way to demonstrate why I add `S3PackageRegistryV1` and `LocalPackageRegistryV1`.
In some near future I'm going to move S3 specific stuff under `backends.s3` and add backend specific `PhysicalKey` with helper methods like `get_bytes()` etc.

## TODO
 - [x] - more polishing?
