### PR TITLE
Fix license on PyPI

### DIFF
--- a/api/python/setup.py
+++ b/api/python/setup.py
@@ -52,7 +52,7 @@ setup(
     ],
     author='quiltdata',
     author_email='contact@quiltdata.io',
-    license='LICENSE',
+    license='Apache-2.0',
     url='https://github.com/quiltdata/quilt',
     keywords='',
     install_requires=[


### PR DESCRIPTION
Currently at https://pypi.org/project/quilt3/:
![image](https://user-images.githubusercontent.com/481910/95499039-225eb380-09be-11eb-9ca5-bb82f6ce12df.png)
