### PR TITLE
Fix JsonEditor/Breadcrumbs vertical align

### DIFF
--- a/catalog/app/components/JsonEditor/Breadcrumbs.tsx
+++ b/catalog/app/components/JsonEditor/Breadcrumbs.tsx
@@ -10,12 +10,18 @@ const useStyles = M.makeStyles((t) => ({
     display: 'flex',
     padding: '5px 8px',
   },
+}))
+
+const useOverrideStyles = M.makeStyles({
+  separator: {
+    alignItems: 'center',
+  },
   li: {
     '&::before': {
       position: 'absolute', // Workaround for sanitize.css a11y styles
     },
   },
-}))
+})
 
 const useItemStyles = M.makeStyles({
   root: {
@@ -55,6 +61,7 @@ interface BreadcrumbsProps {
 
 export default function Breadcrumbs({ items, onSelect }: BreadcrumbsProps) {
   const classes = useStyles()
+  const overrideClasses = useOverrideStyles()
 
   const onBreadcrumb = React.useCallback(
     (index) => {
@@ -69,8 +76,6 @@ export default function Breadcrumbs({ items, onSelect }: BreadcrumbsProps) {
   React.useEffect(() => {
     ref.current?.scrollIntoView()
   }, [ref])
-
-  const overrideClasses = React.useMemo(() => ({ li: classes.li }), [classes])
 
   return (
     <M.Breadcrumbs


### PR DESCRIPTION
Before:
![Screenshot from 2021-10-29 18-19-21](https://user-images.githubusercontent.com/533229/139461993-13217c8c-3d67-4f47-9e94-2f22e1f07fd9.png)

After:
![Screenshot from 2021-10-29 18-22-12](https://user-images.githubusercontent.com/533229/139462021-ef6f3f51-9c0a-4b9a-91b7-7d903db275bc.png)