### PR TITLE
Improve formatting of package load progress bar

### DIFF
--- a/api/python/quilt3/packages.py
+++ b/api/python/quilt3/packages.py
@@ -721,7 +721,15 @@ class Package:
             readable_file.seek(0)
 
             reader = jsonlines.Reader(
-                tqdm(readable_file, desc="Loading manifest", total=line_count, unit="entries", disable=DISABLE_TQDM),
+                tqdm(
+                    readable_file,
+                    desc="Loading manifest",
+                    total=line_count,
+                    unit="",
+                    unit_scale=True,
+                    disable=DISABLE_TQDM,
+                    bar_format='{l_bar}{bar}| {n}/{total} [{elapsed}<{remaining}, {rate_fmt}]',
+                ),
                 loads=json.loads,
             )
             meta = reader.read()

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -9,6 +9,7 @@
 
 # unreleased - YYYY-MM-DD
 ## Python API
+* [Changed] Improved formatting of package load progress bar ([#1897](https://github.com/quiltdata/quilt/pull/1897))
 
 ## CLI
 


### PR DESCRIPTION
# Description
Before:
```
In [1]: import quilt3
In [2]: quilt3.Package.browse("aics/pipeline_integrated_single_cell", registry="
   ...: s3://allencell")
Loading manifest: 100%|█████████| 179067/179067 [00:06<00:00, 28544.67entries/s]
```

After:
```
In [1]: import quilt3
In [2]: quilt3.Package.browse("aics/pipeline_integrated_single_cell", registry="
   ...: s3://allencell")
Loading manifest: 100%|███████████████████| 179067/179067 [00:06<00:00, 29.0k/s]
```

# TODO

- [x] [Changelog](CHANGELOG.md) entry
