### PR TITLE
Package search action, upgrade search endpoint

### DIFF
--- a/lambdas/search/index.py
+++ b/lambdas/search/index.py
@@ -92,9 +92,9 @@ def lambda_handler(request):
                     # see enterprise/**/bucket.py for mappings
                     "fields": [
                         # object
-                        'content', 'comment', 'ext', 'key_text^2', 'meta_text',
-                        # package
-                        'comment', 'handle', 'handle_text^2', 'metadata_string', 'tags'
+                        'content', 'comment', 'key_text^2', 'meta_text',
+                        # package, and boost the fields
+                        'comment^2', 'handle^2', 'handle_text^2', 'metadata_string^2', 'tags^2'
                     ]
                 }
             }

--- a/lambdas/search/index.py
+++ b/lambdas/search/index.py
@@ -99,7 +99,10 @@ def lambda_handler(request):
                 }
             }
         }
-        _source = ['key', 'version_id', 'updated', 'last_modified', 'size', 'user_meta']
+        _source = [
+            'key', 'version_id', 'updated', 'last_modified', 'size', 'user_meta',
+            'comment', 'handle', 'hash', 'tags', 'metadata_string', 'pointer_file'
+        ]
         size = DEFAULT_SIZE
     elif action == 'stats':
         body = {

--- a/lambdas/search/requirements.txt
+++ b/lambdas/search/requirements.txt
@@ -4,7 +4,7 @@ botocore==1.12.228
 certifi==2019.9.11
 chardet==3.0.4
 docutils==0.15.2
-elasticsearch==7.0.4
+elasticsearch==6.8.1
 idna==2.8
 jmespath==0.9.4
 jsonschema==3.0.2

--- a/lambdas/search/tests/test_search.py
+++ b/lambdas/search/tests/test_search.py
@@ -229,7 +229,6 @@ class TestSearch(TestCase):
 
     def test_packages(self):
         """test packages action"""
-        # https://www.example.com:443/bucket/_search?_source=great%2Cexpectations&size=42&timeout=30s  
         query = {
             'action': 'packages',
             'index': 'bucket',

--- a/lambdas/search/tests/test_search.py
+++ b/lambdas/search/tests/test_search.py
@@ -237,20 +237,11 @@ class TestSearch(TestCase):
 
         def _callback(request):
             payload = json.loads(request.body)
-            assert payload == {
-                'query': {
-                    'simple_query_string': {
-                        'analyze_wildcard': True,
-                        'fields': [
-                            'content',
-                            'comment',
-                            'key_text',
-                            'meta_text'
-                        ],
-                        'query': '123'
-                    }
-                }
-            }
+            assert payload['query']
+            assert payload['query']['query_string']
+            assert payload['query']['query_string']['fields']
+            assert payload['query']['query_string']['query']
+
             return 200, {}, json.dumps({'results': 'blah'})
 
         self.requests_mock.add_callback(
@@ -258,7 +249,7 @@ class TestSearch(TestCase):
             url,
             callback=_callback,
             content_type='application/json',
-            match_querystring=True
+            match_querystring=False
         )
 
         query = {
@@ -276,7 +267,7 @@ class TestSearch(TestCase):
         url = 'https://www.example.com:443/bucket/_search?' + urlencode(dict(
             _source='false',  # must match JSON; False will fail match_querystring
             size=0,
-            timeout='15s'
+            timeout='30s'
         ))
 
         def _callback(request):

--- a/lambdas/search/tests/test_search.py
+++ b/lambdas/search/tests/test_search.py
@@ -7,7 +7,6 @@ from unittest import TestCase
 from unittest.mock import patch
 from urllib.parse import urlencode
 
-import pytest
 import responses
 
 from index import lambda_handler, MAX_QUERY_DURATION, post_process


### PR DESCRIPTION
* Use the more powerful query_string (instead of simple_query_string) for 'search' and 'packages' actions
* Fix ES version 😬 to 6.x, not 7.x
* Add a 'packages' action with client-customizable body
* Try dropping terminate_after since it might be harming search quality (and not helping performance?)
* Bump query timeout to 30 sec