### PR TITLE
Bump virtualenv in CircleCI jobs

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -32,7 +32,7 @@ commands:
       - run:
           name: Setup venv
           command: |
-            pip install virtualenv==20.0.25
+            pip install virtualenv==20.8.0
             virtualenv venv
             if [ -e venv/bin/activate ]; then
               echo ". venv/bin/activate" >> $BASH_ENV


### PR DESCRIPTION
The previously used version can't be installed in current
CircleCI images due to conflict with poetry.