### PR TITLE
Allow unicode characters for package routes

### DIFF
--- a/catalog/app/constants/routes.js
+++ b/catalog/app/constants/routes.js
@@ -1,7 +1,7 @@
 import { mkSearch } from 'utils/NamedRoutes'
 import { encode } from 'utils/s3paths'
 
-const PACKAGE_PATTERN = '[a-z0-9-_]+/[a-z0-9-_]+'
+const PACKAGE_PATTERN = '[^/]+/[^/]+'
 
 export const home = {
   path: '/',


### PR DESCRIPTION
Python RegExp slightly different from Javascript. In Python's `\w` Unicode is included, in JavaScript - ASCII only:
![Screenshot from 2021-04-21 19-01-11](https://user-images.githubusercontent.com/533229/115585434-45a2dd80-a2d4-11eb-8c5f-4c6183c7ea01.png)

There is a special characters sequence to match any Unicode symbol: `\p{L}`, but to match Unicode symbols RegExp should be called with 'u' flag. "path-to-regexp" (library behind "react-router") doesn't use it: https://github.com/pillarjs/path-to-regexp/blob/79a5dcf5f2a79a99fbaaccae20cd922a745e0f83/index.js#L261

As a workaround, I allowed any character. Results are:

![Screenshot from 2021-04-21 19-09-40](https://user-images.githubusercontent.com/533229/115586302-1e98db80-a2d5-11eb-8ec8-e9ef2a882ac5.png)
![Screenshot from 2021-04-21 19-09-59](https://user-images.githubusercontent.com/533229/115586304-1f317200-a2d5-11eb-9332-f569f0476677.png)
![Screenshot from 2021-04-21 19-10-07](https://user-images.githubusercontent.com/533229/115586305-1f317200-a2d5-11eb-9e50-bc41235ff3c4.png)