### PR TITLE
JSON is messed up, when user enters invalid JSON into textarea

### DIFF
--- a/catalog/app/containers/Bucket/UploadDialog.js
+++ b/catalog/app/containers/Bucket/UploadDialog.js
@@ -453,7 +453,10 @@ function MetaInput({ schemaError, input, meta, schema }) {
   const error = schemaError ? [schemaError] : meta.submitFailed && meta.error
   const disabled = meta.submitting || meta.submitSucceeded
 
-  const parsedValue = React.useMemo(() => parseJSON(value.text), [value])
+  const parsedValue = React.useMemo(() => {
+    const obj = parseJSON(value.text)
+    return R.is(Object, obj) && !Array.isArray(obj) ? obj : {}
+  }, [value])
 
   const changeMode = (mode) => {
     if (disabled) return


### PR DESCRIPTION
# Description

Steps to reproduce:

- Enter {abcdef} in textarea
- Switch to JSON Editor, it's empty
- Enter some other value
- Switch to textarea

Expected behavior: see valid JSON with entered values. Actual behavior: see a bunch of indexed key/values.