### PR TITLE
JsonEditor breadcrumbs overflow + resize refactoring

### DIFF
--- a/catalog/app/components/JsonEditor/Breadcrumbs.js
+++ b/catalog/app/components/JsonEditor/Breadcrumbs.js
@@ -6,10 +6,9 @@ const useStyles = M.makeStyles((t) => ({
     alignItems: 'center',
     border: `1px solid ${t.palette.grey[400]}`,
     borderWidth: '1px 1px 0',
-    display: 'flex',
-    height: t.spacing(4) + 1,
-    padding: t.spacing(0, 1),
     color: t.palette.text.hint,
+    display: 'flex',
+    padding: '5px 8px',
   },
   objectRoot: {
     marginRight: t.spacing(0.5),

--- a/catalog/app/containers/Bucket/PackageCreateDialog.js
+++ b/catalog/app/containers/Bucket/PackageCreateDialog.js
@@ -570,21 +570,28 @@ function PackageCreateDialog({
 
   const [editorElement, setEditorElement] = React.useState()
 
+  const resizeObserver = React.useMemo(
+    () =>
+      new window.ResizeObserver((entries) => {
+        const { height } = entries[0]?.contentRect
+        setMetaHeight(height)
+      }),
+    [setMetaHeight],
+  )
+
   const onFormChange = React.useCallback(
     ({ dirtyFields, values }) => {
-      if (document.body.contains(editorElement)) {
-        setMetaHeight(editorElement.clientHeight)
-      }
       if (dirtyFields.name) handleNameChange(values.name)
     },
-    [editorElement, handleNameChange, setMetaHeight],
+    [handleNameChange],
   )
 
   React.useEffect(() => {
-    if (document.body.contains(editorElement)) {
-      setMetaHeight(editorElement.clientHeight)
+    if (editorElement) resizeObserver.observe(editorElement)
+    return () => {
+      if (editorElement) resizeObserver.unobserve(editorElement)
     }
-  }, [editorElement, setMetaHeight])
+  }, [editorElement, resizeObserver])
 
   const username = redux.useSelector(authSelectors.username)
   const usernamePrefix = React.useMemo(() => PD.getUsernamePrefix(username), [username])


### PR DESCRIPTION
* Don't restrict breadcrumbs height
* Use ResizeObserver for listening size changes

Before
![1  before](https://user-images.githubusercontent.com/533229/113333271-e41dcd80-932a-11eb-87c1-b2750b3a54ad.png)

After
![2  after](https://user-images.githubusercontent.com/533229/113333277-e5e79100-932a-11eb-86cb-2172570714a2.png)
