### PR TITLE
Fix formatting of long_description for quilt3 PyPI package

### DIFF
--- a/api/python/setup.py
+++ b/api/python/setup.py
@@ -9,16 +9,15 @@ VERSION = Path(Path(__file__).parent, "quilt3", "VERSION").read_text().strip()
 
 
 def readme():
-    readme_short = """
-    Quilt manages data like code (with packages, repositories, browsing and
-    revision history) so that teams can experiment faster in machine learning,
-    biotech, and other data-driven domains.
+    return """\
+Quilt manages data like code (with packages, repositories, browsing and
+revision history) so that teams can experiment faster in machine learning,
+biotech, and other data-driven domains.
 
-    The `quilt3` PyPi package allows you to build, push, and install data packages.
-    Visit the `documentation quickstart <https://docs.quiltdata.com/quickstart>`_
-    to learn more.
-    """
-    return readme_short
+The `quilt3` PyPI package allows you to build, push, and install data packages.
+Visit the `documentation quickstart <https://docs.quiltdata.com/quickstart>`_
+to learn more.
+"""
 
 
 class VerifyVersionCommand(install):


### PR DESCRIPTION
# Description
Currently description is formatted as quote:
![image](https://user-images.githubusercontent.com/481910/151114243-ba7d6f01-170d-40c9-b18b-4a69c7a4de4b.png)
