### PR TITLE
Fix /__embed and /__embed-debug

### DIFF
--- a/catalog/nginx-web.conf
+++ b/catalog/nginx-web.conf
@@ -12,6 +12,9 @@ server {
 
     error_page 404 /index.html;
 
+    rewrite ^/__embed$ /embed.html last;
+    rewrite ^/__embed-debug$ /embed-debug-harness.html last;
+
     location ~ \.(jpg|jpeg|gif|png|chunk\.js)$|^/main\..*\.js$ {
         expires 7776000;
     }
@@ -20,12 +23,8 @@ server {
         expires -1;
     }
 
-    location = /__embed {
-        alias /embed.html;
-    }
-
-    location = /__embed-debug {
-        alias /embed-debug-harness.html;
+    location ~ ^/embed.*\.html$ {
+        expires 600;
     }
 
     location / {


### PR DESCRIPTION
Use rewrite rules instead of aliases.

(Aliases need an absolute file path, including root. But even then, content type gets messed up because it looks at the URL extension.)