### PR TITLE
Public/anon access to pkgselect

### DIFF
--- a/lambdas/pkgselect/index.py
+++ b/lambdas/pkgselect/index.py
@@ -130,6 +130,7 @@ def lambda_handler(request):
 
         # Use the default S3 client configuration
         s3_client = boto3.client('s3')
+        response = s3_client.head_object(Bucket=bucket, Key=key)
     else:
         return make_json_response(
             400,

--- a/lambdas/pkgselect/index.py
+++ b/lambdas/pkgselect/index.py
@@ -3,6 +3,7 @@ Provide a virtual-file-system view of a package's logical keys.
 """
 
 import json
+import os
 
 import boto3
 from botocore import UNSIGNED
@@ -106,6 +107,7 @@ def lambda_handler(request):
     access_key = request.args.get('access_key')
     secret_key = request.args.get('secret_key')
     session_token = request.args.get('session_token')
+    allow_anonymous_access = bool(os.getenv('ALLOW_ANONYMOUS_ACCESS'))
 
     # If credentials are passed in, use them
     # for the client. If no credentials are supplied, test that
@@ -119,6 +121,7 @@ def lambda_handler(request):
             aws_session_token=session_token
         )
     elif (
+        allow_anonymous_access and
         access_key is None and
         secret_key is None and
         session_token is None

--- a/lambdas/pkgselect/index.py
+++ b/lambdas/pkgselect/index.py
@@ -60,11 +60,11 @@ def file_list_to_folder(df: pd.DataFrame) -> dict:
         prefixes = []
         objects = []
     else:
-         # matches all strings; everything before and including the first
-         # / is extracted
+        # matches all strings; everything before and including the first
+        # / is extracted
         folder = pd.Series(df.logical_key.dropna().str.extract('([^/]+/?).*')[0].unique())
-        prefixes=folder[folder.str.endswith('/')].sort_values().tolist()
-        objects=folder[~folder.str.endswith('/')].sort_values().tolist()
+        prefixes = folder[folder.str.endswith('/')].sort_values().tolist()
+        objects = folder[~folder.str.endswith('/')].sort_values().tolist()
 
     return dict(
         prefixes=prefixes,

--- a/lambdas/pkgselect/index.py
+++ b/lambdas/pkgselect/index.py
@@ -53,12 +53,22 @@ def file_list_to_folder(df: pd.DataFrame) -> dict:
     top-level folder view (a special case of the s3-select
     lambda).
     """
-    # matches all strings; everything before and including the first
-    # / is extracted
-    folder = pd.Series(df.logical_key.dropna().str.extract('([^/]+/?).*')[0].unique())
-    return dict(
-        prefixes=folder[folder.str.endswith('/')].sort_values().tolist(),
+    # check for empty manifest (top-level meta only)
+    # calls below will fail if no rows are left after
+    # dropna.
+    if len(df.index) <= 1:
+        prefixes = []
+        objects = []
+    else:
+         # matches all strings; everything before and including the first
+         # / is extracted
+        folder = pd.Series(df.logical_key.dropna().str.extract('([^/]+/?).*')[0].unique())
+        prefixes=folder[folder.str.endswith('/')].sort_values().tolist()
         objects=folder[~folder.str.endswith('/')].sort_values().tolist()
+
+    return dict(
+        prefixes=prefixes,
+        objects=objects
     )
 
 

--- a/lambdas/pkgselect/index.py
+++ b/lambdas/pkgselect/index.py
@@ -5,6 +5,8 @@ Provide a virtual-file-system view of a package's logical keys.
 import json
 
 import boto3
+from botocore import UNSIGNED
+from botocore.client import Config
 import pandas as pd
 
 from t4_lambda_shared.decorator import api, validate
@@ -40,7 +42,7 @@ SCHEMA = {
             'type': 'string'
         }
     },
-    'required': ['bucket', 'manifest', 'access_key', 'secret_key'],
+    'required': ['bucket', 'manifest'],
     'additionalProperties': False
 }
 
@@ -60,21 +62,22 @@ def file_list_to_folder(df: pd.DataFrame) -> dict:
     )
 
 
-def get_s3_client(
+def create_s3_client(
+    *,
     aws_access_key_id: str,
     aws_secret_access_key: str,
     aws_session_token: str
 ):
     """
-    Create an S3 Client using the provided credentials
+    Create an S3 Client using caller-provided credentials.
     """
+    assert aws_access_key_id and aws_secret_access_key and aws_session_token
     session = boto3.Session(
         aws_access_key_id=aws_access_key_id,
         aws_secret_access_key=aws_secret_access_key,
         aws_session_token=aws_session_token
     )
-    s3_client = session.client('s3')
-    return s3_client
+    return session.client('s3')
 
 
 @api(cors_origins=get_default_origins())
@@ -88,14 +91,44 @@ def lambda_handler(request):
     """
     bucket = request.args['bucket']
     key = request.args['manifest']
-    aws_access_key_id = request.args['access_key']
-    aws_secret_access_key = request.args['secret_key']
-    aws_session_token = request.args['session_token']
     prefix = request.args.get('prefix')
     logical_key = request.args.get('logical_key')
+    access_key = request.args.get('access_key')
+    secret_key = request.args.get('secret_key')
+    session_token = request.args.get('session_token')
 
-    # Create an s3 client using the provided credentials
-    s3_client = get_s3_client(aws_access_key_id, aws_secret_access_key, aws_session_token)
+    # If credentials are passed in, use them
+    # for the client. If no credentials are supplied, test that
+    # the manifest object is publicly accessible. If so, create
+    # an s3 client using the underlying IAM role's permissions.
+
+    if access_key and secret_key and session_token:
+        s3_client = create_s3_client(
+            aws_access_key_id=access_key,
+            aws_secret_access_key=secret_key,
+            aws_session_token=session_token
+        )
+    elif (
+        access_key is None and
+        secret_key is None and
+        session_token is None
+    ):
+        # Test to see if the target key is publicly accessible. If not, the call
+        # below will raise and exception and return a 403 response
+        anons3 = boto3.client('s3', config=Config(signature_version=UNSIGNED))
+        response = anons3.head_object(Bucket=bucket, Key=key)
+
+        # Use the default S3 client configuration
+        s3_client = boto3.client('s3')
+    else:
+        return make_json_response(
+            400,
+            {
+                'title': 'Incomplete credentials',
+                'detail': "access_key, secret_key and session_token are required"
+            }
+        )
+    assert s3_client
 
     # Get details of a single file in the package
     if logical_key is not None:

--- a/lambdas/pkgselect/index.py
+++ b/lambdas/pkgselect/index.py
@@ -130,7 +130,6 @@ def lambda_handler(request):
 
         # Use the default S3 client configuration
         s3_client = boto3.client('s3')
-        response = s3_client.head_object(Bucket=bucket, Key=key)
     else:
         return make_json_response(
             400,

--- a/lambdas/pkgselect/test/test_pkgselect.py
+++ b/lambdas/pkgselect/test/test_pkgselect.py
@@ -308,7 +308,7 @@ class TestPackageSelect(TestCase):
         )
 
         response = lambda_handler(self._make_event(params), None)
-        assert response['statusCode'] == 400
+        assert response['statusCode'] == 401
 
     def test_blocked_anon_access(self):
         """
@@ -325,7 +325,7 @@ class TestPackageSelect(TestCase):
         )
 
         response = lambda_handler(self._make_event(params), None)
-        assert response['statusCode'] == 400
+        assert response['statusCode'] == 401
 
     def test_anon_access(self):
         """

--- a/lambdas/pkgselect/test/test_pkgselect.py
+++ b/lambdas/pkgselect/test/test_pkgselect.py
@@ -8,6 +8,7 @@ from unittest import TestCase
 from unittest.mock import patch
 
 import boto3
+from botocore.stub import Stubber
 import pandas as pd
 import responses
 
@@ -308,3 +309,82 @@ class TestPackageSelect(TestCase):
 
         response = lambda_handler(self._make_event(params), None)
         assert response['statusCode'] == 400
+
+    def test_blocked_anon_access(self):
+        """
+        Verify that an anonymous call fails if ALLOW_ANONYMOUS_ACCESS
+        is not set.
+        """
+        bucket = "bucket"
+        key = ".quilt/packages/manifest_hash"
+        logical_key = "bar/file1.txt"
+        params = dict(
+            bucket=bucket,
+            manifest=key,
+            logical_key=logical_key,
+        )
+
+        response = lambda_handler(self._make_event(params), None)
+        assert response['statusCode'] == 400
+
+    def test_anon_access(self):
+        """
+        Test anonymous call w/ ALLOW_ANONYMOUS_ACCESS
+        """
+        bucket = "bucket"
+        key = ".quilt/packages/manifest_hash"
+        params = dict(
+            bucket=bucket,
+            manifest=key,
+        )
+
+        expected_args = {
+            'Bucket': bucket,
+            'Key': key,
+            'Expression': "SELECT SUBSTRING(s.logical_key, 1) AS logical_key FROM s3object s",
+            'ExpressionType': 'SQL',
+            'InputSerialization': {
+                'CompressionType': 'NONE',
+                'JSON': {'Type': 'LINES'}
+                },
+            'OutputSerialization': {'JSON': {'RecordDelimiter': '\n'}},
+        }
+
+        env_patcher = patch.dict(os.environ, {
+            'AWS_ACCESS_KEY_ID': 'test_key',
+            'AWS_SECRET_ACCESS_KEY': 'test_secret',
+            'ALLOW_ANONYMOUS_ACCESS': '1'
+        })
+        env_patcher.start()
+
+        mock_s3 = boto3.client('s3')
+        client_patch = patch.object(
+            mock_s3,
+            'select_object_content',
+            return_value=self.s3response
+        )
+        client_patch.start()
+        response = {
+            'ETag': '12345',
+            'VersionId': '1.0',
+            'ContentLength': 123,
+        }
+        expected_params = {
+            'Bucket': bucket,
+            'Key': key,
+        }
+        s3_stubber = Stubber(mock_s3)
+        s3_stubber.activate()
+        s3_stubber.add_response('head_object', response, expected_params)
+        with patch('boto3.Session.client', return_value=mock_s3):
+            response = lambda_handler(self._make_event(params), None)
+            print(response)
+            assert response['statusCode'] == 200
+            folder = json.loads(read_body(response))['contents']
+            assert len(folder['prefixes']) == 1
+            assert len(folder['objects']) == 1
+            assert 'foo.csv' in folder['objects']
+            assert 'bar/' in folder['prefixes']
+        s3_stubber.deactivate()
+        client_patch.stop()
+        env_patcher.stop()

--- a/lambdas/pkgselect/test/test_pkgselect.py
+++ b/lambdas/pkgselect/test/test_pkgselect.py
@@ -290,3 +290,21 @@ class TestPackageSelect(TestCase):
             assert response['statusCode'] == 200
             json.loads(read_body(response))['contents']
         client_patch.stop()
+
+    def test_incomplete_credentials(self):
+        """
+        Verify that a call with incomplete credentials fails.
+        """
+        bucket = "bucket"
+        key = ".quilt/packages/manifest_hash"
+        logical_key = "bar/file1.txt"
+        params = dict(
+            bucket=bucket,
+            manifest=key,
+            logical_key=logical_key,
+            access_key="TESTKEY",
+            secret_key="TESTSECRET",
+        )
+
+        response = lambda_handler(self._make_event(params), None)
+        assert response['statusCode'] == 400


### PR DESCRIPTION
## Description
Allow access to the `pkgselect` endpoint for anonymous users only for public packages (manifest files that are publicly readable).