### PR TITLE
Fix UnseekableStreamError during upload

### DIFF
--- a/api/python/quilt3/data_transfer.py
+++ b/api/python/quilt3/data_transfer.py
@@ -168,20 +168,22 @@ class S3ClientProvider:
                 event_name, signal_transferring,
                 unique_id='datatransfer-transferring')
 
+    def _build_client(self, get_config):
+        session = self.get_boto_session()
+        return session.client('s3', config=get_config(session))
+
     def _build_standard_client(self):
-        boto_session = self.get_boto_session()
-
-        config = None
-        if boto_session.get_credentials() is None:
-            config = Config(signature_version=UNSIGNED)
-
-        s3_client = boto_session.client('s3', config=config)
+        s3_client = self._build_client(
+            lambda session:
+                Config(signature_version=UNSIGNED)
+                if session.get_credentials() is None
+                else None
+        )
         self.register_signals(s3_client)
         self._standard_client = s3_client
 
     def _build_unsigned_client(self):
-        boto_session = self.get_boto_session()
-        s3_client = boto_session.client('s3', config=Config(signature_version=UNSIGNED))
+        s3_client = self._build_client(lambda session: Config(signature_version=UNSIGNED))
         self.register_signals(s3_client)
         self._unsigned_client = s3_client
 

--- a/api/python/setup.py
+++ b/api/python/setup.py
@@ -68,7 +68,7 @@ setup(
         'PyYAML>=5.1',
         'requests>=2.12.4',
         'tenacity>=5.1.1',
-        'tqdm>=4.26.0',
+        'tqdm>=4.32',
         'requests_futures==1.0.0',
     ],
     extras_require={

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -12,6 +12,8 @@
 * [Performance] Improve performance of hashing of S3 files
   ([#1816](https://github.com/quiltdata/quilt/issues/1816),
    [#1788](https://github.com/quiltdata/quilt/issues/1788)
+* [Fixed] Bump a minimum required version of tqdm.
+  Fixes a tqdm crash (`UnseekableStreamError`) during upload retry.
 
 ## CLI
 * [Added] Add `meta` argument to the push command


### PR DESCRIPTION
## Description

When boto's `put_object()` retries it calls `seek(0)` of Body, which calls progress callback with a negative value. `tqdm.update()` supports negative values since 4.32.

## TODO

Use this section for work-in-progress pull requests. If you're using this section,
please tag your PR "WIP". 

- [x] Unit Tests
- [x] Add a [changelog](CHANGELOG.md) entry
