### PR TITLE
JSON editor UX improvements, part 1

### DIFF
--- a/catalog/app/components/JsonEditor/Cell.js
+++ b/catalog/app/components/JsonEditor/Cell.js
@@ -76,11 +76,6 @@ export default function Cell({
 
   const [value, setValue] = React.useState(initialValue)
 
-  const isEditable = React.useMemo(
-    () => !(column.id === COLUMN_IDS.KEY && row.original && row.original.valueSchema),
-    [column.id, row.original],
-  )
-
   const [editing, setEditing] = React.useState(editingInitial)
   const [menuOpened, setMenuOpened] = React.useState(false)
 
@@ -106,6 +101,14 @@ export default function Cell({
       setEditing(false)
     },
     [column.id, fieldPath, updateMyData],
+  )
+
+  const isKeyCell = column.id === COLUMN_IDS.KEY
+  const isValueCell = column.id === COLUMN_IDS.VALUE
+
+  const isEditable = React.useMemo(
+    () => !(isKeyCell && row.original && row.original.valueSchema),
+    [isKeyCell, row.original],
   )
 
   const onDoubleClick = React.useCallback(() => {
@@ -152,8 +155,6 @@ export default function Cell({
 
   const ValueComponent = editing ? Input : Preview
 
-  const isKeyCell = column.id === COLUMN_IDS.KEY
-  const isValueCell = column.id === COLUMN_IDS.VALUE
   const keyMenuOpened = menuOpened && isKeyCell
   const valueMenuOpened = menuOpened && isValueCell
 

--- a/catalog/app/components/JsonEditor/Cell.js
+++ b/catalog/app/components/JsonEditor/Cell.js
@@ -157,6 +157,11 @@ export default function Cell({
   const keyMenuOpened = menuOpened && isKeyCell
   const valueMenuOpened = menuOpened && isValueCell
 
+  const tabIndex = React.useMemo(() => {
+    if (isKeyCell && row.original && row.original.valueSchema) return null
+    return 0
+  }, [isKeyCell, row])
+
   const menuForKey = React.useMemo(
     () =>
       getMenuForKey({
@@ -178,7 +183,7 @@ export default function Cell({
     <div
       className={cx(classes.root, { [classes.disabled]: !isEditable })}
       role="textbox"
-      tabIndex={0}
+      tabIndex={tabIndex}
       onDoubleClick={onDoubleClick}
       onKeyPress={onKeyPress}
     >

--- a/catalog/app/components/JsonEditor/Cell.js
+++ b/catalog/app/components/JsonEditor/Cell.js
@@ -157,11 +157,6 @@ export default function Cell({
   const keyMenuOpened = menuOpened && isKeyCell
   const valueMenuOpened = menuOpened && isValueCell
 
-  const tabIndex = React.useMemo(() => {
-    if (isKeyCell && row.original && row.original.valueSchema) return null
-    return 0
-  }, [isKeyCell, row])
-
   const menuForKey = React.useMemo(
     () =>
       getMenuForKey({
@@ -183,7 +178,7 @@ export default function Cell({
     <div
       className={cx(classes.root, { [classes.disabled]: !isEditable })}
       role="textbox"
-      tabIndex={tabIndex}
+      tabIndex={isEditable ? null : 0}
       onDoubleClick={onDoubleClick}
       onKeyPress={onKeyPress}
     >

--- a/catalog/app/components/JsonEditor/Cell.js
+++ b/catalog/app/components/JsonEditor/Cell.js
@@ -179,7 +179,7 @@ export default function Cell({
     <div
       className={cx(classes.root, { [classes.disabled]: !isEditable })}
       role="textbox"
-      tabIndex={isEditable ? null : 0}
+      tabIndex={isEditable ? 0 : null}
       onDoubleClick={onDoubleClick}
       onKeyPress={onKeyPress}
     >

--- a/catalog/app/components/JsonEditor/Note.js
+++ b/catalog/app/components/JsonEditor/Note.js
@@ -39,22 +39,29 @@ const getTypeAnnotation = (value, schema) =>
     ? schemaTypeToHumanString(schema)
     : getTypeAnnotationFromValue(value, schema)
 
+function TypeHelp({ humanReadableSchema, schema }) {
+  if (humanReadableSchema === 'undefined') return 'Key/value is not restricted by schema'
+
+  return (
+    <div>
+      Value should be of {humanReadableSchema} type
+      {R.prop('description', schema) && <p>{schema.description}</p>}
+    </div>
+  )
+}
+
 function NoteValue({ schema, value }) {
   const classes = useStyles()
 
-  const schemaType = schemaTypeToHumanString(schema)
+  const humanReadableSchema = schemaTypeToHumanString(schema)
   const mismatch = value !== EMPTY_VALUE && !doesTypeMatchSchema(value, schema)
-  const typeNotInSchema = schemaType === 'undefined'
-  const typeHelp = typeNotInSchema
-    ? 'Key/value is not restricted by schema'
-    : `Value should be of ${schemaType} type`
 
   return (
-    <M.Tooltip title={typeHelp}>
+    <M.Tooltip title={<TypeHelp {...{ humanReadableSchema, schema }} />}>
       <span
         className={cx(classes.default, {
           [classes.mismatch]: mismatch,
-          [classes.notInSchema]: typeNotInSchema,
+          [classes.notInSchema]: humanReadableSchema === 'undefined',
         })}
       >
         {getTypeAnnotation(value, schema)}

--- a/catalog/app/components/JsonEditor/Preview.js
+++ b/catalog/app/components/JsonEditor/Preview.js
@@ -35,7 +35,7 @@ const useStyles = M.makeStyles((t) => ({
     color: t.palette.text.disabled,
   },
   required: {
-    fontWeight: t.typography.fontWeightMedium,
+    fontWeight: t.typography.fontWeightBold,
   },
   menu: {
     marginLeft: 'auto',


### PR DESCRIPTION
# Description

* Navigate with Tab through editable cells only
* Added description to a type help tooltip
* Required key is bolder now