### PR TITLE
Test lambdas against Python 3.8

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -109,7 +109,7 @@ jobs:
           flags: "api-python"
 
   test-lambda:
-    executor: python
+    executor: python-38
     description: "Test lambdas"
     environment:
       QUILT_DISABLE_USAGE_METRICS: true

--- a/lambdas/s3select/test-requirements.txt
+++ b/lambdas/s3select/test-requirements.txt
@@ -1,7 +1,7 @@
 atomicwrites==1.3.0
 importlib-metadata==0.18
 more-itertools==7.1.0
-pluggy==0.12.0
+pluggy==0.13.1
 py==1.10.0
 pyparsing==2.4.0
 pytest==4.3.0

--- a/lambdas/search/test-requirements.txt
+++ b/lambdas/search/test-requirements.txt
@@ -1,7 +1,7 @@
 atomicwrites==1.3.0
 importlib-metadata==0.18
 more-itertools==7.1.0
-pluggy==0.12.0
+pluggy==0.13.1
 py==1.8.0
 pyparsing==2.4.0
 pytest==4.3.0

--- a/lambdas/thumbnail/requirements.txt
+++ b/lambdas/thumbnail/requirements.txt
@@ -5,13 +5,13 @@ chardet==3.0.4
 idna==2.8
 imageio==2.5.0
 jsonschema==3.0.1
-numpy==1.17.0
+numpy==1.21.2
 pdf2image==1.13.1
 Pillow==6.2.2
 psutil==5.7.0
 pyrsistent==0.14.11
 requests==2.24.0
-scipy==1.3.0
+scipy==1.7.1
 tifffile==0.15.1
 six==1.12.0
 urllib3==1.25.10


### PR DESCRIPTION
* Ideally we can run Lambdas in 3.8 so that we can use AWS's CodeGuru profiler
* In a separate PR we will change the lambda `Runtime=` param for all lambda functions created in CloudFormation