### PR TITLE
Show message describing whats happening during manifest download

### DIFF
--- a/catalog/app/containers/Bucket/PackageDialog/PackageCreationForm.tsx
+++ b/catalog/app/containers/Bucket/PackageDialog/PackageCreationForm.tsx
@@ -566,7 +566,7 @@ export function usePackageCreationDialog({
           Loading: () => (
             <DialogLoading
               skeletonElement={<FormSkeleton />}
-              title={ui.title || 'Create package'}
+              title="Downloading manifest and preparing form…"
               submitText={ui.submit}
               onCancel={close}
             />


### PR DESCRIPTION
We can't use progressbar for now because after manifest download UI freezes, so there is text message instead