### PR TITLE
Catalog: Fix inability to select bucket

### DIFF
--- a/catalog/app/containers/NavBar/Search.js
+++ b/catalog/app/containers/NavBar/Search.js
@@ -117,8 +117,15 @@ function SearchBox({
     wrapper: wrapperCls,
     ...classes
   } = useStyles()
+
+  const onClickAway = React.useCallback(() => {
+    if (expanded || helpOpened) {
+      onHelpClose()
+    }
+  }, [helpOpened, expanded, onHelpClose])
+
   return (
-    <M.ClickAwayListener onClickAway={onHelpClose}>
+    <M.ClickAwayListener onClickAway={onClickAway}>
       <div className={wrapperCls}>
         <M.MuiThemeProvider theme={style.appTheme}>
           <M.Fade in={helpOpened}>


### PR DESCRIPTION
## Description

Click outside search box or search help is handled by ClickAwayListener API. It was fired even when there is no real "outside" (no expanded/focused search box and no opened search help).

Now "click away" event fires when search box is focused or search help is opened.