### PR TITLE
Hack for using correct workflow in package name validation

### DIFF
--- a/catalog/app/containers/Bucket/PackageCopyDialog.js
+++ b/catalog/app/containers/Bucket/PackageCopyDialog.js
@@ -141,6 +141,9 @@ function DialogForm({
 
   const [editorElement, setEditorElement] = React.useState()
 
+  // HACK: FIXME: it triggers name validation with correct workflow
+  const [hideMeta, setHideMeta] = React.useState(false)
+
   const onFormChange = React.useCallback(
     async ({ modified, values }) => {
       if (document.body.contains(editorElement)) {
@@ -149,6 +152,12 @@ function DialogForm({
 
       if (modified.workflow && values.workflow !== selectedWorkflow) {
         setWorkflow(values.workflow)
+
+        // HACK: FIXME: it triggers name validation with correct workflow
+        setHideMeta(true)
+        setTimeout(() => {
+          setHideMeta(false)
+        }, 300)
       }
 
       handleNameChange(values.name)
@@ -241,7 +250,7 @@ function DialogForm({
                 }}
               />
 
-              {schemaLoading ? (
+              {schemaLoading || hideMeta ? (
                 <PD.MetaInputSkeleton className={classes.meta} ref={setEditorElement} />
               ) : (
                 <RF.Field

--- a/catalog/app/containers/Bucket/PackageDialog/PackageCreationForm.tsx
+++ b/catalog/app/containers/Bucket/PackageDialog/PackageCreationForm.tsx
@@ -331,6 +331,9 @@ function PackageCreationForm({
     [delayHashing],
   )
 
+  // HACK: FIXME: it triggers name validation with correct workflow
+  const [hideMeta, setHideMeta] = React.useState(false)
+
   return (
     <RF.Form
       onSubmit={onSubmitWrapped}
@@ -365,6 +368,12 @@ function PackageCreationForm({
                 onChange={({ modified, values }) => {
                   if (modified!.workflow && values.workflow !== selectedWorkflow) {
                     setWorkflow(values.workflow)
+
+                    // HACK: FIXME: it triggers name validation with correct workflow
+                    setHideMeta(true)
+                    setTimeout(() => {
+                      setHideMeta(false)
+                    }, 300)
                   }
                 }}
               />
@@ -416,7 +425,7 @@ function PackageCreationForm({
                     }}
                   />
 
-                  {schemaLoading ? (
+                  {schemaLoading || hideMeta ? (
                     <MetaInputSkeleton className={classes.meta} ref={setEditorElement} />
                   ) : (
                     <RF.Field

--- a/catalog/app/containers/Bucket/PackageDirectoryDialog.tsx
+++ b/catalog/app/containers/Bucket/PackageDirectoryDialog.tsx
@@ -201,6 +201,9 @@ function DialogForm({
     }
   }, [editorElement, setMetaHeight])
 
+  // HACK: FIXME: it triggers name validation with correct workflow
+  const [hideMeta, setHideMeta] = React.useState(false)
+
   return (
     <RF.Form
       onSubmit={onSubmitWrapped}
@@ -237,6 +240,12 @@ function DialogForm({
                 onChange={({ modified, values }) => {
                   if (modified?.workflow && values.workflow !== selectedWorkflow) {
                     setWorkflow(values.workflow)
+
+                    // HACK: FIXME: it triggers name validation with correct workflow
+                    setHideMeta(true)
+                    setTimeout(() => {
+                      setHideMeta(false)
+                    }, 300)
                   }
                 }}
               />
@@ -287,7 +296,7 @@ function DialogForm({
                     }}
                   />
 
-                  {schemaLoading ? (
+                  {schemaLoading || hideMeta ? (
                     <PD.MetaInputSkeleton
                       className={classes.meta}
                       ref={setEditorElement}


### PR DESCRIPTION
I couldn't fix this the right way, so I just mocked schema loading behavior, because when the workflow has a schema for JSON validation, then the workflow is correct