### PR TITLE
Remove object-level metadata icon from Directory Dialog

### DIFF
--- a/catalog/app/containers/Bucket/PackageDialog/EditFileMeta.tsx
+++ b/catalog/app/containers/Bucket/PackageDialog/EditFileMeta.tsx
@@ -83,12 +83,13 @@ function MetadataIcon({ color }: MetadataIconProps) {
 }
 
 interface EditMetaProps {
+  disabled?: boolean
   name: string
-  value: JsonValue
   onChange?: (value: JsonValue) => void
+  value: JsonValue
 }
 
-export default function EditFileMeta({ name, value, onChange }: EditMetaProps) {
+export default function EditFileMeta({ disabled, name, value, onChange }: EditMetaProps) {
   // TODO: move innerValue from Dialog here and:
   //       1. add button to reset innerValue
   //       2. show "modified" state
@@ -98,7 +99,9 @@ export default function EditFileMeta({ name, value, onChange }: EditMetaProps) {
   // TODO: simplify R.isEmpty when meta will be normalized to null
   const color = React.useMemo(() => (R.isEmpty(value) ? 'inherit' : 'primary'), [value])
 
-  if (!onChange) {
+  if (!onChange) return null
+
+  if (disabled) {
     return (
       <M.IconButton size="small" disabled>
         <MetadataIcon color="disabled" />

--- a/catalog/app/containers/Bucket/PackageDialog/EditFileMeta.tsx
+++ b/catalog/app/containers/Bucket/PackageDialog/EditFileMeta.tsx
@@ -26,6 +26,7 @@ interface DialogProps {
 }
 
 function Dialog({ name, onChange, onClose, open, value }: DialogProps) {
+  // TODO: add button to reset innerValue
   const [innerValue, setInnerValue] = React.useState(value)
   const classes = useStyles()
   const dialogClasses = useDialogStyles()
@@ -90,9 +91,8 @@ interface EditMetaProps {
 }
 
 export default function EditFileMeta({ disabled, name, value, onChange }: EditMetaProps) {
-  // TODO: move innerValue from Dialog here and:
-  //       1. add button to reset innerValue
-  //       2. show "modified" state
+  // TODO: show "modified" state
+  //       possible solution: store value and its state in one object `metaValue = { value, state }`
   const [open, setOpen] = React.useState(false)
   const closeEditor = React.useCallback(() => setOpen(false), [setOpen])
   const openEditor = React.useCallback(() => setOpen(true), [setOpen])

--- a/catalog/app/containers/Bucket/PackageDialog/FilesInput.tsx
+++ b/catalog/app/containers/Bucket/PackageDialog/FilesInput.tsx
@@ -493,6 +493,7 @@ interface FileProps extends React.HTMLAttributes<HTMLDivElement> {
   size?: number
   action?: React.ReactNode
   meta?: JsonRecord
+  metaDisabled?: boolean
   onMeta?: (value: JsonRecord) => void
   interactive?: boolean
   faint?: boolean
@@ -506,6 +507,7 @@ function File({
   size,
   action,
   meta,
+  metaDisabled,
   onMeta,
   interactive = false,
   faint = false,
@@ -538,7 +540,13 @@ function File({
         </div>
         {size != null && <div className={classes.size}>{readableBytes(size)}</div>}
       </div>
-      <EditFileMeta key={metaKey} name={name} value={meta} onChange={onMeta} />
+      <EditFileMeta
+        disabled={metaDisabled}
+        key={metaKey}
+        name={name}
+        onChange={onMeta}
+        value={meta}
+      />
       {action}
     </div>
   )
@@ -1106,7 +1114,8 @@ function FileUpload({
       name={name}
       size={size}
       meta={meta}
-      onMeta={state !== 'deleted' ? onMeta : undefined}
+      metaDisabled={state === 'deleted'}
+      onMeta={onMeta}
       action={
         <M.IconButton onClick={action.handler} title={action.hint} size="small">
           <M.Icon fontSize="inherit">{action.icon}</M.Icon>


### PR DESCRIPTION
Add explicitly disabled state for object-level metadata trigger. Remove metadata icon from "Create package from Directory" dialog