### PR TITLE
Workflows config unit tests

### DIFF
--- a/catalog/app/containers/Bucket/PackageDialog/PackageDialog.js
+++ b/catalog/app/containers/Bucket/PackageDialog/PackageDialog.js
@@ -12,6 +12,7 @@ import * as APIConnector from 'utils/APIConnector'
 import * as AWS from 'utils/AWS'
 import pipeThru from 'utils/pipeThru'
 import * as validators from 'utils/validators'
+import * as workflows from 'utils/workflows'
 
 import * as requests from '../requests'
 import SelectWorkflow from './SelectWorkflow'
@@ -175,8 +176,8 @@ export const defaultWorkflowFromConfig = (cfg) =>
   cfg ? cfg.workflows.find((item) => item.isDefault) : null
 
 export const getWorkflowApiParam = R.cond([
-  [R.equals(requests.workflowNotAvailable), R.always(undefined)],
-  [R.equals(requests.workflowNotSelected), R.always(null)],
+  [R.equals(workflows.notAvaliable), R.always(undefined)],
+  [R.equals(workflows.notSelected), R.always(null)],
   [R.T, R.identity],
 ])
 

--- a/catalog/app/utils/workflows.js
+++ b/catalog/app/utils/workflows.js
@@ -1,0 +1,56 @@
+import * as R from 'ramda'
+
+import yaml from 'utils/yaml'
+
+export const notAvaliable = Symbol('not available')
+
+export const notSelected = Symbol('not selected')
+
+function getNoWorkflow(data, hasConfig) {
+  return {
+    isDefault: !data.default_workflow,
+    slug: hasConfig ? notSelected : notAvaliable,
+  }
+}
+
+export const emptyConfig = {
+  isRequired: false,
+  workflows: [getNoWorkflow({}, false)],
+}
+
+function parseSchema(schemaSlug, schemas) {
+  return {
+    url: R.path([schemaSlug, 'url'], schemas),
+  }
+}
+
+function parseWorkflow(workflowSlug, workflow, data) {
+  return {
+    description: workflow.description,
+    isDefault: workflowSlug === data.default_workflow,
+    name: workflow.name,
+    schema: parseSchema(workflow.metadata_schema, data.schemas),
+    slug: workflowSlug,
+  }
+}
+
+export function parse(workflowsYaml) {
+  const data = yaml(workflowsYaml)
+  if (!data) return emptyConfig
+
+  const { workflows } = data
+  if (!workflows) return emptyConfig
+
+  const workflowsList = Object.keys(workflows).map((slug) =>
+    parseWorkflow(slug, workflows[slug], data),
+  )
+  if (!workflowsList.length) return emptyConfig
+
+  const noWorkflow =
+    data.is_workflow_required === false ? getNoWorkflow(data, true) : null
+
+  return {
+    isRequired: data.is_workflow_required,
+    workflows: noWorkflow ? [noWorkflow, ...workflowsList] : workflowsList,
+  }
+}

--- a/catalog/app/utils/workflows.spec.js
+++ b/catalog/app/utils/workflows.spec.js
@@ -4,7 +4,7 @@ import * as workflows from './workflows'
 
 describe('utils/workflows', () => {
   describe('parse', () => {
-    describe('For no config input', () => {
+    describe('no config input', () => {
       const config = workflows.parse('')
 
       it('should return default empty values', () => {
@@ -16,7 +16,7 @@ describe('utils/workflows', () => {
       })
     })
 
-    describe("For config without `workflows` (it's invalid config)", () => {
+    describe('config without `workflows` (invalid config)', () => {
       const data = dedent`
         version: "1"
       `
@@ -31,7 +31,7 @@ describe('utils/workflows', () => {
       })
     })
 
-    describe("For config with empty list as `workflows` (it's invalid config)", () => {
+    describe('config with empty list as `workflows` (invalid config)', () => {
       const data = dedent`
         version: "1"
         workflows: []
@@ -47,7 +47,7 @@ describe('utils/workflows', () => {
       })
     })
 
-    describe('Config with required workflow', () => {
+    describe('config with required workflow', () => {
       const data = dedent`
         version: "1"
         is_workflow_required: True
@@ -66,7 +66,7 @@ describe('utils/workflows', () => {
       })
     })
 
-    describe('Config with workflow not required explicitly', () => {
+    describe('config with workflow not required explicitly', () => {
       const data = dedent`
         version: "1"
         is_workflow_required: False
@@ -89,7 +89,7 @@ describe('utils/workflows', () => {
       })
     })
 
-    describe('Config with workflow required implicitly', () => {
+    describe('config with workflow required implicitly', () => {
       const data = dedent`
         version: "1"
         workflows:
@@ -107,7 +107,7 @@ describe('utils/workflows', () => {
       })
     })
 
-    describe('Config with Schema urls', () => {
+    describe('config with Schema urls', () => {
       const data = dedent`
         version: "1"
         workflows:
@@ -131,7 +131,7 @@ describe('utils/workflows', () => {
       })
     })
 
-    describe('Config with default workflow', () => {
+    describe('config with default workflow', () => {
       const data = dedent`
         version: "1"
         default_workflow: workflow_2

--- a/catalog/app/utils/workflows.spec.js
+++ b/catalog/app/utils/workflows.spec.js
@@ -8,7 +8,7 @@ describe('utils/workflows', () => {
       const config = workflows.parse('')
 
       it('should return default empty values', () => {
-        expect(config).toBe(workflows.emptyConfig)
+        expect(config).toEqual(workflows.emptyConfig)
       })
 
       it('should return data with special `notAvailable` workflow', () => {
@@ -23,7 +23,7 @@ describe('utils/workflows', () => {
       const config = workflows.parse(data)
 
       it('should return default empty values', () => {
-        expect(config).toBe(workflows.emptyConfig)
+        expect(config).toEqual(workflows.emptyConfig)
       })
 
       it('should return data with special `notAvailable` workflow', () => {
@@ -39,7 +39,7 @@ describe('utils/workflows', () => {
       const config = workflows.parse(data)
 
       it('should return default empty values', () => {
-        expect(config).toBe(workflows.emptyConfig)
+        expect(config).toEqual(workflows.emptyConfig)
       })
 
       it('should return data with special `notAvailable` workflow', () => {

--- a/catalog/app/utils/workflows.spec.js
+++ b/catalog/app/utils/workflows.spec.js
@@ -1,0 +1,108 @@
+import dedent from 'dedent'
+
+import * as workflows from './workflows'
+
+describe('utils/workflows', () => {
+  describe('Workflows config', () => {
+    it('is correct for an empty file', () => {
+      const config = workflows.parse('')
+      expect(config).toBe(workflows.emptyConfig)
+      expect(config.workflows[0].slug).toBe(workflows.notAvaliable)
+    })
+
+    it('is correct when no workflows', () => {
+      const data = dedent`
+        version: "1"
+      `
+      const config = workflows.parse(data)
+      expect(config).toBe(workflows.emptyConfig)
+      expect(config.workflows[0].slug).toBe(workflows.notAvaliable)
+    })
+
+    it('is correct for empty workflows list', () => {
+      const data = dedent`
+        version: "1"
+        workflows: []
+      `
+      expect(workflows.parse(data)).toBe(workflows.emptyConfig)
+    })
+
+    it('is correct when workflow is required', () => {
+      const data = dedent`
+        version: "1"
+        is_workflow_required: True
+        workflows:
+          workflow_1:
+            name: Workflow №1
+      `
+      const config = workflows.parse(data)
+      expect(config.workflows).toHaveLength(1)
+      expect(config.workflows[0].slug).toBe('workflow_1')
+    })
+
+    it('is correct when workflow is not required explicitly', () => {
+      const data = dedent`
+        version: "1"
+        is_workflow_required: False
+        workflows:
+          workflow_1:
+            name: Workflow №1
+      `
+      const config = workflows.parse(data)
+      expect(config.workflows).toHaveLength(2)
+      expect(config.workflows[0].slug).toBe(workflows.notSelected)
+      expect(config.workflows[1].slug).toBe('workflow_1')
+    })
+
+    it('is correct when workflow is required by default', () => {
+      const data = dedent`
+        version: "1"
+        workflows:
+          workflow_1:
+            name: Workflow №1
+      `
+      const config = workflows.parse(data)
+      expect(config.workflows).toHaveLength(1)
+      expect(config.workflows[0].slug).toBe('workflow_1')
+    })
+
+    it('contains Schema url', () => {
+      const data = dedent`
+        version: "1"
+        workflows:
+          workflow_1:
+            name: Workflow №1
+            metadata_schema: schema_1
+          workflow_2:
+            name: Workflow №2
+            metadata_schema: schema_2
+        schemas:
+          schema_1:
+            url: https://foo
+          schema_2:
+            url: https://bar
+      `
+      const config = workflows.parse(data)
+      expect(config.workflows[0].schema.url).toBe('https://foo')
+      expect(config.workflows[1].schema.url).toBe('https://bar')
+    })
+
+    it('sets default workflow', () => {
+      const data = dedent`
+        version: "1"
+        default_workflow: workflow_2
+        workflows:
+          workflow_1:
+            name: Workflow №1
+          workflow_2:
+            name: Workflow №2
+          workflow_3:
+            name: Workflow №3
+      `
+      const config = workflows.parse(data)
+      expect(config.workflows[0].isDefault).toBe(false)
+      expect(config.workflows[1].isDefault).toBe(true)
+      expect(config.workflows[2].isDefault).toBe(false)
+    })
+  })
+})


### PR DESCRIPTION
Copied from #1922 and restructured tests

I was forced to move workflows into `app/utils` because `jest` can't handle `requests.js` file