### PR TITLE
es/indexer: Drop fatal 40X failures on the floor

### DIFF
--- a/lambdas/es/indexer/index.py
+++ b/lambdas/es/indexer/index.py
@@ -509,7 +509,6 @@ def handler(event, context):
                     logger_.error("Fatal head_object, skipping event: %s", event_)
                     continue
 
-
                 size = head["ContentLength"]
                 last_modified = head["LastModified"]
 


### PR DESCRIPTION
Importantly, we choose to skip the dead letter queue in select cases where we are unlikely to recover from the error, so as to avoid failing the batch. We found a case where list_object_versions may return an object that will never be readable (e.g. due to a foreign owner).