### PR TITLE
Pin urllib3 to avoid contextual version conflict from botocore

### DIFF
--- a/api/python/setup.py
+++ b/api/python/setup.py
@@ -78,6 +78,7 @@ setup(
             'pyarrow>=0.14.1',              # as of 7/5/19: linux/circleci bugs on 0.14.0
         ],
         'tests': [
+            'urllib3<1.26,>=1.25.4'         # https://github.com/quiltdata/quilt/pull/1903
             'numpy>=1.14.0',                # required by pandas, but missing from its dependencies.
             'pandas>=0.19.2',
             'pyarrow>=0.14.1',              # as of 7/5/19: linux/circleci bugs on 0.14.0


### PR DESCRIPTION
Fixes:
```
botocore 1.19.16 requires urllib3<1.26,>=1.25.4; python_version != "3.4", but you'll have urllib3 1.26.1 which is incompatible.
eventlet 0.29.1 requires dnspython<2.0.0,>=1.15.0, but you'll have dnspython 2.0.0 which is incompatible.
detox 0.19 requires tox<3.7,>=3.5, but you'll have tox 3.20.1 which is incompatible.
```