### PR TITLE
Remove 'build' job from CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -67,7 +67,8 @@ workflows:
 
   build_and_deploy:
     jobs:
-      - build:
+      - test-36:
+          name: build
           filters:
             tags:
               only: /.*/
@@ -185,33 +186,6 @@ jobs:
             pytest --cov=lambdas lambdas/<< parameters.path >>
       - codecov:
           flags: "lambda"
-
-  build:
-    docker:
-      - image: circleci/python:3.6
-    environment:
-      QUILT_DISABLE_USAGE_METRICS: true
-    steps:
-      - checkout
-      - restore_cache:
-          key: v1-dependency-cache-{{ checksum "api/python/setup.py" }}-{{ checksum "Makefile" }}
-      - setup-venv
-      - run:
-          name: install python dependencies
-          command: |
-            pip install -e api/python[tests]
-      - save_cache:
-          key: v1-dependency-cache-{{ checksum "api/python/setup.py" }}-{{ checksum "Makefile" }}
-          paths:
-            - "venv"
-      - run:
-          name: run tests
-          command: |
-            pytest --cov=api/python api/python
-      - codecov:
-          flags: "api-python"
-      - store_artifacts:
-          path: htmlcov/
 
   deploy:
     docker:


### PR DESCRIPTION
It does the same as 'test-3.6' job if I'm not mistaken