### PR TITLE
Pin pylint

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -63,7 +63,7 @@ jobs:
       - run:
           name: Install dependencies
           command: |
-            pip install pylint 'pycodestyle>=2.6.0a1'
+            pip install 'pylint<2.9' 'pycodestyle>=2.6.0a1'
       - run:
           name: Run pylint
           command: |


### PR DESCRIPTION
recent pylint 2.9.0 fails with:
```
************* Module quilt3.main
api/python/quilt3/main.py:96:4: R1732: Consider using 'with' for resource-allocating operations (consider-using-with)
api/python/quilt3/main.py:118:4: R1732: Consider using 'with' for resource-allocating operations (consider-using-with)
************* Module quilt3.telemetry
api/python/quilt3/telemetry.py:40:39: R1732: Consider using 'with' for resource-allocating operations (consider-using-with)
************* Module build
gendocs/build.py:84:36: R1732: Consider using 'with' for resource-allocating operations (consider-using-with)
************* Module indexer.test.test_read_notebook
lambdas/es/indexer/test/test_read_notebook.py:32:4: C0206: Consider iterating with .items() (consider-using-dict-items)
lambdas/es/indexer/test/test_read_notebook.py:39:4: C0206: Consider iterating with .items() (consider-using-dict-items)
************* Module test_preview
lambdas/shared/tests/test_preview.py:81:8: C0206: Consider iterating with .items() (consider-using-dict-items)

-----------------------------------
Your code has been rated at 9.99/10
```