### PR TITLE
Deprecate passing sub-package path to Package.install() via package name

### DIFF
--- a/api/python/pytest.ini
+++ b/api/python/pytest.ini
@@ -4,6 +4,7 @@ filterwarnings =
     ignore:::cookies
     ignore::ImportWarning
     ignore:::IPython.lib.pretty
+    error::quilt3.util.RemovedInQuilt4Warning
 
 env =
     QUILT_DISABLE_USAGE_METRICS=True

--- a/api/python/quilt3/main.py
+++ b/api/python/quilt3/main.py
@@ -305,7 +305,9 @@ def create_parser():
     install_p = subparsers.add_parser("install", description=shorthelp, help=shorthelp, allow_abbrev=False)
     install_p.add_argument(
         "name",
-        help="Name of package, in the USER/PKG[/PATH] format",
+        help=(
+            "Name of package, in the USER/PKG[/PATH] format ([/PATH] is deprecated, use --path parameter instead)"
+        ),
         type=str,
     )
     install_p.add_argument(
@@ -329,6 +331,12 @@ def create_parser():
     install_p.add_argument(
         "--dest-registry",
         help="Registry to install package to. Defaults to local registry.",
+        type=str,
+        required=False,
+    )
+    install_p.add_argument(
+        "--path",
+        help="If specified, downloads only PATH or its children.",
         type=str,
         required=False,
     )

--- a/api/python/quilt3/util.py
+++ b/api/python/quilt3/util.py
@@ -80,6 +80,10 @@ class QuiltException(Exception):
             setattr(self, k, v)
 
 
+class RemovedInQuilt4Warning(FutureWarning):
+    pass
+
+
 class PhysicalKey:
     __slots__ = ['bucket', 'path', 'version_id']
 

--- a/docs/API Reference/Package.md
+++ b/docs/API Reference/Package.md
@@ -24,13 +24,14 @@ A string that represents the top hash of the package
 String representation of the Package.
 
 
-## Package.install(name, registry=None, top\_hash=None, dest=None, dest\_registry=None)  {#Package.install}
+## Package.install(name, registry=None, top\_hash=None, dest=None, dest\_registry=None, \*, path=None)  {#Package.install}
 
 Installs a named package to the local registry and downloads its files.
 
 __Arguments__
 
-* __name(str)__:  Name of package to install. It also can be passed as NAME/PATH,
+* __name(str)__:  Name of package to install. It also can be passed as NAME/PATH
+    (/PATH is deprecated, use the `path` parameter instead),
     in this case only the sub-package or the entry specified by PATH will
     be downloaded.
 * __registry(str)__:  Registry where package is located.
@@ -38,6 +39,7 @@ __Arguments__
 * __top_hash(str)__:  Hash of package to install. Defaults to latest.
 * __dest(str)__:  Local path to download files to.
 * __dest_registry(str)__:  Registry to install package to. Defaults to local registry.
+* __path(str)__:  If specified, downloads only `path` or its children.
 
 
 ## Package.resolve\_hash(registry, hash\_prefix)  {#Package.resolve\_hash}

--- a/docs/API Reference/cli.md
+++ b/docs/API Reference/cli.md
@@ -44,12 +44,14 @@ https://quiltdata.com for more information.
 ```
 usage: quilt3 install [-h] [--registry REGISTRY] [--top-hash TOP_HASH]
                       [--dest DEST] [--dest-registry DEST_REGISTRY]
+                      [--path PATH]
                       name
 
 Install a package
 
 positional arguments:
   name                  Name of package, in the USER/PKG[/PATH] format
+                        ([/PATH] is deprecated, use --path parameter instead)
 
 optional arguments:
   -h, --help            show this help message and exit
@@ -60,6 +62,7 @@ optional arguments:
   --dest-registry DEST_REGISTRY
                         Registry to install package to. Defaults to local
                         registry.
+  --path PATH           If specified, downloads only PATH or its children.
 ```
 ## `verify`
 ```


### PR DESCRIPTION
## TODO ##

- [x] regen docs once approved