### PR TITLE
Move Lambdas to Python 3.7

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -109,7 +109,7 @@ jobs:
           flags: "api-python"
 
   test-lambda:
-    executor: python-38
+    executor: python-37
     description: "Test lambdas"
     environment:
       QUILT_DISABLE_USAGE_METRICS: true


### PR DESCRIPTION
The actual Amazon runtime is not consistent with the corresponding Docker Hub container, and is missing key binaries for thumbnail such as libexpat.so.1. The 3.7 runtime has this binary per my direct tests via AWS Console > Lambda. Falling back on 3.7.