### PR TITLE
FilesSelector: remove checkbox icon from select all / none btn

### DIFF
--- a/catalog/app/containers/Bucket/PackageDialog/FilesInput.tsx
+++ b/catalog/app/containers/Bucket/PackageDialog/FilesInput.tsx
@@ -1377,7 +1377,11 @@ export function FilesSelector({
             size="small"
             endIcon={
               <M.Icon fontSize="small">
-                {selected < value.length ? 'check_box' : 'check_box_outline_blank'}
+                {selected === value.length // eslint-disable-line no-nested-ternary
+                  ? 'check_box'
+                  : !selected
+                  ? 'check_box_outline_blank'
+                  : 'indeterminate_check_box_icon'}
               </M.Icon>
             }
           >

--- a/catalog/app/containers/Bucket/PackageDirectoryDialog.tsx
+++ b/catalog/app/containers/Bucket/PackageDirectoryDialog.tsx
@@ -196,13 +196,13 @@ function DialogForm({
       ...dirs.map((dir) => ({
         type: 'dir' as const,
         name: basename(dir),
-        selected: true,
+        selected: false,
       })),
       ...files.map((file) => ({
         type: 'file' as const,
         name: basename(file.key),
         size: file.size,
-        selected: true,
+        selected: false,
       })),
     ],
     [dirs, files],


### PR DESCRIPTION
- no items selected by default
- indeterminate state for "select all / none" checkbox when some items are selected