### PR TITLE
Fix bucket grid layout jump

### DIFF
--- a/catalog/app/utils/scrollIntoView.js
+++ b/catalog/app/utils/scrollIntoView.js
@@ -5,10 +5,10 @@
  * Example: <h1 id="about" ref={scrollIntoView()}>About</h1>
  */
 
-export default (timeout = 100) => (el) => {
+export default ({ timeout = 100, ...opts } = {}) => (el) => {
   const { hash } = window.location
   if (el && el.id && hash) {
     const id = hash.replace('#', '')
-    if (el.id === id) setTimeout(() => el.scrollIntoView(), timeout)
+    if (el.id === id) setTimeout(() => el.scrollIntoView(opts), timeout)
   }
 }

--- a/catalog/app/website/pages/Landing/Buckets/Buckets.js
+++ b/catalog/app/website/pages/Landing/Buckets/Buckets.js
@@ -11,7 +11,7 @@ import usePrevious from 'utils/usePrevious'
 import Backlight from 'website/components/Backgrounds/Backlight1'
 import BucketGrid from 'website/components/BucketGrid'
 
-const PER_PAGE = 3
+const PER_PAGE = 9
 
 const useStyles = M.makeStyles((t) => ({
   root: {
@@ -68,7 +68,7 @@ export default function Buckets() {
 
   usePrevious(page, (prev) => {
     if (prev && page !== prev && scrollRef.current) {
-      scrollRef.current.scrollIntoView()
+      scrollRef.current.scrollIntoView({ behavior: 'smooth' })
     }
   })
 
@@ -76,15 +76,12 @@ export default function Buckets() {
     <div className={classes.root}>
       <Backlight style={{ opacity: 0.5 }} />
       <M.Container maxWidth="lg" className={classes.container}>
+        <div ref={scrollRef} style={{ position: 'relative', top: -72 }} />
         <M.Typography variant="h1" color="textPrimary">
           Explore your buckets
         </M.Typography>
         <M.Box mt={4} />
-        <BucketGrid
-          buckets={paginated}
-          ref={scrollRef}
-          showAddLink={buckets.length <= 2}
-        />
+        <BucketGrid buckets={paginated} showAddLink={buckets.length <= PER_PAGE - 1} />
         <div className={classes.controls}>
           <M.Box mt={2}>
             {buckets.length > 2 && (

--- a/catalog/app/website/pages/OpenLanding/Buckets/Buckets.js
+++ b/catalog/app/website/pages/OpenLanding/Buckets/Buckets.js
@@ -81,7 +81,7 @@ export default function Buckets() {
 
   usePrevious(page, (prev) => {
     if (prev && page !== prev && scrollRef.current) {
-      scrollRef.current.scrollIntoView()
+      scrollRef.current.scrollIntoView({ behavior: 'smooth' })
     }
   })
 
@@ -102,6 +102,7 @@ export default function Buckets() {
       id="buckets"
       ref={scrollIntoView()}
     >
+      <div ref={scrollRef} style={{ position: 'relative', top: -72 }} />
       <M.TextField
         className={classes.filter}
         value={filter}
@@ -125,7 +126,6 @@ export default function Buckets() {
           ) : undefined,
         }}
       />
-      <div ref={scrollRef} />
       {paginated.length ? (
         <BucketGrid
           buckets={paginated}


### PR DESCRIPTION
Buckets on landing pages:
- smooth scroll on page change
- 9 buckets per page in product mode
- compensate for navbar height when scrolling