### PR TITLE
Limit JsonEditor height, small refactoring

### DIFF
--- a/catalog/app/components/JsonEditor/Column.js
+++ b/catalog/app/components/JsonEditor/Column.js
@@ -19,7 +19,7 @@ const useStyles = M.makeStyles((t) => ({
   },
 }))
 
-function getColumntType(columnPath, jsonDict, parent) {
+function getColumnType(columnPath, jsonDict, parent) {
   const columnSchema = getJsonDictValue(columnPath, jsonDict)
   if (!parent) return columnSchema.type
 
@@ -92,7 +92,7 @@ export default function Column({
   })
   const { getTableProps, getTableBodyProps, rows, prepareRow } = tableInstance
 
-  const columnType = getColumntType(columnPath, jsonDict, data.parent)
+  const columnType = getColumnType(columnPath, jsonDict, data.parent)
 
   const onAddRowInternal = React.useCallback(
     (...params) => {

--- a/catalog/app/components/JsonEditor/JsonEditor.js
+++ b/catalog/app/components/JsonEditor/JsonEditor.js
@@ -67,7 +67,7 @@ function JsonEditor({
   )
 
   const columnData = R.last(columns)
-  const columnPath = R.slice(0, columns.length - 1, fieldPath)
+  const columnPath = R.take(columns.length - 1, fieldPath)
 
   return (
     <div className={cx({ [classes.disabled]: disabled }, className)}>

--- a/catalog/app/components/JsonEditor/JsonEditor.js
+++ b/catalog/app/components/JsonEditor/JsonEditor.js
@@ -70,27 +70,25 @@ function JsonEditor({
     [changeValue, onChange],
   )
 
+  const columnData = R.last(newColumns)
+  const columnPath = R.slice(0, newColumns.length - 1, fieldPath)
+
   return (
     <div className={cx({ [classes.disabled]: disabled }, className)}>
       <div className={classes.inner}>
-        {newColumns.map((columnData, index) => {
-          const columnPath = R.slice(0, index, fieldPath)
-          return (
-            <Column
-              {...{
-                columnPath,
-                data: columnData,
-                jsonDict,
-                key: columnPath,
-                onAddRow: addRow,
-                onBreadcrumb: setFieldPath,
-                onExpand: setFieldPath,
-                onMenuAction,
-                onChange: onChangeInternal,
-              }}
-            />
-          )
-        })}
+        <Column
+          {...{
+            columnPath,
+            data: columnData,
+            jsonDict,
+            key: columnPath,
+            onAddRow: addRow,
+            onBreadcrumb: setFieldPath,
+            onExpand: setFieldPath,
+            onMenuAction,
+            onChange: onChangeInternal,
+          }}
+        />
       </div>
 
       <Errors className={classes.errors} errors={error || errors} />

--- a/catalog/app/components/JsonEditor/JsonEditor.js
+++ b/catalog/app/components/JsonEditor/JsonEditor.js
@@ -67,17 +67,16 @@ function JsonEditor({
   )
 
   const columnData = R.last(columns)
-  const columnPath = R.take(columns.length - 1, fieldPath)
 
   return (
     <div className={cx({ [classes.disabled]: disabled }, className)}>
       <div className={classes.inner}>
         <Column
           {...{
-            columnPath,
+            columnPath: fieldPath,
             data: columnData,
             jsonDict,
-            key: columnPath,
+            key: fieldPath,
             onAddRow: addRow,
             onBreadcrumb: setFieldPath,
             onExpand: setFieldPath,

--- a/catalog/app/components/JsonEditor/JsonEditor.js
+++ b/catalog/app/components/JsonEditor/JsonEditor.js
@@ -35,7 +35,7 @@ function JsonEditor({
   changeValue,
   className,
   disabled,
-  newColumns,
+  columns,
   jsonDict,
   error,
   errors,
@@ -66,8 +66,8 @@ function JsonEditor({
     [changeValue, onChange],
   )
 
-  const columnData = R.last(newColumns)
-  const columnPath = R.slice(0, newColumns.length - 1, fieldPath)
+  const columnData = R.last(columns)
+  const columnPath = R.slice(0, columns.length - 1, fieldPath)
 
   return (
     <div className={cx({ [classes.disabled]: disabled }, className)}>

--- a/catalog/app/components/JsonEditor/JsonEditor.js
+++ b/catalog/app/components/JsonEditor/JsonEditor.js
@@ -25,7 +25,7 @@ const useStyles = M.makeStyles((t) => ({
   },
   inner: {
     display: 'flex',
-    maxHeight: t.spacing(45),
+    maxHeight: t.spacing(46),
     overflow: 'auto',
   },
 }))

--- a/catalog/app/components/JsonEditor/JsonEditor.js
+++ b/catalog/app/components/JsonEditor/JsonEditor.js
@@ -20,17 +20,13 @@ const useStyles = M.makeStyles((t) => ({
       top: 0,
     },
   },
-  inner: {
-    display: 'flex',
-    overflowX: 'auto',
-    MsOverflowStyle: 'none',
-    scrollbarWidth: 'none',
-    '&::-webkit-scrollbar': {
-      display: 'none',
-    },
-  },
   errors: {
     marginTop: t.spacing(1),
+  },
+  inner: {
+    display: 'flex',
+    maxHeight: t.spacing(45),
+    overflow: 'auto',
   },
 }))
 

--- a/catalog/app/components/JsonEditor/State.js
+++ b/catalog/app/components/JsonEditor/State.js
@@ -356,7 +356,7 @@ export default function JsonEditorState({ children, obj, optSchema }) {
 
   // NOTE: this data represents table columns shown to user
   //       it's the main source of UI data
-  const newColumns = React.useMemo(
+  const columns = React.useMemo(
     () => iterateJsonDict(jsonDict, data, fieldPath, rootKeys),
     [data, jsonDict, fieldPath, rootKeys],
   )
@@ -464,7 +464,7 @@ export default function JsonEditorState({ children, obj, optSchema }) {
   return children({
     addRow,
     changeValue,
-    newColumns,
+    columns,
     jsonDict,
     errors,
     fieldPath,


### PR DESCRIPTION
Current behavior:
* JsonEditor renders all columns
* only the last one is in the viewport
* rest columns are hidden by CSS (overflow + scrolls, but scrollbars are invisible)

Changed behavior:
* JsonEditor renders current column only
* JsonEditor is limited by height (enough to fit the whole Dialog into 1920x1080)
* Vertical scrollbar is visible