### PR TITLE
Revert field name change

### DIFF
--- a/lambdas/es/indexer/document_queue.py
+++ b/lambdas/es/indexer/document_queue.py
@@ -121,7 +121,7 @@ class DocumentQueue:
                 "_id": f"{handle}:{package_hash}",
                 "handle": handle,
                 "hash": package_hash,
-                "metadata_text": metadata,
+                "metadata": metadata,
                 "pointer_file": pointer_file,
                 "tags": ",".join(tags)
             })


### PR DESCRIPTION
* It's safer and simpler to just use the name sent to ES (and now supported by the ES schema). This changed lived for a very short time and was never released. See [blame](https://github.com/quiltdata/quilt/blame/01453243a22c6c54fa76bd0552bf001c55fb24be/lambdas/es/indexer/document_queue.py#L123).