### PR TITLE
Unskip data transfer tests

### DIFF
--- a/api/python/tests/test_data_transfer.py
+++ b/api/python/tests/test_data_transfer.py
@@ -214,7 +214,6 @@ class DataTransferTest(QuiltTestCase):
             assert urls[0] == PhysicalKey.from_url('s3://example1/foo.csv')
             assert urls[1] == PhysicalKey.from_url('s3://example2/foo.txt?versionId=v123')
 
-    @pytest.mark.skip(reason="Broken due to S3ClientProvider")
     def test_upload_large_file(self):
         path = DATA_DIR / 'large_file.npy'
 
@@ -298,7 +297,6 @@ class DataTransferTest(QuiltTestCase):
         ])
         assert urls[0] == PhysicalKey.from_url('s3://example/large_file.npy?versionId=v2')
 
-    @pytest.mark.skip(reason="Broken due to S3ClientProvider")
     def test_multipart_upload(self):
         name = 'very_large_file.bin'
         path = pathlib.Path(name)


### PR DESCRIPTION
They are skipped since 620035dae6f8e9c2eeafa8dda83ddb2fd5ab1439, but pass again since 4989c4f910152663d2e6ba289d137e692b508b44