### PR TITLE
Set fixed width for JsonEditor's columns

### DIFF
--- a/catalog/app/components/JsonEditor/Column.js
+++ b/catalog/app/components/JsonEditor/Column.js
@@ -17,6 +17,10 @@ const useStyles = M.makeStyles((t) => ({
     position: 'relative',
     width: '100%',
   },
+
+  table: {
+    tableLayout: 'fixed',
+  },
 }))
 
 function getColumntType(columnPath, jsonDict, parent) {
@@ -107,7 +111,7 @@ export default function Column({
       {!!columnPath.length && <Breadcrumbs items={columnPath} onSelect={onBreadcrumb} />}
 
       <M.TableContainer>
-        <M.Table {...getTableProps()}>
+        <M.Table {...getTableProps({ className: classes.table })}>
           <M.TableBody {...getTableBodyProps()}>
             {rows.map((row, index) => {
               const isLastRow = index === rows.length - 1

--- a/catalog/app/components/JsonEditor/Preview.js
+++ b/catalog/app/components/JsonEditor/Preview.js
@@ -27,7 +27,6 @@ const useStyles = M.makeStyles((t) => ({
     height: t.spacing(4),
     lineHeight: `${t.spacing(4) - 2}px`,
     marginRight: t.spacing(1),
-    maxWidth: t.spacing(35),
     overflow: 'hidden',
     textOverflow: 'ellipsis',
     whiteSpace: 'nowrap',

--- a/catalog/app/components/JsonEditor/Row.js
+++ b/catalog/app/components/JsonEditor/Row.js
@@ -10,10 +10,10 @@ const useStyles = M.makeStyles((t) => ({
     padding: 0,
   },
   key: {
-    width: t.spacing(20),
+    width: t.spacing(28),
   },
   value: {
-    width: t.spacing(49),
+    width: t.spacing(40),
   },
 }))
 

--- a/catalog/app/components/JsonEditor/Row.js
+++ b/catalog/app/components/JsonEditor/Row.js
@@ -10,7 +10,7 @@ const useStyles = M.makeStyles((t) => ({
     padding: 0,
   },
   key: {
-    width: t.spacing(28),
+    width: t.spacing(27),
   },
   value: {
     width: t.spacing(40),


### PR DESCRIPTION
* Set fixed layout, so the table will not stretch
* Adjust column widths (maybe they should be even equal)
* Remove `maxWidth` for inner component, it is useless