### PR TITLE
Decrease Bytes range downloading for Vega detection

### DIFF
--- a/catalog/app/components/Preview/loaders/Json.js
+++ b/catalog/app/components/Preview/loaders/Json.js
@@ -14,7 +14,7 @@ import * as utils from './utils'
 
 const MAX_SIZE = 20 * 1024 * 1024
 const SCHEMA_RE = /"\$schema":\s*"https:\/\/vega\.github\.io\/schema\/([\w-]+)\/([\w.-]+)\.json"/
-const BYTES_TO_SCAN = 128 * 1024
+const BYTES_TO_SCAN = 64 * 1024
 
 const map = (fn) => R.ifElse(Array.isArray, R.map(fn), fn)
 


### PR DESCRIPTION
It's a workaround to avoid a Signature Mismatch error.

I think if we wouldn't find out how to fix it properly, it worth using this.