### PR TITLE
.gitignore: add node_modules and ipynb-styling subrepos for eslint

### DIFF
--- a/catalog/.gitignore
+++ b/catalog/.gitignore
@@ -1,3 +1,7 @@
+node_modules
+ipynb-styling/notebook
+ipynb-styling/pygments-css
+
 # Don't check auto-generated stuff into git
 coverage
 build


### PR DESCRIPTION
ESLint reuses .gitignore, so we need to add stuff from ipynb-styling there for ESLint to ignore it, bc it hangs up trying to lint some built artefacts 

