### PR TITLE
Fix ES queries and catalog bugs

### DIFF
--- a/catalog/app/containers/Bucket/PackageList.js
+++ b/catalog/app/containers/Bucket/PackageList.js
@@ -2,7 +2,7 @@ import * as dateFns from 'date-fns'
 import * as R from 'ramda'
 import * as React from 'react'
 import { FormattedRelative, FormattedPlural } from 'react-intl'
-import { useHistory, Link } from 'react-router-dom'
+import { useHistory, Link, Redirect } from 'react-router-dom'
 import * as M from '@material-ui/core'
 import { fade } from '@material-ui/core/styles'
 
@@ -522,6 +522,10 @@ export default function PackageList({
                   }
 
                   const pages = Math.ceil(filteredCount / PER_PAGE)
+
+                  if (computedPage > pages) {
+                    return <Redirect to={makePageUrl(pages)} />
+                  }
 
                   return (
                     <>

--- a/catalog/app/containers/Bucket/requests.js
+++ b/catalog/app/containers/Bucket/requests.js
@@ -396,7 +396,7 @@ export const bucketSummary = async ({ s3, req, bucket, overviewUrl, inStack }) =
         .then(
           R.pipe(
             (r) => JSON.parse(r.Body.toString('utf-8')),
-            R.path(['aggregations', 'other', 'keys', 'buckets']),
+            R.pathOr([], ['aggregations', 'other', 'keys', 'buckets']),
             R.map((b) => ({
               bucket,
               key: b.key,
@@ -424,7 +424,7 @@ export const bucketSummary = async ({ s3, req, bucket, overviewUrl, inStack }) =
     try {
       return await req('/search', { action: 'sample', index: bucket }).then(
         R.pipe(
-          R.path(['aggregations', 'objects', 'buckets']),
+          R.pathOr([], ['aggregations', 'objects', 'buckets']),
           R.map((h) => {
             // eslint-disable-next-line no-underscore-dangle
             const s = h.latest.hits.hits[0]._source
@@ -498,7 +498,7 @@ export const bucketImgs = async ({ req, s3, bucket, overviewUrl, inStack }) => {
         .then(
           R.pipe(
             (r) => JSON.parse(r.Body.toString('utf-8')),
-            R.path(['aggregations', 'images', 'keys', 'buckets']),
+            R.pathOr([], ['aggregations', 'images', 'keys', 'buckets']),
             R.map((b) => ({
               bucket,
               key: b.key,
@@ -518,7 +518,7 @@ export const bucketImgs = async ({ req, s3, bucket, overviewUrl, inStack }) => {
     try {
       return await req('/search', { action: 'images', index: bucket }).then(
         R.pipe(
-          R.path(['aggregations', 'objects', 'buckets']),
+          R.pathOr([], ['aggregations', 'objects', 'buckets']),
           R.map((h) => {
             // eslint-disable-next-line no-underscore-dangle
             const s = h.latest.hits.hits[0]._source

--- a/lambdas/search/index.py
+++ b/lambdas/search/index.py
@@ -202,7 +202,12 @@ def lambda_handler(request):
         }
         size = 0
         _source = False
-        filter_path = 'aggregations.objects.buckets.latest.hits.hits._source'
+        filter_path = ','.join([
+            'took',
+            'timed_out',
+            'hits.total',
+            'aggregations.objects.buckets.latest.hits.hits._source'
+        ])
     elif action == 'sample':
         body = {
             'query': {
@@ -218,7 +223,12 @@ def lambda_handler(request):
         }
         size = NUM_PREVIEW_FILES
         _source = False
-        filter_path = 'aggregations.objects.buckets.latest.hits.hits._source'
+        filter_path = ','.join([
+            'took',
+            'timed_out',
+            'hits.total',
+            'aggregations.objects.buckets.latest.hits.hits._source',
+        ])
     else:
         return make_json_response(400, {"title": "Invalid action"})
 

--- a/lambdas/search/index.py
+++ b/lambdas/search/index.py
@@ -202,12 +202,12 @@ def lambda_handler(request):
         }
         size = 0
         _source = False
-        filter_path = ','.join([
+        filter_path = (
             'took',
             'timed_out',
             'hits.total',
-            'aggregations.objects.buckets.latest.hits.hits._source'
-        ])
+            'aggregations.objects.buckets.latest.hits.hits._source',
+        )
     elif action == 'sample':
         body = {
             'query': {
@@ -223,12 +223,12 @@ def lambda_handler(request):
         }
         size = NUM_PREVIEW_FILES
         _source = False
-        filter_path = ','.join([
+        filter_path = (
             'took',
             'timed_out',
             'hits.total',
             'aggregations.objects.buckets.latest.hits.hits._source',
-        ])
+        )
     else:
         return make_json_response(400, {"title": "Invalid action"})
 


### PR DESCRIPTION
- fix getting total package handle count (affects pagination)
- redirect to the last page when navigating to an out-of-bounds page, fix crash on out-of-bounds pages
- return more data from ES (`took`, `hits.total`, `timed_out`) to aid debugging and benchmarking