### PR TITLE
Embed: load polyfills, bring back prefix filtering, load more

### DIFF
--- a/catalog/app/containers/Bucket/Listing.tsx
+++ b/catalog/app/containers/Bucket/Listing.tsx
@@ -579,6 +579,9 @@ const useFooterStyles = M.makeStyles((t) => ({
     marginLeft: t.spacing(0.5),
   },
   truncationWarning: {
+    alignItems: 'inherit',
+    display: 'inherit',
+
     [t.breakpoints.down('xs')]: {
       display: 'none',
     },

--- a/catalog/app/embed/Dir.js
+++ b/catalog/app/embed/Dir.js
@@ -106,7 +106,7 @@ export default function Dir({
   const [prev, setPrev] = React.useState(null)
 
   React.useLayoutEffect(() => {
-    // reset accumulated results when path and / or prefix change
+    // reset accumulated results when path and/or prefix change
     setPrev(null)
   }, [path, prefix])
 

--- a/catalog/app/embed/index.html
+++ b/catalog/app/embed/index.html
@@ -17,6 +17,7 @@
     />
     <!-- styles for Jupyter Notebooks -->
     <link href="/ipynb.css" rel="stylesheet" />
+    <script src="https://polyfill.io/v3/polyfill.min.js?features=Intl%2Cdefault%2CResizeObserver%2CBlob%2Cfetch%2Ces2016%2Ces2017%2Ces2018%2Ces2019%2Ces2015"></script>
   </head>
   <body>
     <!--[if lte IE 10]>

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -22,6 +22,7 @@
 * [Changed] Don't preview .tif (but keep .tiff), preview .results as plain text ([#2128](https://github.com/quiltdata/quilt/pull/2128))
 * [Changed] Sort packages by modification time by default ([#2126](https://github.com/quiltdata/quilt/pull/2126))
 * [Changed] Resolve logical keys in summaries and vega inside packages ([#2140](https://github.com/quiltdata/quilt/pull/2140))
+* [Changed] Embed: load polyfills, bring back prefix filtering, load more ([#2153](https://github.com/quiltdata/quilt/pull/2153))
 * [Fixed] `UnicodeDecodeError` in indexer and pkgselect lambdas ([#2123](https://github.com/quiltdata/quilt/pull/2123))
 
 # 3.4.0 - 2021-03-15


### PR DESCRIPTION
# Description


# TODO

<!-- Use <del></del> for items that are not required for this PR -->

- [ ] Unit tests
- [ ] Automated tests (e.g. Preflight)
- [ ] Documentation
    - [ ] [Python: Run `build.py`](../gendocs/build.py) for new docstrings
    - [ ] JavaScript: basic explanation and screenshot of new features
- [x] [Changelog](CHANGELOG.md) entry
