### PR TITLE
Don't rely on the registry DNS name

### DIFF
--- a/s3-proxy/nginx.conf
+++ b/s3-proxy/nginx.conf
@@ -73,9 +73,11 @@ http {
         listen [::]:80 default_server;
 
         location ~ ^/zip/.* {
-            proxy_pass $REGISTRY_URL;
+            proxy_pass $INTERNAL_REGISTRY_URL;
             proxy_http_version 1.1;
             proxy_buffering off;
+
+            proxy_set_header Host $REGISTRY_HOST;
 
             # mod_zip cannot handle compressed output from the upstream.
             proxy_set_header Accept-Encoding '';

--- a/s3-proxy/run-nginx.sh
+++ b/s3-proxy/run-nginx.sh
@@ -1,12 +1,18 @@
 #!/bin/bash
 
-if [ -z "$REGISTRY_URL" ]
+if [ -z "$REGISTRY_HOST" ]
 then
-    echo "REGISTRY_URL not set"
+    echo "REGISTRY_HOST not set"
     exit 1
 fi
 
-REGISTRY_URL=${REGISTRY_URL%%/} # Remove a trailing slash.
+if [ -z "$INTERNAL_REGISTRY_URL" ]
+then
+    echo "INTERNAL_REGISTRY_URL not set"
+    exit 1
+fi
+
+INTERNAL_REGISTRY_URL=${INTERNAL_REGISTRY_URL%%/} # Remove a trailing slash.
 
 # Get the DNS server from /etc/resolv.conf
 nameserver=$(awk '{if ($1 == "nameserver") { print $2; exit;}}' < /etc/resolv.conf)
@@ -19,6 +25,6 @@ fi
 
 export NAMESERVER=$nameserver
 
-envsubst '$REGISTRY_URL $NAMESERVER' < /root/nginx.conf.tmpl > /etc/nginx/nginx.conf
+envsubst '$REGISTRY_HOST $INTERNAL_REGISTRY_URL $NAMESERVER' < /root/nginx.conf.tmpl > /etc/nginx/nginx.conf
 
 exec nginx -g 'daemon off;'


### PR DESCRIPTION
Use two variables:
- REGISTRY_HOST: normal hostname that may not have a DNS record yet
- INTERNAL_REGISTRY_URL: something that will definitely exist and point to the right IP, but might not have the correct hostname - e.g. the ELB (`https://whatever.us-east-1.elb.amazonaws.com`)