### PR TITLE
Preview/loaders/Json: render large vega files

### DIFF
--- a/catalog/app/components/Preview/loaders/Json.js
+++ b/catalog/app/components/Preview/loaders/Json.js
@@ -2,19 +2,21 @@ import * as R from 'ramda'
 import * as React from 'react'
 
 import * as AWS from 'utils/AWS'
+import AsyncResult from 'utils/AsyncResult'
 import * as Resource from 'utils/Resource'
 
 import { PreviewData, PreviewError } from '../types'
 import * as Text from './Text'
 import * as utils from './utils'
 
-const MAX_SIZE = 1024 * 1024
+const MAX_SIZE = 20 * 1024 * 1024
 const SCHEMA_RE = /"\$schema":\s*"https:\/\/vega\.github\.io\/schema\/([\w-]+)\/([\w.-]+)\.json"/
 
 const map = (fn) => R.ifElse(Array.isArray, R.map(fn), fn)
 
 function useVegaSpecSigner(handle) {
   const sign = AWS.Signer.useResourceSigner()
+  // eslint-disable-next-line react-hooks/exhaustive-deps
   return React.useCallback(
     R.evolve({
       data: map(
@@ -39,9 +41,9 @@ const detectSchema = (txt) => {
   return { library, version }
 }
 
-function VegaLoader({ handle, children }) {
+function VegaLoader({ handle, gated, children }) {
   const signSpec = useVegaSpecSigner(handle)
-  const data = utils.useObjectGetter(handle)
+  const data = utils.useObjectGetter(handle, { noAutoFetch: gated })
   const processed = utils.useProcessing(
     data.result,
     (r) => {
@@ -58,7 +60,12 @@ function VegaLoader({ handle, children }) {
     },
     [signSpec, handle],
   )
-  return children(utils.useErrorHandling(processed, { handle, retry: data.fetch }))
+  const handled = utils.useErrorHandling(processed, { handle, retry: data.fetch })
+  const result =
+    gated && AsyncResult.Init.is(handled)
+      ? AsyncResult.Err(PreviewError.Gated({ handle, load: data.fetch }))
+      : handled
+  return children(result)
 }
 
 export const detect = R.either(utils.extIs('.json'), R.startsWith('.quilt/'))
@@ -66,8 +73,8 @@ export const detect = R.either(utils.extIs('.json'), R.startsWith('.quilt/'))
 export const Loader = function JsonLoader({ handle, children }) {
   return utils.useFirstBytes({ bytes: 256, handle }).case({
     Ok: ({ firstBytes, contentLength }) =>
-      !!detectSchema(firstBytes) && contentLength <= MAX_SIZE ? (
-        <VegaLoader {...{ handle, children }} />
+      detectSchema(firstBytes) ? (
+        <VegaLoader {...{ handle, children, gated: contentLength > MAX_SIZE }} />
       ) : (
         <Text.Loader {...{ handle, children, forceLang: 'json' }} />
       ),

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -15,6 +15,7 @@
 ## Catalog, Lambdas
 * [Added] Retry logic for failed queries, minimize load on ES for sample, images
 overviews ([#1864](https://github.com/quiltdata/quilt/pull/1864/))
+* [Changed] Render vega specs smaller than 20 MiB right away, render larger ones after pressing a button ([#1873](https://github.com/quiltdata/quilt/pull/1873))
 * [Fixed] Incomplete package stats for empty packages in es/indexer Lambda ([#1869](https://github.com/quiltdata/quilt/pull/1869))
 * [Fixed] Slow parquet preview rendering (and probably other occurances of JsonDisplay) ([#1878](https://github.com/quiltdata/quilt/pull/1878))
 


### PR DESCRIPTION
Render vega files which are <20 MiB right away, render larger ones after pressing a button

# TODO
- [x] [Changelog](CHANGELOG.md) entry
