### PR TITLE
Return 404 for non-existing logical key

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -51,6 +51,7 @@
 * [Fixed] Crashing `pkgselect` lambda's folder view on an empty manifest ([#2147](https://github.com/quiltdata/quilt/pull/2147))
 * [Fixed] Infinite spinner on logout ([#2232](https://github.com/quiltdata/quilt/pull/2232))
 * [Fixed] Dismiss error page when navigating from it ([#2291](https://github.com/quiltdata/quilt/pull/2291))
+* [Fixed] Avoid crash on non-existent logical keys in pkgselect detail view ([#2307](https://github.com/quiltdata/quilt/pull/2307)
 
 # 3.4.0 - 2021-03-15
 ## Python API

--- a/lambdas/pkgselect/index.py
+++ b/lambdas/pkgselect/index.py
@@ -190,12 +190,22 @@ def lambda_handler(request):
     # Get details of a single file in the package
     if logical_key is not None:
         sql_stmt = f"SELECT s.* FROM s3object s WHERE s.logical_key = '{sql_escape(logical_key)}' LIMIT 1"
-        response_data = json.load(query_manifest_content(
+        details = query_manifest_content(
             s3_client,
             bucket=bucket,
             key=key,
             sql_stmt=sql_stmt
-        ))
+        )
+        if details is not None:
+            response_data = json.load(details)
+        else:
+            return make_json_response(
+                404,
+                {
+                    'title': 'Key Not Found',
+                    'detail': f"key, {logical_key} not found in package"
+                }
+            )
     else:
         # Call s3 select to fetch only logical keys matching the
         # desired prefix (folder path)

--- a/lambdas/pkgselect/test/test_pkgselect.py
+++ b/lambdas/pkgselect/test/test_pkgselect.py
@@ -447,7 +447,6 @@ class TestPackageSelect(TestCase):
             print(response)
             assert response['statusCode'] == 404
 
-
     def test_incomplete_credentials(self):
         """
         Verify that a call with incomplete credentials fails.


### PR DESCRIPTION
# Description

Pkgselect should not crash and return a proper error response when queried for details of a non-existing logical key.

# TODO

<!-- Use <del></del> for items that are not required for this PR -->

- [x] Unit tests
- [ ] Automated tests (e.g. Preflight)
- [ ] Documentation
    - [ ] [Python: Run `build.py`](../gendocs/build.py) for new docstrings
    - [ ] JavaScript: basic explanation and screenshot of new features
- [x] [Changelog](CHANGELOG.md) entry
