### PR TITLE
Use temporary files and unique names for scratch files in Lambda

### DIFF
--- a/lambdas/preview/test/test_index.py
+++ b/lambdas/preview/test/test_index.py
@@ -46,11 +46,16 @@ class TestIndex():
         """test fcs extraction
         for extended testing you can download FCS files here
         https://flowrepository.org/experiments/4/download_ziped_files,
-        copy to data/fcs/ and run this unit test (and comment out the 3
-        `assert name ==` lines below)
+        copy to data/fcs/ and run this unit test
         """
         parent = BASE_DIR / "fcs"
-        fcs_files = parent.glob("*.fcs")
+        fcs_files = list(parent.glob("*.fcs"))
+        extended = False
+        if (
+                set(os.path.split(f)[1] for f in fcs_files)
+                != set(['accuri-ao1.fcs', 'bad.fcs', '3215apc 100004.fcs'])
+         ):
+            extended = True
         first = True
         for fcs in fcs_files:
             _, name = os.path.split(fcs)
@@ -77,7 +82,8 @@ class TestIndex():
             body = json.loads(read_body(resp))
             assert 'info' in body
             if 'warnings' not in body['info']:
-                assert name == 'accuri-ao1.fcs'
+                if not extended:
+                    assert name == 'accuri-ao1.fcs'
                 assert body['html'].startswith('<div>')
                 assert body['html'].endswith('</div>')
                 assert body['info']['metadata'].keys()
@@ -85,10 +91,11 @@ class TestIndex():
                 assert not body['html']
                 if 'metadata' not in body['info']:
                     assert body['info']['warnings'].startswith('Unable')
-                    assert name == 'bad.fcs'
+                    if not extended:
+                        assert name == 'bad.fcs'
                 else:
-                    pass
-                    assert name == '3215apc 100004.fcs'
+                    if not extended:
+                        assert name == '3215apc 100004.fcs'
 
     def test_bad(self):
         """send a known bad event (no input query parameter)"""

--- a/lambdas/shared/t4_lambda_shared/preview.py
+++ b/lambdas/shared/t4_lambda_shared/preview.py
@@ -5,6 +5,7 @@ from io import BytesIO
 import math
 import os
 import re
+from uuid import uuid4
 import zlib
 
 import fcsparser
@@ -75,8 +76,9 @@ def extract_fcs(file_, as_html=True):
     data = None
     body = ""
     info = {}
+    # not using tempfile because not sure if it writes to the write place in lambda
     # per Lambda docs we can use tmp/*, OK to overwrite
-    file_path = os.path.join(TEMP_DIR, "quilt-temp.fcs")
+    file_path = os.path.join(TEMP_DIR, str(uuid4()))
     # fcsparser only takes paths, so we need to write to disk; OK because
     # FCS files typically ~1MB
     with open(file_path, 'wb') as real_file:

--- a/lambdas/shared/t4_lambda_shared/preview.py
+++ b/lambdas/shared/t4_lambda_shared/preview.py
@@ -27,7 +27,7 @@ CATALOG_LIMIT_LINES = 512  # must be positive int
 ELASTIC_LIMIT_BYTES = int(os.getenv('DOC_LIMIT_BYTES') or 10_000)
 ELASTIC_LIMIT_LINES = 100_000
 MAX_PREVIEW_ROWS = 1_000
-TEMP_DIR = "/tmp/"
+TEMP_DIR = os.path.join('/tmp/', '')
 # common string used to explain truncation to user
 TRUNCATED = (
     'Rows and columns truncated for preview. '
@@ -81,7 +81,6 @@ def extract_fcs(file_, as_html=True):
     # per Lambda docs we can use tmp/*, OK to overwrite
     with tempfile.NamedTemporaryFile(prefix=TEMP_DIR) as tmp:
         tmp.write(file_.read())
-        tmp.seek(0)
         try:
             meta, data = fcsparser.parse(tmp.name, reformat_meta=True)
         except Exception as first:  # pylint: disable=broad-except

--- a/lambdas/shared/tests/test_preview.py
+++ b/lambdas/shared/tests/test_preview.py
@@ -80,26 +80,25 @@ class TestPreview(TestCase):
                 'has_warnings': True,
             },
         }
-        with TemporaryDirectory() as tmp_dir, patch('t4_lambda_shared.preview.TEMP_DIR', os.path.join(tmp_dir, '')):
-            for file in test_files:
-                in_file = os.path.join(BASE_DIR, 'fcs', file)
+        for file in test_files:
+            in_file = os.path.join(BASE_DIR, 'fcs', file)
 
-                with open(in_file, mode='rb') as fcs:
-                    body, info = extract_fcs(fcs)
-                    if body != "":
-                        assert test_files[file]['in_body'] in body
-                        assert not test_files[file].get('has_warnings')
-                    else:
-                        assert test_files[file]['has_warnings']
-                        assert info['warnings']
-                    assert test_files[file]['in_meta_keys'] in info['metadata'].keys()
-                    assert test_files[file]['in_meta_values'] in info['metadata'].values()
-                    # when there's a body, check if columns only works
-                    if test_files[file].get('in_body'):
-                        # move to start so we can use the file-like a second time
-                        fcs.seek(0)
-                        body, info = extract_fcs(fcs, as_html=False)
-                        assert body == test_files[file]['columns_string']
+            with open(in_file, mode='rb') as fcs:
+                body, info = extract_fcs(fcs)
+                if body != "":
+                    assert test_files[file]['in_body'] in body
+                    assert not test_files[file].get('has_warnings')
+                else:
+                    assert test_files[file]['has_warnings']
+                    assert info['warnings']
+                assert test_files[file]['in_meta_keys'] in info['metadata'].keys()
+                assert test_files[file]['in_meta_values'] in info['metadata'].values()
+                # when there's a body, check if columns only works
+                if test_files[file].get('in_body'):
+                    # move to start so we can use the file-like a second time
+                    fcs.seek(0)
+                    body, info = extract_fcs(fcs, as_html=False)
+                    assert body == test_files[file]['columns_string']
 
     def test_long(self):
         """test a text file with lots of lines"""

--- a/lambdas/shared/tests/test_preview.py
+++ b/lambdas/shared/tests/test_preview.py
@@ -80,7 +80,7 @@ class TestPreview(TestCase):
                 'has_warnings': True,
             },
         }
-        with TemporaryDirectory() as tmp_dir, patch('t4_lambda_shared.preview.TEMP_DIR', tmp_dir):
+        with TemporaryDirectory() as tmp_dir, patch('t4_lambda_shared.preview.TEMP_DIR', tmp_dir + os.path.sep):
             for file in test_files:
                 in_file = os.path.join(BASE_DIR, 'fcs', file)
 

--- a/lambdas/shared/tests/test_preview.py
+++ b/lambdas/shared/tests/test_preview.py
@@ -80,7 +80,7 @@ class TestPreview(TestCase):
                 'has_warnings': True,
             },
         }
-        with TemporaryDirectory() as tmp_dir, patch('t4_lambda_shared.preview.TEMP_DIR', tmp_dir + os.path.sep):
+        with TemporaryDirectory() as tmp_dir, patch('t4_lambda_shared.preview.TEMP_DIR', os.path.join(tmp_dir, '')):
             for file in test_files:
                 in_file = os.path.join(BASE_DIR, 'fcs', file)
 

--- a/lambdas/shared/tests/test_preview.py
+++ b/lambdas/shared/tests/test_preview.py
@@ -3,7 +3,6 @@ Preview helper functions
 """
 import os
 import pathlib
-from tempfile import TemporaryDirectory
 from unittest import TestCase
 from unittest.mock import patch
 


### PR DESCRIPTION
Without this, lambda invocations can stomp on one another's work, corrupting any shared files