### PR TITLE
Fix large uploads

### DIFF
--- a/s3-proxy/nginx.conf
+++ b/s3-proxy/nginx.conf
@@ -26,11 +26,12 @@ http {
         gzip_min_length 1024;
         gzip_types text/plain text/css application/json application/javascript;
 
-        client_max_body_size 8m;
-
         location ~ ^/(?<s3_region>[^/]+)/(?<s3_bucket>[^/]+)(/(?<s3_path>.*))? {
+            client_max_body_size 10G;
+
             proxy_http_version 1.1;
             proxy_buffering off;
+            proxy_request_buffering off;
             proxy_ssl_verify on;
             proxy_ssl_verify_depth 5;
             proxy_ssl_trusted_certificate /etc/nginx/certs.pem;
@@ -99,10 +100,12 @@ http {
         }
 
         location / {
+            client_max_body_size 10G;
+
             proxy_pass http://127.0.0.1:3333;
             proxy_http_version 1.1;
             proxy_buffering off;
-            proxy_intercept_errors on;
+            proxy_request_buffering off;
         }
     }
 }


### PR DESCRIPTION
- Because of weird mod_zip problems, we proxy requests twice - so need to increase the limit in both cases.
- Increase the limit to 10G instead of 8M.
- Don't buffer the uploads.
- Don't intercept errors; that was just a copy/paste bug - we should return S3 errors directly.