### PR TITLE
Fix `copy_data`-based notification

### DIFF
--- a/catalog/app/containers/Bucket/PackageTree.js
+++ b/catalog/app/containers/Bucket/PackageTree.js
@@ -279,7 +279,7 @@ function DirDisplay({ bucket, name, hash, revision, path, crumbs, onRevisionPush
     onExited: onRevisionPush,
   })
 
-  const [bucketCopyTarget, setBucketCopyTarget] = React.useState(null)
+  const [successor, setSuccessor] = React.useState(null)
 
   usePrevious({ bucket, name, revision }, (prev) => {
     // close the dialog when navigating away
@@ -317,14 +317,14 @@ function DirDisplay({ bucket, name, hash, revision, path, crumbs, onRevisionPush
       }))
       return (
         <>
-          {bucketCopyTarget && (
+          {successor && (
             <PackageCopyDialog
               name={name}
-              targetBucket={bucketCopyTarget}
-              sourceBucket={bucket}
+              successor={successor}
+              bucket={bucket}
               hash={hash}
               onExited={onRevisionPush}
-              onClose={() => setBucketCopyTarget(null)}
+              onClose={() => setSuccessor(null)}
             />
           )}
 
@@ -341,7 +341,7 @@ function DirDisplay({ bucket, name, hash, revision, path, crumbs, onRevisionPush
               Revise package
             </M.Button>
             <M.Box ml={1} />
-            <CopyButton bucket={bucket} onChange={(b) => setBucketCopyTarget(b.slug)} />
+            <CopyButton bucket={bucket} onChange={setSuccessor} />
             {!noDownload && (
               <>
                 <M.Box ml={1} />

--- a/catalog/app/utils/workflows.js
+++ b/catalog/app/utils/workflows.js
@@ -21,16 +21,6 @@ export const emptyConfig = {
   workflows: [getNoWorkflow({}, false)],
 }
 
-export function shouldSuccessorCopyData(workflowsConfig, bucket) {
-  if (!workflowsConfig.successors || !workflowsConfig.successors.length)
-    return COPY_DATA_DEFAULT
-
-  const successor = R.find(R.propEq('slug', bucket), workflowsConfig.successors)
-  if (!successor) return COPY_DATA_DEFAULT
-
-  return successor.copyData
-}
-
 function parseSchema(schemaSlug, schemas) {
   return {
     url: R.path([schemaSlug, 'url'], schemas),

--- a/catalog/app/utils/workflows.js
+++ b/catalog/app/utils/workflows.js
@@ -17,7 +17,6 @@ function getNoWorkflow(data, hasConfig) {
 const COPY_DATA_DEFAULT = true
 
 export const emptyConfig = {
-  copyData: COPY_DATA_DEFAULT,
   successors: [],
   workflows: [getNoWorkflow({}, false)],
 }

--- a/catalog/app/utils/workflows.spec.js
+++ b/catalog/app/utils/workflows.spec.js
@@ -227,41 +227,5 @@ describe('utils/workflows', () => {
         ])
       })
     })
-
-    describe('shouldSuccessorCopyData', () => {
-      const data = dedent`
-        version: "1"
-        default_workflow: workflow_2
-        successors:
-          s3://something:
-            title: Successor №1
-            copy_data: True
-          s3://bucket-multiworded:
-            copy_data: False
-            title: Multi worded bucket
-          s3://bucket-copy-default:
-            title: Copy default
-        workflows:
-          workflow_1:
-            name: Workflow №1
-      `
-      const config = workflows.parse(data)
-
-      it('should return true when bucket is not found', () => {
-        expect(workflows.shouldSuccessorCopyData(config, 'fgsfds')).toBe(true)
-      })
-
-      it('should return true when copy_data is not specified', () => {
-        expect(workflows.shouldSuccessorCopyData(config, 'bucket-copy-default')).toBe(
-          true,
-        )
-      })
-
-      it('should return correct value when value set', () => {
-        expect(workflows.shouldSuccessorCopyData(config, 'bucket-multiworded')).toBe(
-          false,
-        )
-      })
-    })
   })
 })


### PR DESCRIPTION
Since `copy_data` is successor scoped rather that config scoped, I passed successor (`{ copy_data, name, slug }`) to the `PackageCopyDialog`.
I changed props for PackageCopyDialog from `sourceBucket/targetBucket` to `bucket/successor` since I need not only URL-friendly bucket's slug but additional info (`copyData`)
Also removed `shouldSuccessorCopyData` function and corresponding unit-test