### PR TITLE
Reduce SentryLoader rerenders from 11 to 5 times

### DIFF
--- a/catalog/app/utils/Sentry.js
+++ b/catalog/app/utils/Sentry.js
@@ -26,7 +26,10 @@ export const Provider = function SentryProvider({ children }) {
 export const Loader = function SentryLoader({ children, userSelector }) {
   const { promise: cfgP } = Config.useConfig({ suspend: false })
   const { sentry, sentryRef } = React.useContext(Ctx)
-  const user = redux.useSelector(userSelector)
+  const user = redux.useSelector(
+    userSelector,
+    (l, r) => l.username === r.username && l.email === r.email,
+  )
   const userRef = React.useRef(user)
 
   React.useEffect(() => {


### PR DESCRIPTION
Error `Warning: Cannot update a component ("SentryLoader") while rendering a different component` still exists but one occurence instead of two