### PR TITLE
Improve S3 proxy config

### DIFF
--- a/s3-proxy/nginx-s3-proxy.conf
+++ b/s3-proxy/nginx-s3-proxy.conf
@@ -13,6 +13,9 @@ server {
     }
 
     location ~ ^/(?<s3_region>[^/]+)/(?<s3_bucket>[^/]+)(/(?<s3_path>.*))? {
+        proxy_http_version 1.1;
+        proxy_buffering off;
+
         # Add CORS headers.
         add_header 'Access-Control-Allow-Headers' $http_access_control_request_headers always;
         add_header 'Access-Control-Allow-Methods' $http_access_control_request_method always;


### PR DESCRIPTION
- Use HTTP 1.1 instead of 1.0 (keep-alive connections, etc.)
- Don't buffer the S3 response before sending it back to the client