### PR TITLE
Tune upload perf, better cleanup logic

### DIFF
--- a/catalog/app/containers/Bucket/PackageDialog/FilesInput.tsx
+++ b/catalog/app/containers/Bucket/PackageDialog/FilesInput.tsx
@@ -1,4 +1,5 @@
 import cx from 'classnames'
+import pLimit from 'p-limit'
 import * as R from 'ramda'
 import * as React from 'react'
 import { useDropzone, FileWithPath } from 'react-dropzone'
@@ -28,31 +29,36 @@ const COLORS = {
 
 interface FileWithHash extends File {
   hash: {
-    value: string | undefined
     ready: boolean
-    promise: Promise<string>
+    value?: string
+    error?: Error
+    promise: Promise<string | undefined>
   }
 }
 
 const hasHash = (f: File): f is FileWithHash => !!f && !!(f as FileWithHash).hash
 
-// XXX: it might make sense to limit concurrency, tho the tests show perf is ok, since hashing is async anyways
+const hashLimit = pLimit(2)
+
 function computeHash(f: File) {
   if (hasHash(f)) return f
-  const promise = PD.hashFile(f)
+  const hashP = hashLimit(PD.hashFile, f)
   const fh = f as FileWithHash
-  fh.hash = { value: undefined, ready: false, promise }
-  promise
+  fh.hash = { ready: false } as any
+  fh.hash.promise = hashP
     .catch((e) => {
       // eslint-disable-next-line no-console
-      console.log('Error hashing file:')
+      console.log(`Error hashing file "${fh.name}":`)
       // eslint-disable-next-line no-console
       console.error(e)
+      fh.hash.error = e
+      fh.hash.ready = true
       return undefined
     })
     .then((hash) => {
       fh.hash.value = hash
       fh.hash.ready = true
+      return hash
     })
   return fh
 }

--- a/catalog/app/containers/Bucket/PackageDialog/PackageDialog.tsx
+++ b/catalog/app/containers/Bucket/PackageDialog/PackageDialog.tsx
@@ -48,9 +48,9 @@ export const getNormalizedPath = (f: { path?: string; name: string }) => {
 }
 
 export async function hashFile(file: File) {
-  if (!window.crypto || !window.crypto.subtle || !window.crypto.subtle.digest)
-    throw new Error('Crypto API unavailable')
+  if (!window.crypto?.subtle?.digest) throw new Error('Crypto API unavailable')
   const buf = await file.arrayBuffer()
+  // XXX: consider using hashwasm for stream-based hashing to support larger files
   const hashBuf = await window.crypto.subtle.digest('SHA-256', buf)
   return Array.from(new Uint8Array(hashBuf))
     .map((b) => b.toString(16).padStart(2, '0'))

--- a/catalog/app/utils/ResourceCache.js
+++ b/catalog/app/utils/ResourceCache.js
@@ -148,6 +148,8 @@ function* handleInit({ resource, input, resolver }) {
 }
 
 function* cleanup() {
+  // TODO: refactor cleanup logic, so that the cleanup action is only dispatched
+  // when there's anything to cleanup (to avoid re-renders every 5 sec)
   while (true) {
     yield effects.delay(RELEASE_TIME)
     yield effects.put(Action.CleanUp({ time: new Date() }))

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -14,6 +14,7 @@
 ## CLI
 
 ## Catalog, Lambdas
+* [Fixed] Improve upload performance and stability, fix some hashing-related errors ([#2532](https://github.com/quiltdata/quilt/pull/2532))
 * [Added] Echarts renderer ([#2382](https://github.com/quiltdata/quilt/pull/2382))
 * [Added] Set height for `quilt_summarize.json` files ([#2474](https://github.com/quiltdata/quilt/pull/2474))
 * [Added] Add a "transcode" lambda for previewing video files ([#2366](https://github.com/quiltdata/quilt/pull/2366/))


### PR DESCRIPTION
# Description

1. Limit hashing concurrency to prevent file access errors
2. Optimize upload code to reduce memory pressure (avoid creating and storing a closure for every upload)
3. Fall back to server-side hashing when it can't be done client-side

# TODO

- [x] [Changelog](CHANGELOG.md) entry
