### PR TITLE
Upgrade coverage package to fix CI failure

### DIFF
--- a/lambdas/es/indexer/test-requirements.txt
+++ b/lambdas/es/indexer/test-requirements.txt
@@ -1,5 +1,5 @@
 atomicwrites==1.3.0
-coverage==4.5.2
+coverage==5.5
 more-itertools==6.0.0
 pluggy==0.9
 py==1.10.0

--- a/lambdas/pkgselect/test-requirements.txt
+++ b/lambdas/pkgselect/test-requirements.txt
@@ -1,4 +1,4 @@
-coverage==4.5.2
+coverage==5.5
 pytest==4.3.0
 pytest-cov==2.6.1
 responses==0.10.5

--- a/lambdas/preview/test-requirements.txt
+++ b/lambdas/preview/test-requirements.txt
@@ -1,5 +1,5 @@
 atomicwrites==1.3.0
-coverage==4.5.2
+coverage==5.5
 more-itertools==6.0.0
 pluggy==0.13.1
 py==1.7.0


### PR DESCRIPTION
# Description

Currently jobs fail like this:
```
Collecting coverage==4.5.2
  Downloading coverage-4.5.2.tar.gz (384 kB)
     |████████████████████████████████| 384 kB 97.6 MB/s eta 0:00:01
    ERROR: Command errored out with exit status 1:
     command: /home/circleci/project/venv/bin/python -c 'import io, os, sys, setuptools, tokenize; sys.argv[0] = '"'"'/tmp/pip-install-neev77c0/coverage_913c20d93ef94628a5288623bd4d6c24/setup.py'"'"'; __file__='"'"'/tmp/pip-install-neev77c0/coverage_913c20d93ef94628a5288623bd4d6c24/setup.py'"'"';f = getattr(tokenize, '"'"'open'"'"', open)(__file__) if os.path.exists(__file__) else io.StringIO('"'"'from setuptools import setup; setup()'"'"');code = f.read().replace('"'"'\r\n'"'"', '"'"'\n'"'"');f.close();exec(compile(code, __file__, '"'"'exec'"'"'))' egg_info --egg-base /tmp/pip-pip-egg-info-sieux3b6
         cwd: /tmp/pip-install-neev77c0/coverage_913c20d93ef94628a5288623bd4d6c24/
    Complete output (1 lines):
    error in coverage setup command: use_2to3 is invalid.
    ----------------------------------------
WARNING: Discarding https://files.pythonhosted.org/packages/fb/af/ce7b0fe063ee0142786ee53ad6197979491ce0785567b6d8be751d2069e8/coverage-4.5.2.tar.gz#sha256=ab235d9fe64833f12d1334d29b558aacedfbca2356dfb9691f2d0d38a8a7bfb4 (from https://pypi.org/simple/coverage/) (requires-python:>=2.6, !=3.0.*, !=3.1.*, !=3.2.*, <4). Command errored out with exit status 1: python setup.py egg_info Check the logs for full command output.
ERROR: Could not find a version that satisfies the requirement coverage==4.5.2 (from versions: 3.0b3, 3.0, 3.0.1, 3.1b1, 3.1, 3.2b1, 3.2b2, 3.2b3, 3.2b4, 3.2, 3.3, 3.3.1, 3.4b1, 3.4b2, 3.4, 3.5b1, 3.5, 3.5.1b1, 3.5.1, 3.5.2b1, 3.5.2, 3.5.3, 3.6b1, 3.6b2, 3.6b3, 3.6, 3.7, 3.7.1, 4.0a1, 4.0a2, 4.0a3, 4.0a4, 4.0a5, 4.0a6, 4.0b1, 4.0b2, 4.0b3, 4.0, 4.0.1, 4.0.2, 4.0.3, 4.1b1, 4.1b2, 4.1b3, 4.1, 4.2b1, 4.2, 4.3, 4.3.1, 4.3.2, 4.3.3, 4.3.4, 4.4b1, 4.4, 4.4.1, 4.4.2, 4.5, 4.5.1, 4.5.2, 4.5.3, 4.5.4, 5.0a1, 5.0a2, 5.0a3, 5.0a4, 5.0a5, 5.0a6, 5.0a7, 5.0a8, 5.0b1, 5.0b2, 5.0, 5.0.1, 5.0.2, 5.0.3, 5.0.4, 5.1, 5.2, 5.2.1, 5.3, 5.3.1, 5.4, 5.5, 5.6b1, 6.0b1)
ERROR: No matching distribution found for coverage==4.5.2

Exited with code exit status 1
```