### PR TITLE
Raise exception when None is passed as registry to Package.rollback()

### DIFF
--- a/api/python/quilt3/packages.py
+++ b/api/python/quilt3/packages.py
@@ -1314,7 +1314,7 @@ class Package:
             top_hash(str): Hash to rollback to.
         """
         validate_package_name(name)
-        registry = get_package_registry(registry)
+        registry = get_package_registry(PhysicalKey.from_url(fix_url(registry)))
         top_hash = registry.resolve_top_hash(name, top_hash)
 
         # Check that both latest and top_hash actually exist.

--- a/api/python/tests/integration/test_packages.py
+++ b/api/python/tests/integration/test_packages.py
@@ -1499,6 +1499,10 @@ class PackageTest(QuiltTestCase):
         with self.assertRaises(QuiltException):
             Package.rollback('quilt/blah', LOCAL_REGISTRY, good_hash)
 
+    def test_rollback_none_registry(self):
+        with pytest.raises(ValueError):
+            Package.rollback('quilt/tmp', None, '12345678' * 8)
+
     @patch('quilt3.backends.base.PackageRegistryV1.shorten_top_hash', lambda self, pkg_name, top_hash: "7a67ff4")
     def test_verify(self):
         pkg = Package()


### PR DESCRIPTION
This restores pre c4cdc527e9486bf513e481cb72b35e7cdf67d840 behavior