### PR TITLE
Fix R.clamp exception on screens less than 400px height

### DIFF
--- a/catalog/app/containers/Bucket/PackageDialog/PackageDialog.spec.ts
+++ b/catalog/app/containers/Bucket/PackageDialog/PackageDialog.spec.ts
@@ -15,4 +15,24 @@ describe('containers/Bucket/PackageDialog/PackageDialog', () => {
       expect(PD.getUsernamePrefix('username@email.co.uk')).toBe('username/')
     })
   })
+
+  describe('calcDialogHeight', () => {
+    test('height should be minimal for small screen', () => {
+      const metaHeight = 0
+      const windowHeight = 100
+      expect(PD.calcDialogHeight(windowHeight, metaHeight)).toBe(420)
+    })
+
+    test('height should fit into normal screen', () => {
+      const metaHeight = 300
+      const windowHeight = 768
+      expect(PD.calcDialogHeight(windowHeight, metaHeight)).toBe(568)
+    })
+
+    test('height should be enough for content on large screen', () => {
+      const metaHeight = 300
+      const windowHeight = 1440
+      expect(PD.calcDialogHeight(windowHeight, metaHeight)).toBe(700)
+    })
+  })
 })

--- a/catalog/app/containers/Bucket/PackageDialog/PackageDialog.tsx
+++ b/catalog/app/containers/Bucket/PackageDialog/PackageDialog.tsx
@@ -670,15 +670,18 @@ export function useCryptoApiValidation() {
   }, [])
 }
 
+export function calcDialogHeight(windowHeight: number, metaHeight: number): number {
+  const neededSpace = 400 /* space to fit other inputs */ + metaHeight
+  const availableSpace = windowHeight - 200 /* free space for headers */
+  const minimalSpace = 420 /* minimal height */
+  if (availableSpace < minimalSpace) return minimalSpace
+  return R.clamp(minimalSpace, availableSpace, neededSpace)
+}
+
 export const useContentStyles = M.makeStyles({
   root: {
-    height: ({ metaHeight }: { metaHeight: number }) => {
-      const neededSpace = 400 /* space to fit other inputs */ + metaHeight
-      const availableSpace = window.innerHeight - 200 /* free space for headers */
-      const minimalSpace = 420 /* minimal height */
-      if (availableSpace < minimalSpace) return minimalSpace
-      return R.clamp(minimalSpace, availableSpace, neededSpace)
-    },
+    height: ({ metaHeight }: { metaHeight: number }) =>
+      calcDialogHeight(window.innerHeight, metaHeight),
     paddingTop: 0,
   },
 })


### PR DESCRIPTION
`R.clamp` accepts min and max arguments in this order only. It throws an error on `R.clamp(max, min)`