### PR TITLE
Test top hash stability with unicode

### DIFF
--- a/api/python/tests/integration/data/top_hash_test_manifest.jsonl
+++ b/api/python/tests/integration/data/top_hash_test_manifest.jsonl
@@ -1,3 +1,3 @@
 {"version": "v0", "top_hash": {"alg": "v0", "value": "20de5433549a4db332a11d8d64b934a82bdea8f144b4aecd901e7d4134f8e733"}}
-{"logical_key": "a.txt", "physical_keys": ["file:///home/dima/src/t4/api/python/tmp/a.txt"], "size": 13, "hash": {"type": "SHA256", "value": "8663bab6d124806b9727f89bb4ab9db4cbcc3862f6bbf22024dfa7212aa4ab7d"}, "meta": {"user_meta": {"x": "y"}}}
+{"logical_key": "куилт.txt", "physical_keys": ["file:///home/dima/src/t4/api/python/tmp/a.txt"], "size": 13, "hash": {"type": "SHA256", "value": "8663bab6d124806b9727f89bb4ab9db4cbcc3862f6bbf22024dfa7212aa4ab7d"}, "meta": {"user_meta": {"x": "y"}}}
 {"logical_key": "b/x.json", "physical_keys": ["file:///home/dima/src/t4/api/python/tmp/b/x.json"], "size": 14, "hash": {"type": "SHA256", "value": "426fc04f04bf8fdb5831dc37bbb6dcf70f63a37e05a68c6ea5f63e85ae579376"}, "meta": {}}

--- a/api/python/tests/integration/test_packages.py
+++ b/api/python/tests/integration/test_packages.py
@@ -933,7 +933,7 @@ class PackageTest(QuiltTestCase):
     def test_top_hash_stable(self):
         """Ensure that top_hash() never changes for a given manifest"""
 
-        top_hash = '20de5433549a4db332a11d8d64b934a82bdea8f144b4aecd901e7d4134f8e733'
+        top_hash = '3426a3f721e41a1d83174c691432a39ff13720426267fc799dccf3583153e850'
         manifest_path = DATA_DIR / 'top_hash_test_manifest.jsonl'
         pkg = Package._from_path(manifest_path)
 


### PR DESCRIPTION
# Description
I decided to add it because I noticed that we dump JSON with different value of [`ensure_ascii`](https://docs.python.org/3/library/json.html#json.dump) parameter for top hash and for manifests.