### PR TITLE
Provide link to current ES version

### DIFF
--- a/docs/Catalog/SearchQuery.md
+++ b/docs/Catalog/SearchQuery.md
@@ -30,7 +30,7 @@ indexing for the following file extensions:
 ![](../imgs/catalog-es-queries-default.png)
 
 Quilt ElasticSearch queries support the following keys:
-- `index` — comma-separated list of indexes to search ([learn more](https://www.elastic.co/guide/en/elasticsearch/reference/7.10/search-search.html#search-search-api-path-params))
+- `index` — comma-separated list of indexes to search ([learn more](https://www.elastic.co/guide/en/elasticsearch/reference/6.8/multi-index.html))
 - `filter_path` — to reducing response nesting, ([learn more](https://www.elastic.co/guide/en/elasticsearch/reference/6.8/common-options.html#common-options-response-filtering))
 - `_source` — boolean that adds or removes the `_source` field, or a list of fields to return ([learn more](https://www.elastic.co/guide/en/elasticsearch/reference/6.8/search-request-source-filtering.html))
 - `size` — limits the number of hits ([learn more](https://www.elastic.co/guide/en/elasticsearch/reference/6.8/search-uri-request.html))


### PR DESCRIPTION
Seems like this link from 6.8 is the closest to the removed 7.10