### PR TITLE
Don't aggressively retry content exceptions

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -18,6 +18,8 @@
 * [Fixed] Bug that caused search to miss delete object and delete package events ([#1987](https://github.com/quiltdata/quilt/pull/1987))
 * [Changed] Tree view for files in package update dialog ([#1989](https://github.com/quiltdata/quilt/pull/1989))
 * [Fixed] lambda previews for time series `AICSImage` data (potential `IndexError` if odd number of time points) ([#1945](https://github.com/quiltdata/quilt/pull/1945))
+* [Changed] Lambda indexing retry logic to not fail content extraction ([#2007](https://github.com/quiltdata/quilt/pull/2007))
+* [Changed] Number of retries per ES and S3 failure in indexing Lambda ([#1987](https://github.com/quiltdata/quilt/pull/1987))
 
 # 3.3.0 - 2020-12-08
 ## Python API

--- a/lambdas/es/indexer/test/test_index.py
+++ b/lambdas/es/indexer/test/test_index.py
@@ -748,7 +748,7 @@ class TestIndex(TestCase):
         assert self.actual_es_calls == expected_es_calls, \
             (
                 f"Expected ES endpoint to be called {expected_es_calls} times, "
-                "got {self.expected_es_calls} calls instead"
+                f"got {self.actual_es_calls} calls instead"
             )
 
     @patch.object(index.DocumentQueue, 'send_all')
@@ -978,15 +978,15 @@ class TestIndex(TestCase):
         """test indexing a single file that throws an exception"""
         class ContentException(Exception):
             pass
-        get_mock.side_effect = ContentException("Unable to get contents")
-        with pytest.raises(ContentException):
-            # get_mock already mocks get_object, so don't mock it in _test_index_event
-            self._test_index_events(
-                ["ObjectCreated:Put"],
-                mock_overrides={
-                    "mock_object": False
-                }
-            )
+        get_mock.side_effect = ContentException("Unable to get contents in Glacier")
+        # get_mock already mocks get_object, so don't mock it in _test_index_event
+        self._test_index_events(
+            ["ObjectCreated:Put"],
+            expected_es_calls=1,
+            mock_overrides={
+                "mock_object": False
+            }
+        )
 
     @patch.object(index.DocumentQueue, 'append')
     def test_index_if_package_delete(self, append_mock):


### PR DESCRIPTION
These codepaths were resulting in long-running lambdas and un-neccessarily aggressive retry loops, and failed batches. Moreover, get_object exceptions are normal with storage classes like Glacier.