### PR TITLE
Return initial state on useData call with new params 

### DIFF
--- a/catalog/app/utils/usePrevious.js
+++ b/catalog/app/utils/usePrevious.js
@@ -1,5 +1,9 @@
 import * as React from 'react'
 
+/**
+ * Fire onChange callback with previous value and memoize current value
+ * TODO: explain why `useEffect`
+ */
 export default (value, onChange) => {
   const ref = React.useRef()
   React.useEffect(() => {

--- a/catalog/app/utils/usePreviousSync.js
+++ b/catalog/app/utils/usePreviousSync.js
@@ -1,0 +1,13 @@
+import * as React from 'react'
+
+/**
+ * Fire callback synchronously with previous value and memoize current value
+ */
+export default function usePreviousSync(value, callback) {
+  const ref = React.useRef()
+
+  if (callback) callback(ref.current)
+
+  ref.current = value
+  return ref.current
+}

--- a/catalog/app/utils/usePreviousSync.spec.js
+++ b/catalog/app/utils/usePreviousSync.spec.js
@@ -1,0 +1,52 @@
+import * as React from 'react'
+import { act, renderHook } from '@testing-library/react-hooks'
+
+import usePreviousSync from './usePreviousSync'
+
+describe('utils/usePreviousSync', () => {
+  it('should return the same value', () => {
+    const initialValue = { initial: 'value' }
+
+    const { result } = renderHook(() => usePreviousSync(initialValue))
+
+    expect(result.current).toBe(initialValue)
+  })
+
+  it('should callback with previous value', () => {
+    const initialValue = { initial: 'value' }
+
+    const useTestCase = (input) => {
+      const prevValueRef = React.useRef()
+      const [value, updateValue] = React.useState(input)
+
+      usePreviousSync(value, (prev) => {
+        prevValueRef.current = prev
+      })
+
+      return {
+        value,
+        updateValue,
+        prevValueRef,
+      }
+    }
+
+    const { result } = renderHook(() => useTestCase(initialValue))
+
+    expect(result.current.value).toBe(initialValue)
+    expect(result.current.prevValueRef.current).toBe(undefined)
+
+    act(() => {
+      result.current.updateValue('next value')
+    })
+
+    expect(result.current.value).toBe('next value')
+    expect(result.current.prevValueRef.current).toBe(initialValue)
+
+    act(() => {
+      result.current.updateValue('third value to be sure')
+    })
+
+    expect(result.current.value).toBe('third value to be sure')
+    expect(result.current.prevValueRef.current).toBe('next value')
+  })
+})

--- a/catalog/package-lock.json
+++ b/catalog/package-lock.json
@@ -2326,6 +2326,27 @@
         "@testing-library/dom": "^7.17.1"
       }
     },
+    "@testing-library/react-hooks": {
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/@testing-library/react-hooks/-/react-hooks-3.6.0.tgz",
+      "integrity": "sha512-7TbqFN4CqEmfR6bC50XOtXbM3A5sizzEOmcH7IBVdm0oFnqmlkPTnu4sMt9BfepsYDvVpF8Y2CaoMJlfmyLYuQ==",
+      "dev": true,
+      "requires": {
+        "@babel/runtime": "^7.12.5",
+        "@types/testing-library__react-hooks": "^3.4.0"
+      },
+      "dependencies": {
+        "@babel/runtime": {
+          "version": "7.12.5",
+          "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.12.5.tgz",
+          "integrity": "sha512-plcc+hbExy3McchJCEQG3knOsuh3HH+Prx1P6cLIkET/0dLuQDEnrT+s27Axgc9bqfsmNUNHfscgMUdBpC9xfg==",
+          "dev": true,
+          "requires": {
+            "regenerator-runtime": "^0.13.4"
+          }
+        }
+      }
+    },
     "@types/anymatch": {
       "version": "1.3.1",
       "resolved": "https://registry.npmjs.org/@types/anymatch/-/anymatch-1.3.1.tgz",
@@ -2551,6 +2572,15 @@
         }
       }
     },
+    "@types/react-test-renderer": {
+      "version": "17.0.0",
+      "resolved": "https://registry.npmjs.org/@types/react-test-renderer/-/react-test-renderer-17.0.0.tgz",
+      "integrity": "sha512-nvw+F81OmyzpyIE1S0xWpLonLUZCMewslPuA8BtjSKc5XEbn8zEQBXS7KuOLHTNnSOEM2Pum50gHOoZ62tqTRg==",
+      "dev": true,
+      "requires": {
+        "@types/react": "*"
+      }
+    },
     "@types/react-transition-group": {
       "version": "4.4.0",
       "resolved": "https://registry.npmjs.org/@types/react-transition-group/-/react-transition-group-4.4.0.tgz",
@@ -2607,6 +2637,15 @@
       "resolved": "https://registry.npmjs.org/@types/tapable/-/tapable-1.0.6.tgz",
       "integrity": "sha512-W+bw9ds02rAQaMvaLYxAbJ6cvguW/iJXNT6lTssS1ps6QdrMKttqEAMEG/b5CR8TZl3/L7/lH0ZV5nNR1LXikA==",
       "dev": true
+    },
+    "@types/testing-library__react-hooks": {
+      "version": "3.4.1",
+      "resolved": "https://registry.npmjs.org/@types/testing-library__react-hooks/-/testing-library__react-hooks-3.4.1.tgz",
+      "integrity": "sha512-G4JdzEcq61fUyV6wVW9ebHWEiLK2iQvaBuCHHn9eMSbZzVh4Z4wHnUGIvQOYCCYeu5DnUtFyNYuAAgbSaO/43Q==",
+      "dev": true,
+      "requires": {
+        "@types/react-test-renderer": "*"
+      }
     },
     "@types/through": {
       "version": "0.0.30",

--- a/catalog/package.json
+++ b/catalog/package.json
@@ -143,6 +143,7 @@
     "@babel/preset-env": "^7.11.0",
     "@babel/preset-react": "^7.10.4",
     "@babel/register": "^7.10.5",
+    "@testing-library/react-hooks": "^3.6.0",
     "babel-eslint": "^10.1.0",
     "babel-loader": "^8.1.0",
     "babel-plugin-dynamic-import-node": "^2.3.3",


### PR DESCRIPTION
`useData` has internal state management. When you pass new params into `useData`
1. state is preserved for a moment
2. returns the previous state
3. then will change according to new params and returns a new result

This leads to the incorrect result, reproduced at #1953

---

Fix contains a workaround: `useData` returns initial state on passing new params