### PR TITLE
limit record size of manifest

### DIFF
--- a/api/python/quilt3/packages.py
+++ b/api/python/quilt3/packages.py
@@ -1098,7 +1098,7 @@ class Package:
                     'Quilt recommends less than 1MB of metadata per object, '
                     'and less than 1MB of package-level metadata. '
                     'This enables S3 select, Athena and downstream services '
-                    'to work correctly. This limit can be overridden with '
+                    'to work correctly. This limit can be overridden with the '
                     'QUILT_MANIFEST_MAX_RECORD_SIZE environment variable.'
                 )
             return data

--- a/api/python/quilt3/packages.py
+++ b/api/python/quilt3/packages.py
@@ -1094,7 +1094,7 @@ class Package:
                 entry_text = 'package metadata' if lk is None else f'entry with logical key {lk!r}'
                 raise QuiltException(
                     f"Size of manifest record for {entry_text} is {encoded_size} bytes, "
-                    f"but it's limited by {MANIFEST_MAX_RECORD_SIZE} bytes. "
+                    f"but must be less than {MANIFEST_MAX_RECORD_SIZE} bytes. "
                     'Quilt recommends less than 1MB of metadata per object, '
                     'and less than 1 MB of package-level metadata. '
                     'This enables S3 select, Athena and downstream services '

--- a/api/python/quilt3/packages.py
+++ b/api/python/quilt3/packages.py
@@ -1094,7 +1094,7 @@ class Package:
                 entry_text = 'package metadata' if lk is None else f'entry with logical key {lk!r}'
                 raise QuiltException(
                     f"Size of manifest record for {entry_text} is {encoded_size} bytes, "
-                    f"but it's limited by {MANIFEST_MAX_RECORD_SIZE} bytes."
+                    f"but it's limited by {MANIFEST_MAX_RECORD_SIZE} bytes. "
                     'Quilt recommends less than 1MB of metadata per object, '
                     'and less than 1MB of package-level metadata. '
                     'This enables S3 select, Athena and downstream services '

--- a/api/python/quilt3/packages.py
+++ b/api/python/quilt3/packages.py
@@ -56,6 +56,16 @@ from .util import (
 logger = logging.getLogger(__name__)
 
 
+# S3 Select limitation:
+# https://docs.aws.amazon.com/AmazonS3/latest/userguide/selecting-content-from-objects.html#selecting-content-from-objects-requirements-and-limits
+# > The maximum length of a record in the input or result is 1 MB.
+# The actual limit is 1 MiB, but it's rounded because column names are included in this limit.
+DEFAULT_MANIFEST_MAX_RECORD_SIZE = 1_000_000
+MANIFEST_MAX_RECORD_SIZE = util.get_pos_int_from_env('QUILT_MANIFEST_MAX_RECORD_SIZE')
+if MANIFEST_MAX_RECORD_SIZE is None:
+    MANIFEST_MAX_RECORD_SIZE = DEFAULT_MANIFEST_MAX_RECORD_SIZE
+
+
 def _fix_docstring(**kwargs):
     def f(wrapped):
         if sys.flags.optimize < 2:
@@ -1074,7 +1084,26 @@ class Package:
         return self._dump(writable_file)
 
     def _dump(self, writable_file):
-        writer = jsonlines.Writer(writable_file)
+        json_encode = json.JSONEncoder(ensure_ascii=False).encode
+
+        def dumps(obj):
+            data = json_encode(obj)
+            encoded_size = len(data.encode())
+            if encoded_size > MANIFEST_MAX_RECORD_SIZE:
+                lk = obj.get('logical_key')
+                entry_text = 'package metadata' if lk is None else f'entry with logical key {lk!r}'
+                raise QuiltException(
+                    f"Size of manifest record for {entry_text} is {encoded_size} bytes, "
+                    f"but it's limited by {MANIFEST_MAX_RECORD_SIZE} bytes."
+                    'Quilt recommends less than 1MB of metadata per object, '
+                    'and less than 1MB of package-level metadata. '
+                    'This enables S3 select, Athena and downstream services '
+                    'to work correctly. This limit can be overridden with '
+                    'QUILT_MANIFEST_MAX_RECORD_SIZE environment variable.'
+                )
+            return data
+
+        writer = jsonlines.Writer(writable_file, dumps=dumps)
         for line in self.manifest:
             writer.write(line)
 

--- a/api/python/quilt3/packages.py
+++ b/api/python/quilt3/packages.py
@@ -1096,7 +1096,7 @@ class Package:
                     f"Size of manifest record for {entry_text} is {encoded_size} bytes, "
                     f"but it's limited by {MANIFEST_MAX_RECORD_SIZE} bytes. "
                     'Quilt recommends less than 1MB of metadata per object, '
-                    'and less than 1MB of package-level metadata. '
+                    'and less than 1 MB of package-level metadata. '
                     'This enables S3 select, Athena and downstream services '
                     'to work correctly. This limit can be overridden with the '
                     'QUILT_MANIFEST_MAX_RECORD_SIZE environment variable.'

--- a/api/python/quilt3/packages.py
+++ b/api/python/quilt3/packages.py
@@ -1095,7 +1095,7 @@ class Package:
                 raise QuiltException(
                     f"Size of manifest record for {entry_text} is {encoded_size} bytes, "
                     f"but must be less than {MANIFEST_MAX_RECORD_SIZE} bytes. "
-                    'Quilt recommends less than 1MB of metadata per object, '
+                    'Quilt recommends less than 1 MB of metadata per object, '
                     'and less than 1 MB of package-level metadata. '
                     'This enables S3 select, Athena and downstream services '
                     'to work correctly. This limit can be overridden with the '

--- a/docs/API Reference/cli.md
+++ b/docs/API Reference/cli.md
@@ -202,6 +202,8 @@ depends on network bandwidth, CPU performance, file sizes, etc.
 ```
 $ export QUILT_TRANSFER_MAX_CONCURRENCY=20
 ```
+### `QUILT_MANIFEST_MAX_RECORD_SIZE`
+Maximum size of a record in package manifest. Defaults to `1_000_000`.
 
 ### `XDG_*`
 Quilt uses appdirs for Python to determine where to write data. You can therefore

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -9,6 +9,7 @@
 
 # unreleased - YYYY-MM-DD
 ## Python API
+* [Added] Size of each manifest record is now limited by 1 MB. This constraint is added to ensure that S3 select, Athena and downstream services work correctly. This limit can be overridden with QUILT_MANIFEST_MAX_RECORD_SIZE environment variable. ([#2114](https://github.com/quiltdata/quilt/pull/2114))
 
 ## CLI
 

--- a/gendocs/env_constants.md
+++ b/gendocs/env_constants.md
@@ -22,6 +22,8 @@ depends on network bandwidth, CPU performance, file sizes, etc.
 ```
 $ export QUILT_TRANSFER_MAX_CONCURRENCY=20
 ```
+### `QUILT_MANIFEST_MAX_RECORD_SIZE`
+Maximum size of a record in package manifest. Defaults to `1_000_000`.
 
 ### `XDG_*`
 Quilt uses appdirs for Python to determine where to write data. You can therefore


### PR DESCRIPTION
# TODO

<!-- Use <del></del> for items that are not required for this PR -->

- [x] Unit tests
- [x] Documentation
    - [x] [Python: Run `build.py`](../gendocs/build.py) for new docstrings
- [x] [Changelog](CHANGELOG.md) entry
