### PR TITLE
JsonDisplay: tune rendering perf

### DIFF
--- a/catalog/app/components/JsonDisplay/JsonDisplay.js
+++ b/catalog/app/components/JsonDisplay/JsonDisplay.js
@@ -104,8 +104,9 @@ function CompoundEntry({
         name ? name.length + 2 : 0,
         4, // braces + spaces
       ])
-    if (availableSpace <= 0 || Array.isArray(value))
+    if (availableSpace <= 0 || Array.isArray(value)) {
       return <More keys={entries.length} classes={classes} />
+    }
     return entries.reduce(
       (acc, [k]) => {
         if (acc.done) return acc

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -17,6 +17,7 @@
 * [Added] Search help dropdown for the index landing page ([#1838](https://github.com/quiltdata/quilt/pull/1838))
 overviews ([#1864](https://github.com/quiltdata/quilt/pull/1864/))
 * [Fixed] Incomplete package stats for empty packages in es/indexer Lambda ([#1869](https://github.com/quiltdata/quilt/pull/1869))
+* [Fixed] Slow parquet preview rendering (and probably other occurances of JsonDisplay) ([#1878](https://github.com/quiltdata/quilt/pull/1878))
 
 # 3.2.1 - 2020-10-14
 ## Python API


### PR DESCRIPTION
# Description

This changeset optimizes JsonDisplay rendering perf by only using one instance of the `useStyles` hook on the top level and avoiding dynamic style injection that came with `Box`es usage.

# TODO

- [x] [Changelog](CHANGELOG.md) entry
