### PR TITLE
Backend-specific subclasses of PhysicalKey

### DIFF
--- a/api/python/quilt3/backends/local.py
+++ b/api/python/quilt3/backends/local.py
@@ -1,11 +1,106 @@
 import operator
 import os
+import pathlib
 import shutil
 from datetime import datetime
+from urllib.parse import urlunparse
+from urllib.request import pathname2url
 
-from quilt3.data_transfer import delete_url
+from quilt3.util import PhysicalKey
 
 from .base import PackageRegistryV1, PackageRegistryV2
+
+
+class LocalPhysicalKey(PhysicalKey):
+    __slots__ = ('path',)
+    bucket = None
+    version_id = None
+
+    def __init__(self, path):
+        assert isinstance(path, str)
+        if os.name == 'nt':
+            assert '\\' not in path, "Paths must use / as a separator"
+
+        self.path = path
+
+    @classmethod
+    def from_path(cls, path):
+        path = os.fspath(path)
+        new_path = os.path.realpath(path)
+        # Use '/' as the path separator.
+        if os.path.sep != '/':
+            new_path = new_path.replace(os.path.sep, '/')
+        # Add back a trailing '/' if the original path has it.
+        if (path.endswith(os.path.sep) or
+           (os.path.altsep is not None and path.endswith(os.path.altsep))):
+            new_path += '/'
+        return cls(new_path)
+
+    def __eq__(self, other):
+        return (
+            isinstance(other, self.__class__) and
+            self.path == other.path
+        )
+
+    def __repr__(self):
+        return f'{self.__class__.__name__}({self.path!r})'
+
+    def __str__(self):
+        if self.bucket is None:
+            return urlunparse(('file', '', pathname2url(self.path.replace('/', os.path.sep)), None, None, None))
+
+    def __fspath__(self):
+        return self.path
+
+    def join(self, rel_path):
+        if os.name == 'nt' and '\\' in rel_path:
+            raise ValueError("Paths must use / as a separator")
+
+        new_path = self.path.rstrip('/') + '/' + rel_path.lstrip('/')
+        return self.__class__(new_path)
+
+    def is_local(self):
+        return True
+
+    def _put_bytes(self, data):
+        dest_file = pathlib.Path(self)
+        dest_file.parent.mkdir(parents=True, exist_ok=True)
+        dest_file.write_bytes(data)
+
+    def get_bytes(self):
+        return pathlib.Path(self).read_bytes()
+
+    def list_url(self):
+        src_file = pathlib.Path(self)
+
+        for f in src_file.rglob('*'):
+            try:
+                if f.is_file():
+                    size = f.stat().st_size
+                    yield f.relative_to(src_file).as_posix(), size
+            except FileNotFoundError:
+                # If a file does not exist, is it really a file?
+                pass
+
+    def delete_url(self):
+        """Deletes the given URL.
+        Follows S3 semantics even for local files:
+        - If the URL does not exist, it's a no-op.
+        - If it's a non-empty directory, it's also a no-op.
+        """
+        src_file = pathlib.Path(self)
+
+        try:
+            if src_file.is_dir():
+                try:
+                    src_file.rmdir()
+                except OSError:
+                    # Ignore non-empty directories, for consistency with S3
+                    pass
+            else:
+                src_file.unlink()
+        except FileNotFoundError:
+            pass
 
 
 def safe_listdir(path):
@@ -33,8 +128,8 @@ class LocalPackageRegistryV1(PackageRegistryV1):
 
     def delete_package_version(self, pkg_name: str, top_hash: str):
         super().delete_package_version(pkg_name, top_hash)
-        delete_url(self.pointers_dir(pkg_name))
-        delete_url(self._pointers_usr_dir(pkg_name))
+        self.pointers_dir(pkg_name).delete_url()
+        self._pointers_usr_dir(pkg_name).delete_url()
 
 
 class LocalPackageRegistryV2(PackageRegistryV2):
@@ -61,8 +156,8 @@ class LocalPackageRegistryV2(PackageRegistryV2):
     def delete_package_version(self, pkg_name: str, top_hash: str):
         shutil.rmtree(self._manifest_parent_pk(pkg_name, top_hash).path)
         super().delete_package_version(pkg_name, top_hash)
-        delete_url(self.pointers_dir(pkg_name))
-        delete_url(self.manifests_package_dir(pkg_name))
+        self.pointers_dir(pkg_name).delete_url()
+        self.manifests_package_dir(pkg_name).delete_url()
 
 
 def get_package_registry(version: int):

--- a/api/python/quilt3/backends/s3.py
+++ b/api/python/quilt3/backends/s3.py
@@ -1,7 +1,281 @@
-from quilt3.data_transfer import S3Api, S3ClientProvider, get_bytes, list_url
+import os
+from enum import Enum
+from urllib.parse import quote, urlencode, urlunparse
+
+import boto3
+from botocore import UNSIGNED
+from botocore.config import Config
+from botocore.exceptions import ClientError
+from s3transfer.utils import signal_not_transferring, signal_transferring
+
+from quilt3.session import create_botocore_session
 from quilt3.util import PhysicalKey
 
 from .base import PackageRegistryV1, PackageRegistryV2
+
+
+class S3Api(Enum):
+    GET_OBJECT = "GET_OBJECT"
+    HEAD_OBJECT = "HEAD_OBJECT"
+    LIST_OBJECT_VERSIONS = "LIST_OBJECT_VERSIONS"
+    LIST_OBJECTS_V2 = "LIST_OBJECTS_V2"
+
+
+class S3NoValidClientError(Exception):
+    def __init__(self, message, **kwargs):
+        # We use NewError("Prefix: " + str(error)) a lot.
+        # To be consistent across Python 2.7 and 3.x:
+        # 1) This `super` call must exist, or 2.7 will have no text for str(error)
+        # 2) This `super` call must have only one argument (the message) or str(error) will be a repr of args
+        super().__init__(message)
+        self.message = message
+        for k, v in kwargs.items():
+            setattr(self, k, v)
+
+
+class S3ClientProvider:
+    """
+    An s3_client is either signed with standard credentials or unsigned. This class exists to dynamically provide the
+    correct s3 client (either standard_client or unsigned_client) for a bucket. This means if standard credentials
+    can't read from the bucket, check if the bucket is public in which case we should be using an unsigned client.
+    This check is expensive at scale so the class also keeps track of which client to use for each bucket+api_call.
+
+    If there are no credentials available at all (i.e. you don't have AWS credentials and you don't have a
+    Quilt-provided role from quilt3.login()), the standard client will also be unsigned so that users can still
+    access public s3 buckets.
+
+    We assume that public buckets are read-only: write operations should always use S3ClientProvider.standard_client
+    """
+
+    def __init__(self):
+        self._use_unsigned_client = {}  # f'{action}/{bucket}' -> use_unsigned_client_bool
+        self._standard_client = None
+        self._unsigned_client = None
+
+    @property
+    def standard_client(self):
+        if self._standard_client is None:
+            self._build_standard_client()
+        return self._standard_client
+
+    @property
+    def unsigned_client(self):
+        if self._unsigned_client is None:
+            self._build_unsigned_client()
+        return self._unsigned_client
+
+    def get_correct_client(self, action: S3Api, bucket: str):
+        if not self.client_type_known(action, bucket):
+            raise RuntimeError("get_correct_client was called, but the correct client type is not known. Only call "
+                               "get_correct_client() after checking if client_type_known()")
+
+        if self.should_use_unsigned_client(action, bucket):
+            return self.unsigned_client
+        else:
+            return self.standard_client
+
+    def key(self, action: S3Api, bucket: str):
+        return f"{action}/{bucket}"
+
+    def set_cache(self, action: S3Api, bucket: str, use_unsigned: bool):
+        self._use_unsigned_client[self.key(action, bucket)] = use_unsigned
+
+    def should_use_unsigned_client(self, action: S3Api, bucket: str):
+        # True if should use unsigned, False if should use standard, None if don't know yet
+        return self._use_unsigned_client.get(self.key(action, bucket))
+
+    def client_type_known(self, action: S3Api, bucket: str):
+        return self.should_use_unsigned_client(action, bucket) is not None
+
+    def find_correct_client(self, api_type, bucket, param_dict):
+        if self.client_type_known(api_type, bucket):
+            return self.get_correct_client(api_type, bucket)
+        else:
+            check_fn_mapper = {
+                S3Api.GET_OBJECT: check_get_object_works_for_client,
+                S3Api.HEAD_OBJECT: check_head_object_works_for_client,
+                S3Api.LIST_OBJECTS_V2: check_list_objects_v2_works_for_client,
+                S3Api.LIST_OBJECT_VERSIONS: check_list_object_versions_works_for_client
+            }
+            assert api_type in check_fn_mapper.keys(), f"Only certain APIs are supported with unsigned_client. The " \
+                f"API '{api_type}' is not current supported. You may want to use S3ClientProvider.standard_client " \
+                f"instead "
+            check_fn = check_fn_mapper[api_type]
+            if check_fn(self.standard_client, param_dict):
+                self.set_cache(api_type, bucket, use_unsigned=False)
+                return self.standard_client
+            else:
+                if check_fn(self.unsigned_client, param_dict):
+                    self.set_cache(api_type, bucket, use_unsigned=True)
+                    return self.unsigned_client
+                else:
+                    raise S3NoValidClientError(f"S3 AccessDenied for {api_type} on bucket: {bucket}")
+
+    def get_boto_session(self):
+        botocore_session = create_botocore_session()
+        boto_session = boto3.Session(botocore_session=botocore_session)
+        return boto_session
+
+    def register_signals(self, s3_client):
+        # Enable/disable file read callbacks when uploading files.
+        # Copied from https://github.com/boto/s3transfer/blob/develop/s3transfer/manager.py#L501
+        event_name = 'request-created.s3'
+        s3_client.meta.events.register_first(
+                event_name, signal_not_transferring,
+                unique_id='datatransfer-not-transferring')
+        s3_client.meta.events.register_last(
+                event_name, signal_transferring,
+                unique_id='datatransfer-transferring')
+
+    def _build_client(self, get_config):
+        session = self.get_boto_session()
+        return session.client('s3', config=get_config(session))
+
+    def _build_standard_client(self):
+        s3_client = self._build_client(
+            lambda session:
+                Config(signature_version=UNSIGNED)
+                if session.get_credentials() is None
+                else None
+        )
+        self.register_signals(s3_client)
+        self._standard_client = s3_client
+
+    def _build_unsigned_client(self):
+        s3_client = self._build_client(lambda session: Config(signature_version=UNSIGNED))
+        self.register_signals(s3_client)
+        self._unsigned_client = s3_client
+
+
+def check_list_object_versions_works_for_client(s3_client, params):
+    try:
+        s3_client.list_object_versions(**params, MaxKeys=1)  # Make this as fast as possible
+    except ClientError as e:
+        return e.response["Error"]["Code"] != "AccessDenied"
+    return True
+
+
+def check_list_objects_v2_works_for_client(s3_client, params):
+    try:
+        s3_client.list_objects_v2(**params, MaxKeys=1)  # Make this as fast as possible
+    except ClientError as e:
+        if e.response["Error"]["Code"] == "AccessDenied":
+            return False
+    return True
+
+
+def check_get_object_works_for_client(s3_client, params):
+    try:
+        head_args = dict(
+                Bucket=params["Bucket"],
+                Key=params["Key"]
+        )
+        if "VersionId" in params:
+            head_args["VersionId"] = params["VersionId"]
+
+        s3_client.head_object(**head_args)  # HEAD/GET share perms, but HEAD always fast
+    except ClientError as e:
+        if e.response["Error"]["Code"] == "403":
+            # This can also happen if you have full get_object access, but not list_objects_v2, and the object does not
+            # exist. Instead of returning a 404, S3 will return a 403.
+            return False
+
+    return True
+
+
+def check_head_object_works_for_client(s3_client, params):
+    try:
+        s3_client.head_object(**params)
+    except ClientError as e:
+        if e.response["Error"]["Code"] == "403":
+            # This can also happen if you have full get_object access, but not list_objects_v2, and the object does not
+            # exist. Instead of returning a 404, S3 will return a 403.
+            return False
+    return True
+
+
+class S3PhysicalKey(PhysicalKey):
+    __slots__ = ('bucket', 'path', 'version_id')
+
+    def __init__(self, bucket, path, version_id):
+        assert bucket is None or isinstance(bucket, str)
+        assert isinstance(path, str)
+        assert not path.startswith('/'), "S3 paths must not start with '/'"
+        assert version_id is None or isinstance(version_id, str)
+
+        self.bucket = bucket
+        self.path = path
+        self.version_id = version_id
+
+    def __eq__(self, other):
+        return (
+            isinstance(other, self.__class__) and
+            self.bucket == other.bucket and
+            self.path == other.path and
+            self.version_id == other.version_id
+        )
+
+    def __repr__(self):
+        return f'{self.__class__.__name__}({self.bucket!r}, {self.path!r}, {self.version_id!r})'
+
+    def __str__(self):
+        if self.version_id is None:
+            params = {}
+        else:
+            params = {'versionId': self.version_id}
+        return urlunparse(('s3', self.bucket, quote(self.path), None, urlencode(params), None))
+
+    def join(self, rel_path):
+        if self.version_id is not None:
+            raise ValueError('Cannot append paths to URLs with a version ID')
+
+        if os.name == 'nt' and '\\' in rel_path:
+            raise ValueError("Paths must use / as a separator")
+
+        if self.path:
+            new_path = self.path.rstrip('/') + '/' + rel_path.lstrip('/')
+        else:
+            new_path = rel_path.lstrip('/')
+
+        return self.__class__(self.bucket, new_path, None)
+
+    def _s3_query_object(self, *, head=False):
+        params = dict(Bucket=self.bucket, Key=self.path)
+        if self.version_id is not None:
+            params.update(VersionId=self.version_id)
+        s3_client = S3ClientProvider().find_correct_client(
+            S3Api.HEAD_OBJECT if head else S3Api.GET_OBJECT, self.bucket, params)
+        return (s3_client.head_object if head else s3_client.get_object)(**params)
+
+    def get_bytes(self):
+        return self._s3_query_object()['Body'].read()
+
+    def _put_bytes(self, data):
+        if self.version_id is not None:
+            raise ValueError("Cannot set VersionId on destination")
+        s3_client = S3ClientProvider().standard_client
+        s3_client.put_object(
+            Bucket=self.bucket,
+            Key=self.path,
+            Body=data,
+        )
+
+    def list_url(self):
+        if self.version_id is not None:
+            raise ValueError(f"Directories cannot have version IDs: {self}")
+        src_path = self.path
+        if not self._looks_like_dir():
+            src_path += '/'
+        for response in s3_list_objects(Bucket=self.bucket, Prefix=src_path):
+            for obj in response.get('Contents', []):
+                key = obj['Key']
+                if not key.startswith(src_path):
+                    raise ValueError("Unexpected key: %r" % key)
+                yield key[len(src_path):], obj['Size']
+
+    def delete_url(self):
+        s3_client = S3ClientProvider().standard_client
+        s3_client.delete_object(Bucket=self.bucket, Key=self.path)
 
 
 def s3_list_objects(**kwargs):
@@ -19,7 +293,7 @@ def delete_url_recursively(src: PhysicalKey):
 class S3PackageRegistryV1(PackageRegistryV1):
     def list_packages(self):
         prev_pkg = None
-        for path, _ in list_url(self.pointers_global_dir):
+        for path, _ in self.pointers_global_dir.list_url():
             pkg = path.rpartition('/')[0]
             # A package can have multiple versions, but we should only return the name once.
             if pkg != prev_pkg:
@@ -28,8 +302,8 @@ class S3PackageRegistryV1(PackageRegistryV1):
 
     def list_package_pointers(self, pkg_name: str):
         package_dir = self.pointers_dir(pkg_name)
-        for path, _ in list_url(package_dir):
-            pkg_hash = get_bytes(package_dir.join(path))
+        for path, _ in package_dir.list_url():
+            pkg_hash = package_dir.join(path).get_bytes()
             yield path, pkg_hash.decode().strip()
 
     def delete_package(self, pkg_name: str):

--- a/api/python/tests/integration/test_workflows.py
+++ b/api/python/tests/integration/test_workflows.py
@@ -5,7 +5,6 @@ from tests.utils import QuiltTestCase
 
 from quilt3 import workflows
 from quilt3.backends import get_package_registry
-from quilt3.data_transfer import put_bytes
 from quilt3.util import PhysicalKey, QuiltException
 
 
@@ -15,12 +14,12 @@ def get_v1_conf_data(conf_data):
 
 
 def set_local_conf_data(conf_data):
-    put_bytes(conf_data.encode(), get_package_registry().workflow_conf_pk)
+    get_package_registry().workflow_conf_pk.put_bytes(conf_data.encode())
 
 
 def create_local_tmp_schema(data):
     pk = get_package_registry().root.join('schemas/schema')
-    put_bytes(data.encode(), pk)
+    pk.put_bytes(data.encode())
     return pk
 
 


### PR DESCRIPTION
# Description
This change is mostly for avoiding annoying `if pk.is_local()` and to ease addition of new backends when/if we decide to do it.

This is a POC, I'll finish it if this change is generally approved.

# TODO

<!-- Use <del></del> for items that are not required for this PR -->

- [ ] Unit tests
- [ ] Documentation
    - [ ] [Run `build.py`](../gendocs/build.py) for new docstrings
- [ ] [Changelog](CHANGELOG.md) entry
