### PR TITLE
Add Python 3.10 to CircleCI test jobs

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -23,6 +23,9 @@ executors:
   python-39:
     docker:
       - image: cimg/python:3.9
+  python-310:
+    docker:
+      - image: cimg/python:3.10
   python: python-36
 
 commands:
@@ -223,6 +226,7 @@ workflows:
                 - python-37
                 - python-38
                 - python-39
+                - python-310
           filters:
             <<: *release-tags
       - test-client:

--- a/api/python/setup.py
+++ b/api/python/setup.py
@@ -50,6 +50,7 @@ setup(
         'Programming Language :: Python :: 3.7',
         'Programming Language :: Python :: 3.8',
         'Programming Language :: Python :: 3.9',
+        'Programming Language :: Python :: 3.10',
     ],
     author='quiltdata',
     author_email='contact@quiltdata.io',


### PR DESCRIPTION
<del>Currently fails because there are no pyarrow wheels for 3.10.</del>

<del>Currently fails because pytest version we use (it's old) seems incompatible with Python 3.10.</del>