### PR TITLE
Fix default value for is_workflow_required in schema

### DIFF
--- a/api/python/quilt3/workflows/config-1.schema.json
+++ b/api/python/quilt3/workflows/config-1.schema.json
@@ -14,7 +14,7 @@
     "is_workflow_required": {
       "type": "boolean",
       "description": "If true, users must succeed a workflow in order to push. If false, users may skip workflows altogether.",
-      "default": false
+      "default": true
     },
     "default_workflow": {
       "type": "string",

--- a/catalog/app/containers/Bucket/requests.js
+++ b/catalog/app/containers/Bucket/requests.js
@@ -58,7 +58,8 @@ function parseWorkflows(workflowsYaml) {
   )
   if (!workflowsList.length) return emptyWorkflowsConfig
 
-  const noWorkflow = data.is_workflow_required ? null : getNoWorkflow(data, true)
+  const noWorkflow =
+    data.is_workflow_required === false ? getNoWorkflow(data, true) : null
 
   return {
     isRequired: data.is_workflow_required,


### PR DESCRIPTION
# Description
`is_workflow_required` was supposed to be `true` by default, but I messed it up in schema.
Python API handles missing `is_workflow_required` like `true`, but I think that @fiskus assumed that schema doesn't lie about this.