### PR TITLE
Webpack devServer disableDotRule

### DIFF
--- a/catalog/internals/webpack/webpack.dev.js
+++ b/catalog/internals/webpack/webpack.dev.js
@@ -15,6 +15,7 @@ module.exports = require('./webpack.base')({
       directory: 'static-dev/',
     },
     historyApiFallback: {
+      disableDotRule: true,
       rewrites: [
         { from: /^\/__embed$/, to: '/embed.html' },
         { from: /^\/__embed-debug$/, to: '/embed-debug-harness.html' },


### PR DESCRIPTION
Dev server couldn't open direct links to files like this: http://localhost:3000/b/fiskus-sandbox-dev/tree/fiskus/sandbox/7fa968bc-60f2-454c-b11a-3b28b6966828.csv