### PR TITLE
Fix TypeError on import when running with PYTHONOPTIMIZE=2

### DIFF
--- a/api/python/quilt3/packages.py
+++ b/api/python/quilt3/packages.py
@@ -8,6 +8,7 @@ import logging
 import os
 import pathlib
 import shutil
+import sys
 import tempfile
 import textwrap
 import time
@@ -57,7 +58,8 @@ logger = logging.getLogger(__name__)
 
 def _fix_docstring(**kwargs):
     def f(wrapped):
-        wrapped.__doc__ = textwrap.dedent(wrapped.__doc__) % kwargs
+        if sys.flags.optimize < 2:
+            wrapped.__doc__ = textwrap.dedent(wrapped.__doc__) % kwargs
         return wrapped
     return f
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -27,6 +27,7 @@
 * [Added] Support for callable `dest` parameter in `Package.push()` ([#2095](https://github.com/quiltdata/quilt/pull/2095))
 * [Changed] Removed unused dependency on `packaging` ([#2090](https://github.com/quiltdata/quilt/pull/2090))
 * [Fixed] Possible downloading of truncated manifests ([#1977](https://github.com/quiltdata/quilt/pull/1977))
+* [Fixed] `TypeError` on import when running with `PYTHONOPTIMIZE=2` ([#2102](https://github.com/quiltdata/quilt/pull/2102))
 
 ## Catalog, Lambdas
 * [Added] Support for EventBridge S3 events to es/indexer ([#1987](https://github.com/quiltdata/quilt/pull/1987))


### PR DESCRIPTION
# Description
```
$ PYTHONOPTIMIZE=2 quilt3
```
```python
Traceback (most recent call last):
  File "/home/sergey/dev/work/quiltdata/venv-3.6/bin/quilt3", line 33, in <module>
    sys.exit(load_entry_point('quilt3', 'console_scripts', 'quilt3')())
  File "/home/sergey/dev/work/quiltdata/venv-3.6/bin/quilt3", line 25, in importlib_load_entry_point
    return next(matches).load()
  File "/home/sergey/dev/work/quiltdata/venv-3.6/lib/python3.6/site-packages/importlib_metadata/__init__.py", line 96, in load
    module = import_module(match.group('module'))
  File "/usr/lib/python3.6/importlib/__init__.py", line 126, in import_module
    return _bootstrap._gcd_import(name[level:], package, level)
  File "<frozen importlib._bootstrap>", line 994, in _gcd_import
  File "<frozen importlib._bootstrap>", line 971, in _find_and_load
  File "<frozen importlib._bootstrap>", line 941, in _find_and_load_unlocked
  File "<frozen importlib._bootstrap>", line 219, in _call_with_frames_removed
  File "<frozen importlib._bootstrap>", line 994, in _gcd_import
  File "<frozen importlib._bootstrap>", line 971, in _find_and_load
  File "<frozen importlib._bootstrap>", line 955, in _find_and_load_unlocked
  File "<frozen importlib._bootstrap>", line 665, in _load_unlocked
  File "<frozen importlib._bootstrap_external>", line 678, in exec_module
  File "<frozen importlib._bootstrap>", line 219, in _call_with_frames_removed
  File "/home/sergey/dev/work/quiltdata/quilt/api/python/quilt3/__init__.py", line 24, in <module>
    from .packages import Package
  File "/home/sergey/dev/work/quiltdata/quilt/api/python/quilt3/packages.py", line 345, in <module>
    class Package:
  File "/home/sergey/dev/work/quiltdata/quilt/api/python/quilt3/packages.py", line 1015, in Package
    def build(self, name, registry=None, message=None, *, workflow=...):
  File "/home/sergey/dev/work/quiltdata/quilt/api/python/quilt3/packages.py", line 57, in f
    wrapped.__doc__ = textwrap.dedent(wrapped.__doc__) % kwargs
  File "/usr/lib/python3.6/textwrap.py", line 430, in dedent
    text = _whitespace_only_re.sub('', text)
TypeError: expected string or bytes-like object
```


# TODO

<!-- Use <del></del> for items that are not required for this PR -->

- [ ] Unit tests?
- [x] [Changelog](CHANGELOG.md) entry
