### PR TITLE
Fix download path for download button

### DIFF
--- a/catalog/app/containers/Bucket/Download.tsx
+++ b/catalog/app/containers/Bucket/Download.tsx
@@ -12,20 +12,13 @@ import * as FileView from './FileView'
 import Section from './Section'
 
 interface DownloadButtonProps {
-  bucket: string
   className: string
   label?: string
   onClick: () => void
   path?: string
 }
 
-export function DownloadButton({
-  bucket,
-  className,
-  label,
-  onClick,
-  path,
-}: DownloadButtonProps) {
+export function DownloadButton({ className, label, onClick, path }: DownloadButtonProps) {
   const { desktop, noDownload }: { desktop: boolean; noDownload: boolean } = Config.use()
 
   if (noDownload) return null
@@ -42,13 +35,7 @@ export function DownloadButton({
     )
   }
 
-  return (
-    <FileView.ZipDownloadForm
-      className={className}
-      suffix={`package/${bucket}/${path}`}
-      label={label}
-    />
-  )
+  return <FileView.ZipDownloadForm className={className} label={label} suffix={path} />
 }
 
 const useConfirmDownloadDialogStyles = M.makeStyles({

--- a/catalog/app/containers/Bucket/Download.tsx
+++ b/catalog/app/containers/Bucket/Download.tsx
@@ -45,7 +45,7 @@ export function DownloadButton({
   return (
     <FileView.ZipDownloadForm
       className={className}
-      suffix={`dir/${bucket}/${path}`}
+      suffix={`package/${bucket}/${path}`}
       label={label}
     />
   )
@@ -108,7 +108,9 @@ export function ConfirmDialog({
 
   return (
     <M.Dialog maxWidth={maxWidth} open={open}>
-      <M.DialogTitle>Confirm download</M.DialogTitle>
+      <M.DialogTitle>
+        {syncing ? 'Package is downloading' : 'Confirm download'}
+      </M.DialogTitle>
       <M.DialogContent>
         {syncing && (
           <M.LinearProgress

--- a/catalog/app/containers/Bucket/PackageTree/PackageTree.tsx
+++ b/catalog/app/containers/Bucket/PackageTree/PackageTree.tsx
@@ -342,9 +342,7 @@ function DirDisplay({
     )
     .filter(Boolean)
 
-  const downloadPath = path
-    ? `package/${bucket}/${name}/${hash}/${path}`
-    : `package/${bucket}/${name}/${hash}`
+  const downloadPath = path ? `${name}/${hash}/${path}` : `${name}/${hash}`
 
   return (
     <>

--- a/catalog/app/containers/Bucket/PackageTree/PackageTree.tsx
+++ b/catalog/app/containers/Bucket/PackageTree/PackageTree.tsx
@@ -342,7 +342,9 @@ function DirDisplay({
     )
     .filter(Boolean)
 
-  const downloadPath = path ? `${name}/${hash}/${path}` : `${name}/${hash}`
+  const downloadPath = path
+    ? `package/${bucket}/${name}/${hash}/${path}`
+    : `package/${bucket}/${name}/${hash}`
 
   return (
     <>
@@ -393,7 +395,6 @@ function DirDisplay({
           </CopyButton>
         )}
         <Download.DownloadButton
-          bucket={bucket}
           className={classes.button}
           label={path ? 'Download sub-package' : 'Download package'}
           onClick={() => setExpandedLocalFolder(true)}


### PR DESCRIPTION
* In #2660 I provided incorrect `suffix` value for `<FileView.ZipDownloadForm />`
* Also, removed extra argument `bucket`, since `path` already contains it
* And adjusted dialog title during download 