### PR TITLE
Decrease size of Package in-memory representation

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -10,6 +10,7 @@
 # unreleased - YYYY-MM-DD
 ## Python API
 * [Added] Size of each manifest record is now limited by 1 MB. This constraint is added to ensure that S3 select, Athena and downstream services work correctly. This limit can be overridden with QUILT_MANIFEST_MAX_RECORD_SIZE environment variable. ([#2114](https://github.com/quiltdata/quilt/pull/2114))
+* [Changed] Decrease size of `Package` in-memory representation ([#1943](https://github.com/quiltdata/quilt/pull/1943))
 
 ## CLI
 


### PR DESCRIPTION
# Description
Bechmarked with this:

```python
from sys import getsizeof, stderr
from itertools import chain
from collections import deque
import reprlib
import operator

import quilt3


def total_size(o, handlers=None, f=stderr, verbose=False):
    """ Returns the approximate memory footprint an object and all of its contents.

    Automatically finds the contents of the following builtin containers and
    their subclasses:  tuple, list, deque, dict, set and frozenset.
    To search other containers, add handlers to iterate over their contents:

        handlers = {SomeContainerClass: iter,
                    OtherContainerClass: OtherContainerClass.get_elements}
    """
    dict_handler = lambda d: chain(d, d.items())
    all_handlers = {
        tuple: iter,
        list: iter,
        deque: iter,
        dict: dict_handler,
        set: iter,
        frozenset: iter,
        **(handlers or {}),
    }
    # track which object id's have already been seen
    seen = {}               
    # estimate sizeof object without __sizeof__
    default_size = getsizeof(None)       

    def sizeof(o):
        _id = id(o)
        if _id in seen:       # do not double count the same object
            return 0
        seen[_id] = o
        s = getsizeof(o, default_size)

        if verbose:
            print(s, type(o), reprlib.repr(o), file=f)

        for typ, handler in all_handlers.items():
            if isinstance(o, typ):
                s += sum(map(sizeof, handler(o)))
                break
        return s

    return sizeof(o), seen
    
    
total_size(
    quilt3.Package.browse(
        'aics/pipeline_integrated_single_cell', 
        registry='s3://allencell', 
        top_hash='7fd488f05ec41968607c7263cb13b3e70812972a24e832ef6f72195bdd35f1b2'
    ), 
    handlers={
        quilt3.Package: lambda p: (p.__dict__,), 
        quilt3.packages.PackageEntry: operator.attrgetter(*quilt3.packages.PackageEntry.__slots__),
        quilt3.util.PhysicalKey: operator.attrgetter(*quilt3.util.PhysicalKey.__slots__),
    }
)[0]
```

Before:
```
1066639992
```

After:
```
834581989
```

# TODO

<!-- Use <del></del> for items that are not required for this PR -->

- [x] <del>Unit tests</del>
- [x] <del>Documentation</del>
    - [x] <del>[Run `build.py`](../gendocs/build.py) for new docstrings</del>
- [x] [Changelog](CHANGELOG.md) entry
- [x] Add code comments
