### PR TITLE
Fix UnicodeDecodeError in buffer_s3response()

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -20,6 +20,7 @@
 * [Changed] Don't preview .tif (but keep .tiff), preview .results as plain text ([#2128](https://github.com/quiltdata/quilt/pull/2128))
 * [Changed] Sort packages by modification time by default ([#2126](https://github.com/quiltdata/quilt/pull/2126))
 * [Changed] Resolve logical keys in summaries and vega inside packages ([#2140](https://github.com/quiltdata/quilt/pull/2140))
+* [Fixed] `UnicodeDecodeError` in indexer and pkgselect lambdas ([#2123](https://github.com/quiltdata/quilt/pull/2123))
 
 # 3.4.0 - 2021-03-15
 ## Python API

--- a/lambdas/shared/t4_lambda_shared/utils.py
+++ b/lambdas/shared/t4_lambda_shared/utils.py
@@ -109,16 +109,16 @@ def sql_escape(s):
 def buffer_s3response(s3response):
     """
     Read a streaming response (botocore.eventstream.EventStream) from s3 select
-    into a StringIO buffer
+    into a BytesIO buffer
     """
     logger_ = logging.getLogger(LOGGER_NAME)
-    response = io.StringIO()
+    response = io.BytesIO()
     end_event_received = False
     stats = None
     found_records = False
     for event in s3response['Payload']:
         if 'Records' in event:
-            records = event['Records']['Payload'].decode()
+            records = event['Records']['Payload']
             response.write(records)
             found_records = True
         elif 'Progress' in event:
@@ -141,7 +141,7 @@ def query_manifest_content(
         bucket: str,
         key: str,
         sql_stmt: str
-) -> io.StringIO:
+) -> io.BytesIO:
     """
     Call S3 Select to read only the logical keys from a
     package manifest that match the desired folder path

--- a/lambdas/shared/tests/test_utils.py
+++ b/lambdas/shared/tests/test_utils.py
@@ -34,14 +34,19 @@ class TestUtils(TestCase):
         for key in logical_keys:
             jsonl += "{\"logical_key\": \"%s\"}\n" % key
         streambytes = jsonl.encode()
+        records_unicode = '{"logical_key": "💩"}\n'.encode()
+        records_unicode = (records_unicode[:-4], records_unicode[-4:])
 
         self.s3response = {
             'Payload': [
-                {
-                    'Records': {
-                        'Payload': streambytes
+                *[
+                    {
+                        'Records': {
+                            'Payload': payload
+                        }
                     }
-                },
+                    for payload in (streambytes, *records_unicode)
+                ],
                 {
                     'Progress': {
                         'Details': {


### PR DESCRIPTION
# Description
```python
s3_client.put_object(
    Bucket='quilt-dev-null',
    Key='test-s3-select',
    Body=b''.join(['ы'.encode() * 65 * 2 ** 9, b'\n'] * 2)
)
buffer_s3response(
    s3_client.select_object_content(
        Bucket='quilt-dev-null',
        Key='test-s3-select',
        ExpressionType='SQL',
        Expression='SELECT * FROM s3object s LIMIT 5',
        InputSerialization={'CSV': {}}, OutputSerialization={'CSV': {}}
    )
)
---------------------------------------------------------------------------
UnicodeDecodeError                        Traceback (most recent call last)
<ipython-input-22-f63d210a5ddd> in <module>
     10         ExpressionType='SQL',
     11         Expression='SELECT * FROM s3object s LIMIT 5',
---> 12         InputSerialization={'CSV': {}}, OutputSerialization={'CSV': {}}
     13     )
     14 )

<ipython-input-12-f3176c1b158b> in buffer_s3response(s3response)
     10     for event in s3response['Payload']:
     11         if 'Records' in event:
---> 12             records = event['Records']['Payload'].decode()
     13             response.write(records)
     14             found_records = True

UnicodeDecodeError: 'utf-8' codec can't decode byte 0xd1 in position 64999: unexpected end of data
```


# TODO

<!-- Use <del></del> for items that are not required for this PR -->

- [x] Unit tests
- [ ] [Changelog](CHANGELOG.md) entry
