### PR TITLE
Fix removing of package revision with short hash

### DIFF
--- a/api/python/quilt3/packages.py
+++ b/api/python/quilt3/packages.py
@@ -487,6 +487,7 @@ class Package:
             hash_prefix(string): hash prefix with length between 6 and 64 characters
         """
         assert isinstance(registry, PhysicalKey)
+        assert not str(registry).rstrip('/').endswith('.quilt')
         if len(hash_prefix) == 64:
             top_hash = hash_prefix
         elif 6 <= len(hash_prefix) < 64:


### PR DESCRIPTION
Removing of package revision with short hash is broken:
```python
In [4]: import quilt3                                

In [5]: top_hash = quilt3.Package().build("test/test")                                                    

In [6]: quilt3.api.delete_package("test/test", top_hash=top_hash[:-1])                                    
---------------------------------------------------------------------------
QuiltException                            Traceback (most recent call last)
<ipython-input-6-fd5db34ebc7a> in <module>
----> 1 quilt3.api.delete_package("test/test", top_hash=top_hash[:-1])

~/dev/work/quilt/api/python/quilt3/telemetry.py in decorated(*args, **kwargs)
    129             ApiTelemetry.report_api_use(self.api_name, ApiTelemetry.session_id)
    130 
--> 131             results = func(*args, **kwargs)
    132             # print(f"{len(ApiTelemetry.pending_reqs)} request(s) pending!")
    133 

~/dev/work/quilt/api/python/quilt3/api.py in delete_package(name, registry, top_hash)
     47 
     48     paths = list(list_url(package_path))
---> 49     if not paths:
     50         raise QuiltException("No such package exists in the given directory.")
     51 

~/dev/work/quilt/api/python/quilt3/packages.py in resolve_hash(cls, registry, hash_prefix)
    495                                in list_url(registry.join('.quilt/packages/'))
    496                                if h.startswith(hash_prefix)]
--> 497             if not matching_hashes:
    498                 raise QuiltException("Found zero matches for %r" % hash_prefix)
    499             elif len(matching_hashes) > 1:

QuiltException: Found zero matches for '2a5a67156ca9238c14d12042db51c5b52260fdd5511b61ea89b58929d6e1769'
```