### PR TITLE
downolad vega data files from s3 via proxy

### DIFF
--- a/catalog/app/components/Preview/loaders/Json.js
+++ b/catalog/app/components/Preview/loaders/Json.js
@@ -31,7 +31,7 @@ export const traverseUrls = (fn, spec) =>
 
 // NOTE: downloads content from urls embeded in `{ data: url-here-becomes-json }`
 function useVegaSpecSigner(handle) {
-  const sign = AWS.Signer.useS3Signer()
+  const sign = AWS.Signer.useS3Signer({ forceProxy: true })
   const resolveLogicalKey = useLogicalKeyResolver()
 
   const resolvePath = React.useMemo(

--- a/catalog/app/utils/AWS/S3.js
+++ b/catalog/app/utils/AWS/S3.js
@@ -19,6 +19,7 @@ const DEFAULT_OPTS = {
 
 const PROXIED = Symbol('proxied')
 const PRESIGN = Symbol('presign')
+const FORCE_PROXY = Symbol('forceProxy')
 
 const Ctx = React.createContext()
 
@@ -113,7 +114,7 @@ function useSmartS3() {
 
       prepareSignedUrl(req) {
         super.prepareSignedUrl(req)
-        req.httpRequest[PRESIGN] = true
+        if (!req.httpRequest[FORCE_PROXY]) req.httpRequest[PRESIGN] = true
       }
 
       makeRequest(operation, params, callback) {
@@ -124,7 +125,15 @@ function useSmartS3() {
           params = null
         }
 
+        let forceProxy = false
+        if (params && 'forceProxy' in params) {
+          forceProxy = params.forceProxy
+          delete params.forceProxy
+        }
         const req = super.makeRequest(operation, params)
+        if (forceProxy) {
+          req.httpRequest[FORCE_PROXY] = true
+        }
         const type = this.getReqType(req)
 
         if (type !== 'signed') {

--- a/catalog/app/utils/AWS/Signer.js
+++ b/catalog/app/utils/AWS/Signer.js
@@ -15,7 +15,7 @@ const LAG = POLL_INTERVAL * 3
 
 const Ctx = React.createContext({ urlExpiration: DEFAULT_URL_EXPIRATION })
 
-export function useS3Signer({ urlExpiration: exp } = {}) {
+export function useS3Signer({ urlExpiration: exp, forceProxy = false } = {}) {
   const ctx = React.useContext(Ctx)
   const urlExpiration = exp || ctx.urlExpiration
   Credentials.use().suspend()
@@ -31,10 +31,11 @@ export function useS3Signer({ urlExpiration: exp } = {}) {
             Key: key,
             VersionId: version,
             Expires: urlExpiration,
+            forceProxy,
             ...opts,
           })
         : handleToHttpsUri({ bucket, key, version }), // TODO: handle ResponseContentDisposition for unsigned case
-    [mode, isInStack, authenticated, s3, urlExpiration],
+    [mode, isInStack, authenticated, s3, urlExpiration, forceProxy],
   )
 }
 


### PR DESCRIPTION
# Description

Vega fails downloading data files from s3 buckets that dont have CORS properly set up. We can work around that by routing such requests via s3 proxy.


# TODO

- [ ] [Changelog](CHANGELOG.md) entry
