### PR TITLE
Use Suspense/lazy to defer JsonDisplay rendering nested parts

### DIFF
--- a/catalog/app/components/JsonDisplay/JsonDisplay.js
+++ b/catalog/app/components/JsonDisplay/JsonDisplay.js
@@ -257,10 +257,12 @@ export default function JsonDisplay({
 
   return (
     <M.Box className={cx(className, classes.root)} {...props}>
-      <JsonDisplayInner
-        {...{ name, value, topLevel, defaultExpanded, classes }}
-        showKeysWhenCollapsed={computedKeys}
-      />
+      <React.Suspense fallback={<WaitingJsonRender />}>
+        <JsonDisplayInner
+          {...{ name, value, topLevel, defaultExpanded, classes }}
+          showKeysWhenCollapsed={computedKeys}
+        />
+      </React.Suspense>
     </M.Box>
   )
 }

--- a/catalog/app/components/JsonDisplay/JsonDisplay.js
+++ b/catalog/app/components/JsonDisplay/JsonDisplay.js
@@ -44,6 +44,7 @@ const useWaitingJsonRenderStyles = M.makeStyles((t) => ({
     display: 'flex',
     fontFamily: t.typography.monospace.fontFamily,
     fontSize: t.typography.body2.fontSize,
+    marginLeft: t.spacing(2),
   },
 }))
 
@@ -172,7 +173,14 @@ function CompoundEntry({
         )}
       </div>
       {expanded && (
-        <React.Suspense fallback={<WaitingJsonRender />}>
+        <React.Suspense
+          fallback={
+            <>
+              <WaitingJsonRender />
+              {braces[1]}
+            </>
+          }
+        >
           <div className={cx(classes.compoundInner)}>
             {entries.map(([k, v]) => (
               <JsonDisplayInner
@@ -209,7 +217,7 @@ const isPrimitive = R.anyPass([
 function useComponentOnNextTick(Component, props, optTimeout) {
   return useMemoEq([Component, props], () =>
     React.lazy(async () => {
-      await wait(optTimeout || 300)
+      await wait(optTimeout || 0)
       return {
         default: () => <Component {...props} />,
       }

--- a/catalog/app/components/JsonDisplay/JsonDisplay.js
+++ b/catalog/app/components/JsonDisplay/JsonDisplay.js
@@ -46,6 +46,7 @@ const useWaitingJsonRenderStyles = M.makeStyles((t) => ({
     fontSize: t.typography.body2.fontSize,
   },
 }))
+
 const WaitingJsonRender = () => {
   const classes = useWaitingJsonRenderStyles()
   return (

--- a/catalog/app/components/JsonDisplay/JsonDisplay.js
+++ b/catalog/app/components/JsonDisplay/JsonDisplay.js
@@ -3,6 +3,9 @@ import * as R from 'ramda'
 import * as React from 'react'
 import * as M from '@material-ui/core'
 
+import useMemoEq from 'utils/useMemoEq'
+import wait from 'utils/wait'
+
 const useStyles = M.makeStyles((t) => ({
   root: {
     fontFamily: t.typography.monospace.fontFamily,
@@ -34,6 +37,23 @@ const useStyles = M.makeStyles((t) => ({
 const IconBlank = ({ classes }) => <div className={classes.iconBlank} />
 const IconExpand = () => <M.Icon fontSize="small">chevron_right</M.Icon>
 const IconCollapse = () => <M.Icon fontSize="small">expand_more</M.Icon>
+
+const useWaitingJsonRenderStyles = M.makeStyles((t) => ({
+  root: {
+    color: t.palette.text.secondary,
+    display: 'flex',
+    fontFamily: t.typography.monospace.fontFamily,
+    fontSize: t.typography.body2.fontSize,
+  },
+}))
+const WaitingJsonRender = () => {
+  const classes = useWaitingJsonRenderStyles()
+  return (
+    <span className={classes.root}>
+      <M.Icon fontSize="small">hourglass_empty</M.Icon>rendering…
+    </span>
+  )
+}
 
 function Key({ children, classes }) {
   return !!children && <div className={classes.key}>{children}: </div>
@@ -94,7 +114,7 @@ function CompoundEntry({
   const empty = !entries.length
   const expanded = !empty && stateExpanded
 
-  const renderCollapsed = () => {
+  const renderCollapsed = React.useCallback(() => {
     const availableSpace =
       showKeysWhenCollapsed -
       R.sum([
@@ -127,7 +147,7 @@ function CompoundEntry({
       },
       { str: null, availableSpace, keys: 0, done: false },
     ).str
-  }
+  }, [classes, entries, name, showKeysWhenCollapsed, value])
 
   return (
     <div>
@@ -150,25 +170,29 @@ function CompoundEntry({
           </>
         )}
       </div>
-      <div className={cx(classes.compoundInner, !expanded && classes.hidden)}>
-        {entries.map(([k, v]) => (
-          <JsonDisplayInner
-            classes={classes}
-            key={k}
-            name={k}
-            value={v}
-            topLevel={false}
-            defaultExpanded={
-              Number.isInteger(defaultExpanded) && defaultExpanded > 0
-                ? defaultExpanded - 1
-                : defaultExpanded
-            }
-            showKeysWhenCollapsed={showKeysWhenCollapsed - 20 / CHAR_W}
-          />
-        ))}
-        {/* eslint-disable-next-line jsx-a11y/no-static-element-interactions, jsx-a11y/click-events-have-key-events */}
-        <div onClick={toggle}>{braces[1]}</div>
-      </div>
+      {expanded && (
+        <React.Suspense fallback={<WaitingJsonRender />}>
+          <div className={cx(classes.compoundInner)}>
+            {entries.map(([k, v]) => (
+              <JsonDisplayInner
+                classes={classes}
+                key={k}
+                name={k}
+                value={v}
+                topLevel={false}
+                defaultExpanded={
+                  Number.isInteger(defaultExpanded) && defaultExpanded > 0
+                    ? defaultExpanded - 1
+                    : defaultExpanded
+                }
+                showKeysWhenCollapsed={showKeysWhenCollapsed - 20 / CHAR_W}
+              />
+            ))}
+            {/* eslint-disable-next-line jsx-a11y/no-static-element-interactions, jsx-a11y/click-events-have-key-events */}
+            <div onClick={toggle}>{braces[1]}</div>
+          </div>
+        </React.Suspense>
+      )}
     </div>
   )
 }
@@ -181,9 +205,23 @@ const isPrimitive = R.anyPass([
   R.equals(undefined),
 ])
 
+function useComponentOnNextTick(Component, props, optTimeout) {
+  return useMemoEq([Component, props], () =>
+    React.lazy(async () => {
+      await wait(optTimeout || 300)
+      return {
+        default: () => <Component {...props} />,
+      }
+    }),
+  )
+}
+
 function JsonDisplayInner(props) {
-  const Component = isPrimitive(props.value) ? PrimitiveEntry : CompoundEntry
-  return <Component {...props} />
+  const Component = useComponentOnNextTick(
+    isPrimitive(props.value) ? PrimitiveEntry : CompoundEntry,
+    props,
+  )
+  return <Component />
 }
 
 function useCurrentBreakpointWidth() {


### PR DESCRIPTION
When a package has huge metadata page freezes and consumes 100% CPU even when idle.

Solution: don't render (not just hide) collapsed parts of JSON. This leads to the new problem: UI becomes unresponsive after click while the expanded part is rendering. Next solution: render this expanded part with lazy (setTimeout trick to render DOM on new tick).

---
Please, see details in Slack, if you need it: URL with huge metadata and screencasts