### PR TITLE
Hide Intercom launcher on Package dialog open

### DIFF
--- a/catalog/app/components/Intercom/Intercom.js
+++ b/catalog/app/components/Intercom/Intercom.js
@@ -93,3 +93,22 @@ export function useIntercom() {
 }
 
 export { IntercomProvider as Provider, useIntercom as use }
+
+export function usePauseVisibilityWhen(condition) {
+  const intercom = useIntercom()
+  const [isVisible, setVisible] = React.useState(true)
+  const showIntercom = React.useCallback(
+    (shouldShow) => {
+      if (isVisible === shouldShow) return
+      intercom('update', {
+        hide_default_launcher: !shouldShow,
+      })
+      setVisible(shouldShow)
+    },
+    [intercom, isVisible, setVisible],
+  )
+  React.useEffect(() => {
+    if (condition) showIntercom(false)
+    return () => showIntercom(true)
+  }, [condition, showIntercom])
+}

--- a/catalog/app/containers/Bucket/PackageCopyDialog.js
+++ b/catalog/app/containers/Bucket/PackageCopyDialog.js
@@ -4,6 +4,7 @@ import * as React from 'react'
 import * as RF from 'react-final-form'
 import * as M from '@material-ui/core'
 
+import * as Intercom from 'components/Intercom'
 import AsyncResult from 'utils/AsyncResult'
 import * as AWS from 'utils/AWS'
 import * as Data from 'utils/Data'
@@ -404,6 +405,8 @@ export default function PackageCopyDialog({
     if (onClose) onClose()
     setSuccess(null)
   }, [submitting, success, setSuccess, onClose, onExited])
+
+  Intercom.usePauseVisibilityWhen(open)
 
   return (
     <M.Dialog fullWidth onClose={close} onExited={handleExited} open={open} scroll="body">

--- a/catalog/app/containers/Bucket/PackageCreateDialog.js
+++ b/catalog/app/containers/Bucket/PackageCreateDialog.js
@@ -9,6 +9,7 @@ import { Link } from 'react-router-dom'
 import * as redux from 'react-redux'
 import * as M from '@material-ui/core'
 
+import * as Intercom from 'components/Intercom'
 import * as authSelectors from 'containers/Auth/selectors'
 import AsyncResult from 'utils/AsyncResult'
 import * as AWS from 'utils/AWS'
@@ -752,6 +753,8 @@ export default function PackageCreateDialogWrapper({ bucket, open, onClose, refr
     setWorkflow(null)
     onClose()
   }, [submitting, success, onClose])
+
+  Intercom.usePauseVisibilityWhen(open)
 
   return (
     <M.Dialog

--- a/catalog/app/containers/Bucket/PackageDirectoryDialog.tsx
+++ b/catalog/app/containers/Bucket/PackageDirectoryDialog.tsx
@@ -6,6 +6,7 @@ import * as RF from 'react-final-form'
 import * as redux from 'react-redux'
 import * as M from '@material-ui/core'
 
+import * as Intercom from 'components/Intercom'
 import * as authSelectors from 'containers/Auth/selectors'
 import AsyncResult from 'utils/AsyncResult'
 import * as AWS from 'utils/AWS'
@@ -467,6 +468,8 @@ export default function PackageDirectoryDialog({
     if (onClose) onClose()
     setSuccess(null)
   }, [submitting, success, setSuccess, onClose, onExited])
+
+  Intercom.usePauseVisibilityWhen(open)
 
   return (
     <M.Dialog

--- a/catalog/app/containers/Bucket/PackageUpdateDialog.tsx
+++ b/catalog/app/containers/Bucket/PackageUpdateDialog.tsx
@@ -8,6 +8,7 @@ import * as RF from 'react-final-form'
 import { Link } from 'react-router-dom'
 import * as M from '@material-ui/core'
 
+import * as Intercom from 'components/Intercom'
 import AsyncResult from 'utils/AsyncResult'
 import * as AWS from 'utils/AWS'
 import * as BucketPreferences from 'utils/BucketPreferences'
@@ -717,6 +718,8 @@ export function usePackageUpdateDialog({
       if (shouldRefreshManifest) refreshManifest()
     }
   }, [setExited, setSuccess, success, onExited, refreshManifest])
+
+  Intercom.usePauseVisibilityWhen(isOpen)
 
   const state = React.useMemo<DialogState>(() => {
     if (exited) return DialogState.Closed()

--- a/catalog/app/global-styles.tsx
+++ b/catalog/app/global-styles.tsx
@@ -28,9 +28,6 @@ const useGlobalStyles = makeStyles({
       marginBlockEnd: 0,
       marginBlockStart: 0,
     },
-    'body .intercom-lightweight-app-launcher, body .intercom-lightweight-app': {
-      zIndex: 1200,
-    },
   },
 })
 


### PR DESCRIPTION
Sometimes Intercom was above dialog (blocking buttons). Probably because of new messages and different from ".intercom-lightweight-app-launcher" class.

Instead of setting lower `zIndex` I decided to hide launcher with javascript.