### PR TITLE
install quilt3 from PyPI rather than from git commit

### DIFF
--- a/lambdas/pkgpush/requirements.txt
+++ b/lambdas/pkgpush/requirements.txt
@@ -1,1 +1,1 @@
-https://github.com/quiltdata/quilt/archive/989b0223952a821cef978d6ee902af9ed5d23b10.tar.gz#egg=quilt3&subdirectory=api/python
+quilt3==3.5.0


### PR DESCRIPTION
This is just for clarity.