### PR TITLE
Move close button inside calendly popup

### DIFF
--- a/catalog/app/components/TalkToUs/TalkToUs.js
+++ b/catalog/app/components/TalkToUs/TalkToUs.js
@@ -10,6 +10,13 @@ const CALENDLY_JS = 'https://assets.calendly.com/assets/external/widget.js'
 
 const CALENDLY_PROMISE = Symbol('calendly')
 
+function moveCloseButtonToPopup() {
+  const closeEl = document.querySelector('.calendly-popup-close')
+  const popupEl = document.querySelector('.calendly-popup')
+  closeEl.parentElement.removeChild(closeEl)
+  popupEl.appendChild(closeEl)
+}
+
 function insertEl(tag, attrs) {
   const el = Object.assign(window.document.createElement(tag), attrs)
   window.document.head.appendChild(el)
@@ -69,6 +76,8 @@ export function TalkToUsProvider({ children }) {
         // }
         // window.addEventListener('message', handleCalendlyEvent)
         C.initPopupWidget({ url: cfg.calendlyLink })
+
+        moveCloseButtonToPopup()
       })
     },
     [t, cfg.calendlyLink, calendlyP],


### PR DESCRIPTION
It's still not good, but, in my opinion, better. If it doesn't improve UX in your opinion, I'll remove PR

Before:
![1  before](https://user-images.githubusercontent.com/533229/144046523-7b9c5007-048b-4483-b8b3-1e5271b91860.png)

After:
![2  after](https://user-images.githubusercontent.com/533229/144046531-a26218a9-2b67-4eb3-9a83-4fb5ed291f6b.png)