### PR TITLE
Show text errors too

### DIFF
--- a/catalog/app/utils/APIConnector.js
+++ b/catalog/app/utils/APIConnector.js
@@ -92,7 +92,7 @@ export class HTTPError extends BaseError {
     try {
       json = JSON.parse(text)
     } catch (e) {
-      // ignore it
+      json = { message: message || text }
     }
 
     super(message || (json && (json.message || json.error)) || resp.statusText, {


### PR DESCRIPTION
Text errors were just stripped away. I don't know if it was intentional or slipped. If it slipped, then this is the fix

In practice it means the following:

Before:
![Screenshot from 2021-09-15 18-13-04](https://user-images.githubusercontent.com/533229/133460620-e007f260-f12c-47ac-a4b7-2b59eb68af1d.png)


After:
![Screenshot from 2021-09-15 18-12-30](https://user-images.githubusercontent.com/533229/133460633-7a6dd103-df4b-4f18-9ea8-804ac6bb176c.png)
