### PR TITLE
Search lambda: add "freeform" action

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -20,6 +20,7 @@
 * [Added] Populate package name with username prefix ([#2016](https://github.com/quiltdata/quilt/pull/2016))
 * [Added] Link from bucket overview page to bucket settings ([#2022](https://github.com/quiltdata/quilt/pull/2022))
 * [Added] Folder to package dialog ([#2040](https://github.com/quiltdata/quilt/pull/2040))
+* [Added] Search lambda: `freeform` action ([#2087](https://github.com/quiltdata/quilt/pull/2087))
 * [Changed] Tree view for files in package update dialog ([#1989](https://github.com/quiltdata/quilt/pull/1989))
 * [Changed] Lambda indexing retry logic to not fail content extraction ([#2007](https://github.com/quiltdata/quilt/pull/2007))
 * [Changed] Number of retries per ES and S3 failure in indexing Lambda ([#1987](https://github.com/quiltdata/quilt/pull/1987))

--- a/lambdas/search/index.py
+++ b/lambdas/search/index.py
@@ -229,6 +229,10 @@ def lambda_handler(request):
             'hits.total',
             'aggregations.objects.buckets.latest.hits.hits._source',
         )
+    elif action == 'freeform':
+        body = user_body
+        size = user_size
+        _source = user_source
     else:
         return make_json_response(400, {"title": "Invalid action"})
 


### PR DESCRIPTION
# Description

Add "freeform" search action which passes the "body" param to elastic as is.

# TODO

<!-- Use <del></del> for items that are not required for this PR -->

- [x] Unit tests
- [x] [Changelog](CHANGELOG.md) entry
