### PR TITLE
Fix Schema placeholders for deep nested objects

### DIFF
--- a/catalog/app/components/JsonEditor/State.js
+++ b/catalog/app/components/JsonEditor/State.js
@@ -201,7 +201,7 @@ function getJsonDictItem(jsonDict, obj, parentPath, key) {
 const noKeys = []
 
 function getObjValueKeys(objValue) {
-  if (Array.isArray(objValue)) return objValue.map((_v, i) => i)
+  if (Array.isArray(objValue)) return R.range(0, objValue.length)
   if (R.is(Object, objValue)) return Object.keys(objValue)
   return noKeys
 }


### PR DESCRIPTION
Created a more sophisticated way of getting "Object.keys()" for a current nesting level of object + schema:

Example

Object: `{ "a": { "b": "c" }}`
Schema: `{ "properties": { "a": { "properties": { d, e } }}}`
Path to object: `["a"]`
Result: `[ "b", "d", "e" ]`

---

Vocabulary:
* `objValue` is a link to an object or array inside object
* `schemaItem` is a link to schema property inside Schema