### PR TITLE
Expose custom header, X-QUILT-INFO

### DIFF
--- a/lambdas/shared/t4_lambda_shared/decorator.py
+++ b/lambdas/shared/t4_lambda_shared/decorator.py
@@ -12,7 +12,7 @@ from jsonschema import Draft4Validator, ValidationError
 
 GZIP_MIN_LENGTH = 1024
 GZIP_TYPES = {'text/plain', 'application/json'}
-# Used, e.g., for binayr responses when metadata belongs in headers, not body
+# Used, e.g., for binary responses when metadata belongs in headers, not body
 QUILT_INFO_HEADER = 'X-Quilt-Info'
 
 
@@ -81,7 +81,7 @@ def api(cors_origins=()):
                     # for preflight checks, not sure we need it for header to work?
                     # https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Access-Control-Expose-Headers
                     'access-control-expose-headers': (
-                        request.headers.get('access-control-request-headers', '')
+                        f"*, Authorization, {QUILT_INFO_HEADER}"
                     ),
                     'access-control-max-age': 86400
                 })

--- a/lambdas/shared/t4_lambda_shared/decorator.py
+++ b/lambdas/shared/t4_lambda_shared/decorator.py
@@ -12,6 +12,8 @@ from jsonschema import Draft4Validator, ValidationError
 
 GZIP_MIN_LENGTH = 1024
 GZIP_TYPES = {'text/plain', 'application/json'}
+# Used, e.g., for binayr responses when metadata belongs in headers, not body
+QUILT_INFO_HEADER = 'X-Quilt-Info'
 
 
 class Request:
@@ -73,7 +75,14 @@ def api(cors_origins=()):
                 response_headers.update({
                     'access-control-allow-origin': '*',
                     'access-control-allow-methods': 'OPTIONS,HEAD,GET,POST',
-                    'access-control-allow-headers': request.headers.get('access-control-request-headers', ''),
+                    'access-control-allow-headers': (
+                        request.headers.get('access-control-request-headers', '')
+                    ),
+                    # for preflight checks, not sure we need it for header to work?
+                    # https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Access-Control-Expose-Headers
+                    'access-control-expose-headers': (
+                        request.headers.get('access-control-request-headers', '')
+                    ),
                     'access-control-max-age': 86400
                 })
 

--- a/lambdas/shared/tests/test_decorator.py
+++ b/lambdas/shared/tests/test_decorator.py
@@ -113,7 +113,7 @@ class TestDecorator(TestCase):
             'access-control-allow-origin': '*',
             'access-control-allow-methods': 'OPTIONS,HEAD,GET,POST',
             'access-control-allow-headers': 'X-Quilt-Info',
-            'access-control-expose-headers': 'X-Quilt-Info',
+            'access-control-expose-headers': '*, Authorization, X-Quilt-Info',
             'access-control-max-age': 86400
         }
 
@@ -159,7 +159,7 @@ class TestDecorator(TestCase):
             'access-control-allow-origin': '*',
             'access-control-allow-methods': 'OPTIONS,HEAD,GET,POST',
             'access-control-allow-headers': '',
-            'access-control-expose-headers': '',
+            'access-control-expose-headers': '*, Authorization, X-Quilt-Info',
             'access-control-max-age': 86400
         }
 

--- a/lambdas/shared/tests/test_decorator.py
+++ b/lambdas/shared/tests/test_decorator.py
@@ -97,8 +97,13 @@ class TestDecorator(TestCase):
 
         # Request with a correct origin.
         resp = handler(self._make_get(
-            {'foo': 'bar'},
-            {'origin': 'https://example.com', 'access-control-request-headers': 'x-foo'}
+            {
+                'foo': 'bar'
+            },
+            {
+                'origin': 'https://example.com',
+                'access-control-request-headers': 'X-Quilt-Info'
+            },
         ), None)
 
         assert resp['statusCode'] == 200
@@ -107,7 +112,8 @@ class TestDecorator(TestCase):
             'Content-Type': 'text/plain',
             'access-control-allow-origin': '*',
             'access-control-allow-methods': 'OPTIONS,HEAD,GET,POST',
-            'access-control-allow-headers': 'x-foo',
+            'access-control-allow-headers': 'X-Quilt-Info',
+            'access-control-expose-headers': 'X-Quilt-Info',
             'access-control-max-age': 86400
         }
 
@@ -153,6 +159,7 @@ class TestDecorator(TestCase):
             'access-control-allow-origin': '*',
             'access-control-allow-methods': 'OPTIONS,HEAD,GET,POST',
             'access-control-allow-headers': '',
+            'access-control-expose-headers': '',
             'access-control-max-age': 86400
         }
 

--- a/lambdas/thumbnail/index.py
+++ b/lambdas/thumbnail/index.py
@@ -70,13 +70,13 @@ SCHEMA = {
             'enum': ['json', 'raw']
         },
         'page': {
-            'type': 'integer',
-            'minimum': 1
+            'type': 'string',
+            'pattern': r'^\d+$',
         },
         # not boolean because URL params like "true" always get converted to strings
         # clients should do this ONCE per document because it incurs latency and memory
         'countPages': {
-            'enum': ['true']
+            'enum': ['true', 'false']
         }
     },
     'required': ['url', 'size'],
@@ -253,7 +253,7 @@ def lambda_handler(request):
     size = SIZE_PARAMETER_MAP[request.args['size']]
     input_ = request.args.get('input', 'image')
     output = request.args.get('output', 'json')
-    page = request.args.get('page', 1)
+    page = int(request.args.get('page', '1'))
     count_pages = request.args.get('countPages') == 'true'
 
     # Handle request

--- a/lambdas/thumbnail/index.py
+++ b/lambdas/thumbnail/index.py
@@ -27,7 +27,7 @@ import requests
 from aicsimageio import AICSImage, readers
 from PIL import Image
 
-from t4_lambda_shared.decorator import api, validate
+from t4_lambda_shared.decorator import api, QUILT_INFO_HEADER, validate
 from t4_lambda_shared.utils import get_default_origins, make_json_response
 
 # Eventually we'll want to precompute/cache thumbnails, so we won't be able to support
@@ -336,7 +336,7 @@ def lambda_handler(request):
         # Not JSON response ('raw')
         headers = {
             'Content-Type': Image.MIME[thumbnail_format],
-            'X-Quilt-Info': json.dumps(info)
+            QUILT_INFO_HEADER: json.dumps(info)
         }
         return 200, data, headers
 

--- a/lambdas/thumbnail/tests/test_thumbnail.py
+++ b/lambdas/thumbnail/tests/test_thumbnail.py
@@ -64,19 +64,19 @@ def _make_event(query, headers=None):
         # then call `pytest --poppler` to execute
         pytest.param(
             "MUMmer.pdf",
-            {"size": "w1024h768", "input": "pdf", "page": 4},
+            {"size": "w1024h768", "input": "pdf", "page": "4"},
             "pdf-page4-1024w.jpeg", None, [1024, 1450], None,
             marks=pytest.mark.poppler
         ),
         pytest.param(
             "MUMmer.pdf",
-            {"size": "w256h256", "input": "pdf", "page": 8},
+            {"size": "w256h256", "input": "pdf", "page": "8"},
             "pdf-page8-256w.jpeg", None, [256, 363], None,
             marks=pytest.mark.poppler
         ),
         pytest.param(
             "MUMmer.pdf",
-            {"size": "w1024h768", "input": "pdf", "page": 4, "countPages": "true"},
+            {"size": "w1024h768", "input": "pdf", "page": "4", "countPages": "true"},
             "pdf-page4-1024w.jpeg", None, [1024, 1450], 8,
             marks=pytest.mark.poppler
         ),


### PR DESCRIPTION
Since this endpoint is binary, this is the first time we're sending metadata back in the headers. I'm kinda surprised that this even works or is needed since `Expose-Headers` is for preflight checks, but this is what @nl0 asked for :)