### PR TITLE
Fix Search Help code samples color

### DIFF
--- a/catalog/app/components/Preview/renderers/util.js
+++ b/catalog/app/components/Preview/renderers/util.js
@@ -14,7 +14,7 @@ const useMsgStyles = M.makeStyles((t) => ({
     overflow: 'auto',
   },
   info: {
-    background: t.palette.info.light,
+    background: t.palette.info.main,
     color: t.palette.info.contrastText,
   },
   warning: {

--- a/catalog/app/containers/NavBar/Help.js
+++ b/catalog/app/containers/NavBar/Help.js
@@ -153,7 +153,7 @@ const useCodeStyles = M.makeStyles((t) => ({
   root: {
     background: t.palette.grey[300],
     borderRadius: '2px',
-    color: t.palette.info.contrastText,
+    color: t.palette.text.primary,
     fontFamily: t.typography.monospace.fontFamily,
     padding: '0 3px',
     whiteSpace: 'pre-wrap',


### PR DESCRIPTION
![Screenshot from 2020-12-10 17-47-19](https://user-images.githubusercontent.com/533229/101788126-d8569300-3b10-11eb-8b66-8a844b27d20b.png)

Bug introduced when palette color was changed here https://github.com/quiltdata/quilt/commit/7e9d55e87337b394486b4e1b95571f7d6681e217#diff-2ed22fdab5adaa5e8a227ab73e252f19321d01d1828ed3fd36a68ca4b3a57b8cL15

`textContrast` is calculated from `main` color https://github.com/mui-org/material-ui/blob/417a446ef66d036a1d6129cda8a115c4df0ffe62/packages/material-ui/src/styles/createPalette.js#L196

---

`info.contrastText` is used by `<Msg />`, but it seems that `<Msg type="info" />` is never appears, and I can't test it in the wild.