### PR TITLE
Hash-based package routes

### DIFF
--- a/catalog/app/components/SearchResults/SearchResults.js
+++ b/catalog/app/components/SearchResults/SearchResults.js
@@ -109,7 +109,7 @@ function ObjectHeader({ handle, showBucket, downloadable }) {
   )
 }
 
-function PackageHeader({ bucket, handle, revision, showBucket }) {
+function PackageHeader({ bucket, handle, hash, showBucket }) {
   const { urls } = NamedRoutes.use()
   return (
     <Heading mb={1}>
@@ -126,16 +126,12 @@ function PackageHeader({ bucket, handle, revision, showBucket }) {
             &nbsp;/{' '}
           </>
         )}
-        <CrumbLink to={urls.bucketPackageTree(bucket, handle, revision)}>
+        <CrumbLink to={urls.bucketPackageTree(bucket, handle, hash)}>
           {handle}
-          {revision !== 'latest' && (
-            <>
-              <M.Box component="span" color="text.hint">
-                @
-              </M.Box>
-              {revision}
-            </>
-          )}
+          <M.Box component="span" color="text.hint">
+            @
+          </M.Box>
+          {R.take(10, hash)}
         </CrumbLink>
       </span>
       <M.Box flexGrow={1} />
@@ -435,17 +431,9 @@ const useRevisionInfoStyles = M.makeStyles((t) => ({
     overflowWrap: 'break-word',
     textOverflow: 'ellipsis',
   },
-  hash: {
-    ...t.typography.body2,
-    color: t.palette.text.secondary,
-    fontFamily: t.typography.monospace.fontFamily,
-    marginTop: t.spacing(1),
-    overflow: 'hidden',
-    textOverflow: 'ellipsis',
-  },
 }))
 
-function RevisionInfo({ bucket, handle, revision, hash, comment, lastModified }) {
+function RevisionInfo({ bucket, handle, hash, comment, lastModified }) {
   const classes = useRevisionInfoStyles()
   const { urls } = NamedRoutes.use()
   return (
@@ -454,10 +442,11 @@ function RevisionInfo({ bucket, handle, revision, hash, comment, lastModified })
         <Nowrap>
           Revision{' '}
           <StyledLink
-            to={urls.bucketPackageTree(bucket, handle, revision)}
+            to={urls.bucketPackageTree(bucket, handle, hash)}
             className={classes.mono}
+            title={hash}
           >
-            {revision}
+            {R.take(10, hash)}
           </StyledLink>
         </Nowrap>{' '}
         <Nowrap>
@@ -465,7 +454,6 @@ function RevisionInfo({ bucket, handle, revision, hash, comment, lastModified })
         </Nowrap>
       </p>
       <p className={classes.msg}>{comment || <i>No message</i>}</p>
-      <p className={classes.hash}>{hash}</p>
     </M.Box>
   )
 }
@@ -506,12 +494,12 @@ function ObjectHit({ showBucket, hit: { path, versions, bucket } }) {
 
 function PackageHit({
   showBucket,
-  hit: { bucket, handle, revision, hash, lastModified, meta, tags, comment },
+  hit: { bucket, handle, hash, lastModified, meta, tags, comment },
 }) {
   return (
     <Section>
-      <PackageHeader {...{ handle, bucket, revision, showBucket }} />
-      <RevisionInfo {...{ bucket, handle, revision, hash, comment, lastModified }} />
+      <PackageHeader {...{ handle, bucket, hash, showBucket }} />
+      <RevisionInfo {...{ bucket, handle, hash, comment, lastModified }} />
       {tags && tags.length > 0 && (
         <M.Box mt={2}>
           {tags.map((t) => (

--- a/catalog/app/containers/Bucket/PackageCreateDialog.js
+++ b/catalog/app/containers/Bucket/PackageCreateDialog.js
@@ -445,7 +445,7 @@ function PackageCreateDialog({ bucket, open, workflowsConfig, onClose, refresh }
         await new Promise((resolve) => setTimeout(resolve, PD.ES_LAG))
         refresh()
       }
-      setSuccess({ name, revision: res.timestamp })
+      setSuccess({ name, hash: res.top_hash })
     } catch (e) {
       // eslint-disable-next-line no-console
       console.log('error creating manifest', e)
@@ -480,9 +480,9 @@ function PackageCreateDialog({ bucket, open, workflowsConfig, onClose, refresh }
                 <M.Typography>
                   Package{' '}
                   <StyledLink
-                    to={urls.bucketPackageTree(bucket, success.name, success.revision)}
+                    to={urls.bucketPackageTree(bucket, success.name, success.hash)}
                   >
-                    {success.name}@{success.revision}
+                    {success.name}@{R.take(10, success.hash)}
                   </StyledLink>{' '}
                   successfully created
                 </M.Typography>
@@ -491,7 +491,7 @@ function PackageCreateDialog({ bucket, open, workflowsConfig, onClose, refresh }
                 <M.Button onClick={handleClose()}>Close</M.Button>
                 <M.Button
                   component={Link}
-                  to={urls.bucketPackageTree(bucket, success.name, success.revision)}
+                  to={urls.bucketPackageTree(bucket, success.name, success.hash)}
                   variant="contained"
                   color="primary"
                 >

--- a/catalog/app/containers/Bucket/PackageRevisions.js
+++ b/catalog/app/containers/Bucket/PackageRevisions.js
@@ -289,17 +289,7 @@ const useRevisionStyles = M.makeStyles((t) => ({
   },
 }))
 
-function Revision({
-  bucket,
-  name,
-  hash,
-  id,
-  stats,
-  message,
-  modified,
-  metadata,
-  counts,
-}) {
+function Revision({ bucket, name, hash, stats, message, modified, metadata, counts }) {
   const classes = useRevisionStyles()
   const { urls } = NamedRoutes.use()
   const t = M.useTheme()
@@ -308,7 +298,7 @@ function Revision({
   return (
     <RevisionLayout
       link={
-        <Link className={classes.time} to={urls.bucketPackageTree(bucket, name, id)}>
+        <Link className={classes.time} to={urls.bucketPackageTree(bucket, name, hash)}>
           {dateFns.format(modified, dateFmt)}
         </Link>
       }

--- a/catalog/app/containers/Bucket/PackageTree.js
+++ b/catalog/app/containers/Bucket/PackageTree.js
@@ -26,6 +26,7 @@ import { ListingItem, ListingWithLocalFiltering } from './Listing'
 import { usePackageUpdateDialog } from './PackageUpdateDialog'
 import Section from './Section'
 import Summary from './Summary'
+import * as errors from './errors'
 import renderPreview from './renderPreview'
 import * as requests from './requests'
 
@@ -57,7 +58,7 @@ const useRevisionInfoStyles = M.makeStyles((t) => ({
   },
 }))
 
-function RevisionInfo({ revision, bucket, name, path }) {
+function RevisionInfo({ revisionData, revision, bucket, name, path }) {
   const { urls } = NamedRoutes.use()
   const classes = useRevisionInfoStyles()
 
@@ -66,18 +67,28 @@ function RevisionInfo({ revision, bucket, name, path }) {
   const open = React.useCallback(() => setOpened(true), [])
   const close = React.useCallback(() => setOpened(false), [])
 
-  const data = useRevisionsData({ bucket, name })
+  const revisionsData = useRevisionsData({ bucket, name })
+  const data = revisionsData.case({
+    Ok: (revisions) =>
+      revisionData.case({
+        Ok: ({ hash }) =>
+          AsyncResult.Ok(revisions.map((r) => ({ ...r, selected: r.hash === hash }))),
+        Err: () => AsyncResult.Ok(revisions),
+        _: R.identity,
+      }),
+    _: R.identity,
+  })
 
   return (
     <>
       {/* eslint-disable-next-line jsx-a11y/click-events-have-key-events, jsx-a11y/no-static-element-interactions */}
-      <span className={classes.revision} onClick={open} ref={setAnchor}>
-        {revision === 'latest' ? (
-          'latest'
-        ) : (
-          <span className={classes.mono}>{revision}</span>
-        )}{' '}
-        <M.Icon>expand_more</M.Icon>
+      <span
+        className={classes.revision}
+        onClick={open}
+        ref={setAnchor}
+        title={revision.length > 10 ? revision : undefined}
+      >
+        {R.take(10, revision)} <M.Icon>expand_more</M.Icon>
       </span>
 
       <M.Popover
@@ -88,53 +99,50 @@ function RevisionInfo({ revision, bucket, name, path }) {
         transformOrigin={{ vertical: 'top', horizontal: 'center' }}
       >
         <M.List className={classes.list}>
-          {data.case({
-            Ok: R.map((r) => (
-              <M.ListItem
-                key={r.hash}
-                button
-                onClick={close}
-                selected={r.id === revision}
-                component={RRLink}
-                to={urls.bucketPackageTree(bucket, name, r.id, path)}
-              >
-                <M.ListItemText
-                  primary={
-                    <>
-                      <span className={classes.mono}>{r.id}</span>
-                      {' | '}
-                      {dateFns.format(r.modified, 'MMMM do yyyy - h:mma')}
-                    </>
-                  }
-                  secondary={
-                    <span className={classes.secondaryText}>
-                      <span className={classes.line}>
-                        {r.message || <i>No message</i>}
+          {AsyncResult.case(
+            {
+              Ok: R.map((r) => (
+                <M.ListItem
+                  key={r.hash}
+                  button
+                  onClick={close}
+                  selected={r.selected}
+                  component={RRLink}
+                  to={urls.bucketPackageTree(bucket, name, r.hash, path)}
+                >
+                  <M.ListItemText
+                    primary={dateFns.format(r.modified, 'MMMM do yyyy - h:mma')}
+                    secondary={
+                      <span className={classes.secondaryText}>
+                        <span className={classes.line}>
+                          {r.message || <i>No message</i>}
+                        </span>
+                        <br />
+                        <span className={cx(classes.line, classes.mono)}>{r.hash}</span>
                       </span>
-                      <br />
-                      <span className={cx(classes.line, classes.mono)}>{r.hash}</span>
-                    </span>
-                  }
-                />
-              </M.ListItem>
-            )),
-            Err: () => (
-              <M.ListItem>
-                <M.ListItemIcon>
-                  <M.Icon>error</M.Icon>
-                </M.ListItemIcon>
-                <M.Typography variant="body1">Error fetching revisions</M.Typography>
-              </M.ListItem>
-            ),
-            _: () => (
-              <M.ListItem>
-                <M.ListItemIcon>
-                  <M.CircularProgress size={24} />
-                </M.ListItemIcon>
-                <M.Typography variant="body1">Fetching revisions</M.Typography>
-              </M.ListItem>
-            ),
-          })}
+                    }
+                  />
+                </M.ListItem>
+              )),
+              Err: () => (
+                <M.ListItem>
+                  <M.ListItemIcon>
+                    <M.Icon>error</M.Icon>
+                  </M.ListItemIcon>
+                  <M.Typography variant="body1">Error fetching revisions</M.Typography>
+                </M.ListItem>
+              ),
+              _: () => (
+                <M.ListItem>
+                  <M.ListItemIcon>
+                    <M.CircularProgress size={24} />
+                  </M.ListItemIcon>
+                  <M.Typography variant="body1">Fetching revisions</M.Typography>
+                </M.ListItem>
+              ),
+            },
+            data,
+          )}
           <M.Divider />
           <M.ListItem
             button
@@ -152,62 +160,54 @@ function RevisionInfo({ revision, bucket, name, path }) {
   )
 }
 
-function ExposeLinkedData({ bucketCfg, bucket, name, revision }) {
-  const s3 = AWS.S3.use()
+function ExposeLinkedData({ bucketCfg, bucket, name, hash, modified }) {
   const sign = AWS.Signer.useS3Signer()
   const { apiGatewayEndpoint: endpoint } = Config.use()
   const data = useData(requests.getRevisionData, {
-    s3,
     sign,
     endpoint,
     bucket,
-    name,
-    id: revision,
+    hash,
     maxKeys: 0,
   })
   return data.case({
     _: () => null,
-    Ok: ({ hash, modified, header }) => (
+    Ok: ({ header }) => (
       <React.Suspense fallback={null}>
         <LinkedData.PackageData
-          {...{ bucket: bucketCfg, name, revision, hash, modified, header }}
+          {...{ bucket: bucketCfg, name, hash, modified, header }}
         />
       </React.Suspense>
     ),
   })
 }
 
-function PkgCode({ data, bucket, name, revision, path }) {
-  const code = data.case({
-    Ok: ({ hash }) => {
-      const nameWithPath = JSON.stringify(s3paths.ensureNoSlash(`${name}/${path}`))
-      const hashDisplay = revision === 'latest' ? '' : hash.substring(0, 10)
-      const hashPy = hashDisplay && `, top_hash="${hashDisplay}"`
-      const hashCli = hashDisplay && ` --top-hash ${hashDisplay}`
-      return [
-        {
-          label: 'Python',
-          hl: 'python',
-          contents: dedent`
-            import quilt3
-            # browse
-            p = quilt3.Package.browse("${name}"${hashPy}, registry="s3://${bucket}")
-            # download (be mindful of large packages)
-            quilt3.Package.install(${nameWithPath}${hashPy}, registry="s3://${bucket}", dest=".")
-          `,
-        },
-        {
-          label: 'CLI',
-          hl: 'bash',
-          contents: dedent`
-            quilt3 install ${nameWithPath}${hashCli} --registry s3://${bucket} --dest .
-          `,
-        },
-      ]
+function PkgCode({ bucket, name, hash, revision, path }) {
+  const nameWithPath = JSON.stringify(s3paths.ensureNoSlash(`${name}/${path}`))
+  const hashDisplay = revision === 'latest' ? '' : R.take(10, hash)
+  const hashPy = hashDisplay && `, top_hash="${hashDisplay}"`
+  const hashCli = hashDisplay && ` --top-hash ${hashDisplay}`
+  const code = [
+    {
+      label: 'Python',
+      hl: 'python',
+      contents: dedent`
+        import quilt3
+        # browse
+        p = quilt3.Package.browse("${name}"${hashPy}, registry="s3://${bucket}")
+        # download (be mindful of large packages)
+        quilt3.Package.install(${nameWithPath}${hashPy}, registry="s3://${bucket}", dest=".")
+      `,
     },
-    _: () => null,
-  })
-  return code && <Code>{code}</Code>
+    {
+      label: 'CLI',
+      hl: 'bash',
+      contents: dedent`
+        quilt3 install ${nameWithPath}${hashCli} --registry s3://${bucket} --dest .
+      `,
+    },
+  ]
+  return <Code>{code}</Code>
 }
 
 const useTopBarStyles = M.makeStyles((t) => ({
@@ -243,7 +243,7 @@ function TopBar({ crumbs, children }) {
   )
 }
 
-function DirDisplay({ bucket, name, revision, path, crumbs, onRevisionPush }) {
+function DirDisplay({ bucket, name, hash, revision, path, crumbs, onRevisionPush }) {
   const s3 = AWS.S3.use()
   const { apiGatewayEndpoint: endpoint, noDownload } = Config.use()
   const credentials = AWS.Credentials.use()
@@ -261,11 +261,9 @@ function DirDisplay({ bucket, name, revision, path, crumbs, onRevisionPush }) {
     endpoint,
     bucket,
     name,
-    revision,
+    hash,
     prefix: path,
   })
-
-  const hashData = useData(requests.loadRevisionHash, { s3, bucket, name, id: revision })
 
   const mkUrl = React.useCallback(
     (handle) => urls.bucketPackageTree(bucket, name, revision, handle.logicalKey),
@@ -275,7 +273,7 @@ function DirDisplay({ bucket, name, revision, path, crumbs, onRevisionPush }) {
   const updateDialog = usePackageUpdateDialog({
     bucket,
     name,
-    revision,
+    hash,
     onExited: onRevisionPush,
   })
 
@@ -326,21 +324,17 @@ function DirDisplay({ bucket, name, revision, path, crumbs, onRevisionPush }) {
             >
               Revise package
             </M.Button>
-            {!noDownload &&
-              hashData.case({
-                Ok: ({ hash }) => (
-                  <>
-                    <M.Box ml={1} />
-                    <FileView.ZipDownloadForm
-                      label="Download package"
-                      suffix={`package/${bucket}/${name}/${hash}`}
-                    />
-                  </>
-                ),
-                _: () => null,
-              })}
+            {!noDownload && (
+              <>
+                <M.Box ml={1} />
+                <FileView.ZipDownloadForm
+                  label="Download package"
+                  suffix={`package/${bucket}/${name}/${hash}`}
+                />
+              </>
+            )}
           </TopBar>
-          <PkgCode {...{ data: hashData, bucket, name, revision, path }} />
+          <PkgCode {...{ bucket, name, hash, revision, path }} />
           <FileView.Meta data={AsyncResult.Ok(meta)} />
           <M.Box mt={2}>
             <ListingWithLocalFiltering items={items} />
@@ -396,7 +390,7 @@ function DirDisplay({ bucket, name, revision, path, crumbs, onRevisionPush }) {
   })
 }
 
-function FileDisplay({ bucket, name, revision, path, crumbs }) {
+function FileDisplay({ bucket, name, hash, revision, path, crumbs }) {
   const s3 = AWS.S3.use()
   const credentials = AWS.Credentials.use()
   const { apiGatewayEndpoint: endpoint, noDownload } = Config.use()
@@ -407,11 +401,9 @@ function FileDisplay({ bucket, name, revision, path, crumbs }) {
     endpoint,
     bucket,
     name,
-    revision,
+    hash,
     path,
   })
-
-  const hashData = useData(requests.loadRevisionHash, { s3, bucket, name, id: revision })
 
   const renderProgress = () => (
     // TODO: skeleton placeholder
@@ -470,7 +462,7 @@ function FileDisplay({ bucket, name, revision, path, crumbs }) {
                     <FileView.DownloadButton handle={handle} />
                   )}
                 </TopBar>
-                <PkgCode {...{ data: hashData, bucket, name, revision, path }} />
+                <PkgCode {...{ bucket, name, hash, revision, path }} />
                 <FileView.Meta data={AsyncResult.Ok(meta)} />
                 <Section icon="remove_red_eye" heading="Preview" expandable={false}>
                   {withPreview({ archived, deleted, handle }, renderPreview)}
@@ -506,6 +498,7 @@ export default function PackageTree({
   },
 }) {
   const classes = useStyles()
+  const s3 = AWS.S3.use()
   const { urls } = NamedRoutes.use()
   const bucketCfg = BucketConfig.useCurrentBucketConfig()
 
@@ -538,7 +531,7 @@ export default function PackageTree({
         // refresh revision list if a new revision of the current package has been pushed
         setRevisionListKey(R.inc)
         if (revision === 'latest') {
-          // when browsing 'latest' revision, also refresh the pacakge view
+          // when browsing 'latest' revision, also refresh the package view
           setRevisionKey(R.inc)
         }
       }
@@ -546,33 +539,83 @@ export default function PackageTree({
     [name, revision, setRevisionKey, setRevisionListKey],
   )
 
+  const revisionData = useData(requests.resolvePackageRevision, {
+    s3,
+    bucket,
+    name,
+    revision,
+    revisionKey,
+  })
+
   return (
     <FileView.Root>
-      {!!bucketCfg && (
-        <ExposeLinkedData
-          {...{ bucketCfg, bucket, name, revision }}
-          key={`links:${revisionKey}`}
-        />
-      )}
+      {!!bucketCfg &&
+        revisionData.case({
+          Ok: ({ hash, modified }) => (
+            <ExposeLinkedData {...{ bucketCfg, bucket, name, hash, modified }} />
+          ),
+          _: () => null,
+        })}
       <M.Typography variant="body1">
         <Link to={urls.bucketPackageDetail(bucket, name)} className={classes.name}>
           {name}
         </Link>
         {' @ '}
         <RevisionInfo
-          {...{ revision, bucket, name, path }}
+          {...{ revisionData, revision, bucket, name, path }}
           key={`revinfo:${revisionListKey}`}
         />
       </M.Typography>
 
-      {isDir ? (
-        <DirDisplay
-          {...{ bucket, name, revision, path, crumbs, onRevisionPush }}
-          key={`dir:${revisionKey}`}
-        />
-      ) : (
-        <FileDisplay {...{ bucket, name, revision, path, crumbs }} />
-      )}
+      {revisionData.case({
+        Ok: ({ hash }) =>
+          isDir ? (
+            <DirDisplay
+              {...{
+                bucket,
+                name,
+                hash,
+                path,
+                revision,
+                crumbs,
+                onRevisionPush,
+                key: hash,
+              }}
+            />
+          ) : (
+            <FileDisplay {...{ bucket, name, hash, revision, path, crumbs }} />
+          ),
+        Err: (e) => {
+          if (!(e instanceof errors.BadRevision)) throw e
+          return (
+            <>
+              <TopBar crumbs={crumbs} />
+              <M.Box mt={4}>
+                <M.Typography variant="h4" align="center" gutterBottom>
+                  Error resolving revision
+                </M.Typography>
+                <M.Typography variant="body1" align="center">
+                  Revision{' '}
+                  <M.Box
+                    component="span"
+                    fontWeight="fontWeightMedium"
+                  >{`"${e.revision}"`}</M.Box>{' '}
+                  could not be resolved.
+                </M.Typography>
+              </M.Box>
+            </>
+          )
+        },
+        _: () => (
+          // TODO: skeleton placeholder
+          <>
+            <TopBar crumbs={crumbs} />
+            <M.Box mt={2}>
+              <M.CircularProgress />
+            </M.Box>
+          </>
+        ),
+      })}
     </FileView.Root>
   )
 }

--- a/catalog/app/containers/Bucket/PackageUpdateDialog.js
+++ b/catalog/app/containers/Bucket/PackageUpdateDialog.js
@@ -588,7 +588,7 @@ function DialogForm({
           workflow: PD.getWorkflowApiParam(workflow.slug),
         },
       })
-      onSuccess({ name, revision: res.timestamp })
+      onSuccess({ name, hash: res.top_hash })
     } catch (e) {
       // eslint-disable-next-line no-console
       console.log('error creating manifest', e)
@@ -839,7 +839,7 @@ function DialogError({ error, close }) {
   )
 }
 
-function DialogSuccess({ bucket, name, revision, close }) {
+function DialogSuccess({ bucket, name, hash, close }) {
   const { urls } = NamedRoutes.use()
   return (
     <>
@@ -847,8 +847,8 @@ function DialogSuccess({ bucket, name, revision, close }) {
       <M.DialogContent style={{ paddingTop: 0 }}>
         <M.Typography>
           Package revision{' '}
-          <StyledLink to={urls.bucketPackageTree(bucket, name, revision)}>
-            {name}@{revision}
+          <StyledLink to={urls.bucketPackageTree(bucket, name, hash)}>
+            {name}@{R.take(10, hash)}
           </StyledLink>{' '}
           successfully created
         </M.Typography>
@@ -857,7 +857,7 @@ function DialogSuccess({ bucket, name, revision, close }) {
         <M.Button onClick={close}>Close</M.Button>
         <M.Button
           component={Link}
-          to={urls.bucketPackageTree(bucket, name, revision)}
+          to={urls.bucketPackageTree(bucket, name, hash)}
           variant="contained"
           color="primary"
         >
@@ -886,10 +886,10 @@ const DialogState = tagged([
   'Loading',
   'Error',
   'Form', // { manifest, workflowsConfig }
-  'Success', // { name, revision }
+  'Success', // { name, hash }
 ])
 
-export function usePackageUpdateDialog({ bucket, name, revision, onExited }) {
+export function usePackageUpdateDialog({ bucket, name, hash, onExited }) {
   const s3 = AWS.S3.use()
 
   const [isOpen, setOpen] = React.useState(false)
@@ -902,7 +902,7 @@ export function usePackageUpdateDialog({ bucket, name, revision, onExited }) {
 
   const manifestData = Data.use(
     requests.loadManifest,
-    { s3, bucket, name, revision, key },
+    { s3, bucket, name, hash, key },
     { noAutoFetch: !wasOpened },
   )
   const workflowsData = Data.use(requests.workflowsList, { s3, bucket })

--- a/catalog/app/containers/Bucket/errors.js
+++ b/catalog/app/containers/Bucket/errors.js
@@ -30,6 +30,9 @@ export class FileNotFound extends BucketError {}
 export class VersionNotFound extends BucketError {}
 
 export class ManifestTooLarge extends BucketError {
+  // eslint-disable-next-line react/static-property-placement
+  static displayName = 'ManifestTooLarge'
+
   constructor(props) {
     super(
       `Package manifest at s3://${props.bucket}/${props.key} is too large: ${props.actualSize} (max size: ${props.maxSize})`,
@@ -37,7 +40,18 @@ export class ManifestTooLarge extends BucketError {
     )
   }
 }
-ManifestTooLarge.displayName = 'ManifestTooLarge'
+
+export class BadRevision extends BucketError {
+  // eslint-disable-next-line react/static-property-placement
+  static displayName = 'BadRevision'
+
+  constructor(props) {
+    super(
+      `Could not resolve revision "${props.revision}" for package "${props.handle}" in s3://${props.bucket}`,
+      props,
+    )
+  }
+}
 
 const WhenAuth = connect(
   createStructuredSelector({

--- a/catalog/app/utils/LinkedData.js
+++ b/catalog/app/utils/LinkedData.js
@@ -55,16 +55,7 @@ function mkBucketAnnotation({ bucket, catalog, urls }) {
   }
 }
 
-const mkPackageAnnotation = ({
-  bucket,
-  name,
-  revision,
-  hash,
-  modified,
-  header,
-  catalog,
-  urls,
-}) => {
+const mkPackageAnnotation = ({ bucket, name, hash, modified, header, catalog, urls }) => {
   const getLD = (prop) => R.path(['user_meta', 'json-ld', prop], header)
   return {
     '@context': 'https://schema.org/',
@@ -72,7 +63,7 @@ const mkPackageAnnotation = ({
     name: getLD('name') || name,
     alternateName: getLD('name') && name,
     description: getLD('description'),
-    url: window.location.origin + urls.bucketPackageTree(bucket.name, name, revision),
+    url: window.location.origin + urls.bucketPackageTree(bucket.name, name, hash),
     version: hash,
     dateModified: modified,
     sameAs: getLD('sameAs'),

--- a/catalog/app/utils/search.js
+++ b/catalog/app/utils/search.js
@@ -34,7 +34,6 @@ Package: {
   score: num,
   bucket: str,
   handle: str,
-  revision: str,
   hash: str,
   lastModified: ?Date,
   meta: str, // should it be parsed?
@@ -90,7 +89,6 @@ const extractPkgData = ({ bucket, score, src }) => {
       bucket,
       score,
       handle: src.handle,
-      revision: src.pointer_file || 'latest',
       hash: src.hash,
       lastModified: parseDate(src.last_modified),
       meta: parseJSON(src.metadata),
@@ -181,7 +179,9 @@ export default async function search({
         throw new SearchError('Timeout')
       }
     }
+    // eslint-disable-next-line no-console
     console.log('Search error:')
+    // eslint-disable-next-line no-console
     console.error(e)
     throw new SearchError('Unexpected', { originalError: e })
   }

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -13,6 +13,7 @@
 ## CLI
 
 ## Catalog, Lambdas
+* [Changed] `top_hash`-based package routes (backwards compatible) ([#1938](https://github.com/quiltdata/quilt/pull/1938))
 
 # 3.3.0rc1 - 2020-11-25
 ## Python API

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -13,7 +13,7 @@
 ## CLI
 
 ## Catalog, Lambdas
-* [Changed] `top_hash`-based package routes (backwards compatible) ([#1938](https://github.com/quiltdata/quilt/pull/1938))
+* [Changed] `top_hash`-based package routes (timestamp routes are still supported in the same way) ([#1938](https://github.com/quiltdata/quilt/pull/1938))
 
 # 3.3.0rc1 - 2020-11-25
 ## Python API


### PR DESCRIPTION
# Description

Use top_hash in package routes, completely remove timestamps from the UI (timestamp revisions are still resolved, so it's backwards compatible).

# TODO

- [x] [Changelog](CHANGELOG.md) entry
