### PR TITLE
Prevent possible downloading of truncated file

### DIFF
--- a/api/python/quilt3/data_transfer.py
+++ b/api/python/quilt3/data_transfer.py
@@ -808,7 +808,9 @@ def copy_file(src: PhysicalKey, dest: PhysicalKey, size=None, message=None, call
         if _looks_like_dir(dest):
             dest = dest.join(src.basename())
         if size is None:
-            size, _ = get_size_and_version(src)
+            size, version_id = get_size_and_version(src)
+            if src.version_id is None:
+                src = PhysicalKey(src.bucket, src.path, version_id)
         url_list.append((src, dest, size))
 
     _copy_file_list_internal(url_list, [None] * len(url_list), message, callback)

--- a/api/python/tests/integration/test_packages.py
+++ b/api/python/tests/integration/test_packages.py
@@ -131,6 +131,7 @@ class PackageTest(QuiltTestCase):
                 },
                 expected_params={
                     'Bucket': pkg_registry.root.bucket,
+                    'VersionId': 'v1',
                     'Key': pkg_registry.manifest_pk(pkg_name, top_hash).path,
                 }
             )

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -11,6 +11,7 @@
 ## Python API
 * [Added] `QUILT_TRANSFER_MAX_CONCURRENCY` environment variable ([#2092](https://github.com/quiltdata/quilt/pull/2092))
 * [Changed] Removed unused dependency on `packaging` ([#2090](https://github.com/quiltdata/quilt/pull/2090))
+* [Fixed] Possible downloading of truncated manifests ([#1977](https://github.com/quiltdata/quilt/pull/1977))
 
 ## CLI
 


### PR DESCRIPTION
# Description
If file is modified after we getting its size with `head_object`, the truncated file will be downloaded.


# TODO

<!-- Use <del></del> for items that are not required for this PR -->

- [x] Unit tests
- [x] <del>Documentation</del>
    - [x] <del>[Run `build.py`](../gendocs/build.py) for new docstrings</del>
- [x] [Changelog](CHANGELOG.md) entry
