### PR TITLE
Desktop download package

### DIFF
--- a/catalog/app/containers/Bucket/Download.tsx
+++ b/catalog/app/containers/Bucket/Download.tsx
@@ -30,8 +30,6 @@ export function DownloadButton({
 
   if (noDownload) return null
 
-  if (noDownload) return null
-
   if (desktop) {
     return (
       <FileView.DownloadButtonLayout

--- a/catalog/app/containers/Bucket/Download.tsx
+++ b/catalog/app/containers/Bucket/Download.tsx
@@ -1,0 +1,26 @@
+import * as React from 'react'
+
+import * as Config from 'utils/Config'
+
+import * as FileView from './FileView'
+
+interface DownloadButtonProps {
+  bucket: string
+  className: string
+  label?: string
+  path?: string
+}
+
+export function DownloadButton({ bucket, className, label, path }: DownloadButtonProps) {
+  const { noDownload }: { noDownload: boolean } = Config.use()
+
+  if (noDownload) return null
+
+  return (
+    <FileView.ZipDownloadForm
+      className={className}
+      suffix={`dir/${bucket}/${path}`}
+      label={label}
+    />
+  )
+}

--- a/catalog/app/containers/Bucket/Download.tsx
+++ b/catalog/app/containers/Bucket/Download.tsx
@@ -1,20 +1,48 @@
+import cx from 'classnames'
 import * as React from 'react'
+import * as M from '@material-ui/core'
 
+import Mono from 'components/Code'
 import * as Config from 'utils/Config'
+import * as IPC from 'utils/electron/ipc-provider'
+import * as packageHandleUtils from 'utils/packageHandle'
+import mkStorage from 'utils/storage'
 
 import * as FileView from './FileView'
+import Section from './Section'
 
 interface DownloadButtonProps {
   bucket: string
   className: string
   label?: string
+  onClick: () => void
   path?: string
 }
 
-export function DownloadButton({ bucket, className, label, path }: DownloadButtonProps) {
-  const { noDownload }: { noDownload: boolean } = Config.use()
+export function DownloadButton({
+  bucket,
+  className,
+  label,
+  onClick,
+  path,
+}: DownloadButtonProps) {
+  const { desktop, noDownload }: { desktop: boolean; noDownload: boolean } = Config.use()
 
   if (noDownload) return null
+
+  if (noDownload) return null
+
+  if (desktop) {
+    return (
+      <FileView.DownloadButtonLayout
+        className={className}
+        label={label}
+        icon="archive"
+        type="submit"
+        onClick={onClick}
+      />
+    )
+  }
 
   return (
     <FileView.ZipDownloadForm
@@ -23,4 +51,156 @@ export function DownloadButton({ bucket, className, label, path }: DownloadButto
       label={label}
     />
   )
+}
+
+const useConfirmDownloadDialogStyles = M.makeStyles({
+  progressbar: {
+    margin: '0 0 16px',
+  },
+  shrink: {
+    width: 0,
+  },
+})
+
+interface ConfirmDownloadDialogProps {
+  localPath: string
+  onClose: () => void
+  open: boolean
+  packageHandle: packageHandleUtils.PackageHandle
+  maxWidth?: 'xs' | 'sm' | 'md' | 'lg' | 'xl' | false
+}
+
+export function ConfirmDialog({
+  localPath,
+  onClose,
+  open,
+  maxWidth = 'md',
+  packageHandle,
+}: ConfirmDownloadDialogProps) {
+  const ipc = IPC.use()
+
+  const classes = useConfirmDownloadDialogStyles()
+  const [syncing, setSyncing] = React.useState(false)
+
+  const handleCancel = React.useCallback(() => onClose(), [onClose])
+  const handleConfirm = React.useCallback(async () => {
+    setSyncing(true)
+    await ipc.invoke(IPC.EVENTS.DOWNLOAD_PACKAGE, packageHandle, localPath)
+    onClose()
+  }, [ipc, localPath, onClose, packageHandle])
+
+  const [fakeProgress, setFakeProgress] = React.useState(0)
+  const handleCliOutput = React.useCallback(() => {
+    if (fakeProgress) {
+      setFakeProgress((100 - fakeProgress) * 0.1 + fakeProgress)
+    } else {
+      setFakeProgress(1)
+      setTimeout(() => {
+        setFakeProgress((100 - fakeProgress) * 0.1 + fakeProgress)
+      }, 300)
+    }
+  }, [fakeProgress, setFakeProgress])
+  React.useEffect(() => {
+    ipc.on(IPC.EVENTS.CLI_OUTPUT, handleCliOutput)
+    return () => {
+      ipc.off(IPC.EVENTS.CLI_OUTPUT, handleCliOutput)
+    }
+  }, [ipc, handleCliOutput])
+  const progressVariant = fakeProgress ? 'determinate' : 'indeterminate'
+
+  return (
+    <M.Dialog maxWidth={maxWidth} open={open}>
+      <M.DialogTitle>Confirm download</M.DialogTitle>
+      <M.DialogContent>
+        {syncing && (
+          <M.LinearProgress
+            color="primary"
+            className={cx(classes.progressbar, { [classes.shrink]: fakeProgress === 1 })}
+            variant={progressVariant}
+            value={fakeProgress === 1 ? 0 : fakeProgress}
+          />
+        )}
+        From <Mono>{`s3://${packageHandle.bucket}/${packageHandle.name}`}</Mono> to{' '}
+        <Mono>{localPath}</Mono>
+      </M.DialogContent>
+      <M.DialogActions>
+        <M.Button disabled={syncing} onClick={handleCancel}>
+          Cancel
+        </M.Button>
+        <M.Button
+          disabled={syncing}
+          color="primary"
+          onClick={handleConfirm}
+          variant="contained"
+        >
+          Download
+        </M.Button>
+      </M.DialogActions>
+    </M.Dialog>
+  )
+}
+
+interface LocalFolderInputProps {
+  onChange: (path: string) => void
+  open: boolean
+  value: string | null
+}
+
+export function LocalFolderInput({ onChange, open, value }: LocalFolderInputProps) {
+  const ipc = IPC.use()
+
+  const handleClick = React.useCallback(async () => {
+    const newLocalPath = await ipc.invoke(IPC.EVENTS.LOCALPATH_REQUEST)
+    if (!newLocalPath) return
+    onChange(newLocalPath)
+  }, [ipc, onChange])
+
+  return (
+    <Section
+      icon="folder_open"
+      extraSummary={null}
+      heading="Local folder"
+      defaultExpanded={open}
+      gutterTop
+      gutterBottom
+    >
+      <M.TextField
+        fullWidth
+        size="small"
+        disabled={false}
+        helperText="Click to set local folder with your file browser"
+        id="localPath"
+        label="Path to local folder"
+        onClick={handleClick}
+        value={value}
+      />
+    </Section>
+  )
+}
+
+const STORAGE_KEYS = {
+  LOCAL_FOLDER: 'LOCAL_FOLDER',
+}
+const storage = mkStorage({
+  [STORAGE_KEYS.LOCAL_FOLDER]: STORAGE_KEYS.LOCAL_FOLDER,
+})
+
+export function useLocalFolder(): [string, (v: string) => void] {
+  const [value, setValue] = React.useState(() => {
+    try {
+      return storage.get(STORAGE_KEYS.LOCAL_FOLDER) || ''
+    } catch (error) {
+      // eslint-disable-next-line no-console
+      console.error(error)
+      return ''
+    }
+  })
+  const onChange = React.useCallback(
+    (path) => {
+      storage.set(STORAGE_KEYS.LOCAL_FOLDER, path)
+      setValue(path)
+    },
+    [setValue],
+  )
+  return React.useMemo(() => [value, onChange], [value, onChange])
 }

--- a/catalog/app/containers/Bucket/PackageTree/PackageTree.tsx
+++ b/catalog/app/containers/Bucket/PackageTree/PackageTree.tsx
@@ -32,6 +32,7 @@ import { UseQueryResult, useQuery } from 'utils/useQuery'
 
 import Code from '../Code'
 import CopyButton from '../CopyButton'
+import * as Download from '../Download'
 import * as FileView from '../FileView'
 import Listing, { Item as ListingItem } from '../Listing'
 import PackageCopyDialog from '../PackageCopyDialog'
@@ -187,7 +188,7 @@ function DirDisplay({
   crumbs,
   onRevisionPush,
 }: DirDisplayProps) {
-  const { desktop, noDownload } = Config.use()
+  const { desktop } = Config.use()
   const history = RRDom.useHistory()
   const { urls } = NamedRoutes.use()
   const classes = useDirDisplayStyles()
@@ -383,13 +384,12 @@ function DirDisplay({
             Push to bucket
           </CopyButton>
         )}
-        {!noDownload && (
-          <FileView.ZipDownloadForm
-            className={classes.button}
-            label={path ? 'Download sub-package' : 'Download package'}
-            suffix={downloadPath}
-          />
-        )}
+        <Download.DownloadButton
+          bucket={bucket}
+          className={classes.button}
+          label={path ? 'Download sub-package' : 'Download package'}
+          path={downloadPath}
+        />
         {preferences?.ui?.actions?.deleteRevision && (
           <RevisionMenu className={classes.button} onDelete={onPackageDeleteDialogOpen} />
         )}

--- a/catalog/app/containers/Bucket/PackageTree/PackageTree.tsx
+++ b/catalog/app/containers/Bucket/PackageTree/PackageTree.tsx
@@ -265,6 +265,9 @@ function DirDisplay({
     [bucket, name, hash],
   )
 
+  const [expandedLocalFolder, setExpandedLocalFolder] = React.useState(false)
+  const [localFolder, setLocalFolder] = Download.useLocalFolder()
+
   // XXX: use different "strategy" (e.g. network-only)?
   if (dirQuery.fetching || dirQuery.stale) {
     // TODO: skeleton placeholder
@@ -366,6 +369,13 @@ function DirDisplay({
 
       {updateDialog.element}
 
+      <Download.ConfirmDialog
+        localPath={localFolder}
+        onClose={() => setExpandedLocalFolder(false)}
+        open={!!localFolder && !!expandedLocalFolder}
+        packageHandle={packageHandle}
+      />
+
       <TopBar crumbs={crumbs}>
         {preferences?.ui?.actions?.revisePackage && !desktop && (
           <M.Button
@@ -388,6 +398,7 @@ function DirDisplay({
           bucket={bucket}
           className={classes.button}
           label={path ? 'Download sub-package' : 'Download package'}
+          onClick={() => setExpandedLocalFolder(true)}
           path={downloadPath}
         />
         {preferences?.ui?.actions?.deleteRevision && (
@@ -395,6 +406,13 @@ function DirDisplay({
         )}
       </TopBar>
       <PkgCode {...{ ...packageHandle, hashOrTag, path }} />
+      {desktop && (
+        <Download.LocalFolderInput
+          onChange={setLocalFolder}
+          open={expandedLocalFolder}
+          value={localFolder}
+        />
+      )}
       <FileView.Meta data={AsyncResult.Ok(dir.metadata)} />
       <M.Box mt={2}>
         <Listing items={items} />

--- a/catalog/app/utils/electron/events.ts
+++ b/catalog/app/utils/electron/events.ts
@@ -1,0 +1,13 @@
+export const CLI_OUTPUT = 'cli_output'
+export const CONFIG_GET = 'config_get'
+export const CONFIRM_REQUEST = 'confirm_request'
+export const CONFIRM_RESPONSE = 'confirm_response'
+export const LOCALPATH_REQUEST = 'localpath_request' // TODO: OPEN_IN_EXPLORER
+export const LOCK_SET = 'lock'
+export const LOCK_UNSET = 'unlock'
+export const OPEN_IN_BROWSER = 'open_in_browser'
+export const OPEN_IN_EXPLORER = 'open_in_explorer'
+export const QUIT = 'quit'
+export const READY = 'ready'
+export const DOWNLOAD_PACKAGE = 'download_package'
+export const UPLOAD_PACKAGE = 'upload_package'

--- a/catalog/app/utils/electron/events.ts
+++ b/catalog/app/utils/electron/events.ts
@@ -1,13 +1,3 @@
 export const CLI_OUTPUT = 'cli_output'
-export const CONFIG_GET = 'config_get'
-export const CONFIRM_REQUEST = 'confirm_request'
-export const CONFIRM_RESPONSE = 'confirm_response'
 export const LOCALPATH_REQUEST = 'localpath_request' // TODO: OPEN_IN_EXPLORER
-export const LOCK_SET = 'lock'
-export const LOCK_UNSET = 'unlock'
-export const OPEN_IN_BROWSER = 'open_in_browser'
-export const OPEN_IN_EXPLORER = 'open_in_explorer'
-export const QUIT = 'quit'
-export const READY = 'ready'
 export const DOWNLOAD_PACKAGE = 'download_package'
-export const UPLOAD_PACKAGE = 'upload_package'

--- a/catalog/app/utils/electron/ipc-provider.tsx
+++ b/catalog/app/utils/electron/ipc-provider.tsx
@@ -1,0 +1,66 @@
+import * as React from 'react'
+
+import * as AWS from 'utils/AWS'
+
+export * as EVENTS from './events'
+
+interface Credentials {
+  accessKeyId: string
+  secretAccessKey: string
+  sessionToken: string
+}
+
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+const handler = (eventName: string, callback: (event: any, ...args: any[]) => void) => {}
+
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+const request = (eventName: string, ...args: any[]): Promise<any> => Promise.resolve(null)
+
+export interface IPC {
+  on: typeof handler
+  off: typeof handler
+  invoke: typeof request
+  send: typeof request
+}
+
+const Ctx = React.createContext({
+  on: handler,
+  off: handler,
+  invoke: request,
+  send: request,
+})
+
+interface SentryProviderProps {
+  children: React.ReactNode
+  value: IPC
+}
+
+const serializeCredentials = (credentials: Credentials) => ({
+  accessKeyId: credentials.accessKeyId,
+  secretAccessKey: credentials.secretAccessKey,
+  sessionToken: credentials.sessionToken,
+})
+
+export const Provider = function SentryProvider({
+  children,
+  value: { off, on, invoke, send },
+}: SentryProviderProps) {
+  const credentials: Credentials = AWS.Credentials.use()
+  const ipc = React.useMemo(
+    () => ({
+      off,
+      on,
+      invoke: (channel: string, ...args: any[]) =>
+        invoke(channel, serializeCredentials(credentials), ...args),
+      send,
+    }),
+    [credentials, on, off, send, invoke],
+  )
+  return <Ctx.Provider value={ipc}>{children}</Ctx.Provider>
+}
+
+function useIPC(): IPC {
+  return React.useContext(Ctx)
+}
+
+export const use = useIPC

--- a/catalog/app/utils/electron/ipc-provider.tsx
+++ b/catalog/app/utils/electron/ipc-provider.tsx
@@ -41,7 +41,7 @@ const serializeCredentials = (credentials: Credentials) => ({
   sessionToken: credentials.sessionToken,
 })
 
-export const Provider = function SentryProvider({
+export const Provider = function IpcProvider({
   children,
   value: { off, on, invoke, send },
 }: SentryProviderProps) {


### PR DESCRIPTION
* Added IPC React context for electron events. Actual electron implementation is not in this PR
* Wrapped "Download package" button in separate component switching web and electron implementation
* Added LocalFolderInput to set local directory destination and ConfirmDialog (it is also progressabar with fake progress)


![Screenshot from 2022-02-03 19-03-53](https://user-images.githubusercontent.com/533229/152380808-baf730ad-e8dd-4ed6-8a32-01736e51565e.png)

![Screenshot from 2022-02-03 19-04-09](https://user-images.githubusercontent.com/533229/152380867-9fd04ce8-b45b-4876-a1ec-70c0c9f733fd.png)

![Screenshot from 2022-02-03 19-04-19](https://user-images.githubusercontent.com/533229/152380885-213304ee-0194-4898-abdb-5e1fe86dbd8c.png)