### PR TITLE
Update package name warning texts

### DIFF
--- a/catalog/app/components/Code/Code.tsx
+++ b/catalog/app/components/Code/Code.tsx
@@ -1,0 +1,19 @@
+import * as React from 'react'
+import * as M from '@material-ui/core'
+
+const useCodeStyles = M.makeStyles((t) => ({
+  root: {
+    background: t.palette.grey[300],
+    borderRadius: '2px',
+    color: t.palette.text.primary,
+    fontFamily: (t.typography as $TSFixMe).monospace.fontFamily,
+    padding: '0 3px',
+    whiteSpace: 'pre-wrap',
+  },
+}))
+
+export default function Code({ children }: React.PropsWithChildren<{}>) {
+  const classes = useCodeStyles()
+
+  return <code className={classes.root}>{children}</code>
+}

--- a/catalog/app/components/Code/index.ts
+++ b/catalog/app/components/Code/index.ts
@@ -1,0 +1,1 @@
+export { default } from './Code'

--- a/catalog/app/containers/Bucket/PackageCopyDialog.js
+++ b/catalog/app/containers/Bucket/PackageCopyDialog.js
@@ -4,6 +4,7 @@ import * as React from 'react'
 import * as RF from 'react-final-form'
 import * as M from '@material-ui/core'
 
+import Code from 'components/Code'
 import AsyncResult from 'utils/AsyncResult'
 import * as APIConnector from 'utils/APIConnector'
 import * as AWS from 'utils/AWS'
@@ -162,13 +163,13 @@ function DialogForm({
       if (nameExists) {
         warning = (
           <>
-            <code>{fullName}</code> already exists. Click Push to create a new revision.
+            <Code>{fullName}</Code> already exists. Click Push to create a new revision.
           </>
         )
       } else if (name) {
         warning = (
           <>
-            <code>{fullName}</code> is a new package
+            <Code>{fullName}</Code> is a new package
           </>
         )
       }

--- a/catalog/app/containers/Bucket/PackageCopyDialog.js
+++ b/catalog/app/containers/Bucket/PackageCopyDialog.js
@@ -82,8 +82,6 @@ function DialogTitle({ bucket }) {
   )
 }
 
-const defaultNameWarning = ' ' // Reserve space for warning
-
 const useStyles = M.makeStyles((t) => ({
   meta: {
     marginTop: t.spacing(3),
@@ -158,13 +156,21 @@ function DialogForm({
       const { name } = values
       const fullName = `${successor.slug}/${name}`
 
-      let warning = defaultNameWarning
+      let warning = ''
 
       const nameExists = await nameExistence.validate(name)
       if (nameExists) {
-        warning = `Package "${fullName}" exists. Submitting will revise it`
+        warning = (
+          <>
+            <code>{fullName}</code> already exists. Click Push to create a new revision.
+          </>
+        )
       } else if (name) {
-        warning = `Package "${fullName}" will be created`
+        warning = (
+          <>
+            <code>{fullName}</code> is a new package
+          </>
+        )
       }
 
       if (warning !== nameWarning) {

--- a/catalog/app/containers/Bucket/PackageCreateDialog.js
+++ b/catalog/app/containers/Bucket/PackageCreateDialog.js
@@ -382,8 +382,6 @@ const getTotalProgress = R.pipe(
   }),
 )
 
-const defaultNameWarning = ' ' // Reserve space for warning
-
 const useNameExistsWarningStyles = M.makeStyles(() => ({
   root: {
     marginRight: '4px',
@@ -422,7 +420,7 @@ function PackageCreateDialog({
   const [uploads, setUploads] = React.useState({})
   const nameValidator = PD.useNameValidator()
   const nameExistence = PD.useNameExistence(bucket)
-  const [nameWarning, setNameWarning] = React.useState(defaultNameWarning)
+  const [nameWarning, setNameWarning] = React.useState('')
   const classes = useStyles()
 
   const totalProgress = getTotalProgress(uploads)
@@ -526,7 +524,7 @@ function PackageCreateDialog({
 
   const handleNameChange = React.useCallback(
     async (name) => {
-      let warning = defaultNameWarning
+      let warning = ''
 
       const nameExists = await nameExistence.validate(name)
       if (nameExists) {

--- a/catalog/app/containers/Bucket/PackageCreateDialog.js
+++ b/catalog/app/containers/Bucket/PackageCreateDialog.js
@@ -397,7 +397,7 @@ const NameExistsWarning = ({ name }) => {
       <M.Icon className={classes.root} fontSize="small">
         error_outline
       </M.Icon>
-      <Code>{name}</Code> already exists, you are about to create a new revision
+      <Code>{name}</Code> already exists. Click Push to create a new revision.
     </>
   )
 }

--- a/catalog/app/containers/Bucket/PackageCreateDialog.js
+++ b/catalog/app/containers/Bucket/PackageCreateDialog.js
@@ -9,6 +9,7 @@ import { Link } from 'react-router-dom'
 import * as redux from 'react-redux'
 import * as M from '@material-ui/core'
 
+import Code from 'components/Code'
 import * as authSelectors from 'containers/Auth/selectors'
 import AsyncResult from 'utils/AsyncResult'
 import * as APIConnector from 'utils/APIConnector'
@@ -396,7 +397,7 @@ const NameExistsWarning = ({ name }) => {
       <M.Icon className={classes.root} fontSize="small">
         error_outline
       </M.Icon>
-      Package &quot;{name}&quot; already exists, you are about to create a new revision
+      <Code>{name}</Code> already exists, you are about to create a new revision
     </>
   )
 }

--- a/catalog/app/containers/Bucket/PackageDirectoryDialog.js
+++ b/catalog/app/containers/Bucket/PackageDirectoryDialog.js
@@ -53,8 +53,6 @@ function DialogTitle({ bucket, path }) {
   )
 }
 
-const defaultNameWarning = ' ' // Reserve space for warning
-
 const useStyles = M.makeStyles((t) => ({
   files: {
     height: '100%',
@@ -143,13 +141,21 @@ function DialogForm({
       const { name } = values
       const fullName = `${successor.slug}/${name}`
 
-      let warning = defaultNameWarning
+      let warning = ''
 
       const nameExists = await nameExistence.validate(name)
       if (nameExists) {
-        warning = `Package "${fullName}" exists. Submitting will revise it`
+        warning = (
+          <>
+            <code>{fullName}</code> already exists. Click Push to create a new revision.
+          </>
+        )
       } else if (name) {
-        warning = `Package "${fullName}" will be created`
+        warning = (
+          <>
+            <code>{fullName}</code> is a new package
+          </>
+        )
       }
 
       if (warning !== nameWarning) {

--- a/catalog/app/containers/Bucket/PackageDirectoryDialog.js
+++ b/catalog/app/containers/Bucket/PackageDirectoryDialog.js
@@ -5,6 +5,7 @@ import * as React from 'react'
 import * as RF from 'react-final-form'
 import * as M from '@material-ui/core'
 
+import Code from 'components/Code'
 import * as APIConnector from 'utils/APIConnector'
 import AsyncResult from 'utils/AsyncResult'
 import * as AWS from 'utils/AWS'
@@ -147,13 +148,13 @@ function DialogForm({
       if (nameExists) {
         warning = (
           <>
-            <code>{fullName}</code> already exists. Click Push to create a new revision.
+            <Code>{fullName}</Code> already exists. Click Push to create a new revision.
           </>
         )
       } else if (name) {
         warning = (
           <>
-            <code>{fullName}</code> is a new package
+            <Code>{fullName}</Code> is a new package
           </>
         )
       }

--- a/catalog/app/containers/Bucket/PackageUpdateDialog.js
+++ b/catalog/app/containers/Bucket/PackageUpdateDialog.js
@@ -6,6 +6,7 @@ import * as RF from 'react-final-form'
 import { Link } from 'react-router-dom'
 import * as M from '@material-ui/core'
 
+import Code from 'components/Code'
 import * as APIConnector from 'utils/APIConnector'
 import AsyncResult from 'utils/AsyncResult'
 import * as AWS from 'utils/AWS'
@@ -240,9 +241,17 @@ function DialogForm({
       if (name !== initialName) {
         const nameExists = await nameExistence.validate(name)
         if (nameExists) {
-          warning = 'Package with this name exists already'
+          warning = (
+            <>
+              <Code>{name}</Code> already exists. Click Push to create a new revision.
+            </>
+          )
         } else {
-          warning = 'New package will be created'
+          warning = (
+            <>
+              <Code>{name}</Code> is a new package
+            </>
+          )
         }
       }
 

--- a/catalog/app/containers/Bucket/PackageUpdateDialog.js
+++ b/catalog/app/containers/Bucket/PackageUpdateDialog.js
@@ -61,8 +61,6 @@ const getTotalProgress = R.pipe(
   }),
 )
 
-const defaultNameWarning = ' ' // Reserve space for warning
-
 function DialogForm({
   bucket,
   close,
@@ -237,7 +235,7 @@ function DialogForm({
 
       const { name } = values
 
-      let warning = defaultNameWarning
+      let warning = ''
 
       if (name !== initialName) {
         const nameExists = await nameExistence.validate(name)

--- a/catalog/app/containers/NavBar/Help.js
+++ b/catalog/app/containers/NavBar/Help.js
@@ -3,6 +3,7 @@ import * as M from '@material-ui/core'
 import * as Lab from '@material-ui/lab'
 
 import StyledLink from 'utils/StyledLink'
+import Code from 'components/Code'
 
 const ES_V = '6.7'
 const ES_REF = `https://www.elastic.co/guide/en/elasticsearch/reference/${ES_V}/query-dsl-query-string-query.html#query-string-syntax`
@@ -148,23 +149,6 @@ const syntaxHelpRows = [
     ],
   },
 ]
-
-const useCodeStyles = M.makeStyles((t) => ({
-  root: {
-    background: t.palette.grey[300],
-    borderRadius: '2px',
-    color: t.palette.text.primary,
-    fontFamily: t.typography.monospace.fontFamily,
-    padding: '0 3px',
-    whiteSpace: 'pre-wrap',
-  },
-}))
-
-function Code({ children }) {
-  const classes = useCodeStyles()
-
-  return <code className={classes.root}>{children}</code>
-}
 
 function Item({ item }) {
   const t = M.useTheme()


### PR DESCRIPTION
* Move `<Code />` to separate component and reuse it for messages
* Make messages identical with the new text proposed by @akarve 

![Screenshot from 2021-02-17 16-47-32](https://user-images.githubusercontent.com/533229/108213217-d415aa00-713f-11eb-85ee-85494f3cc42f.png)
