### PR TITLE
Fix construction of exception in package creation lambda

### DIFF
--- a/lambdas/pkgpush/index.py
+++ b/lambdas/pkgpush/index.py
@@ -226,7 +226,7 @@ class ApiException(Exception):
             boto_response['Error']['Code'],
             boto_response['Error']['Message']
         )
-        raise cls(status_code, message)
+        return cls(status_code, message)
 
 
 def api_exception_handler(f):


### PR DESCRIPTION
It was nicely catched by linter after its update
