### PR TITLE
Ignore ES modules for Jest

### DIFF
--- a/catalog/jest.config.js
+++ b/catalog/jest.config.js
@@ -25,5 +25,8 @@ module.exports = {
   setupFiles: ['raf/polyfill', 'jest-localstorage-mock'],
   testRegex: '.*\\.(test|spec)\\.js$',
   testURL: 'https://quilt-test',
+  transformIgnorePatterns: [
+    'node_modules/(?!(redux-form/es|connected-react-router/esm)/)',
+  ],
   snapshotSerializers: [],
 }


### PR DESCRIPTION
# Description

Jest doesn't Babel-transform modules inside `node_modules` by default.

https://jestjs.io/docs/en/configuration#transformignorepatterns-arraystring

---

I found `grep -r import app | grep '/es'` modules imported as ES modules, and added them to ignore pattern.