### PR TITLE
Nicer handling of --meta option in CLI

### DIFF
--- a/api/python/quilt3/main.py
+++ b/api/python/quilt3/main.py
@@ -24,6 +24,13 @@ from .util import (
 )
 
 
+def parse_arg_json(value):
+    try:
+        return json.loads(value)
+    except json.JSONDecodeError:
+        raise argparse.ArgumentTypeError(f'{value!r} is not a valid json string.')
+
+
 def cmd_config(catalog_url, **kwargs):
     """
     Configure quilt3 to a Quilt stack
@@ -222,11 +229,6 @@ def cmd_verify(name, registry, top_hash, dir, extra_files_ok):
 
 def cmd_push(name, dir, registry, dest, message, meta):
     pkg = Package()
-    if meta:
-        try:
-            meta = json.loads(meta)
-        except ValueError:
-            raise QuiltException(f'{meta!r} is not a valid json string.')
     pkg.set_dir('.', dir, meta=meta)
     pkg.push(name, registry=registry, dest=dest, message=message)
 
@@ -440,7 +442,7 @@ def create_parser():
             Sets package-level metadata.
             Format: A json string with keys in double quotes '{"key": "value"}'
             """,
-        type=str,
+        type=parse_arg_json,
     )
     push_p.set_defaults(func=cmd_push)
 


### PR DESCRIPTION
# Description
before:
```
$ quilt3 push --dir . --meta 'test meta' --registry=s3://quilt-dev-null test/test
'test meta' is not a valid json string.
```

after:
```
$ quilt3 push --dir . --meta 'test meta' --registry=s3://quilt-dev-null test/test
usage: quilt3 push --dir DIR [-h] [--registry REGISTRY] [--dest DEST]
                   [--message MESSAGE] [--meta META]
                   name
quilt3 push: error: argument --meta: 'test meta' is not a valid json string.
```


# TODO

<!-- Use <del></del> for items that are not required for this PR -->

- [x] Unit tests

