### PR TITLE
Reduce preview size for large Jupyter notebooks

### DIFF
--- a/lambdas/preview/test/test_index.py
+++ b/lambdas/preview/test/test_index.py
@@ -2,6 +2,7 @@
 Test functions for preview endpoint
 """
 import json
+import math
 import os
 from pathlib import Path
 import re
@@ -257,7 +258,8 @@ class TestIndex():
         body = json.loads(read_body(resp))
         assert resp['statusCode'] == 200, 'preview failed on nb_1200727.ipynb'
         body_html = body['html']
-        assert len(body_html) == 18084, "Hmm, didn't chop nb_1200727.ipynb"
+        # isclose bc string sizes differ, e.g. on Linux
+        assert math.isclose(len(body_html), 18084, abs_tol=200), "Hmm, didn't chop nb_1200727.ipynb"
 
     @responses.activate
     def test_ipynb_exclude(self):

--- a/lambdas/preview/test/test_index.py
+++ b/lambdas/preview/test/test_index.py
@@ -241,7 +241,7 @@ class TestIndex():
             '<span class="p">'
         ) in body_html, 'Last cell output missing'
 
-    @patch(__name__ + '.index.LAMBDA_MAX_OUT', 86_000)
+    @patch(__name__ + '.index.LAMBDA_MAX_OUT', 89_322)
     @responses.activate
     def test_ipynb_chop(self):
         """test that we eliminate output cells when we're in danger of breaking


### PR DESCRIPTION
Lambda only allows us to send a max of 6MB back. Even though we GZIP, notebooks with lots of images won't don't come under 6MB.