### PR TITLE
Do not create process pool unless we have temporary files

### DIFF
--- a/api/python/quilt3/packages.py
+++ b/api/python/quilt3/packages.py
@@ -1421,15 +1421,16 @@ class Package:
             return pathlib.Path(pk.path).parent == APP_DIR_TEMPFILE_DIR
 
         temp_file_logical_keys = [lk for lk, entry in self.walk() if physical_key_is_temp_file(entry.physical_key)]
-        temp_file_physical_keys = [self[lk].physical_key for lk in temp_file_logical_keys]
+        if temp_file_logical_keys:
+            temp_file_physical_keys = [self[lk].physical_key for lk in temp_file_logical_keys]
 
-        # Now that data has been pushed, delete tmp files created by pkg.set('KEY', obj)
-        with Pool(10) as p:
-            p.map(_delete_local_physical_key, temp_file_physical_keys)
+            # Now that data has been pushed, delete tmp files created by pkg.set('KEY', obj)
+            with Pool(10) as p:
+                p.map(_delete_local_physical_key, temp_file_physical_keys)
 
-        # Update old package to point to the materialized location of the file since the tempfile no longest exists
-        for lk in temp_file_logical_keys:
-            self._set(lk, pkg[lk])
+            # Update old package to point to the materialized location of the file since the tempfile no longest exists
+            for lk in temp_file_logical_keys:
+                self._set(lk, pkg[lk])
 
         pkg._push_manifest(name, registry, top_hash)
 


### PR DESCRIPTION
# Description
That saves 100 msec, but mostly that's [workaround for our lambda](https://stackoverflow.com/questions/34005930/multiprocessing-semlock-is-not-implemented-when-running-on-aws-lambda).
