### PR TITLE
Remove infinite spinner after failed form submit

### DIFF
--- a/catalog/app/containers/Bucket/PackageCreateDialog.js
+++ b/catalog/app/containers/Bucket/PackageCreateDialog.js
@@ -510,6 +510,7 @@ function PackageCreateDialog({ bucket, open, workflowsConfig, onClose, refresh }
                     onBlur={() => {
                       // Do nothing, just redefine final-form's onBlur.
                       // That way input is not getting inactive before validation becomes fullfilled
+                      // TODO: remove when issue will be fixed https://github.com/final-form/react-final-form/issues/676
                     }}
                     placeholder="Enter a package name"
                     validate={validators.composeAsync(

--- a/catalog/app/containers/Bucket/PackageCreateDialog.js
+++ b/catalog/app/containers/Bucket/PackageCreateDialog.js
@@ -507,6 +507,10 @@ function PackageCreateDialog({ bucket, open, workflowsConfig, onClose, refresh }
                     component={PD.Field}
                     name="name"
                     label="Name"
+                    onBlur={() => {
+                      // Do nothing, just redefine final-form's onBlur.
+                      // That way input is not getting inactive before validation becomes fullfilled
+                    }}
                     placeholder="Enter a package name"
                     validate={validators.composeAsync(
                       validators.required,

--- a/catalog/app/containers/Bucket/PackageDialog/PackageDialog.js
+++ b/catalog/app/containers/Bucket/PackageDialog/PackageDialog.js
@@ -88,11 +88,13 @@ export function useNameValidator() {
         })
         // Final-form field's `state.blur()` on next tick
         // Field should update UI before becomes inactive
+        // TODO: remove when issue will be fixed https://github.com/final-form/react-final-form/issues/676
         setTimeout(meta.blur)
         if (!res.valid) return 'invalid'
       }
       // Final-form field's `state.blur()` on next tick
       // Field should update UI before becomes inactive
+      // TODO: remove when issue will be fixed https://github.com/final-form/react-final-form/issues/676
       setTimeout(meta.blur)
       return undefined
     }, 200),

--- a/catalog/app/containers/Bucket/PackageDialog/PackageDialog.js
+++ b/catalog/app/containers/Bucket/PackageDialog/PackageDialog.js
@@ -79,15 +79,21 @@ export function useNameValidator() {
 
   // eslint-disable-next-line react-hooks/exhaustive-deps
   const validate = React.useCallback(
-    cacheDebounce(async (name) => {
+    cacheDebounce(async (name, values, meta) => {
       if (name) {
         const res = await req({
           endpoint: '/package_name_valid',
           method: 'POST',
           body: { name },
         })
+        // Final-form field's `state.blur()` on next tick
+        // Field should update UI before becomes inactive
+        setTimeout(meta.blur)
         if (!res.valid) return 'invalid'
       }
+      // Final-form field's `state.blur()` on next tick
+      // Field should update UI before becomes inactive
+      setTimeout(meta.blur)
       return undefined
     }, 200),
     [req, counter],

--- a/catalog/app/utils/validators.js
+++ b/catalog/app/utils/validators.js
@@ -137,8 +137,8 @@ export const jsonObject = (v) => {
   }
 }
 
-export const composeAsync = (...validators) => (value) =>
+export const composeAsync = (...validators) => (value, values, meta) =>
   validators.reduce(
-    (error, next) => Promise.resolve(error).then((e) => e || next(value)),
+    (error, next) => Promise.resolve(error).then((e) => e || next(value, values, meta)),
     undefined,
   )


### PR DESCRIPTION
`final-form` calls internal `state.blur()` method when `onBlur`, and make field non-`active`. I didn't dig so deep to understand how `active` relates to `meta.validating` property update.

Rough fix for that: don't call `state.blur()` immediately, wait for validation's end