### PR TITLE
Do ES timeouts properly (in the client)

### DIFF
--- a/lambdas/search/index.py
+++ b/lambdas/search/index.py
@@ -14,7 +14,7 @@ from t4_lambda_shared.decorator import api
 from t4_lambda_shared.utils import get_default_origins, make_json_response
 
 DEFAULT_SIZE = 1_000
-MAX_QUERY_DURATION = '27s'  # Just shy of 29s API Gateway limit
+MAX_QUERY_DURATION = 27  # Just shy of 29s API Gateway limit
 NUM_PREVIEW_IMAGES = 100
 NUM_PREVIEW_FILES = 20
 COMPRESSION_EXTS = ['.gz']
@@ -176,7 +176,8 @@ def lambda_handler(request):
         http_auth=auth,
         use_ssl=True,
         verify_certs=True,
-        connection_class=RequestsHttpConnection
+        connection_class=RequestsHttpConnection,
+        timeout=MAX_QUERY_DURATION,
     )
 
     to_search = f"{user_indexes},{index_overrides}" if index_overrides else user_indexes
@@ -188,7 +189,6 @@ def lambda_handler(request):
         size=size,
         # try turning this off to consider all documents
         terminate_after=terminate_after,
-        timeout=MAX_QUERY_DURATION
     )
 
     return make_json_response(200, post_process(result, action))

--- a/lambdas/search/tests/test_search.py
+++ b/lambdas/search/tests/test_search.py
@@ -9,7 +9,7 @@ from urllib.parse import urlencode
 
 import responses
 
-from index import lambda_handler, MAX_QUERY_DURATION, post_process
+from index import lambda_handler, post_process
 
 ES_STATS_RESPONSES = {
     'all_gz': {

--- a/lambdas/search/tests/test_search.py
+++ b/lambdas/search/tests/test_search.py
@@ -240,7 +240,6 @@ class TestSearch(TestCase):
         url = f'https://www.example.com:443/{query["index"]}/_search?' + urlencode(dict(
             _source='great,expectations',
             size=42,
-            timeout=MAX_QUERY_DURATION,
         ))
 
         def _callback(request):
@@ -279,9 +278,7 @@ class TestSearch(TestCase):
 
     def test_search(self):
         url = 'https://www.example.com:443/bucket/_search?' + urlencode(dict(
-            timeout=MAX_QUERY_DURATION,
             size=1000,
-            terminate_after=10000,
             _source=','.join(['key', 'version_id', 'updated', 'last_modified', 'size', 'user_meta']),
         ))
 
@@ -317,7 +314,6 @@ class TestSearch(TestCase):
         url = 'https://www.example.com:443/bucket/_search?' + urlencode(dict(
             _source='false',  # must match JSON; False will fail match_querystring
             size=0,
-            timeout=MAX_QUERY_DURATION,
         ))
 
         def _callback(request):


### PR DESCRIPTION
At present the client default timeout (10s) is overriding the query timeout