### PR TITLE
Use EncodingType=url for S3 list* requests to handle special chars

### DIFF
--- a/catalog/app/containers/Bucket/requests.js
+++ b/catalog/app/containers/Bucket/requests.js
@@ -33,13 +33,13 @@ export const bucketListing = ({ s3, bucket, path = '', prefix }) =>
       R.applySpec({
         dirs: R.pipe(
           R.prop('CommonPrefixes'),
-          R.map((p) => decodeURI(p.Prefix)),
+          R.map((p) => decodeURIComponent(p.Prefix)),
           R.filter((d) => d !== '/' && d !== '../'),
           R.uniq,
         ),
         files: R.pipe(
           R.prop('Contents'),
-          R.map(R.evolve({ Key: decodeURI })),
+          R.map(R.evolve({ Key: decodeURIComponent })),
           // filter-out "directory-files" (files that match prefixes)
           R.filter(({ Key }) => Key !== path && !Key.endsWith('/')),
           R.map((i) => ({
@@ -449,7 +449,7 @@ export const bucketSummary = async ({ s3, req, bucket, overviewUrl, inStack }) =
       .then(
         R.pipe(
           R.path(['Contents']),
-          R.map(R.evolve({ Key: decodeURI })),
+          R.map(R.evolve({ Key: decodeURIComponent })),
           R.filter(
             R.propSatisfies(
               R.allPass([
@@ -544,7 +544,7 @@ export const bucketImgs = async ({ req, s3, bucket, overviewUrl, inStack }) => {
       .then(
         R.pipe(
           R.path(['Contents']),
-          R.map(R.evolve({ Key: decodeURI })),
+          R.map(R.evolve({ Key: decodeURIComponent })),
           R.filter(
             (i) =>
               i.StorageClass !== 'GLACIER' &&
@@ -572,7 +572,7 @@ export const objectVersions = ({ s3, bucket, path }) =>
     .then(
       R.pipe(
         ({ Versions, DeleteMarkers }) => Versions.concat(DeleteMarkers),
-        R.map(R.evolve({ Key: decodeURI })),
+        R.map(R.evolve({ Key: decodeURIComponent })),
         R.filter((v) => v.Key === path),
         R.map((v) => ({
           isLatest: v.IsLatest || false,

--- a/catalog/app/containers/Bucket/requests.js
+++ b/catalog/app/containers/Bucket/requests.js
@@ -26,18 +26,20 @@ export const bucketListing = ({ s3, bucket, path = '', prefix }) =>
       Bucket: bucket,
       Delimiter: '/',
       Prefix: path + (prefix || ''),
+      EncodingType: 'url',
     })
     .promise()
     .then(
       R.applySpec({
         dirs: R.pipe(
           R.prop('CommonPrefixes'),
-          R.pluck('Prefix'),
+          R.map((p) => decodeURI(p.Prefix)),
           R.filter((d) => d !== '/' && d !== '../'),
           R.uniq,
         ),
         files: R.pipe(
           R.prop('Contents'),
+          R.map(R.evolve({ Key: decodeURI })),
           // filter-out "directory-files" (files that match prefixes)
           R.filter(({ Key }) => Key !== path && !Key.endsWith('/')),
           R.map((i) => ({
@@ -442,11 +444,12 @@ export const bucketSummary = async ({ s3, req, bucket, overviewUrl, inStack }) =
   }
   try {
     return await s3
-      .listObjectsV2({ Bucket: bucket })
+      .listObjectsV2({ Bucket: bucket, EncodingType: 'url' })
       .promise()
       .then(
         R.pipe(
           R.path(['Contents']),
+          R.map(R.evolve({ Key: decodeURI })),
           R.filter(
             R.propSatisfies(
               R.allPass([
@@ -536,11 +539,12 @@ export const bucketImgs = async ({ req, s3, bucket, overviewUrl, inStack }) => {
   }
   try {
     return await s3
-      .listObjectsV2({ Bucket: bucket })
+      .listObjectsV2({ Bucket: bucket, EncodingType: 'url' })
       .promise()
       .then(
         R.pipe(
           R.path(['Contents']),
+          R.map(R.evolve({ Key: decodeURI })),
           R.filter(
             (i) =>
               i.StorageClass !== 'GLACIER' &&
@@ -563,11 +567,12 @@ export const bucketImgs = async ({ req, s3, bucket, overviewUrl, inStack }) => {
 
 export const objectVersions = ({ s3, bucket, path }) =>
   s3
-    .listObjectVersions({ Bucket: bucket, Prefix: path })
+    .listObjectVersions({ Bucket: bucket, Prefix: path, EncodingType: 'url' })
     .promise()
     .then(
       R.pipe(
         ({ Versions, DeleteMarkers }) => Versions.concat(DeleteMarkers),
+        R.map(R.evolve({ Key: decodeURI })),
         R.filter((v) => v.Key === path),
         R.map((v) => ({
           isLatest: v.IsLatest || false,
@@ -1360,6 +1365,7 @@ export const ensurePackageIsPresent = async ({ s3, bucket, name }) => {
       Bucket: bucket,
       Prefix: `${PACKAGES_PREFIX}${name}/`,
       MaxKeys: 1,
+      EncodingType: 'url',
     })
     .promise()
   return !!response.KeyCount


### PR DESCRIPTION
Currently some weird key names (e.g. '\r\n') crash AWS SDK while performing list* operations, so we need to tell it explicitly to url-encode the keys (and then we need to manually decode them). However those keys still arent properly supported by the catalog -- they render with empty names and arent navigable (some quite involved refactoring required to fully handle this).