### PR TITLE
Fix package preview while 416 HTTP Status

### DIFF
--- a/catalog/app/components/Preview/Display.js
+++ b/catalog/app/components/Preview/Display.js
@@ -126,6 +126,12 @@ export default function PreviewDisplay({
             body: 'Something went wrong while loading preview',
             action: !!retry && renderAction({ label: 'Retry', onClick: retry }),
           }),
+        __: ({ retry }) =>
+          renderMessage({
+            heading: 'Unexpected Error',
+            body: 'Something went wrong while loading preview',
+            action: !!retry && renderAction({ label: 'Retry', onClick: retry }),
+          }),
       }),
     }),
   )


### PR DESCRIPTION
`InvalidRange` error was a cause of a broken page. Instead of adding one more case, I added `__` placeholder, because I think there are other errors that could happen.