### PR TITLE
Fix #1929: Load package manifest using UTF-8 regardless of locale

### DIFF
--- a/api/python/quilt3/packages.py
+++ b/api/python/quilt3/packages.py
@@ -588,7 +588,7 @@ class Package:
     @classmethod
     def _from_path(cls, path):
         """ Takes a path and returns a package loaded from that path"""
-        with open(path) as open_file:
+        with open(path, encoding='utf-8') as open_file:
             pkg = cls._load(open_file)
         return pkg
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -11,6 +11,7 @@
 ## Python API
 * [Added] Metadata quality API ([#1855](https://github.com/quiltdata/quilt/pull/1874)). For details see this [section](Advanced Features/workflows.md).
 * [Changed] Improved formatting of package load progress bar ([#1897](https://github.com/quiltdata/quilt/pull/1897))
+* [Fixed] Crash during load of package manifest with unicode symbols with non-unicode locale set ([#1931](https://github.com/quiltdata/quilt/pull/1931))
 
 ## CLI
 


### PR DESCRIPTION
# TODO

<!-- Use <del></del> for items that are not required for this PR -->

- [x] Unit tests
- [x] [Changelog](CHANGELOG.md) entry
