### PR TITLE
Be sure to search key field on normal searches

### DIFF
--- a/lambdas/search/index.py
+++ b/lambdas/search/index.py
@@ -72,7 +72,7 @@ def lambda_handler(request):
         query = request.args.get('query', '')
         my_fields = user_fields or [
             # object
-            'content', 'comment^2', 'ext^2', 'key_text^2', 'meta_text',
+            'content', 'comment', 'ext', 'key', 'key_text^2', 'meta_text',
             # package, and boost the fields
             'handle^2', 'handle_text^2', 'metadata^2', 'tags^2'
         ]

--- a/lambdas/search/index.py
+++ b/lambdas/search/index.py
@@ -72,7 +72,7 @@ def lambda_handler(request):
         query = request.args.get('query', '')
         my_fields = user_fields or [
             # object
-            'content', 'comment', 'ext', 'key', 'key_text^2', 'meta_text',
+            'content', 'comment', 'ext', 'key', 'key_text', 'meta_text',
             # package, and boost the fields
             'handle^2', 'handle_text^2', 'metadata^2', 'tags^2'
         ]


### PR DESCRIPTION
This allows the user to use wildcards on the key (e.g. */research/*) for a research folder anywhere, and results in higher quality results. Also reduce field boosting to ext: and comment: fields.