### PR TITLE
Listing: load more

### DIFF
--- a/catalog/app/containers/Bucket/Dir.tsx
+++ b/catalog/app/containers/Bucket/Dir.tsx
@@ -15,6 +15,7 @@ import * as NamedRoutes from 'utils/NamedRoutes'
 import * as BucketPreferences from 'utils/BucketPreferences'
 import parseSearch from 'utils/parseSearch'
 import { getBreadCrumbs, ensureNoSlash, withoutPrefix, up, decode } from 'utils/s3paths'
+import type * as workflows from 'utils/workflows'
 
 import Code from './Code'
 import CopyButton from './CopyButton'
@@ -93,6 +94,74 @@ const formatListing = ({ urls }: { urls: Urls }, r: ListingResponse) => {
   return R.uniqBy(R.prop('name'), items)
 }
 
+interface DirContentsProps {
+  response: ListingResponse
+  locked: boolean
+  bucket: string
+  path: string
+  successor: workflows.Successor | null
+  setSuccessor: (successor: workflows.Successor | null) => void
+  loadMore?: () => void
+}
+
+function DirContents({
+  response,
+  locked,
+  bucket,
+  path,
+  successor,
+  setSuccessor,
+  loadMore,
+}: DirContentsProps) {
+  const history = RRDom.useHistory()
+  const { urls } = NamedRoutes.use<RouteMap>()
+
+  const onPackageDirectoryDialogExited = React.useCallback(() => {
+    setSuccessor(null)
+  }, [setSuccessor])
+
+  const setPrefix = React.useCallback(
+    (newPrefix) => {
+      history.push(urls.bucketDir(bucket, path, newPrefix))
+    },
+    [history, urls, bucket, path],
+  )
+
+  const items = React.useMemo(() => formatListing({ urls }, response), [urls, response])
+
+  // TODO: should prefix filtering affect summary?
+  return (
+    <>
+      <PackageDirectoryDialog
+        bucket={bucket}
+        path={path}
+        files={response.files}
+        dirs={response.dirs}
+        truncated={response.truncated}
+        open={!!successor}
+        successor={successor}
+        onExited={onPackageDirectoryDialogExited}
+      />
+
+      <Listing
+        items={items}
+        locked={locked}
+        loadMore={loadMore}
+        truncated={response.truncated}
+        prefixFilter={response.prefix}
+        toolbarContents={
+          <PrefixFilter
+            key={`${response.bucket}/${response.path}`}
+            prefix={response.prefix}
+            setPrefix={setPrefix}
+          />
+        }
+      />
+      <Summary files={response.files} mkUrl={null} />
+    </>
+  )
+}
+
 const useStyles = M.makeStyles((t) => ({
   crumbs: {
     ...t.typography.body1,
@@ -115,8 +184,8 @@ export default function Dir({
   const classes = useStyles()
   const { urls } = NamedRoutes.use<RouteMap>()
   const { noDownload } = Config.use()
-  const history = RRDom.useHistory()
   const s3 = AWS.S3.use()
+  const preferences = BucketPreferences.use()
   const { prefix } = parseSearch(l.search)
   const path = decode(encodedPath)
   const dest = path ? basename(path) : bucket
@@ -149,27 +218,35 @@ export default function Dir({
     [bucket, path, dest],
   )
 
-  const [successor, setSuccessor] = React.useState(null)
+  const [successor, setSuccessor] = React.useState<workflows.Successor | null>(null)
 
-  const onPackageDirectoryDialogExited = React.useCallback(() => {
-    setSuccessor(null)
-  }, [setSuccessor])
+  const [prev, setPrev] = React.useState<requests.BucketListingResult | null>(null)
+
+  React.useLayoutEffect(() => {
+    // reset accumulated results when path and / or prefix change
+    setPrev(null)
+  }, [path, prefix])
 
   const data = useData(requests.bucketListing, {
     s3,
     bucket,
     path,
     prefix,
+    prev,
   })
 
-  const setPrefix = React.useCallback(
-    (newPrefix) => {
-      history.push(urls.bucketDir(bucket, path, newPrefix))
-    },
-    [history, urls, bucket, path],
-  )
-
-  const preferences = BucketPreferences.use()
+  const loadMore = React.useCallback(() => {
+    AsyncResult.case(
+      {
+        Ok: (res: requests.BucketListingResult) => {
+          // this triggers a re-render and fetching of next page of results
+          if (res.continuationToken) setPrev(res)
+        },
+        _: () => {},
+      },
+      data.result,
+    )
+  }, [data.result])
 
   return (
     <M.Box pt={2} pb={4}>
@@ -200,55 +277,19 @@ export default function Dir({
         Err: displayError(),
         Init: () => null,
         _: (x: $TSFixMe) => {
-          const res: ListingResponse | null = AsyncResult.case(
-            {
-              Ok: R.identity,
-              Pending: AsyncResult.case({
-                Ok: R.identity,
-                _: () => null,
-              }),
-              _: () => null,
-            },
-            x,
-          )
-
-          if (!res) return <M.CircularProgress />
-
-          // TODO: memoize
-          const items = formatListing({ urls }, res)
-
-          const locked = !AsyncResult.Ok.is(x)
-
-          // TODO: should prefix filtering affect summary?
-          return (
-            <>
-              <PackageDirectoryDialog
-                bucket={bucket}
-                path={path}
-                files={res.files}
-                dirs={res.dirs}
-                truncated={res.truncated}
-                open={!!successor}
-                successor={successor}
-                onExited={onPackageDirectoryDialogExited}
-              />
-
-              <Listing
-                items={items}
-                locked={locked}
-                truncated={res.truncated}
-                prefixFilter={res.prefix}
-                toolbarContents={
-                  <PrefixFilter
-                    key={`${res.bucket}/${res.path}`}
-                    prefix={res.prefix}
-                    setPrefix={setPrefix}
-                  />
-                }
-              />
-              {/* @ts-expect-error */}
-              <Summary files={res.files} />
-            </>
+          const res: ListingResponse | null = AsyncResult.getPrevResult(x)
+          return res ? (
+            <DirContents
+              response={res}
+              locked={!AsyncResult.Ok.is(x)}
+              bucket={bucket}
+              path={path}
+              successor={successor}
+              setSuccessor={setSuccessor}
+              loadMore={loadMore}
+            />
+          ) : (
+            <M.CircularProgress />
           )
         },
       })}

--- a/catalog/app/containers/Bucket/Listing.tsx
+++ b/catalog/app/containers/Bucket/Listing.tsx
@@ -15,6 +15,8 @@ const EMPTY = <i>{'<EMPTY>'}</i>
 
 const TIP_DELAY = 1000
 
+const TOOLBAR_INNER_HEIGHT = 28
+
 export interface Item {
   type: 'dir' | 'file'
   name: string
@@ -63,6 +65,11 @@ function WrappedAutosizeInput({ className, ...props }: WrappedAutosizeInputProps
 
 const usePrefixFilterStyles = M.makeStyles((t) => ({
   root: {
+    height: TOOLBAR_INNER_HEIGHT,
+    position: 'relative',
+    zIndex: 1, // to be rendered above the lock
+  },
+  input: {
     fontSize: 14,
     height: 20,
     lineHeight: '20px',
@@ -138,7 +145,7 @@ export function PrefixFilter({ prefix = '', setPrefix }: PrefixFilterProps) {
       onChange={handleChange}
       onKeyDown={handleKeyDown}
       placeholder="Filter current directory by prefix"
-      classes={{ input: classes.root }}
+      classes={{ root: classes.root, input: classes.input }}
       inputComponent={WrappedAutosizeInput}
       inputRef={inputRef}
       startAdornment={<M.Icon className={classes.searchIcon}>search</M.Icon>}
@@ -177,6 +184,8 @@ const usePaginationStyles = M.makeStyles((t) => ({
   root: {
     alignItems: 'center',
     display: 'flex',
+    flexGrow: 1,
+    height: TOOLBAR_INNER_HEIGHT,
   },
   select: {
     alignItems: 'center',
@@ -188,14 +197,11 @@ const usePaginationStyles = M.makeStyles((t) => ({
   },
   input: {
     fontSize: 'inherit',
+    marginRight: t.spacing(0.5),
 
-    // TODO: xs?
-    [t.breakpoints.down('sm')]: {
+    [t.breakpoints.down('xs')]: {
       display: 'none',
     },
-  },
-  actions: {
-    marginLeft: t.spacing(0.5),
   },
   button: {
     color: t.palette.action.active,
@@ -209,7 +215,12 @@ const usePaginationStyles = M.makeStyles((t) => ({
   },
 }))
 
-function Pagination() {
+interface PaginationProps {
+  truncated?: boolean
+  loadMore?: () => void
+}
+
+function Pagination({ truncated, loadMore }: PaginationProps) {
   const classes = usePaginationStyles()
 
   const apiRef = React.useContext(DG.GridApiContext)
@@ -258,6 +269,7 @@ function Pagination() {
 
   return (
     <div className={classes.root}>
+      <M.Box flexGrow={1} />
       {rowsPerPageOptions.length > 1 && (
         <M.Select
           classes={{ select: classes.select }}
@@ -272,23 +284,27 @@ function Pagination() {
           ))}
         </M.Select>
       )}
-      <div className={classes.actions}>
-        <M.IconButton
+      <M.IconButton size="small" disabled={page === 1} onClick={() => setPage(page - 1)}>
+        <M.Icon fontSize="small">chevron_left</M.Icon>
+      </M.IconButton>
+      {renderPageRange({ page, pages, renderPage, renderGap, max: 10 })}
+      {truncated && !!loadMore && (
+        <M.Button
           size="small"
-          disabled={page === 1}
-          onClick={() => setPage(page - 1)}
+          className={classes.button}
+          onClick={loadMore}
+          title="Load more"
         >
-          <M.Icon fontSize="small">chevron_left</M.Icon>
-        </M.IconButton>
-        {renderPageRange({ page, pages, renderPage, renderGap, max: 10 })}
-        <M.IconButton
-          size="small"
-          disabled={page === pages}
-          onClick={() => setPage(page + 1)}
-        >
-          <M.Icon fontSize="small">chevron_right</M.Icon>
-        </M.IconButton>
-      </div>
+          &hellip;
+        </M.Button>
+      )}
+      <M.IconButton
+        size="small"
+        disabled={page === pages}
+        onClick={() => setPage(page + 1)}
+      >
+        <M.Icon fontSize="small">chevron_right</M.Icon>
+      </M.IconButton>
     </div>
   )
 }
@@ -366,32 +382,54 @@ const useToolbarStyles = M.makeStyles((t) => ({
     alignItems: 'center',
     borderBottom: `1px solid ${t.palette.divider}`,
     display: 'flex',
-    height: 36,
-    padding: t.spacing(0, 1),
+    flexWrap: 'wrap',
+    padding: t.spacing(0.5, 1),
+    position: 'relative',
   },
   icon: {
     fontSize: t.typography.body1.fontSize,
     marginRight: t.spacing(0.5),
   },
   truncated: {
+    ...t.typography.body2,
     alignItems: 'center',
     color: t.palette.text.secondary,
     display: 'flex',
+    height: TOOLBAR_INNER_HEIGHT,
     marginLeft: t.spacing(1),
   },
-  spacer: {
-    flexGrow: 1,
+  lock: {
+    background: fade(t.palette.background.paper, 0.5),
+    bottom: 0,
+    left: 0,
+    position: 'absolute',
+    right: 0,
+    top: 0,
+  },
+  loadMore: {
+    font: 'inherit',
+  },
+  progress: {
+    marginLeft: t.spacing(0.5),
   },
 }))
 
 interface ToolbarOwnProps {
   children?: React.ReactNode
   truncated?: boolean
+  locked?: boolean
+  loadMore?: () => void
 }
 
 type ToolbarProps = ToolbarOwnProps & DG.GridBaseComponentProps
 
-function Toolbar({ truncated = false, rows, children }: ToolbarProps) {
+function Toolbar({
+  truncated = false,
+  locked = false,
+  loadMore,
+  rows,
+  children,
+}: ToolbarProps) {
   const classes = useToolbarStyles()
   const items = (rows as unknown) as Item[]
   return (
@@ -401,11 +439,25 @@ function Toolbar({ truncated = false, rows, children }: ToolbarProps) {
         <div className={classes.truncated}>
           <M.Icon className={classes.icon}>warning</M.Icon>
           Showing first {items.length} objects
+          {!!loadMore && (
+            <>
+              <> &rarr;&nbsp;</>
+              <M.Link
+                onClick={loadMore}
+                className={classes.loadMore}
+                component="button"
+                underline="always"
+              >
+                load more
+              </M.Link>
+              {locked && <M.CircularProgress size={16} className={classes.progress} />}
+            </>
+          )}
         </div>
       )}
-      <div className={classes.spacer} />
-      <Pagination />
+      <Pagination truncated={truncated} loadMore={loadMore} />
       <FilterToolbarButton />
+      {locked && <div className={classes.lock} />}
     </div>
   )
 }
@@ -497,8 +549,18 @@ const useFooterStyles = M.makeStyles((t) => ({
     color: t.palette.text.secondary,
     display: 'flex',
     height: 36,
+    position: 'relative',
+  },
+  lock: {
+    background: fade(t.palette.background.paper, 0.5),
+    bottom: 0,
+    left: 0,
+    position: 'absolute',
+    right: 0,
+    top: 0,
   },
   group: {
+    ...t.typography.body2,
     alignItems: 'center',
     display: 'flex',
 
@@ -509,6 +571,17 @@ const useFooterStyles = M.makeStyles((t) => ({
   icon: {
     fontSize: t.typography.body1.fontSize,
     marginRight: t.spacing(0.5),
+  },
+  loadMore: {
+    font: 'inherit',
+  },
+  progress: {
+    marginLeft: t.spacing(0.5),
+  },
+  truncationWarning: {
+    [t.breakpoints.down('xs')]: {
+      display: 'none',
+    },
   },
   cellFirst: {
     alignItems: 'center',
@@ -531,11 +604,19 @@ const useFooterStyles = M.makeStyles((t) => ({
 
 interface FooterOwnProps {
   truncated?: boolean
+  locked?: boolean
+  loadMore?: () => void
 }
 
 type FooterProps = FooterOwnProps & DG.GridBaseComponentProps
 
-function Footer({ truncated = false, rows, state }: FooterProps) {
+function Footer({
+  truncated = false,
+  locked = false,
+  loadMore,
+  rows,
+  state,
+}: FooterProps) {
   const classes = useFooterStyles()
 
   const apiRef = React.useContext(DG.GridApiContext)
@@ -588,7 +669,25 @@ function Footer({ truncated = false, rows, state }: FooterProps) {
           // TODO: show tooltip with detailed description?
           <div className={classes.group}>
             <M.Icon className={classes.icon}>warning</M.Icon>
-            Showing first {items.length} objects
+            <span className={classes.truncationWarning}>
+              Showing first {items.length} objects
+              {!!loadMore && (
+                <>
+                  <> &rarr;&nbsp;</>
+                  <M.Link
+                    onClick={loadMore}
+                    className={classes.loadMore}
+                    component="button"
+                    underline="always"
+                  >
+                    load more
+                  </M.Link>
+                  {locked && (
+                    <M.CircularProgress size={16} className={classes.progress} />
+                  )}
+                </>
+              )}
+            </span>
           </div>
         )}
       </div>
@@ -600,6 +699,7 @@ function Footer({ truncated = false, rows, state }: FooterProps) {
       <div className={classes.cellLast}>
         {modified && `${truncated ? '~' : ''}${modified.toLocaleString()}`}
       </div>
+      {locked && <div className={classes.lock} />}
     </div>
   )
 }
@@ -716,6 +816,21 @@ const useStyles = M.makeStyles((t) => ({
       },
     },
   },
+  locked: {
+    '& .MuiDataGrid-columnsContainer': {
+      position: 'absolute',
+
+      '&::after': {
+        background: fade(t.palette.background.paper, 0.5),
+        bottom: 0,
+        content: '""',
+        left: 0,
+        position: 'absolute',
+        right: 0,
+        top: 0,
+      },
+    },
+  },
   link: {
     padding: t.spacing(0, 1),
     width: '100%',
@@ -739,6 +854,7 @@ interface ListingProps {
   locked?: boolean
   prefixFilter?: string
   toolbarContents?: React.ReactNode
+  loadMore?: () => void
 }
 
 export function Listing({
@@ -747,6 +863,7 @@ export function Listing({
   locked = false,
   toolbarContents,
   prefixFilter,
+  loadMore,
 }: ListingProps) {
   const classes = useStyles()
 
@@ -863,14 +980,14 @@ export function Listing({
     <M.Paper className={classes.root}>
       <DataGrid
         onFilterModelChange={handleFilterModelChange}
-        className={classes.grid}
+        className={cx(classes.grid, locked && classes.locked)}
         rows={items}
         columns={columns}
         autoHeight
         components={{ Toolbar, Footer, Panel, ColumnMenu, LoadingOverlay }}
         componentsProps={{
-          toolbar: { truncated, children: toolbarContents },
-          footer: { truncated },
+          toolbar: { truncated, locked, loadMore, children: toolbarContents },
+          footer: { truncated, locked, loadMore },
         }}
         getRowId={(row) => row.name}
         pagination

--- a/catalog/app/containers/Bucket/errors.tsx
+++ b/catalog/app/containers/Bucket/errors.tsx
@@ -1,8 +1,7 @@
 import * as R from 'ramda'
 import * as React from 'react'
-import { connect } from 'react-redux'
+import * as redux from 'react-redux'
 import { Route, Link } from 'react-router-dom'
-import { createStructuredSelector } from 'reselect'
 import Button from '@material-ui/core/Button'
 
 import Message from 'components/Message'
@@ -32,21 +31,29 @@ export class FileNotFound extends BucketError {}
 
 export class VersionNotFound extends BucketError {}
 
+export interface BucketPreferencesInvalidProps {
+  errors: { dataPath: string; message: string }[]
+}
+
 export class BucketPreferencesInvalid extends BucketError {
   static displayName = 'BucketPreferencesInvalid'
 
-  constructor(props) {
+  constructor(props: BucketPreferencesInvalidProps) {
     super(
       props.errors.map(({ dataPath, message }) => `${dataPath} ${message}`).join(', '),
       props,
     )
   }
+}
+
+export interface WorkflowsConfigInvalidProps {
+  errors: { dataPath: string; message: string }[]
 }
 
 export class WorkflowsConfigInvalid extends BucketError {
   static displayName = 'WorkflowsConfigInvalid'
 
-  constructor(props) {
+  constructor(props: WorkflowsConfigInvalidProps) {
     super(
       props.errors.map(({ dataPath, message }) => `${dataPath} ${message}`).join(', '),
       props,
@@ -54,10 +61,17 @@ export class WorkflowsConfigInvalid extends BucketError {
   }
 }
 
+export interface ManifestTooLargeProps {
+  bucket: string
+  key: string
+  actualSize: number
+  maxSize: number
+}
+
 export class ManifestTooLarge extends BucketError {
   static displayName = 'ManifestTooLarge'
 
-  constructor(props) {
+  constructor(props: ManifestTooLargeProps) {
     super(
       `Package manifest at s3://${props.bucket}/${props.key} is too large: ${props.actualSize} (max size: ${props.maxSize})`,
       props,
@@ -65,10 +79,16 @@ export class ManifestTooLarge extends BucketError {
   }
 }
 
+export interface BadRevisionProps {
+  bucket: string
+  handle: string
+  revision: string
+}
+
 export class BadRevision extends BucketError {
   static displayName = 'BadRevision'
 
-  constructor(props) {
+  constructor(props: BadRevisionProps) {
     super(
       `Could not resolve revision "${props.revision}" for package "${props.handle}" in s3://${props.bucket}`,
       props,
@@ -76,13 +96,21 @@ export class BadRevision extends BucketError {
   }
 }
 
-const WhenAuth = connect(
-  createStructuredSelector({
-    authenticated: Auth.selectors.authenticated,
-  }),
-)(({ authenticated, cases, args }) => cases[authenticated](...args))
+interface WhenAuthCases {
+  true: () => React.ReactElement
+  false: () => React.ReactElement
+}
 
-const whenAuth = (cases) => (...args) => <WhenAuth {...{ cases, args }} />
+interface WhenAuthProps {
+  cases: WhenAuthCases
+}
+
+function WhenAuth({ cases }: WhenAuthProps) {
+  const authenticated = redux.useSelector(Auth.selectors.authenticated)
+  return cases[`${authenticated}` as 'true' | 'false']()
+}
+
+const whenAuth = (cases: WhenAuthCases) => () => <WhenAuth cases={cases} />
 
 function SignIn() {
   const { urls } = NamedRoutes.use()
@@ -102,7 +130,7 @@ function SignIn() {
   )
 }
 
-const defaultHandlers = [
+const defaultHandlers: ErrorHandler[] = [
   [
     R.is(CORSError),
     () => (
@@ -181,7 +209,9 @@ const defaultHandlers = [
   ],
 ]
 
-export const displayError = (pairs = []) =>
+type ErrorHandler = [(error: unknown) => boolean, (error: unknown) => React.ReactElement]
+
+export const displayError = (pairs: ErrorHandler[] = []) =>
   R.cond([
     ...defaultHandlers,
     ...pairs,
@@ -193,10 +223,12 @@ export const displayError = (pairs = []) =>
     ],
   ])
 
-const startsWithSafe = (prefix) => (str) =>
+const startsWithSafe = (prefix: string) => (str: unknown) =>
   typeof str === 'string' ? str.startsWith(prefix) : false
 
-export const catchErrors = (pairs = []) =>
+type ErrorCatcher = [(error: unknown) => boolean, (error: unknown) => never]
+
+export const catchErrors = (pairs: ErrorCatcher[] = []) =>
   R.cond([
     [
       R.propEq('message', 'Network Failure'),
@@ -260,4 +292,4 @@ export const catchErrors = (pairs = []) =>
         throw e
       },
     ],
-  ])
+  ]) as (reason: unknown) => never

--- a/catalog/app/containers/Bucket/requests/bucketListing.ts
+++ b/catalog/app/containers/Bucket/requests/bucketListing.ts
@@ -1,0 +1,83 @@
+import type { S3 } from 'aws-sdk'
+import * as R from 'ramda'
+
+import * as errors from '../errors'
+
+import { decodeS3Key } from './utils'
+
+interface File {
+  bucket: string
+  key: string
+  modified: Date
+  size: number
+  etag: string
+  archived: boolean
+}
+
+export interface BucketListingResult {
+  dirs: string[]
+  files: File[]
+  truncated: boolean
+  continuationToken?: string
+  bucket: string
+  path: string
+  prefix?: string
+}
+
+interface BucketListingParams {
+  s3: S3
+  bucket: string
+  path?: string
+  prefix?: string
+  prev?: BucketListingResult
+}
+
+export const bucketListing = ({
+  s3,
+  bucket,
+  path = '',
+  prefix,
+  prev,
+}: BucketListingParams): Promise<BucketListingResult> =>
+  s3
+    .listObjectsV2({
+      Bucket: bucket,
+      Delimiter: '/',
+      Prefix: path + (prefix || ''),
+      EncodingType: 'url',
+      ContinuationToken: prev ? prev.continuationToken : undefined,
+    })
+    .promise()
+    .then((res) => {
+      let dirs = (res.CommonPrefixes || [])
+        .map((p) => decodeS3Key(p.Prefix!))
+        .filter((d) => d !== '/' && d !== '../')
+      if (prev && prev.dirs) dirs = prev.dirs.concat(dirs)
+      dirs = R.uniq(dirs)
+
+      let files = (res.Contents || [])
+        .map(R.evolve({ Key: decodeS3Key }))
+        // filter-out "directory-files" (files that match prefixes)
+        .filter(({ Key }: S3.Object) => Key !== path && !Key!.endsWith('/'))
+        .map((i: S3.Object) => ({
+          // TODO: expose VersionId?
+          bucket,
+          key: i.Key!,
+          modified: i.LastModified!,
+          size: i.Size!,
+          etag: i.ETag!,
+          archived: i.StorageClass === 'GLACIER' || i.StorageClass === 'DEEP_ARCHIVE',
+        }))
+      if (prev && prev.files) files = prev.files.concat(files)
+
+      return {
+        dirs,
+        files,
+        truncated: res.IsTruncated!,
+        continuationToken: res.NextContinuationToken,
+        bucket,
+        path,
+        prefix,
+      }
+    })
+    .catch(errors.catchErrors())

--- a/catalog/app/containers/Bucket/requests/index.ts
+++ b/catalog/app/containers/Bucket/requests/index.ts
@@ -1,0 +1,2 @@
+export * from './requestsUntyped'
+export * from './bucketListing'

--- a/catalog/app/containers/Bucket/requests/utils.ts
+++ b/catalog/app/containers/Bucket/requests/utils.ts
@@ -1,0 +1,3 @@
+import * as R from 'ramda'
+
+export const decodeS3Key = R.pipe(R.replace(/\+/g, ' '), decodeURIComponent)

--- a/catalog/app/utils/AsyncResult.js
+++ b/catalog/app/utils/AsyncResult.js
@@ -16,4 +16,10 @@ AsyncResult.props = R.curryN(2, (names, ...args) =>
   ),
 )
 
+AsyncResult.getPrevResult = AsyncResult.case({
+  Ok: R.identity,
+  Pending: (p) => AsyncResult.getPrevResult(p),
+  _: () => null,
+})
+
 export default AsyncResult

--- a/catalog/app/utils/error.ts
+++ b/catalog/app/utils/error.ts
@@ -7,7 +7,7 @@ export class BaseError extends Error {
    *
    * @param props - Properties to assign to the created instance.
    */
-  constructor(msg: string, props?: {}) {
+  constructor(msg?: string, props?: {}) {
     super(msg)
     Object.setPrototypeOf(this, new.target.prototype)
     // XXX: do we still need this?

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -16,6 +16,7 @@
 ## Catalog, Lambdas
 * [Added] Prepopulate today date for metadata ([#2121](https://github.com/quiltdata/quilt/pull/2121))
 * [Added] Limit and offset parameters in pkgselect lambda ([#2124](https://github.com/quiltdata/quilt/pull/2124))
+* [Added] File listing: "load more" button to fetch more entries from S3 ([#2150](https://github.com/quiltdata/quilt/pull/2150))
 * [Changed] New DataGrid-based file listing UI with arbitrary sorting and filtering ([#2097](https://github.com/quiltdata/quilt/pull/2097))
 * [Changed] Item selection in folder-to-package dialog ([#2122](https://github.com/quiltdata/quilt/pull/2122))
 * [Changed] Don't preview .tif (but keep .tiff), preview .results as plain text ([#2128](https://github.com/quiltdata/quilt/pull/2128))


### PR DESCRIPTION
# Description

There's two ways to load more results: "load more" button in header / footer and second "..." button (displayed after the last page in pagination)
<img width="1252" alt="Screenshot 2021-04-05 at 22 25 03" src="https://user-images.githubusercontent.com/122294/113603820-daafa080-965d-11eb-9645-453f14f40bee.png">


# TODO

<!-- Use <del></del> for items that are not required for this PR -->

- [ ] Unit tests
- [ ] Automated tests (e.g. Preflight)
- [ ] Documentation
    - [ ] [Python: Run `build.py`](../gendocs/build.py) for new docstrings
    - [ ] JavaScript: basic explanation and screenshot of new features
- [x] [Changelog](CHANGELOG.md) entry
