### PR TITLE
Fix `Loader.detect` arity

### DIFF
--- a/catalog/app/components/Preview/load.js
+++ b/catalog/app/components/Preview/load.js
@@ -34,21 +34,13 @@ const loaderChain = [
   fallback,
 ]
 
-const isUsingExtendedOptions = (Loader) =>
-  // TODO: fix detect arity and remove this function
-  Loader === Echarts.Loader || Loader === Voila.Loader
-
 function findLoader(key, options) {
-  return loaderChain.find(({ Loader, detect }) =>
-    isUsingExtendedOptions(Loader) ? detect(key, options) : detect(key),
-  )
+  return loaderChain.find(({ detect }) => detect(key, options))
 }
 
 export function getRenderProps(key, options) {
-  const { Loader, detect } = findLoader(key, options)
-  const optionsSpecificToType = isUsingExtendedOptions(Loader)
-    ? detect(key, options)
-    : detect(key)
+  const { detect } = findLoader(key, options)
+  const optionsSpecificToType = detect(key, options)
   return optionsSpecificToType && optionsSpecificToType.style
     ? {
         style: optionsSpecificToType.style,

--- a/catalog/app/components/Preview/loaders/Echarts.js
+++ b/catalog/app/components/Preview/loaders/Echarts.js
@@ -70,8 +70,7 @@ async function downloadDatasetFromWeb(url) {
   return loadedDatasetResponse.text()
 }
 
-const sourceFormatRegex = /(.tsv|.csv)$/
-const isSupportedSourceFormat = (filename) => sourceFormatRegex.test(filename)
+const isSupportedSourceFormat = utils.extIn(['.tsv', '.csv'])
 
 function useDataSetLoader() {
   // TODO: use utils.useObjectGetter

--- a/catalog/app/components/Preview/loaders/Text.js
+++ b/catalog/app/components/Preview/loaders/Text.js
@@ -48,7 +48,7 @@ const LANGS = {
 
 const langPairs = Object.entries(LANGS)
 
-const findLang = R.pipe(basename, R.toLower, utils.stripCompression, (name) =>
+const findLang = R.pipe(R.unary(basename), R.toLower, utils.stripCompression, (name) =>
   langPairs.find(([, re]) => re.test(name)),
 )
 


### PR DESCRIPTION
Only `catalog/app/components/Preview/loaders/Text.js` acts differently with the second argument. Other `detect` functions work with one argument -  filename