### PR TITLE
Respect terminate_after for all searches

### DIFF
--- a/lambdas/search/index.py
+++ b/lambdas/search/index.py
@@ -67,6 +67,7 @@ def lambda_handler(request):
             raise ValueError("'packages' action searching indexes that don't end in '_packages'")
         _source = user_source
         size = user_size
+        terminate_after = None
     elif action == 'search':
         query = request.args.get('query', '')
         my_fields = user_fields or [

--- a/lambdas/search/index.py
+++ b/lambdas/search/index.py
@@ -67,7 +67,6 @@ def lambda_handler(request):
             raise ValueError("'packages' action searching indexes that don't end in '_packages'")
         _source = user_source
         size = user_size
-        terminate_after = None
     elif action == 'search':
         query = request.args.get('query', '')
         my_fields = user_fields or [
@@ -104,8 +103,6 @@ def lambda_handler(request):
             'comment', 'handle', 'hash', 'tags', 'metadata', 'pointer_file'
         ]
         size = DEFAULT_SIZE
-        if not user_retry:
-            terminate_after = None
     elif action == 'stats':
         body = {
             "query": {"match_all": {}},

--- a/lambdas/search/requirements.txt
+++ b/lambdas/search/requirements.txt
@@ -1,6 +1,6 @@
 attrs==19.1.0
 aws-requests-auth==0.4.2
-botocore==1.12.228
+botocore==1.19.15
 certifi==2019.9.11
 chardet==3.0.4
 docutils==0.15.2
@@ -10,6 +10,6 @@ jmespath==0.9.4
 jsonschema==3.0.2
 pyrsistent==0.15.4
 python-dateutil==2.8.0
-requests==2.22.0
+requests==2.25.0
 six==1.12.0
-urllib3==1.25.3
+urllib3==1.25.4

--- a/lambdas/search/tests/test_search.py
+++ b/lambdas/search/tests/test_search.py
@@ -226,7 +226,6 @@ class TestSearch(TestCase):
         assert map_stats['size']['value'] == sum(raw_stats[i]['size']['value'] for i in (7, 9)), \
             'Unexpected size for .map'
 
-
     @patch.dict(os.environ, {'MAX_DOCUMENTS_PER_SHARD': '538'})
     def test_packages(self):
 

--- a/lambdas/search/tests/test_search.py
+++ b/lambdas/search/tests/test_search.py
@@ -342,13 +342,10 @@ class TestSearch(TestCase):
             'size': 1000,
             'from': 0,
             '_source': ','.join([
-                'key',
-                'version_id',
-                'updated',
-                'last_modified',
-                'size',
-                'user_meta'
+                'key', 'version_id', 'updated', 'last_modified', 'size', 'user_meta',
+                'comment', 'handle', 'hash', 'tags', 'metadata', 'pointer_file'
             ]),
+            'terminate_after': 10000,
         })
 
         def _callback(request):
@@ -368,6 +365,7 @@ class TestSearch(TestCase):
             url,
             callback=_callback,
             content_type='application/json',
+            match_querystring=True,
         )
 
         for retry in [0, 1, 2, 3]:

--- a/lambdas/search/tests/test_search.py
+++ b/lambdas/search/tests/test_search.py
@@ -226,9 +226,7 @@ class TestSearch(TestCase):
         assert map_stats['size']['value'] == sum(raw_stats[i]['size']['value'] for i in (7, 9)), \
             'Unexpected size for .map'
 
-    @patch.dict(os.environ, {'MAX_DOCUMENTS_PER_SHARD': '538'})
     def test_packages(self):
-
         """test packages action"""
         query = {
             'action': 'packages',
@@ -237,11 +235,12 @@ class TestSearch(TestCase):
             'size': 42,
             'from': 10,
             '_source': ','.join(['great', 'expectations']),
-            'terminate_after': 538,
         }
 
         url = f'https://www.example.com:443/{query["index"]}/_search?' + urlencode({
-            k: v for k, v in query.items() if k in ['size', 'from', '_source', 'terminate_after']
+            k: v for k, v in query.items() if k in [
+                'size', 'from', '_source'
+            ]
         })
 
         def _callback(request):
@@ -296,7 +295,48 @@ class TestSearch(TestCase):
             assert resp['statusCode'] == 500
             assert 'int' in resp['body']
 
+    @patch.dict(os.environ, {'MAX_DOCUMENTS_PER_SHARD': '538'})
     def test_search(self):
+        """test standard search function"""
+        url = 'https://www.example.com:443/bucket/_search?' + urlencode({
+            'size': 1000,
+            'from': 0,
+            '_source': ','.join([
+                'key', 'version_id', 'updated', 'last_modified', 'size', 'user_meta',
+                'comment', 'handle', 'hash', 'tags', 'metadata', 'pointer_file'
+            ]),
+            'terminate_after': 538,
+        })
+
+        def _callback(request):
+            payload = json.loads(request.body)
+            assert payload['query']
+            assert payload['query']['query_string']
+            assert payload['query']['query_string']['fields']
+            assert payload['query']['query_string']['query']
+
+            return 200, {}, json.dumps({'results': 'blah'})
+
+        self.requests_mock.add_callback(
+            responses.GET,
+            url,
+            callback=_callback,
+            content_type='application/json',
+            match_querystring=True,
+        )
+
+        query = {
+            'action': 'search',
+            'index': 'bucket',
+            'query': '123',
+        }
+
+        event = self._make_event(query)
+        resp = lambda_handler(event, None)
+        assert resp['statusCode'] == 200
+        assert json.loads(resp['body']) == {'results': 'blah'}
+
+    def test_search_retry(self):
         """test standard search function"""
         url = 'https://www.example.com:443/bucket/_search?' + urlencode({
             'size': 1000,

--- a/lambdas/search/tests/test_search.py
+++ b/lambdas/search/tests/test_search.py
@@ -226,7 +226,10 @@ class TestSearch(TestCase):
         assert map_stats['size']['value'] == sum(raw_stats[i]['size']['value'] for i in (7, 9)), \
             'Unexpected size for .map'
 
+
+    @patch.dict(os.environ, {'MAX_DOCUMENTS_PER_SHARD': '538'})
     def test_packages(self):
+
         """test packages action"""
         query = {
             'action': 'packages',
@@ -234,11 +237,12 @@ class TestSearch(TestCase):
             'body': {'custom': 'body'},
             'size': 42,
             'from': 10,
-            '_source': ','.join(['great', 'expectations'])
+            '_source': ','.join(['great', 'expectations']),
+            'terminate_after': 538,
         }
 
         url = f'https://www.example.com:443/{query["index"]}/_search?' + urlencode({
-            k: v for k, v in query.items() if k in ['size', 'from', '_source']
+            k: v for k, v in query.items() if k in ['size', 'from', '_source', 'terminate_after']
         })
 
         def _callback(request):


### PR DESCRIPTION
* Open was acting slow, probably because sooo many documents per shard
* We should always respect the template-provided terminate_after so that searches finish
* In a future PR we can add some kind of setting to force a deep search but we will still be up against 29 sec API gateway limits