### PR TITLE
Support custom nav link (incl. admin UI)

### DIFF
--- a/catalog/app/constants/routes.js
+++ b/catalog/app/constants/routes.js
@@ -151,3 +151,7 @@ export const adminBuckets = {
   path: '/admin/buckets',
   url: (bucket) => `/admin/buckets${mkSearch({ bucket })}`,
 }
+export const adminSettings = {
+  path: '/admin/settings',
+  url: () => '/admin/settings',
+}

--- a/catalog/app/containers/Admin/Admin.js
+++ b/catalog/app/containers/Admin/Admin.js
@@ -14,6 +14,7 @@ const mkLazy = (load) =>
 
 const UsersAndRoles = mkLazy(() => import('./UsersAndRoles'))
 const Buckets = mkLazy(() => import('./Buckets'))
+const Settings = mkLazy(() => import('./Settings'))
 
 const match = (cases) => (pathname) => {
   // eslint-disable-next-line no-restricted-syntax
@@ -29,6 +30,7 @@ const match = (cases) => (pathname) => {
 const sections = {
   users: { path: 'adminUsers', exact: true },
   buckets: { path: 'adminBuckets', exact: true },
+  settings: { path: 'adminSettings', exact: true },
 }
 
 const getAdminSection = (paths) =>
@@ -69,6 +71,7 @@ function AdminLayout({ section = false, children }) {
             <M.Tabs value={section} centered>
               <NavTab label="Users and roles" value="users" to={urls.adminUsers()} />
               <NavTab label="Buckets" value="buckets" to={urls.adminBuckets()} />
+              <NavTab label="Settings" value="settings" to={urls.adminSettings()} />
             </M.Tabs>
           </M.AppBar>
           <M.Container maxWidth="lg">{children}</M.Container>
@@ -85,6 +88,7 @@ export default function Admin({ location }) {
       <RR.Switch>
         <RR.Route path={paths.adminUsers} component={UsersAndRoles} exact strict />
         <RR.Route path={paths.adminBuckets} component={Buckets} exact />
+        <RR.Route path={paths.adminSettings} component={Settings} exact />
         <RR.Route component={ThrowNotFound} />
       </RR.Switch>
     </AdminLayout>

--- a/catalog/app/containers/Admin/Settings.tsx
+++ b/catalog/app/containers/Admin/Settings.tsx
@@ -12,16 +12,10 @@ import * as validators from 'utils/validators'
 import * as Form from './Form'
 
 const useNavLinkEditorStyles = M.makeStyles((t) => ({
-  section: {
+  actions: {
     alignItems: 'center',
     display: 'flex',
     marginTop: t.spacing(1),
-  },
-  fields: {
-    display: 'flex',
-    flexDirection: 'column',
-    marginRight: t.spacing(2),
-    overflow: 'hidden',
   },
   field: {
     display: 'flex',
@@ -115,39 +109,41 @@ function NavLinkEditor() {
   return (
     <>
       {settings?.customNavLink ? (
-        <div className={classes.section}>
-          <div className={classes.fields}>
-            <div className={classes.field}>
-              <div className={classes.fieldName}>URL:</div>
-              <div className={classes.fieldValue}>{settings.customNavLink.url}</div>
-            </div>
-            <div className={classes.field}>
-              <div className={classes.fieldName}>Label:</div>
-              <div className={classes.fieldValue}>{settings.customNavLink.label}</div>
-            </div>
+        <>
+          <div className={classes.field}>
+            <div className={classes.fieldName}>URL:</div>
+            <div className={classes.fieldValue}>{settings.customNavLink.url}</div>
           </div>
-          <M.Button
-            variant="outlined"
-            color="primary"
-            size="small"
-            onClick={edit}
-            disabled={removing}
-          >
-            Edit
-          </M.Button>
-          <M.Box pl={1} />
-          <M.Button color="primary" size="small" onClick={remove} disabled={removing}>
-            Remove
-          </M.Button>
-          {removing && <M.CircularProgress size={24} className={classes.progress} />}
-        </div>
+          <div className={classes.field}>
+            <div className={classes.fieldName}>Label:</div>
+            <div className={classes.fieldValue}>{settings.customNavLink.label}</div>
+          </div>
+          <div className={classes.actions}>
+            <M.Button
+              variant="outlined"
+              color="primary"
+              size="small"
+              onClick={edit}
+              disabled={removing}
+            >
+              Edit
+            </M.Button>
+            <M.Box pl={1} />
+            <M.Button color="primary" size="small" onClick={remove} disabled={removing}>
+              Remove
+            </M.Button>
+            {removing && <M.CircularProgress size={24} className={classes.progress} />}
+          </div>
+        </>
       ) : (
-        <div className={classes.section}>
+        <>
           <div className={classes.notConfigured}>Not configured</div>
-          <M.Button variant="outlined" color="primary" size="small" onClick={edit}>
-            Add link
-          </M.Button>
-        </div>
+          <div className={classes.actions}>
+            <M.Button variant="outlined" color="primary" size="small" onClick={edit}>
+              Configure link
+            </M.Button>
+          </div>
+        </>
       )}
       <M.Dialog open={editing} onExited={handleExited} fullWidth>
         <RF.Form onSubmit={onSubmit} key={formKey}>
@@ -235,6 +231,7 @@ const useStyles = M.makeStyles((t) => ({
   sectionHeading: {
     ...t.typography.body1,
     fontWeight: t.typography.fontWeightMedium,
+    marginBottom: t.spacing(1),
   },
 }))
 

--- a/catalog/app/containers/Admin/Settings.tsx
+++ b/catalog/app/containers/Admin/Settings.tsx
@@ -1,0 +1,257 @@
+import * as FF from 'final-form'
+import * as R from 'ramda'
+import * as React from 'react'
+import * as RF from 'react-final-form'
+import * as M from '@material-ui/core'
+
+import SubmitSpinner from 'containers/Bucket/PackageDialog/SubmitSpinner'
+import * as Notifications from 'containers/Notifications'
+import * as CatalogSettings from 'utils/CatalogSettings'
+import * as validators from 'utils/validators'
+
+import * as Form from './Form'
+
+const useNavLinkEditorStyles = M.makeStyles((t) => ({
+  section: {
+    alignItems: 'center',
+    display: 'flex',
+    marginTop: t.spacing(1),
+  },
+  fields: {
+    display: 'flex',
+    flexDirection: 'column',
+    marginRight: t.spacing(2),
+    overflow: 'hidden',
+  },
+  field: {
+    display: 'flex',
+  },
+  fieldName: {
+    ...t.typography.body2,
+    flexShrink: 0,
+    fontWeight: t.typography.fontWeightMedium,
+    width: 50,
+  },
+  fieldValue: {
+    ...t.typography.body2,
+    overflow: 'hidden',
+    textOverflow: 'ellipsis',
+  },
+  progress: {
+    marginLeft: t.spacing(1),
+  },
+  notConfigured: {
+    ...t.typography.body1,
+    marginRight: t.spacing(2),
+  },
+}))
+
+function NavLinkEditor() {
+  const settings = CatalogSettings.use()
+  const writeSettings = CatalogSettings.useWriteSettings()
+
+  const { push } = Notifications.use()
+
+  const classes = useNavLinkEditorStyles()
+
+  const [editing, setEditing] = React.useState(false)
+  const [formKey, setFormKey] = React.useState(1)
+  const [removing, setRemoving] = React.useState(false)
+
+  const edit = React.useCallback(() => {
+    if (removing) return
+    setEditing(true)
+  }, [removing])
+
+  const cancel = React.useCallback(() => {
+    setEditing(false)
+  }, [])
+
+  const handleExited = React.useCallback(() => {
+    // reset the form
+    setFormKey(R.inc)
+  }, [])
+
+  const remove = React.useCallback(async () => {
+    if (editing || removing || !settings?.customNavLink) return
+    // XXX: implement custom MUI Dialog-based confirm?
+    // eslint-disable-next-line no-restricted-globals, no-alert
+    if (!confirm('You are about to remove custom link')) return
+    setRemoving(true)
+    try {
+      await writeSettings(R.dissoc('customNavLink', settings))
+    } catch (e) {
+      // eslint-disable-next-line no-console
+      console.warn('Error saving settings:')
+      // eslint-disable-next-line no-console
+      console.error(e)
+      push("Couldn't save settings, see console for details")
+    } finally {
+      setRemoving(false)
+    }
+  }, [editing, removing, settings, writeSettings, push])
+
+  const onSubmit = React.useCallback(
+    async (values: { url: string; label: string }) => {
+      try {
+        await writeSettings({
+          ...settings,
+          customNavLink: { url: values.url, label: values.label },
+        })
+        setEditing(false)
+        return undefined
+      } catch (e) {
+        // eslint-disable-next-line no-console
+        console.warn('Error saving settings:')
+        // eslint-disable-next-line no-console
+        console.error(e)
+        return { [FF.FORM_ERROR]: "Couldn't save settings, see console for details" }
+      }
+    },
+    [settings, writeSettings],
+  )
+
+  return (
+    <>
+      {settings?.customNavLink ? (
+        <div className={classes.section}>
+          <div className={classes.fields}>
+            <div className={classes.field}>
+              <div className={classes.fieldName}>URL:</div>
+              <div className={classes.fieldValue}>{settings.customNavLink.url}</div>
+            </div>
+            <div className={classes.field}>
+              <div className={classes.fieldName}>Label:</div>
+              <div className={classes.fieldValue}>{settings.customNavLink.label}</div>
+            </div>
+          </div>
+          <M.Button
+            variant="outlined"
+            color="primary"
+            size="small"
+            onClick={edit}
+            disabled={removing}
+          >
+            Edit
+          </M.Button>
+          <M.Box pl={1} />
+          <M.Button color="primary" size="small" onClick={remove} disabled={removing}>
+            Remove
+          </M.Button>
+          {removing && <M.CircularProgress size={24} className={classes.progress} />}
+        </div>
+      ) : (
+        <div className={classes.section}>
+          <div className={classes.notConfigured}>Not configured</div>
+          <M.Button variant="outlined" color="primary" size="small" onClick={edit}>
+            Add link
+          </M.Button>
+        </div>
+      )}
+      <M.Dialog open={editing} onExited={handleExited} fullWidth>
+        <RF.Form onSubmit={onSubmit} key={formKey}>
+          {({
+            handleSubmit,
+            submitting,
+            submitFailed,
+            submitError,
+            error,
+            hasValidationErrors,
+          }) => (
+            <>
+              <M.DialogTitle>Configure custom link</M.DialogTitle>
+              <M.DialogContent>
+                <form onSubmit={handleSubmit}>
+                  <RF.Field
+                    component={Form.Field}
+                    initialValue={settings?.customNavLink?.url || ''}
+                    name="url"
+                    label="URL"
+                    placeholder="e.g. https://example.com/path"
+                    validate={validators.required as FF.FieldValidator<string>}
+                    errors={{
+                      required: 'Enter URL to link to',
+                    }}
+                    disabled={submitting}
+                    fullWidth
+                    InputLabelProps={{ shrink: true }}
+                  />
+                  <M.Box pt={2} />
+                  <RF.Field
+                    component={Form.Field}
+                    initialValue={settings?.customNavLink?.label || ''}
+                    name="label"
+                    label="Label"
+                    placeholder="Enter link label"
+                    validate={validators.required as FF.FieldValidator<string>}
+                    errors={{
+                      required: 'Enter link label',
+                    }}
+                    disabled={submitting}
+                    fullWidth
+                    InputLabelProps={{ shrink: true }}
+                  />
+                  <input type="submit" style={{ display: 'none' }} />
+                </form>
+              </M.DialogContent>
+              <M.DialogActions>
+                {submitting ? (
+                  <SubmitSpinner />
+                ) : (
+                  (!!error || !!submitError) && (
+                    <M.Box flexGrow={1} display="flex" alignItems="center" pl={2}>
+                      <M.Icon color="error">error_outline</M.Icon>
+                      <M.Box pl={1} />
+                      <M.Typography variant="body2" color="error">
+                        {error || submitError}
+                      </M.Typography>
+                    </M.Box>
+                  )
+                )}
+
+                <M.Button
+                  type="submit"
+                  onClick={handleSubmit}
+                  variant="contained"
+                  color="primary"
+                  disabled={submitting || (submitFailed && hasValidationErrors)}
+                >
+                  Save
+                </M.Button>
+                <M.Button onClick={cancel} disabled={submitting}>
+                  Cancel
+                </M.Button>
+              </M.DialogActions>
+            </>
+          )}
+        </RF.Form>
+      </M.Dialog>
+    </>
+  )
+}
+
+const useStyles = M.makeStyles((t) => ({
+  sectionHeading: {
+    ...t.typography.body1,
+    fontWeight: t.typography.fontWeightMedium,
+  },
+}))
+
+export default function Settings() {
+  const classes = useStyles()
+  return (
+    <M.Box mt={2} mb={2}>
+      <M.Paper>
+        <M.Box px={3} pt={2} pb={1}>
+          <M.Typography variant="h6">Catalog Customization</M.Typography>
+        </M.Box>
+        <M.Box px={3} pb={2}>
+          <div className={classes.sectionHeading}>Custom navbar link</div>
+          <React.Suspense fallback={<M.CircularProgress />}>
+            <NavLinkEditor />
+          </React.Suspense>
+        </M.Box>
+      </M.Paper>
+    </M.Box>
+  )
+}

--- a/catalog/app/containers/Admin/Settings.tsx
+++ b/catalog/app/containers/Admin/Settings.tsx
@@ -36,6 +36,7 @@ const useNavLinkEditorStyles = M.makeStyles((t) => ({
     ...t.typography.body2,
     overflow: 'hidden',
     textOverflow: 'ellipsis',
+    whiteSpace: 'nowrap',
   },
   progress: {
     marginLeft: t.spacing(1),

--- a/catalog/app/containers/Bucket/PackageDialog/SubmitSpinner.tsx
+++ b/catalog/app/containers/Bucket/PackageDialog/SubmitSpinner.tsx
@@ -6,7 +6,7 @@ import * as M from '@material-ui/core'
 import Delay from 'utils/Delay'
 
 interface SubmitSpinnerProps {
-  children: React.ReactNode
+  children?: React.ReactNode
   value?: number
 }
 
@@ -24,11 +24,15 @@ export default function SubmitSpinner({ children, value }: SubmitSpinnerProps) {
               value={hasValue ? value! * 0.9 : undefined}
             />
 
-            <M.Box pl={1} />
+            {!!children && (
+              <>
+                <M.Box pl={1} />
 
-            <M.Typography variant="body2" color="textSecondary">
-              {children}
-            </M.Typography>
+                <M.Typography variant="body2" color="textSecondary">
+                  {children}
+                </M.Typography>
+              </>
+            )}
           </M.Box>
         </M.Fade>
       )}

--- a/catalog/app/containers/NavBar/NavBar.tsx
+++ b/catalog/app/containers/NavBar/NavBar.tsx
@@ -38,15 +38,21 @@ interface ItemProps extends M.MenuItemProps {
 
 // FIXME: doesn't compile with Ref<unknown>
 // const Item = React.forwardRef((props: ItemProps, ref: React.Ref<unknown>) => (
-const Item = React.forwardRef((props: ItemProps, ref: React.Ref<any>) => (
-  <M.MenuItem
-    // @ts-expect-error
-    // eslint-disable-next-line no-nested-ternary
-    component={props.to ? Link : props.href ? 'a' : undefined}
-    ref={ref}
-    {...props}
-  />
-))
+const Item = React.forwardRef(
+  ({ children, ...props }: ItemProps, ref: React.Ref<any>) => (
+    <M.MenuItem
+      // @ts-expect-error
+      // eslint-disable-next-line no-nested-ternary
+      component={props.to ? Link : props.href ? 'a' : undefined}
+      ref={ref}
+      {...props}
+    >
+      <M.Box component="span" textOverflow="ellipsis" overflow="hidden" maxWidth={400}>
+        {children}
+      </M.Box>
+    </M.MenuItem>
+  ),
+)
 
 const selectUser = createStructuredSelector({
   name: authSelectors.username,
@@ -316,6 +322,15 @@ const NavLink = React.forwardRef((props: NavLinkProps, ref: React.Ref<unknown>) 
       mr={2}
       color={isActive ? 'text.disabled' : 'text.secondary'}
       fontSize="body2.fontSize"
+      maxWidth={64}
+      whiteSpace="nowrap"
+      overflow="hidden"
+      textOverflow="ellipsis"
+      title={
+        typeof props.children === 'string' && props.children.length > 10
+          ? props.children
+          : undefined
+      }
       {...props}
       ref={ref}
     />

--- a/catalog/app/containers/NavBar/NavBar.tsx
+++ b/catalog/app/containers/NavBar/NavBar.tsx
@@ -99,7 +99,7 @@ function UserDropdown() {
         <M.Menu anchorEl={anchor} open={!!anchor} onClose={close}>
           {user.isAdmin && (
             <Item to={urls.admin()} onClick={close} selected={isAdmin} divider>
-              <M.Icon fontSize="small">security</M.Icon>&nbsp;Users and buckets
+              <M.Icon fontSize="small">security</M.Icon>&nbsp;Admin settings
             </Item>
           )}
           {cfg.mode === 'OPEN' && (
@@ -181,7 +181,7 @@ function AuthHamburger({ authenticated, waiting, error }: AuthHamburgerProps) {
             <Item key="admin" to={urls.admin()} onClick={ham.close} selected={isAdmin}>
               <M.Box component="span" pr={2} />
               <M.Icon fontSize="small">security</M.Icon>
-              &nbsp;Users and buckets
+              &nbsp;Admin settings
             </Item>
           ),
           cfg.mode === 'OPEN' && (

--- a/catalog/app/containers/NavBar/NavBar.tsx
+++ b/catalog/app/containers/NavBar/NavBar.tsx
@@ -10,6 +10,7 @@ import * as style from 'constants/style'
 import * as URLS from 'constants/urls'
 import * as authSelectors from 'containers/Auth/selectors'
 import * as BucketConfig from 'utils/BucketConfig'
+import * as CatalogSettings from 'utils/CatalogSettings'
 import * as Config from 'utils/Config'
 import HashLink from 'utils/HashLink'
 import * as NamedRoutes from 'utils/NamedRoutes'
@@ -330,7 +331,12 @@ interface LinkDescriptor {
 function useLinks(): LinkDescriptor[] {
   const { paths, urls } = NamedRoutes.use()
   const cfg = Config.useConfig()
+  const settings = CatalogSettings.use()
   return [
+    settings?.customNavLink && {
+      href: settings.customNavLink.url,
+      label: settings.customNavLink.label,
+    },
     cfg.mode !== 'MARKETING' && {
       to: urls.uriResolver(),
       label: 'URI',

--- a/catalog/app/utils/CatalogSettings.tsx
+++ b/catalog/app/utils/CatalogSettings.tsx
@@ -1,0 +1,78 @@
+import type { S3 } from 'aws-sdk'
+import * as React from 'react'
+
+import * as AWS from 'utils/AWS'
+import * as Config from 'utils/Config'
+import * as Cache from 'utils/ResourceCache'
+
+const CONFIG_KEY = 'catalog/settings.json'
+
+export interface CatalogSettings {
+  customNavLink?: {
+    url: string
+    label: string
+  }
+}
+
+async function fetchSettings({
+  s3,
+  serviceBucket,
+  mode,
+}: {
+  s3: S3
+  serviceBucket: string
+  mode: string
+}) {
+  if (mode === 'MARKETING') return null
+
+  const location = `s3://${serviceBucket}/${CONFIG_KEY}`
+  try {
+    const res = await s3.getObject({ Bucket: serviceBucket, Key: CONFIG_KEY }).promise()
+    const text = res.Body!.toString('utf-8')
+    return JSON.parse(text) as CatalogSettings
+  } catch (e) {
+    // eslint-disable-next-line no-console
+    console.warn(`Error fetching catalog settings from "${location}":`)
+    // eslint-disable-next-line no-console
+    console.error(e)
+    return null
+  }
+}
+
+const CatalogSettingsResource = Cache.createResource({
+  name: 'CatalogSettings.config',
+  fetch: fetchSettings,
+  // @ts-expect-error
+  key: () => null,
+})
+
+function format(settings: CatalogSettings) {
+  return JSON.stringify(settings, null, 2)
+}
+
+export function useWriteSettings() {
+  const { serviceBucket } = Config.use()
+  const s3 = AWS.S3.use()
+  const cache = Cache.use()
+
+  return React.useCallback(
+    async (settings: CatalogSettings) => {
+      const body = format(settings)
+      await s3.putObject({ Bucket: serviceBucket, Key: CONFIG_KEY, Body: body }).promise()
+      cache.patchOk(CatalogSettingsResource, null, () => settings)
+    },
+    [serviceBucket, s3, cache],
+  )
+}
+
+export function useCatalogSettings() {
+  const { serviceBucket, mode } = Config.use()
+  const s3 = AWS.S3.use()
+  return Cache.useData(
+    CatalogSettingsResource,
+    { serviceBucket, mode, s3 },
+    { suspend: true },
+  ) as CatalogSettings | null
+}
+
+export { useCatalogSettings as use }

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -20,6 +20,7 @@
 * [Added] File listing: "load more" button to fetch more entries from S3 ([#2150](https://github.com/quiltdata/quilt/pull/2150))
 * [Added] Ability to add files from S3 while revising a package ([#2171](https://github.com/quiltdata/quilt/pull/2171))
 * [Added] Lambdas for pushing an existing package/creation of package ([#2147](https://github.com/quiltdata/quilt/pull/2147), [#2180](https://github.com/quiltdata/quilt/pull/2180))
+* [Added] Custom navbar link configurable via admin UI ([#2192](https://github.com/quiltdata/quilt/pull/2192))
 * [Changed] New DataGrid-based file listing UI with arbitrary sorting and filtering ([#2097](https://github.com/quiltdata/quilt/pull/2097))
 * [Changed] Item selection in folder-to-package dialog ([#2122](https://github.com/quiltdata/quilt/pull/2122))
 * [Changed] Don't preview .tif (but keep .tiff), preview .results as plain text ([#2128](https://github.com/quiltdata/quilt/pull/2128))


### PR DESCRIPTION
# Description

1. Support catalog settings file at `$serviceBucket/catalog/settings.json` with the single `customNavLink` field (using schemaless JSON bc it's not supposed to be editable by hand, only written by the catalog code).

2. Add admin section for customizing catalog settings.

![Screen Shot 2021-05-10 at 17 19 56](https://user-images.githubusercontent.com/122294/117658368-12a58880-b1b4-11eb-854b-a6bedb9cccdc.png)
![Screen Shot 2021-05-10 at 17 20 06](https://user-images.githubusercontent.com/122294/117658375-1507e280-b1b4-11eb-9bc9-8c4f63bd6af3.png)
![Screen Shot 2021-05-10 at 17 20 28](https://user-images.githubusercontent.com/122294/117658382-16390f80-b1b4-11eb-9169-78d9de353734.png)



# TODO

<!-- Use <del></del> for items that are not required for this PR -->

- [x] [Changelog](CHANGELOG.md) entry
