### PR TITLE
Landing: only show sticky footer in MARKETING mode

### DIFF
--- a/catalog/app/website/pages/Landing/Landing.js
+++ b/catalog/app/website/pages/Landing/Landing.js
@@ -37,7 +37,7 @@ export default function Landing() {
       {cfg.mode !== 'LOCAL' && <Highlights />}
       {cfg.mode === 'MARKETING' && <Pricing />}
       {cfg.mode !== 'LOCAL' && <Contribute />}
-      {cfg.mode !== 'LOCAL' && <StickyFooter />}
+      {cfg.mode === 'MARKETING' && <StickyFooter />}
     </Layout>
   )
 }


### PR DESCRIPTION
seems like it's not needed in PRODUCT mode