### PR TITLE
Populate value with Schema defaults

### DIFF
--- a/catalog/app/containers/Bucket/PackageDialog/PackageDialog.js
+++ b/catalog/app/containers/Bucket/PackageDialog/PackageDialog.js
@@ -12,7 +12,7 @@ import Delay from 'utils/Delay'
 import AsyncResult from 'utils/AsyncResult'
 import * as APIConnector from 'utils/APIConnector'
 import * as AWS from 'utils/AWS'
-import { makeSchemaValidator } from 'utils/json-schema'
+import { makeSchemaValidator, setDefaultValues } from 'utils/json-schema'
 import pipeThru from 'utils/pipeThru'
 import { readableBytes } from 'utils/string'
 import * as validators from 'utils/validators'
@@ -359,8 +359,9 @@ export function MetaInput({
 
   const parsedValue = React.useMemo(() => {
     const obj = parseJSON(value.text)
-    return R.is(Object, obj) && !Array.isArray(obj) ? obj : {}
-  }, [value.text])
+    const validObj = R.is(Object, obj) && !Array.isArray(obj) ? obj : {}
+    return setDefaultValues(schema, validObj)
+  }, [schema, value.text])
 
   const changeMode = (mode) => {
     if (disabled) return
@@ -387,6 +388,13 @@ export function MetaInput({
   const onJsonEditor = React.useCallback((json) => changeText(stringifyJSON(json)), [
     changeText,
   ])
+
+  // We populated value with Schema defaults
+  // and should save this new value in final-form
+  React.useEffect(() => {
+    onJsonEditor(parsedValue)
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [schema, onJsonEditor])
 
   const { push: notify } = Notifications.use()
   const [locked, setLocked] = React.useState(false)

--- a/catalog/app/containers/Bucket/PackageDialog/PackageDialog.js
+++ b/catalog/app/containers/Bucket/PackageDialog/PackageDialog.js
@@ -12,7 +12,7 @@ import Delay from 'utils/Delay'
 import AsyncResult from 'utils/AsyncResult'
 import * as APIConnector from 'utils/APIConnector'
 import * as AWS from 'utils/AWS'
-import { makeSchemaValidator, setDefaultValues } from 'utils/json-schema'
+import { makeSchemaValidator, makeSchemaDefaultsSetter } from 'utils/json-schema'
 import pipeThru from 'utils/pipeThru'
 import { readableBytes } from 'utils/string'
 import * as validators from 'utils/validators'
@@ -357,11 +357,13 @@ export function MetaInput({
   const error = schemaError || ((meta.modified || meta.submitFailed) && meta.error)
   const disabled = meta.submitting || meta.submitSucceeded
 
+  const schemaDefaults = React.useMemo(() => makeSchemaDefaultsSetter(schema), [schema])
+
   const parsedValue = React.useMemo(() => {
     const obj = parseJSON(value.text)
     const validObj = R.is(Object, obj) && !Array.isArray(obj) ? obj : {}
-    return setDefaultValues(schema, validObj)
-  }, [schema, value.text])
+    return schemaDefaults(validObj)
+  }, [schemaDefaults, value.text])
 
   const changeMode = (mode) => {
     if (disabled) return

--- a/catalog/app/utils/json-schema/json-schema.js
+++ b/catalog/app/utils/json-schema/json-schema.js
@@ -116,3 +116,11 @@ export function makeSchemaValidator(optSchema) {
     return () => [e]
   }
 }
+
+export function setDefaultValues(optSchema, obj) {
+  if (!optSchema) return obj
+  const ajv = new Ajv({ schemaId: 'auto', useDefaults: true })
+  const validate = ajv.compile(optSchema)
+  validate(obj)
+  return obj
+}

--- a/catalog/app/utils/json-schema/json-schema.js
+++ b/catalog/app/utils/json-schema/json-schema.js
@@ -117,10 +117,16 @@ export function makeSchemaValidator(optSchema) {
   }
 }
 
-export function setDefaultValues(optSchema, obj) {
-  if (!optSchema) return obj
+export function makeSchemaDefaultsSetter(optSchema) {
+  if (!optSchema) return R.identity
   const ajv = new Ajv({ schemaId: 'auto', useDefaults: true })
-  const validate = ajv.compile(optSchema)
-  validate(obj)
-  return obj
+  try {
+    const validate = ajv.compile(optSchema)
+    return (obj) => {
+      validate(obj)
+      return obj
+    }
+  } catch (e) {
+    return R.identity
+  }
 }


### PR DESCRIPTION
* Use `Ajv` to populate an object with Schema defaults
* Trigger `onChange` with the populated object when schema changed


Using `initialValue` doesn't work (instead of `useEffect` workaround), because `initialValue` set once, but we can change Schema by selecting another workflow.