### PR TITLE
Adjust code samples for packages

### DIFF
--- a/catalog/app/containers/Bucket/PackageTree.js
+++ b/catalog/app/containers/Bucket/PackageTree.js
@@ -191,7 +191,7 @@ function PkgCode({ data, bucket, name, revision, path }) {
             import quilt3
             # browse
             p = quilt3.Package.browse("${name}"${hashPy}, registry="s3://${bucket}")
-            # download
+            # download (be mindful of large packages)
             p = quilt3.Package.install("${name}"${pathPy}${hashPy}, registry="s3://${bucket}", dest=".")
           `,
         },

--- a/catalog/app/containers/Bucket/PackageTree.js
+++ b/catalog/app/containers/Bucket/PackageTree.js
@@ -178,8 +178,7 @@ function ExposeLinkedData({ bucketCfg, bucket, name, revision }) {
 function PkgCode({ data, bucket, name, revision, path }) {
   const code = data.case({
     Ok: ({ hash }) => {
-      const pathPy = path ? `, path="${path}"` : ''
-      const pathCli = path ? ` --path="${path}"` : ''
+      const nameWithPath = JSON.stringify(s3paths.ensureNoSlash(`${name}/${path}`))
       const hashDisplay = revision === 'latest' ? '' : hash.substring(0, 10)
       const hashPy = hashDisplay && `, top_hash="${hashDisplay}"`
       const hashCli = hashDisplay && ` --top-hash ${hashDisplay}`
@@ -192,14 +191,14 @@ function PkgCode({ data, bucket, name, revision, path }) {
             # browse
             p = quilt3.Package.browse("${name}"${hashPy}, registry="s3://${bucket}")
             # download (be mindful of large packages)
-            p = quilt3.Package.install("${name}"${pathPy}${hashPy}, registry="s3://${bucket}", dest=".")
+            p = quilt3.Package.install(${nameWithPath}${hashPy}, registry="s3://${bucket}", dest=".")
           `,
         },
         {
           label: 'CLI',
           hl: 'bash',
           contents: dedent`
-            quilt3 install ${name}${pathCli}${hashCli} --registry s3://${bucket} --dest .
+            quilt3 install ${nameWithPath}${hashCli} --registry s3://${bucket} --dest .
           `,
         },
       ]

--- a/catalog/app/containers/Bucket/PackageTree.js
+++ b/catalog/app/containers/Bucket/PackageTree.js
@@ -178,7 +178,8 @@ function ExposeLinkedData({ bucketCfg, bucket, name, revision }) {
 function PkgCode({ data, bucket, name, revision, path }) {
   const code = data.case({
     Ok: ({ hash }) => {
-      const nameWithPath = path ? `${name}/${path}` : name
+      const pathPy = path ? `, path="${path}"` : ''
+      const pathCli = path ? ` --path="${path}"` : ''
       const hashDisplay = revision === 'latest' ? '' : hash.substring(0, 10)
       const hashPy = hashDisplay && `, top_hash="${hashDisplay}"`
       const hashCli = hashDisplay && ` --top-hash ${hashDisplay}`
@@ -189,16 +190,16 @@ function PkgCode({ data, bucket, name, revision, path }) {
           contents: dedent`
             import quilt3
             # browse
-            quilt3.Package.browse("${name}"${hashPy}, registry="s3://${bucket}")
+            p = quilt3.Package.browse("${name}"${hashPy}, registry="s3://${bucket}")
             # download
-            quilt3.Package.install("${nameWithPath}"${hashPy}, registry="s3://${bucket}", dest=".")
+            p = quilt3.Package.install("${name}"${pathPy}${hashPy}, registry="s3://${bucket}", dest=".")
           `,
         },
         {
           label: 'CLI',
           hl: 'bash',
           contents: dedent`
-            quilt3 install ${nameWithPath}${hashCli} --registry s3://${bucket} --dest .
+            quilt3 install ${name}${pathCli}${hashCli} --registry s3://${bucket} --dest .
           `,
         },
       ]

--- a/catalog/app/containers/Bucket/PackageTree.js
+++ b/catalog/app/containers/Bucket/PackageTree.js
@@ -191,7 +191,7 @@ function PkgCode({ data, bucket, name, revision, path }) {
             # browse
             p = quilt3.Package.browse("${name}"${hashPy}, registry="s3://${bucket}")
             # download (be mindful of large packages)
-            p = quilt3.Package.install(${nameWithPath}${hashPy}, registry="s3://${bucket}", dest=".")
+            quilt3.Package.install(${nameWithPath}${hashPy}, registry="s3://${bucket}", dest=".")
           `,
         },
         {


### PR DESCRIPTION
### TODO
- [x] dont use `path`, revert to the old syntax
- [x] strip traling slash
- [x] escape arguments