### PR TITLE
jsoneditor addition to package.json

### DIFF
--- a/catalog/package.json
+++ b/catalog/package.json
@@ -81,6 +81,7 @@
     "invariant": "^2.2.4",
     "ip": "^1.1.5",
     "js-yaml": "^4.1.0",
+    "jsoneditor": "^9.4.1",
     "jsoneditor-react": "^3.1.1",
     "katex": "^0.13.5",
     "lodash": "^4.17.21",


### PR DESCRIPTION
PR for issue: https://github.com/quiltdata/quilt/issues/2207

# Description
Facing the following issue when I navigate to  ./catalog and do `npm start`:

>ERROR in ./node_modules/jsoneditor-react/es/index.js 3:0-63
>Module not found: Error: Can't resolve 'jsoneditor/dist/jsoneditor-minimalist' in ...

>ERROR in ./node_modules/jsoneditor-react/es/index.js 4:0-40
>Module not found: Error: Can't resolve 'jsoneditor/dist/jsoneditor.css' in ...

Upon examination saw the the following two lines in `node_modules/jsoneditor-react/es/index.js` 
>line 3: `import JSONEditor from 'jsoneditor/dist/jsoneditor-minimalist';`
>line 4: `import 'jsoneditor/dist/jsoneditor.css';`

And package `jsoneditor` missing from `package.json`

# TODO

<!-- Use <del></del> for items that are not required for this PR -->

<del>- [ ] Unit tests</del>
<del>- [ ] Automated tests (e.g. Preflight)</del>
<del>- [ ] Documentation</del>
<del>    - [ ] [Python: Run `build.py`](../gendocs/build.py) for new docstrings</del>
<del>    - [ ] JavaScript: basic explanation and screenshot of new features</del>
<del>- [ ] [Changelog](CHANGELOG.md) entry</del>
- [x] Bugfix