### PR TITLE
chart tweaks

### DIFF
--- a/catalog/app/containers/Bucket/Overview.js
+++ b/catalog/app/containers/Bucket/Overview.js
@@ -613,6 +613,7 @@ function Downloads({ bucket, colorPool, ...props }) {
                         areaFills={counts.byExtCollapsed.map((e) =>
                           SVG.Paint.Color(colorPool.get(e.ext)),
                         )}
+                        lineStroke={SVG.Paint.Color(M.colors.grey[500])}
                         extendL
                         extendR
                         px={10}


### PR DESCRIPTION
- softer (grey) cursor lines
- fix cursor tracking
- use transparency instead of lightening for fills
- remove transparency for root element
- remove unused and unnecessary `fade` prop
- swap area rendering order so that bottom areas overlap top areas (this also aligns order of the areas with the order of the items in the legend tooltip)