### PR TITLE
Fix 'test-gendocs' job in CircleCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -146,7 +146,7 @@ jobs:
       - setup-venv
       - run:
           name: install deps
-          command: pip install api/python nbconvert git+https://github.com/quiltdata/pydoc-markdown.git@quilt
+          command: pip install PyYAML~=5.4.1 api/python nbconvert git+https://github.com/quiltdata/pydoc-markdown.git@quilt
       - run:
           name: generate docs
           command: cd gendocs && python build.py


### PR DESCRIPTION
Probably https://github.com/quiltdata/pydoc-markdown is the right
place to fix this, but I don't want to touch it, since I think we
shouldn't use our homebrew solution at all.

# Description
Currently job fails: https://app.circleci.com/pipelines/github/quiltdata/quilt/4414/workflows/a1f570fc-8025-4261-83e6-348dc682d268/jobs/91860
