### PR TITLE
Encase ` — ` with spaces

### DIFF
--- a/catalog/app/website/components/Videos/Videos.js
+++ b/catalog/app/website/components/Videos/Videos.js
@@ -105,7 +105,7 @@ const useStyles = M.makeStyles((t) => ({
 export default function Videos() {
   const classes = useStyles()
   const [index, setIndex] = React.useState(0)
-  const onChangeIndex = React.useCallback(R.unary(setIndex), [])
+  const onChangeIndex = R.unary(setIndex)
   const nearestZero = Math.floor(index / videos.length) * videos.length
   const goToNearestIndex = (i) => setIndex(nearestZero + i)
 
@@ -122,7 +122,7 @@ export default function Videos() {
         />
       </div>
     ),
-    [],
+    [classes.iframe, classes.slide],
   )
 
   return (
@@ -138,8 +138,8 @@ export default function Videos() {
       </M.Typography>
       <M.Box mt={3} mb={5} maxWidth={720}>
         <M.Typography variant="body1" color="textSecondary" align="center">
-          Bring your team together around a data portal that is accessible to
-          everyone&mdash;from business users, to analysts, to developers.
+          Bring your team together around a data portal that is accessible to everyone
+          &mdash; from business users, to analysts, to developers.
         </M.Typography>
       </M.Box>
       <div className={classes.adornment}>

--- a/catalog/app/website/pages/Landing/Highlights/Highlights.js
+++ b/catalog/app/website/pages/Landing/Highlights/Highlights.js
@@ -105,9 +105,9 @@ const HIGHLIGHTS = [
     contents: (
       <>
         <p>
-          Executives and team leads&mdash;anyone with a web browser&mdash;can use Quilt to
-          view, search, and visualize the same data, visualizations, and notebooks that
-          data scientists and data engineers use for modeling.
+          Executives and team leads &mdash; anyone with a web browser &mdash; can use
+          Quilt to view, search, and visualize the same data, visualizations, and
+          notebooks that data scientists and data engineers use for modeling.
         </p>
         <p>
           Data analysts can stop making decks and stop emailing files. Instead, invite
@@ -233,7 +233,7 @@ export default function Highlights() {
         <M.Box mt={5} textAlign={{ xs: 'center', md: 'unset' }} maxWidth={800}>
           <M.Typography variant="body1" color="textSecondary" gutterBottom>
             Bring your team together around a visual data repository that is accessible to
-            everyone on the team&mdash;
+            everyone on the team &mdash;
             <em>from business users, to analysts, to developers</em>.
           </M.Typography>
           <M.Typography variant="body1" color="textSecondary">

--- a/catalog/app/website/pages/Landing/UseQuilt/UseQuilt.js
+++ b/catalog/app/website/pages/Landing/UseQuilt/UseQuilt.js
@@ -36,8 +36,8 @@ const SECTIONS = [
         .
       </>,
       <>
-        Spin up Quilt so that your core infrastructure is done and your users&mdash;from
-        data scientists to executives&mdash;can self serve from high-performance data
+        Spin up Quilt so that your core infrastructure is done and your users &mdash; from
+        data scientists to executives &mdash; can self serve from high-performance data
         formats like Parquet, using nothing more than a simple web URL to your private
         Quilt catalog. Now you are free to focus on advanced infrastructure (instead of
         one-off requests for data dumps, ETL jobs, or temporary S3 buckets).
@@ -233,7 +233,7 @@ const useStyles = M.makeStyles((t) => ({
 export default function UseQuilt() {
   const classes = useStyles()
   const [index, setIndex] = React.useState(0)
-  const onChangeIndex = React.useCallback(R.unary(setIndex), [])
+  const onChangeIndex = R.unary(setIndex)
 
   return (
     <M.Container maxWidth="lg" style={{ position: 'relative', zIndex: 1 }}>

--- a/catalog/app/website/pages/OpenLanding/QuiltIsDifferent/QuiltIsDifferent.js
+++ b/catalog/app/website/pages/OpenLanding/QuiltIsDifferent/QuiltIsDifferent.js
@@ -85,7 +85,7 @@ export default function QuiltIsDifferent() {
                   <strong>Unlimited scale</strong>, backed by AWS S3
                 </Bullet>
                 <Bullet color="primary" dense>
-                  <strong>Privacy and control</strong>&mdash;data in Quilt can remain in
+                  <strong>Privacy and control</strong> &mdash; data in Quilt can remain in
                   buckets that you control
                 </Bullet>
                 <Bullet color="primary" dense>
@@ -93,8 +93,8 @@ export default function QuiltIsDifferent() {
                   metadata
                 </Bullet>
                 <Bullet color="primary" dense>
-                  <strong>Performance</strong>&mdash;if you are computing in AWS, Quilt is
-                  the fastest, cheapest way access data
+                  <strong>Performance</strong> &mdash; if you are computing in AWS, Quilt
+                  is the fastest, cheapest way access data
                 </Bullet>
               </M.Box>
             </div>


### PR DESCRIPTION
## Description

Added spaces around `&mdash`. It was stuck to the closest words.

Also linting.

Then:
![1 then](https://user-images.githubusercontent.com/533229/96907277-b2632980-14a3-11eb-94b3-f4a710b63a7a.png)

Now:
![2 now](https://user-images.githubusercontent.com/533229/96907281-b3945680-14a3-11eb-9629-73bcf80a7df7.png)
