### PR TITLE
Bucket/File: handle case when object access is denied

### DIFF
--- a/catalog/app/containers/Bucket/File.js
+++ b/catalog/app/containers/Bucket/File.js
@@ -444,6 +444,13 @@ export default function File({
       {objExistsData.case({
         _: () => <CenteredProgress />,
         Err: (e) => {
+          if (e.code === 'Forbidden') {
+            return (
+              <Message headline="Access Denied">
+                You don&apos;t have access to this object.
+              </Message>
+            )
+          }
           throw e
         },
         Ok: requests.ObjectExistence.case({


### PR DESCRIPTION
dont crash when object access is forbidden, just show the "access denied' message