### PR TITLE
Handle delete markers for objects in ES

### DIFF
--- a/catalog/app/components/SearchResults/SearchResults.js
+++ b/catalog/app/components/SearchResults/SearchResults.js
@@ -236,7 +236,11 @@ function VersionInfo({ bucket, path, version, versions }) {
               {' from '}
               <Bold>{v.updated.toLocaleString()}</Bold>
               {' | '}
-              <Bold>{readableBytes(v.size)}</Bold>
+              {v.deleteMarker ? (
+                <Bold>Delete Marker</Bold>
+              ) : (
+                <Bold>{readableBytes(v.size)}</Bold>
+              )}
             </M.Typography>
           ))}
         </SmallerSection>

--- a/catalog/app/containers/Bucket/Overview.js
+++ b/catalog/app/containers/Bucket/Overview.js
@@ -757,89 +757,82 @@ function Head({ req, s3, overviewUrl, bucket, description }) {
   const classes = useHeadStyles()
   const isRODA = !!overviewUrl && overviewUrl.includes(`/${RODA_BUCKET}/`)
   const colorPool = useConst(() => mkKeyedPool(COLOR_MAP))
+  const statsData = useData(requests.bucketStats, { req, s3, bucket, overviewUrl })
+  const pkgStatsData = useData(requests.bucketPkgStats, { req, bucket })
   return (
-    <Data fetch={requests.bucketStats} params={{ req, s3, bucket, overviewUrl }}>
-      {(res) => (
-        <M.Paper className={classes.root}>
-          <M.Box className={classes.top}>
-            <M.Typography variant="h5">{bucket}</M.Typography>
-            {!!description && (
-              <M.Box mt={1}>
-                <M.Typography variant="body1">{description}</M.Typography>
-              </M.Box>
-            )}
-            {isRODA && (
-              <M.Box
-                mt={1}
-                position={{ md: 'absolute' }}
-                right={{ md: 32 }}
-                bottom={{ md: 31 }}
-                color="grey.300"
-                textAlign={{ md: 'right' }}
-              >
-                <M.Typography variant="body2">
-                  From the{' '}
-                  <M.Link href={RODA_LINK} color="inherit" underline="always">
-                    Registry of Open Data on AWS
-                  </M.Link>
-                </M.Typography>
-              </M.Box>
-            )}
-            <M.Box mt={{ xs: 2, sm: 3 }} display="flex" alignItems="baseline">
-              <StatDisplay
-                value={AsyncResult.prop('totalBytes', res)}
-                format={readableBytes}
-                fallback={() => '? B'}
-              />
-              <StatDisplay
-                value={AsyncResult.prop('totalObjects', res)}
-                format={readableQuantity}
-                label="Objects"
-                fallback={() => '?'}
-              />
-              <StatDisplay
-                value={AsyncResult.prop('totalPackages', res)}
-                format={formatQuantity}
-                label="Packages"
-                fallback={() => null}
-              />
-            </M.Box>
+    <M.Paper className={classes.root}>
+      <M.Box className={classes.top}>
+        <M.Typography variant="h5">{bucket}</M.Typography>
+        {!!description && (
+          <M.Box mt={1}>
+            <M.Typography variant="body1">{description}</M.Typography>
           </M.Box>
+        )}
+        {isRODA && (
           <M.Box
-            p={{ xs: 2, sm: 4 }}
-            display="flex"
-            flexDirection={{ xs: 'column', md: 'row' }}
-            alignItems={{ md: 'flex-start' }}
-            position="relative"
+            mt={1}
+            position={{ md: 'absolute' }}
+            right={{ md: 32 }}
+            bottom={{ md: 31 }}
+            color="grey.300"
+            textAlign={{ md: 'right' }}
           >
-            <ObjectsByExt
-              data={AsyncResult.prop('exts', res)}
-              width="100%"
-              flexShrink={1}
-              colorPool={colorPool}
-            />
-            <M.Box
-              display="flex"
-              flexDirection="column"
-              justifyContent="center"
-              flexShrink={0}
-              height={{ xs: 32, md: '100%' }}
-              width={{ xs: '100%', md: 32 }}
-            >
-              <M.Hidden mdUp>
-                <M.Divider />
-              </M.Hidden>
-            </M.Box>
-            <Downloads
-              bucket={bucket}
-              colorPool={colorPool}
-              width="100%"
-              flexShrink={1}
-            />
+            <M.Typography variant="body2">
+              From the{' '}
+              <M.Link href={RODA_LINK} color="inherit" underline="always">
+                Registry of Open Data on AWS
+              </M.Link>
+            </M.Typography>
           </M.Box>
-        </M.Paper>
-      )}
-    </Data>
+        )}
+        <M.Box mt={{ xs: 2, sm: 3 }} display="flex" alignItems="baseline">
+          <StatDisplay
+            value={AsyncResult.prop('totalBytes', statsData.result)}
+            format={readableBytes}
+            fallback={() => '? B'}
+          />
+          <StatDisplay
+            value={AsyncResult.prop('totalObjects', statsData.result)}
+            format={readableQuantity}
+            label="Objects"
+            fallback={() => '?'}
+          />
+          <StatDisplay
+            value={AsyncResult.prop('totalPackages', pkgStatsData.result)}
+            format={formatQuantity}
+            label="Packages"
+            fallback={() => null}
+          />
+        </M.Box>
+      </M.Box>
+      <M.Box
+        p={{ xs: 2, sm: 4 }}
+        display="flex"
+        flexDirection={{ xs: 'column', md: 'row' }}
+        alignItems={{ md: 'flex-start' }}
+        position="relative"
+      >
+        <ObjectsByExt
+          data={AsyncResult.prop('exts', statsData.result)}
+          width="100%"
+          flexShrink={1}
+          colorPool={colorPool}
+        />
+        <M.Box
+          display="flex"
+          flexDirection="column"
+          justifyContent="center"
+          flexShrink={0}
+          height={{ xs: 32, md: '100%' }}
+          width={{ xs: '100%', md: 32 }}
+        >
+          <M.Hidden mdUp>
+            <M.Divider />
+          </M.Hidden>
+        </M.Box>
+        <Downloads bucket={bucket} colorPool={colorPool} width="100%" flexShrink={1} />
+      </M.Box>
+    </M.Paper>
   )
 }
 

--- a/catalog/app/containers/Bucket/requests.js
+++ b/catalog/app/containers/Bucket/requests.js
@@ -432,7 +432,8 @@ export const bucketSummary = async ({ s3, req, bucket, overviewUrl, inStack }) =
             // eslint-disable-next-line no-underscore-dangle
             const s = (h.inner_hits.latest.hits.hits[0] || {})._source
             return (
-              s && {
+              s &&
+              !s.delete_marker && {
                 bucket,
                 key: s.key,
                 version: s.version_id,
@@ -533,7 +534,8 @@ export const bucketImgs = async ({ req, s3, bucket, overviewUrl, inStack }) => {
             // eslint-disable-next-line no-underscore-dangle
             const s = (h.inner_hits.latest.hits.hits[0] || {})._source
             return (
-              s && {
+              s &&
+              !s.delete_marker && {
                 bucket,
                 key: s.key,
                 version: s.version_id,

--- a/catalog/app/containers/Bucket/requests.js
+++ b/catalog/app/containers/Bucket/requests.js
@@ -181,7 +181,6 @@ const processStats = R.applySpec({
   ),
   totalObjects: R.path(['hits', 'total']),
   totalBytes: R.path(['aggregations', 'totalBytes', 'value']),
-  totalPackages: R.path(['aggregations', 'totalPackageHandles', 'value']),
 })
 
 export const bucketStats = async ({ req, s3, bucket, overviewUrl }) => {
@@ -204,9 +203,7 @@ export const bucketStats = async ({ req, s3, bucket, overviewUrl }) => {
   }
 
   try {
-    return await req('/search', { index: `${bucket}*`, action: 'stats' }).then(
-      processStats,
-    )
+    return await req('/search', { index: bucket, action: 'stats' }).then(processStats)
   } catch (e) {
     // eslint-disable-next-line no-console
     console.log('Unable to fetch live stats:')
@@ -215,6 +212,24 @@ export const bucketStats = async ({ req, s3, bucket, overviewUrl }) => {
   }
 
   throw new Error('Stats unavailable')
+}
+
+export const bucketPkgStats = async ({ req, bucket }) => {
+  try {
+    // TODO: use pkg_stats action when it's implemented
+    return await req('/search', { index: `${bucket}_packages`, action: 'stats' }).then(
+      R.applySpec({
+        totalPackages: R.path(['aggregations', 'totalPackageHandles', 'value']),
+      }),
+    )
+  } catch (e) {
+    // eslint-disable-next-line no-console
+    console.log('Unable to fetch package stats:')
+    // eslint-disable-next-line no-console
+    console.error(e)
+  }
+
+  throw new Error('Package stats unavailable')
 }
 
 const fetchFileVersioned = async ({ s3, bucket, path, version }) => {

--- a/catalog/app/utils/search.js
+++ b/catalog/app/utils/search.js
@@ -66,6 +66,7 @@ const extractObjData = ({ bucket, score, src }) => {
           lastModified: parseDate(src.last_modified),
           size: src.size,
           meta: src.user_meta,
+          deleteMarker: src.delete_marker,
         },
       ],
     },

--- a/lambdas/search/index.py
+++ b/lambdas/search/index.py
@@ -103,8 +103,19 @@ def lambda_handler(request):
                 }
             }
         _source = user_source or [
-            'key', 'version_id', 'updated', 'last_modified', 'size', 'user_meta',
-            'comment', 'handle', 'hash', 'tags', 'metadata', 'pointer_file'
+            'key',
+            'version_id',
+            'updated',
+            'last_modified',
+            'size',
+            'user_meta',
+            'comment',
+            'handle',
+            'hash',
+            'tags',
+            'metadata',
+            'pointer_file',
+            'delete_marker',
         ]
         size = DEFAULT_SIZE
     elif action == 'stats':

--- a/lambdas/search/index.py
+++ b/lambdas/search/index.py
@@ -137,7 +137,12 @@ def lambda_handler(request):
         terminate_after = None
     elif action == 'images':
         body = {
-            'query': {'regexp': {'ext': IMG_EXTS}},
+            'query': {
+                'bool': {
+                    'must': [{'regexp': {'ext': IMG_EXTS}}],
+                    'must_not': [{'match': {'delete_marker': True}}],
+                }
+            },
             'collapse': {
                 'field': 'key',
                 'inner_hits': {
@@ -158,6 +163,7 @@ def lambda_handler(request):
                     'must_not': [
                         {'terms': {'key': README_KEYS + [SUMMARIZE_KEY]}},
                         {'wildcard': {'key': '*/' + SUMMARIZE_KEY}},
+                        {'match': {'delete_marker': True}},
                     ],
                 },
             },

--- a/lambdas/search/index.py
+++ b/lambdas/search/index.py
@@ -137,12 +137,7 @@ def lambda_handler(request):
         terminate_after = None
     elif action == 'images':
         body = {
-            'query': {
-                'bool': {
-                    'must': [{'regexp': {'ext': IMG_EXTS}}],
-                    'must_not': [{'match': {'delete_marker': True}}],
-                }
-            },
+            'query': {'regexp': {'ext': IMG_EXTS}},
             'collapse': {
                 'field': 'key',
                 'inner_hits': {
@@ -163,7 +158,6 @@ def lambda_handler(request):
                     'must_not': [
                         {'terms': {'key': README_KEYS + [SUMMARIZE_KEY]}},
                         {'wildcard': {'key': '*/' + SUMMARIZE_KEY}},
-                        {'match': {'delete_marker': True}},
                     ],
                 },
             },

--- a/lambdas/search/index.py
+++ b/lambdas/search/index.py
@@ -132,7 +132,7 @@ def lambda_handler(request):
                     'name': 'latest',
                     'size': 1,
                     'sort': [{'last_modified': 'desc'}],
-                    '_source': ['key', 'version_id'],
+                    '_source': ['key', 'version_id', 'delete_marker'],
                 },
             },
         }
@@ -155,7 +155,7 @@ def lambda_handler(request):
                     'name': 'latest',
                     'size': 1,
                     'sort': [{'last_modified': 'desc'}],
-                    '_source': ['key', 'version_id'],
+                    '_source': ['key', 'version_id', 'delete_marker'],
                 },
             },
         }

--- a/lambdas/search/index.py
+++ b/lambdas/search/index.py
@@ -109,13 +109,14 @@ def lambda_handler(request):
         size = DEFAULT_SIZE
     elif action == 'stats':
         body = {
-            "query": {"match_all": {}},
+            "query": {"term": {"delete_marker": False}},
             "aggs": {
                 "totalBytes": {"sum": {"field": 'size'}},
                 "exts": {
                     "terms": {"field": 'ext'},
                     "aggs": {"size": {"sum": {"field": 'size'}}},
                 },
+                # TODO: move this to a separate action (pkg_stats)
                 "totalPackageHandles": {"value_count": {"field": "handle"}},
             }
         }

--- a/lambdas/search/tests/test_search.py
+++ b/lambdas/search/tests/test_search.py
@@ -302,8 +302,19 @@ class TestSearch(TestCase):
             'size': 1000,
             'from': 0,
             '_source': ','.join([
-                'key', 'version_id', 'updated', 'last_modified', 'size', 'user_meta',
-                'comment', 'handle', 'hash', 'tags', 'metadata', 'pointer_file'
+                'key',
+                'version_id',
+                'updated',
+                'last_modified',
+                'size',
+                'user_meta',
+                'comment',
+                'handle',
+                'hash',
+                'tags',
+                'metadata',
+                'pointer_file',
+                'delete_marker',
             ]),
             'terminate_after': 538,
         })
@@ -342,8 +353,19 @@ class TestSearch(TestCase):
             'size': 1000,
             'from': 0,
             '_source': ','.join([
-                'key', 'version_id', 'updated', 'last_modified', 'size', 'user_meta',
-                'comment', 'handle', 'hash', 'tags', 'metadata', 'pointer_file'
+                'key',
+                'version_id',
+                'updated',
+                'last_modified',
+                'size',
+                'user_meta',
+                'comment',
+                'handle',
+                'hash',
+                'tags',
+                'metadata',
+                'pointer_file',
+                'delete_marker',
             ]),
             'terminate_after': 10000,
         })
@@ -393,13 +415,14 @@ class TestSearch(TestCase):
         def _callback(request):
             payload = json.loads(request.body)
             assert payload == {
-                "query": {"match_all": {}},
+                "query": {"term": {"delete_marker": False}},
                 "aggs": {
-                    "totalBytes": {"sum": {"field": "size"}},
+                    "totalBytes": {"sum": {"field": 'size'}},
                     "exts": {
                         "terms": {"field": 'ext'},
-                        "aggs": {"size": {"sum": {"field": "size"}}},
+                        "aggs": {"size": {"sum": {"field": 'size'}}},
                     },
+                    # TODO: move this to a separate action (pkg_stats)
                     "totalPackageHandles": {"value_count": {"field": "handle"}},
                 }
             }


### PR DESCRIPTION
- catalog
  - bucket overview
    - filter-out deleted objects from bucket summary (images and sample)
    - fix object count query
  - search results
    - show 'Delete Marker' labels
- search lambda
  - expose `delete_marker` by default in `search` action
  - expose `delete_marker` in `images` and `sample` actions

caveat: images and sample files result sets are filtered from delete markers after querying / limiting, so when delete markers are encountered, the sets will be smaller than the respective limits (`NUM_PREVIEW_IMAGES = 100` and `NUM_PREVIEW_FILES = 20`)