### PR TITLE
Pin coverage==6.2 to fix tests

### DIFF
--- a/api/python/setup.py
+++ b/api/python/setup.py
@@ -85,6 +85,7 @@ setup(
             'pyarrow>=0.14.1',              # as of 7/5/19: linux/circleci bugs on 0.14.0
             'pytest==6.*',
             'pytest-cov',
+            'coverage==6.2',
             'pytest-env',
             'pytest-subtests',
             'responses',


### PR DESCRIPTION
See https://github.com/nedbat/coveragepy/issues/1310 and
https://github.com/nedbat/coveragepy/issues/1312.