### PR TITLE
Fixed JSON editor help tooltip

### DIFF
--- a/catalog/app/components/JsonEditor/Note.tsx
+++ b/catalog/app/components/JsonEditor/Note.tsx
@@ -39,43 +39,42 @@ interface TypeHelpArgs {
 }
 
 function getTypeHelps({ errors, humanReadableSchema, mismatch, schema }: TypeHelpArgs) {
-  const output: string[] = []
+  const output: string[][] = []
 
   if (errors.length) {
-    errors.forEach(({ message }) => {
-      if (!message) return
-      output.push(message)
-    })
+    output.push(errors.filter(Boolean).map(({ message }) => message) as string[])
   }
 
   if (humanReadableSchema) {
-    if (output.length) output.push('—')
     if (humanReadableSchema === 'undefined') {
-      output.push('Key/value is not restricted by schema')
+      output.push(['Key/value is not restricted by schema'])
     } else {
-      output.push(`${mismatch ? 'Required type' : 'Type'}: ${humanReadableSchema}`)
+      output.push([`${mismatch ? 'Required type' : 'Type'}: ${humanReadableSchema}`])
     }
   }
 
   if (schema?.description) {
-    if (output.length) output.push('—')
-    output.push(`Description: ${schema.description}`)
+    output.push([`Description: ${schema.description}`])
   }
 
   return output
 }
 
 interface TypeHelpProps {
-  typeHelps: string[]
+  typeHelps: string[][]
 }
 
-function TypeHelp({ typeHelps }: TypeHelpProps) {
+function TypeHelp({ typeHelps: groups }: TypeHelpProps) {
   return (
     <div>
-      {typeHelps.map((typeHelp, index) => {
-        if (typeHelp === '—') return <hr key={`typeHelp_${index}`} />
-        return <p key={`typeHelp_${index}`}>{typeHelp}</p>
-      })}
+      {groups.map((group, i) => (
+        <div key={`typeHelp_group_${i}`}>
+          {i > 0 && <hr key={`typeHelp_group_${i}`} />}
+          {group.map((typeHelp, j) => (
+            <p key={`typeHelp_${i}_${j}`}>{typeHelp}</p>
+          ))}
+        </div>
+      ))}
     </div>
   )
 }

--- a/catalog/app/components/JsonEditor/Note.tsx
+++ b/catalog/app/components/JsonEditor/Note.tsx
@@ -16,21 +16,6 @@ import {
   ValidationErrors,
 } from './constants'
 
-const useStyles = M.makeStyles((t) => ({
-  default: {
-    color: t.palette.divider,
-    fontFamily: (t.typography as $TSFixMe).monospace.fontFamily,
-    fontSize: t.typography.caption.fontSize,
-    display: 'flex',
-    '&:hover': {
-      color: t.palette.text.disabled,
-    },
-  },
-  mismatch: {
-    color: t.palette.error.main,
-  },
-}))
-
 interface TypeHelpArgs {
   errors: ValidationErrors
   humanReadableSchema: string
@@ -60,16 +45,26 @@ function getTypeHelps({ errors, humanReadableSchema, mismatch, schema }: TypeHel
   return output
 }
 
+const useTypeHelpStyles = M.makeStyles((t) => ({
+  group: {
+    '& + &': {
+      borderTop: `1px solid ${t.palette.common.white}`,
+      marginTop: t.spacing(1),
+      paddingTop: t.spacing(1),
+    },
+  },
+}))
+
 interface TypeHelpProps {
   typeHelps: string[][]
 }
 
 function TypeHelp({ typeHelps: groups }: TypeHelpProps) {
+  const classes = useTypeHelpStyles()
   return (
     <div>
       {groups.map((group, i) => (
-        <div key={`typeHelp_group_${i}`}>
-          {i > 0 && <hr key={`typeHelp_group_${i}`} />}
+        <div className={classes.group} key={`typeHelp_group_${i}`}>
           {group.map((typeHelp, j) => (
             <p key={`typeHelp_${i}_${j}`}>{typeHelp}</p>
           ))}
@@ -85,8 +80,23 @@ interface NoteValueProps {
   value: JsonValue
 }
 
+const useNoteValueStyles = M.makeStyles((t) => ({
+  default: {
+    color: t.palette.divider,
+    fontFamily: (t.typography as $TSFixMe).monospace.fontFamily,
+    fontSize: t.typography.caption.fontSize,
+    display: 'flex',
+    '&:hover': {
+      color: t.palette.text.disabled,
+    },
+  },
+  mismatch: {
+    color: t.palette.error.main,
+  },
+}))
+
 function NoteValue({ errors, schema, value }: NoteValueProps) {
-  const classes = useStyles()
+  const classes = useNoteValueStyles()
 
   const humanReadableSchema = schemaTypeToHumanString(schema)
   const mismatch = value !== EMPTY_VALUE && !doesTypeMatchSchema(value, schema)

--- a/catalog/app/utils/reactTools.tsx
+++ b/catalog/app/utils/reactTools.tsx
@@ -30,26 +30,3 @@ export const mkLazy = (
     </React.Suspense>
   )
 }
-
-/**
- * TODO: add keys, add tests, remove extra fragments
- * Acts similar to Array#join:
- * `RT.join([<A1 />, <A2 />, <A3 />], <S />) -> <A1 /><S /><A2 /><S /><A3 />`
- */
-export const join = (
-  list: React.ReactNode[],
-  separator: React.ReactNode,
-): React.ReactNode => {
-  if (list.length < 2) return <>{list}</>
-  return (
-    <>
-      {list.reduce((acc, item) => (
-        <>
-          {item}
-          {separator}
-          {acc}
-        </>
-      ))}
-    </>
-  )
-}


### PR DESCRIPTION
* Show description even when no Schema type for this value
* Also, refactored component. Now I create an array of type helps separated into three groups: errors, type, description. And create tooltip help from this array
* Removed RT.join, I don't use it, and there is no reason to leave it since it has optimization issues

![Screenshot from 2022-02-04 16-55-57](https://user-images.githubusercontent.com/533229/152553152-6cc70b80-39ed-4c30-952f-d0fbd6e16e2f.png)
![Screenshot from 2022-02-04 16-56-22](https://user-images.githubusercontent.com/533229/152553158-da7c0ae7-15cf-4f62-9640-32ce83ab062a.png)

