### PR TITLE
telemetry changes in client for pkgpush lambda v2

### DIFF
--- a/api/python/quilt3/telemetry.py
+++ b/api/python/quilt3/telemetry.py
@@ -21,9 +21,16 @@ DISABLE_USAGE_METRICS_ENVVAR = "QUILT_DISABLE_USAGE_METRICS"
 MAX_CLEANUP_WAIT_SECS = 5
 
 
+@functools.lru_cache(maxsize=None)
+def get_session_id():
+    return str(uuid.uuid4())
+
+
+reset_session_id = get_session_id.cache_clear
+
+
 class ApiTelemetry:
     session = None
-    session_id = str(uuid.uuid4())
     pending_reqs = []
     pending_reqs_lock = Lock()
     telemetry_disabled = None
@@ -123,7 +130,7 @@ class ApiTelemetry:
         def decorated(*args, **kwargs):
 
             ApiTelemetry.cleanup_completed_requests()
-            ApiTelemetry.report_api_use(self.api_name, ApiTelemetry.session_id)
+            ApiTelemetry.report_api_use(self.api_name, get_session_id())
 
             results = func(*args, **kwargs)
             # print(f"{len(ApiTelemetry.pending_reqs)} request(s) pending!")

--- a/api/python/tests/test_telemetry.py
+++ b/api/python/tests/test_telemetry.py
@@ -1,6 +1,7 @@
 import unittest
 from unittest import mock
 
+import quilt3
 from quilt3.telemetry import ApiTelemetry
 
 
@@ -22,7 +23,6 @@ class TelemetryTest(unittest.TestCase):
         self.mock_report_api_use = patcher.start()
         self.addCleanup(patcher.stop)
 
-    @mock.patch('quilt3.telemetry.ApiTelemetry.telemetry_disabled', False)
     def test_session_id(self):
         """
         Session ID stays the same across the calls.
@@ -34,3 +34,16 @@ class TelemetryTest(unittest.TestCase):
         self.mock_report_api_use.reset_mock()
         test_api_function2()
         self.mock_report_api_use.assert_called_once_with(mock.sentinel.API_NAME2, session_id)
+
+    def test_session_reset_session_id(self):
+        test_api_function1()
+        self.mock_report_api_use.assert_called_once_with(mock.sentinel.API_NAME1, mock.ANY)
+        session_id = self.mock_report_api_use.call_args[0][1]
+
+        self.mock_report_api_use.reset_mock()
+        quilt3.telemetry.reset_session_id()
+        test_api_function2()
+        self.mock_report_api_use.assert_called_once_with(mock.sentinel.API_NAME2, mock.ANY)
+        new_session_id = self.mock_report_api_use.call_args[0][1]
+
+        assert new_session_id != session_id


### PR DESCRIPTION
# Description
Needed for #2139.
Stripped down version of #2151 that allows only to reset session ID.


# TODO

- [x] Unit tests