### PR TITLE
Count pages in PDFs via countPages=true param

### DIFF
--- a/lambdas/thumbnail/index.py
+++ b/lambdas/thumbnail/index.py
@@ -260,7 +260,10 @@ def lambda_handler(request):
     resp = requests.get(url)
     if resp.ok:
         try:
-            thumbnail_format = SUPPORTED_BROWSER_FORMATS.get(imageio.get_reader(resp.content), "PNG")
+            thumbnail_format = SUPPORTED_BROWSER_FORMATS.get(
+                imageio.get_reader(resp.content),
+                "PNG"
+            )
         except ValueError:
             thumbnail_format = "JPEG" if input_ == "pdf" else "PNG"
         if input_ == "pdf":

--- a/lambdas/thumbnail/tests/test_thumbnail.py
+++ b/lambdas/thumbnail/tests/test_thumbnail.py
@@ -33,32 +33,51 @@ def _make_event(query, headers=None):
     }
 
 
+@patch.dict(os.environ, {
+    'LAMBDA_TASK_ROOT': str(Path('/var/task')),
+    # need the real OS path so that we can find pdftoppm, but patch to avoid side-effects
+    'PATH': os.environ.get("PATH"),
+    'LD_LIBRARY_PATH': str(Path('/lib64')) + os.pathsep + str(Path('/usr/lib64')),
+    # set_pdf_env() will blow this away
+    # it's only here to prevent side-effects on the test host
+    'FONT_CONFIG_PATH': ''
+})
 @responses.activate
-@pytest.mark.parametrize("input_file, params, expected_thumb, expected_original_size, expected_thumb_size", [
-    ("penguin.jpg", {"size": "w256h256"}, "penguin-256.jpg", [1526, 1290, 3], [217, 256]),
-    ("cell.tiff", {"size": "w640h480"}, "cell-480.png", [15, 1, 158, 100], [514, 480]),
-    ("cell.png", {"size": "w64h64"}, "cell-64.png", [168, 104, 3], [39, 64]),
-    ("sat_greyscale.tiff", {"size": "w640h480"}, "sat_greyscale-480.png", [512, 512], [480, 480]),
-    ("generated.ome.tiff", {"size": "w256h256"}, "generated-256.png", [6, 36, 76, 68], [224, 167]),
-    ("sat_rgb.tiff", {"size": "w256h256"}, "sat_rgb-256.png", [256, 256, 4], [256, 256]),
-    ("single_cell.ome.tiff", {"size": "w256h256"}, "single_cell.png", [6, 40, 152, 126], [256, 205]),
+@pytest.mark.parametrize("input_file, params, expected_thumb, expected_original_size, expected_thumb_size, num_pages", [
+    ("penguin.jpg", {"size": "w256h256"}, "penguin-256.jpg", [1526, 1290, 3], [217, 256], None),
+    ("cell.tiff", {"size": "w640h480"}, "cell-480.png", [15, 1, 158, 100], [514, 480], None),
+    ("cell.png", {"size": "w64h64"}, "cell-64.png", [168, 104, 3], [39, 64], None),
+    ("sat_greyscale.tiff", {"size": "w640h480"}, "sat_greyscale-480.png", [512, 512], [480, 480], None),
+    ("generated.ome.tiff", {"size": "w256h256"}, "generated-256.png", [6, 36, 76, 68], [224, 167], None),
+    ("sat_rgb.tiff", {"size": "w256h256"}, "sat_rgb-256.png", [256, 256, 4], [256, 256], None),
+    ("single_cell.ome.tiff", {"size": "w256h256"}, "single_cell.png", [6, 40, 152, 126], [256, 205], None),
     # Following PDF tests should only be run if poppler-utils installed;
     # then call pytest with --poppler
     pytest.param(
         "MUMmer.pdf",
         {"size": "w1024h768", "input": "pdf", "page": 4},
-        "pdf-page4-1024w.jpeg", None, [1024, 1450],
+        "pdf-page4-1024w.jpeg", None, [1024, 1450], None,
         marks=pytest.mark.poppler
     ),
     pytest.param(
         "MUMmer.pdf",
         {"size": "w256h256", "input": "pdf", "page": 8},
-        # pdf ignores the height dimension
-        "pdf-page8-256w.jpeg", None, [256, 363],
+        "pdf-page8-256w.jpeg", None, [256, 363], None,
+        marks=pytest.mark.poppler
+    ),
+    pytest.param(
+        "MUMmer.pdf",
+        {"size": "w1024h768", "input": "pdf", "page": 4, "countPages": "true"},
+        "pdf-page4-1024w.jpeg", None, [1024, 1450], 8,
         marks=pytest.mark.poppler
     ),
     # Test for statusCode error
-    pytest.param("cell.png", {"size": "w1h1"}, None, None, None, marks=pytest.mark.xfail(raises=AssertionError))
+    pytest.param(
+        "cell.png",
+        {"size": "w1h1"},
+        None, None, None, None,
+        marks=pytest.mark.xfail(raises=AssertionError)
+    )
 ])
 def test_generate_thumbnail(
         data_dir,
@@ -66,7 +85,8 @@ def test_generate_thumbnail(
         params,
         expected_thumb,
         expected_original_size,
-        expected_thumb_size
+        expected_thumb_size,
+        num_pages
 ):
     # Resolve the input file path
     input_file = data_dir / input_file
@@ -83,13 +103,15 @@ def test_generate_thumbnail(
     # Get the response
     response = lambda_handler(event, None)
     # Assert the request was handled with no errors
-    assert response["statusCode"] == 200
+    assert response["statusCode"] == 200, f"response: {response}"
     # Parse the body / the returned thumbnail
     body = json.loads(read_body(response))
     # Assert basic metadata was filled properly
+    assert body["info"]["thumbnail_size"] == expected_thumb_size
     if expected_original_size:  # PDFs don't have an expected size
         assert body["info"]["original_size"] == expected_original_size
-    assert body["info"]["thumbnail_size"] == expected_thumb_size
+    if "countPages" in params:
+        assert body["info"]["page_count"] == num_pages
     # Assert the produced image is the same as the expected
     if params.get('input') == 'pdf':
         actual = Image.open(BytesIO(base64.b64decode(body['thumbnail'])))
@@ -103,7 +125,10 @@ def test_generate_thumbnail(
 @patch.dict(os.environ, {
     'LAMBDA_TASK_ROOT': str(Path('/var/task')),
     'PATH': str(Path('/one/two')) + os.pathsep + str(Path('/three')),
-    'LD_LIBRARY_PATH': str(Path('/lib64')) + os.pathsep + str(Path('/usr/lib64'))
+    'LD_LIBRARY_PATH': str(Path('/lib64')) + os.pathsep + str(Path('/usr/lib64')),
+    # set_pdf_env() will blow this away
+    # it's only here to prevent side-effects on the test host
+    'FONT_CONFIG_PATH': ''
 })
 def test_pdf_env():
     """test that env vars are set so that poppler, pdf2image work properly"""

--- a/lambdas/thumbnail/tests/test_thumbnail.py
+++ b/lambdas/thumbnail/tests/test_thumbnail.py
@@ -80,7 +80,8 @@ def _make_event(query, headers=None):
             "pdf-page4-1024w.jpeg", None, [1024, 1450], 8,
             marks=pytest.mark.poppler
         ),
-])
+    ]
+)
 def test_generate_thumbnail(
         data_dir,
         input_file,

--- a/lambdas/thumbnail/tests/test_thumbnail.py
+++ b/lambdas/thumbnail/tests/test_thumbnail.py
@@ -44,41 +44,42 @@ def _make_event(query, headers=None):
 })
 @responses.activate
 @pytest.mark.parametrize(
-    "input_file, params, expected_thumb, expected_original_size, expected_thumb_size, num_pages", [
-    ("penguin.jpg", {"size": "w256h256"}, "penguin-256.jpg", [1526, 1290, 3], [217, 256], None),
-    ("cell.tiff", {"size": "w640h480"}, "cell-480.png", [15, 1, 158, 100], [514, 480], None),
-    ("cell.png", {"size": "w64h64"}, "cell-64.png", [168, 104, 3], [39, 64], None),
-    ("sat_greyscale.tiff", {"size": "w640h480"}, "sat_greyscale-480.png", [512, 512], [480, 480], None),
-    ("generated.ome.tiff", {"size": "w256h256"}, "generated-256.png", [6, 36, 76, 68], [224, 167], None),
-    ("sat_rgb.tiff", {"size": "w256h256"}, "sat_rgb-256.png", [256, 256, 4], [256, 256], None),
-    ("single_cell.ome.tiff", {"size": "w256h256"}, "single_cell.png", [6, 40, 152, 126], [256, 205], None),
-    # Test for statusCode error
-    pytest.param(
-        "cell.png",
-        {"size": "w1h1"},
-        None, None, None, None,
-        marks=pytest.mark.xfail(raises=AssertionError)
-    ),
-    # The following PDF tests should only run if poppler-utils is installed;
-    # then call `pytest --poppler` to execute
-    pytest.param(
-        "MUMmer.pdf",
-        {"size": "w1024h768", "input": "pdf", "page": 4},
-        "pdf-page4-1024w.jpeg", None, [1024, 1450], None,
-        marks=pytest.mark.poppler
-    ),
-    pytest.param(
-        "MUMmer.pdf",
-        {"size": "w256h256", "input": "pdf", "page": 8},
-        "pdf-page8-256w.jpeg", None, [256, 363], None,
-        marks=pytest.mark.poppler
-    ),
-    pytest.param(
-        "MUMmer.pdf",
-        {"size": "w1024h768", "input": "pdf", "page": 4, "countPages": "true"},
-        "pdf-page4-1024w.jpeg", None, [1024, 1450], 8,
-        marks=pytest.mark.poppler
-    ),
+    "input_file, params, expected_thumb, expected_original_size, expected_thumb_size, num_pages",
+    [
+        ("penguin.jpg", {"size": "w256h256"}, "penguin-256.jpg", [1526, 1290, 3], [217, 256], None),
+        ("cell.tiff", {"size": "w640h480"}, "cell-480.png", [15, 1, 158, 100], [514, 480], None),
+        ("cell.png", {"size": "w64h64"}, "cell-64.png", [168, 104, 3], [39, 64], None),
+        ("sat_greyscale.tiff", {"size": "w640h480"}, "sat_greyscale-480.png", [512, 512], [480, 480], None),
+        ("generated.ome.tiff", {"size": "w256h256"}, "generated-256.png", [6, 36, 76, 68], [224, 167], None),
+        ("sat_rgb.tiff", {"size": "w256h256"}, "sat_rgb-256.png", [256, 256, 4], [256, 256], None),
+        ("single_cell.ome.tiff", {"size": "w256h256"}, "single_cell.png", [6, 40, 152, 126], [256, 205], None),
+        # Test for statusCode error
+        pytest.param(
+            "cell.png",
+            {"size": "w1h1"},
+            None, None, None, None,
+            marks=pytest.mark.xfail(raises=AssertionError)
+        ),
+        # The following PDF tests should only run if poppler-utils is installed;
+        # then call `pytest --poppler` to execute
+        pytest.param(
+            "MUMmer.pdf",
+            {"size": "w1024h768", "input": "pdf", "page": 4},
+            "pdf-page4-1024w.jpeg", None, [1024, 1450], None,
+            marks=pytest.mark.poppler
+        ),
+        pytest.param(
+            "MUMmer.pdf",
+            {"size": "w256h256", "input": "pdf", "page": 8},
+            "pdf-page8-256w.jpeg", None, [256, 363], None,
+            marks=pytest.mark.poppler
+        ),
+        pytest.param(
+            "MUMmer.pdf",
+            {"size": "w1024h768", "input": "pdf", "page": 4, "countPages": "true"},
+            "pdf-page4-1024w.jpeg", None, [1024, 1450], 8,
+            marks=pytest.mark.poppler
+        ),
 ])
 def test_generate_thumbnail(
         data_dir,

--- a/lambdas/thumbnail/tests/test_thumbnail.py
+++ b/lambdas/thumbnail/tests/test_thumbnail.py
@@ -43,7 +43,8 @@ def _make_event(query, headers=None):
     'FONT_CONFIG_PATH': ''
 })
 @responses.activate
-@pytest.mark.parametrize("input_file, params, expected_thumb, expected_original_size, expected_thumb_size, num_pages", [
+@pytest.mark.parametrize(
+    "input_file, params, expected_thumb, expected_original_size, expected_thumb_size, num_pages", [
     ("penguin.jpg", {"size": "w256h256"}, "penguin-256.jpg", [1526, 1290, 3], [217, 256], None),
     ("cell.tiff", {"size": "w640h480"}, "cell-480.png", [15, 1, 158, 100], [514, 480], None),
     ("cell.png", {"size": "w64h64"}, "cell-64.png", [168, 104, 3], [39, 64], None),
@@ -51,8 +52,15 @@ def _make_event(query, headers=None):
     ("generated.ome.tiff", {"size": "w256h256"}, "generated-256.png", [6, 36, 76, 68], [224, 167], None),
     ("sat_rgb.tiff", {"size": "w256h256"}, "sat_rgb-256.png", [256, 256, 4], [256, 256], None),
     ("single_cell.ome.tiff", {"size": "w256h256"}, "single_cell.png", [6, 40, 152, 126], [256, 205], None),
-    # Following PDF tests should only be run if poppler-utils installed;
-    # then call pytest with --poppler
+    # Test for statusCode error
+    pytest.param(
+        "cell.png",
+        {"size": "w1h1"},
+        None, None, None, None,
+        marks=pytest.mark.xfail(raises=AssertionError)
+    ),
+    # The following PDF tests should only run if poppler-utils is installed;
+    # then call `pytest --poppler` to execute
     pytest.param(
         "MUMmer.pdf",
         {"size": "w1024h768", "input": "pdf", "page": 4},
@@ -71,13 +79,6 @@ def _make_event(query, headers=None):
         "pdf-page4-1024w.jpeg", None, [1024, 1450], 8,
         marks=pytest.mark.poppler
     ),
-    # Test for statusCode error
-    pytest.param(
-        "cell.png",
-        {"size": "w1h1"},
-        None, None, None, None,
-        marks=pytest.mark.xfail(raises=AssertionError)
-    )
 ])
 def test_generate_thumbnail(
         data_dir,


### PR DESCRIPTION
* `countPages=true` returns `body["info"]["page_count"]` in the response. This call is not efficient (it must render the entire PDF, pressuring memory and increasing latency. Nevertheless, pdftoppm provides no facility for just counting (and not rendering) pages.