### PR TITLE
Preview: fix re-rendering (and re-requesting) images in markdown files every 5 sec (cleanup interval)

### DIFF
--- a/catalog/app/components/Preview/loaders/utils.js
+++ b/catalog/app/components/Preview/loaders/utils.js
@@ -204,7 +204,7 @@ export function usePreview({ type, handle, query }) {
 }
 
 export function useProcessing(asyncResult, process, deps = []) {
-  return useMemoEq([asyncResult, process, deps], () =>
+  return useMemoEq([asyncResult, deps], () =>
     AsyncResult.case(
       {
         Ok: R.tryCatch(R.pipe(process, AsyncResult.Ok), AsyncResult.Err),


### PR DESCRIPTION
dont re-run processing function when its identity changes, since it's
usually inline and changes on every render (instead we should list deps explicitly
when required)