### PR TITLE
Implement semi-atomic push

### DIFF
--- a/api/python/quilt3/packages.py
+++ b/api/python/quilt3/packages.py
@@ -41,6 +41,7 @@ from .util import TEMPFILE_DIR_PATH as APP_DIR_TEMPFILE_DIR
 from .util import (
     PhysicalKey,
     QuiltException,
+    QuiltConflictException,
     catalog_package_url,
     extract_file_extension,
     fix_url,
@@ -1409,9 +1410,10 @@ class Package:
                 raise
 
             if self._origin is None or latest_hash != self._origin.top_hash:
-                raise QuiltException(
-                    f"Package with an unexpected hash {latest_hash} already exists at the destination; "
-                    "use force=True to overwrite"
+                raise QuiltConflictException(
+                    f"Package with hash {latest_hash} already exists at the destination; "
+                    f"expected {None if self._origin is None else self._origin.top_hash}. "
+                    "Use force=True to overwrite."
                 )
 
         # Check the top hash and fail early if it's unexpected.

--- a/api/python/quilt3/packages.py
+++ b/api/python/quilt3/packages.py
@@ -40,8 +40,8 @@ from .util import CACHE_PATH, DISABLE_TQDM, PACKAGE_UPDATE_POLICY
 from .util import TEMPFILE_DIR_PATH as APP_DIR_TEMPFILE_DIR
 from .util import (
     PhysicalKey,
-    QuiltException,
     QuiltConflictException,
+    QuiltException,
     catalog_package_url,
     extract_file_extension,
     fix_url,

--- a/api/python/quilt3/packages.py
+++ b/api/python/quilt3/packages.py
@@ -17,6 +17,7 @@ import warnings
 from collections import deque
 from multiprocessing import Pool
 
+import botocore.exceptions
 import jsonlines
 from tqdm import tqdm
 
@@ -375,11 +376,10 @@ class ManifestJSONDecoder(json.JSONDecoder):
 class Package:
     """ In-memory representation of a package """
 
-    _origin = None
-
     def __init__(self):
         self._children = {}
         self._meta = {'version': 'v0'}
+        self._origin = None
 
     @ApiTelemetry("package.__repr__")
     def __repr__(self, max_lines=20):
@@ -604,7 +604,9 @@ class Package:
                     stack.callback(os.unlink, local_pkg_manifest)
                 download_manifest(local_pkg_manifest)
 
-            return cls._from_path(local_pkg_manifest)
+            pkg = cls._from_path(local_pkg_manifest)
+            pkg._origin = PackageRevInfo(str(registry.base), name, top_hash)
+            return pkg
 
     @classmethod
     def _from_path(cls, path):
@@ -1039,8 +1041,7 @@ class Package:
     def _push_manifest(self, name, registry, top_hash):
         manifest = io.BytesIO()
         self._dump(manifest)
-        self._timestamp = registry.push_manifest(name, top_hash, manifest.getvalue())
-        self._origin = PackageRevInfo(str(registry.base), name, top_hash)
+        registry.push_manifest(name, top_hash, manifest.getvalue())
 
     @ApiTelemetry("package.dump")
     def dump(self, writable_file):
@@ -1290,7 +1291,7 @@ class Package:
 
     @ApiTelemetry("package.push")
     @_fix_docstring(workflow=_WORKFLOW_PARAM_DOCSTRING)
-    def push(self, name, registry=None, dest=None, message=None, selector_fn=None, *, workflow=...):
+    def push(self, name, registry=None, dest=None, message=None, selector_fn=None, *, workflow=..., force=False):
         """
         Copies objects to path, then creates a new package that points to those objects.
         Copies each object in this package to path according to logical key structure,
@@ -1330,9 +1331,9 @@ class Package:
         Returns:
             A new package that points to the copied objects.
         """
-        return self._push(name, registry, dest, message, selector_fn, workflow=workflow, print_info=True)
+        return self._push(name, registry, dest, message, selector_fn, workflow=workflow, print_info=True, force=force)
 
-    def _push(self, name, registry=None, dest=None, message=None, selector_fn=None, *, workflow, print_info):
+    def _push(self, name, registry=None, dest=None, message=None, selector_fn=None, *, workflow, print_info, force):
         if selector_fn is None:
             def selector_fn(*args):
                 return True
@@ -1391,12 +1392,34 @@ class Package:
         registry = get_package_registry(registry)
         self._validate_with_workflow(registry=registry, workflow=workflow, name=name, message=message)
 
+        def check_latest_hash():
+            if force:
+                return
+
+            try:
+                latest_hash = get_bytes(registry.pointer_latest_pk(name)).decode()
+            except botocore.exceptions.ClientError as ex:
+                if ex.response['Error']['Code'] == 'NoSuchKey':
+                    # Expected
+                    return
+                raise
+
+            if self._origin is None or latest_hash != self._origin.top_hash:
+                raise QuiltException(
+                    f"Package with an unexpected hash {latest_hash} already exists at the destination; "
+                    "use force=True to overwrite"
+                )
+
+        # Check the top hash and fail early if it's unexpected.
+        check_latest_hash()
+
         self._fix_sha256()
 
         pkg = self.__class__()
         pkg._meta = self._meta
         pkg._set_commit_message(message)
         top_hash = self._calculate_top_hash(pkg._meta, self.walk())
+        pkg._origin = PackageRevInfo(str(registry.base), name, top_hash)
 
         # Since all that is modified is physical keys, pkg will have the same top hash
         file_list = []
@@ -1445,6 +1468,9 @@ class Package:
             # Update old package to point to the materialized location of the file since the tempfile no longest exists
             for lk in temp_file_logical_keys:
                 self._set(lk, pkg[lk])
+
+        # Check top hash again just before pushing, to minimize the race condition.
+        check_latest_hash()
 
         pkg._push_manifest(name, registry, top_hash)
 

--- a/api/python/quilt3/packages.py
+++ b/api/python/quilt3/packages.py
@@ -1314,6 +1314,9 @@ class Package:
         If `selector_fn('entry_1', pkg["entry_1"]) == True`,
         `new_pkg["entry_1"] = ["s3://bucket/prefix/entry_1.json"]`
 
+        By default, push will not overwrite an existing package if its top hash does not match
+        the parent hash of the package being pushed. Use `force=True` to skip the check.
+
         Args:
             name: name for package in registry
             dest: where to copy the objects in the package
@@ -1327,6 +1330,7 @@ class Package:
                 are spread over multiple buckets and you add a single local file, you can use selector_fn to
                 only push the local file to s3 (instead of pushing all data to the destination bucket).
             %(workflow)s
+            force: skip the top hash check and overwrite any existing package
 
         Returns:
             A new package that points to the copied objects.

--- a/api/python/quilt3/util.py
+++ b/api/python/quilt3/util.py
@@ -108,6 +108,10 @@ class QuiltException(Exception):
             setattr(self, k, v)
 
 
+class QuiltConflictException(QuiltException):
+    pass
+
+
 class RemovedInQuilt4Warning(FutureWarning):
     pass
 

--- a/api/python/tests/integration/test_packages.py
+++ b/api/python/tests/integration/test_packages.py
@@ -1,4 +1,5 @@
 """ Integration tests for Quilt Packages. """
+from functools import partial
 import io
 import locale
 import os
@@ -1186,7 +1187,7 @@ class PackageTest(QuiltTestCase):
     @patch('quilt3.workflows.validate', mock.MagicMock(return_value='workflow data'))
     def test_manifest_workflow(self):
         self.patch_s3_registry('shorten_top_hash', return_value='7a67ff4')
-        for method in (Package.build, Package.push):
+        for method in (Package.build, partial(Package.push, force=True)):
             with self.subTest(method=method):
                 pkg = Package()
                 method(pkg, 'foo/bar', registry='s3://test-bucket')
@@ -1610,7 +1611,7 @@ class PackageTest(QuiltTestCase):
         pkg_registry = self.S3PackageRegistryDefault(PhysicalKey.from_url('s3://test-bucket'))
         self.patch_s3_registry('shorten_top_hash', return_value='7a67ff4')
 
-        for method in (Package.build, Package.push):
+        for method in (Package.build, partial(Package.push, force=True)):
             with self.subTest(method=method):
                 with patch('quilt3.Package._push_manifest') as push_manifest_mock:
                     pkg = Package().set('foo', DATA_DIR / 'foo.txt')
@@ -1625,7 +1626,7 @@ class PackageTest(QuiltTestCase):
                     assert pkg._workflow is mock.sentinel.returned_workflow
                     push_manifest_mock.assert_called_once()
                     workflow_validate_mock.reset_mock()
-                    if method is Package.push:
+                    if method is not Package.build:
                         copy_file_list_mock.assert_called_once()
                         copy_file_list_mock.reset_mock()
 
@@ -1649,7 +1650,7 @@ class PackageTest(QuiltTestCase):
                     assert pkg._workflow is mock.sentinel.returned_workflow
                     push_manifest_mock.assert_called_once()
                     workflow_validate_mock.reset_mock()
-                    if method is Package.push:
+                    if method is not Package.build:
                         copy_file_list_mock.assert_called_once()
                         copy_file_list_mock.reset_mock()
 

--- a/api/python/tests/integration/test_packages.py
+++ b/api/python/tests/integration/test_packages.py
@@ -25,7 +25,7 @@ from quilt3.backends.local import (
     LocalPackageRegistryV2,
 )
 from quilt3.backends.s3 import S3PackageRegistryV1, S3PackageRegistryV2
-from quilt3.util import PhysicalKey, QuiltException, validate_package_name
+from quilt3.util import PhysicalKey, QuiltException, QuiltConflictException, validate_package_name
 
 from ..utils import QuiltTestCase
 
@@ -1124,7 +1124,7 @@ class PackageTest(QuiltTestCase):
                 pkg_registry, pkg_name, pointer='latest', top_hash=pkg2.top_hash
             )
 
-            with self.assertRaisesRegex(QuiltException, 'Package with an unexpected hash'):
+            with self.assertRaisesRegex(QuiltConflictException, 'already exists'):
                 pkg2.push('Quilt/test', 's3://test-bucket')
 
     @patch('quilt3.workflows.validate', return_value=None)

--- a/api/python/tests/integration/test_packages.py
+++ b/api/python/tests/integration/test_packages.py
@@ -1,5 +1,4 @@
 """ Integration tests for Quilt Packages. """
-from functools import partial
 import io
 import locale
 import os
@@ -9,6 +8,7 @@ import tempfile
 from collections import Counter
 from contextlib import redirect_stderr
 from datetime import datetime
+from functools import partial
 from io import BytesIO
 from pathlib import Path
 from unittest import mock
@@ -1677,7 +1677,10 @@ class PackageTest(QuiltTestCase):
     def test_push_dest_fn_s3_uri_with_version_id(self):
         pkg = Package().set('foo', DATA_DIR / 'foo.txt')
         with pytest.raises(ValueError) as excinfo:
-            pkg.push('foo/bar', registry='s3://test-bucket', dest=lambda *args, **kwargs: 's3://bucket/ds?versionId=v', force=True)
+            pkg.push(
+                'foo/bar', registry='s3://test-bucket',
+                dest=lambda *args, **kwargs: 's3://bucket/ds?versionId=v', force=True
+            )
         assert 'URI must not include versionId' in str(excinfo.value)
 
     @patch('quilt3.workflows.validate', mock.MagicMock(return_value=None))

--- a/api/python/tests/integration/test_packages.py
+++ b/api/python/tests/integration/test_packages.py
@@ -25,7 +25,12 @@ from quilt3.backends.local import (
     LocalPackageRegistryV2,
 )
 from quilt3.backends.s3 import S3PackageRegistryV1, S3PackageRegistryV2
-from quilt3.util import PhysicalKey, QuiltException, QuiltConflictException, validate_package_name
+from quilt3.util import (
+    PhysicalKey,
+    QuiltConflictException,
+    QuiltException,
+    validate_package_name,
+)
 
 from ..utils import QuiltTestCase
 

--- a/api/python/tests/integration/test_packages.py
+++ b/api/python/tests/integration/test_packages.py
@@ -462,7 +462,7 @@ class PackageTest(QuiltTestCase):
         )
         with patch('time.time', return_value=timestamp1), \
              patch('quilt3.data_transfer.MAX_CONCURRENCY', 1):
-            remote_pkg = new_pkg.push(pkg_name, registry)
+            remote_pkg = new_pkg.push(pkg_name, registry, force=True)
 
         # Modify one file, and check that only that file gets uploaded.
         add_pkg_file(remote_pkg, 'foo2', 'bar3', '!!!', version='v2')
@@ -480,7 +480,7 @@ class PackageTest(QuiltTestCase):
             stderr = io.StringIO()
 
             with redirect_stderr(stderr), patch('quilt3.packages.DISABLE_TQDM', True):
-                remote_pkg.push(pkg_name, registry)
+                remote_pkg.push(pkg_name, registry, force=True)
             assert not stderr.getvalue()
 
     def test_package_deserialize(self):
@@ -717,7 +717,7 @@ class PackageTest(QuiltTestCase):
         # Test that push cleans up the temporary files, if and only if the serialization_location was not set
         with patch('quilt3.Package._push_manifest'), \
              patch('quilt3.packages.copy_file_list', _mock_copy_file_list):
-            pkg.push('Quilt/test_pkg_name', 's3://test-bucket')
+            pkg.push('Quilt/test_pkg_name', 's3://test-bucket', force=True)
 
         for lk in ["mydataframe1.parquet", "mydataframe2.csv", "mydataframe3.tsv"]:
             file_path = pkg[lk].physical_key.path
@@ -1059,19 +1059,19 @@ class PackageTest(QuiltTestCase):
 
         # disallow pushing not to the top level of a remote S3 registry
         with pytest.raises(QuiltException):
-            p.push('Quilt/Test', 's3://test-bucket/foo/bar')
+            p.push('Quilt/Test', 's3://test-bucket/foo/bar', force=True)
 
         # disallow pushing to the local filesystem (use install instead)
         with pytest.raises(QuiltException):
-            p.push('Quilt/Test', './')
+            p.push('Quilt/Test', './', force=True)
 
         # disallow pushing the package manifest to remote but package data to local
         with pytest.raises(QuiltException):
-            p.push('Quilt/Test', 's3://test-bucket', dest='./')
+            p.push('Quilt/Test', 's3://test-bucket', dest='./', force=True)
 
         # disallow pushing the pacakge manifest to remote but package data to a different remote
         with pytest.raises(QuiltException):
-            p.push('Quilt/Test', 's3://test-bucket', dest='s3://other-test-bucket')
+            p.push('Quilt/Test', 's3://test-bucket', dest='s3://other-test-bucket', force=True)
 
     @patch('quilt3.workflows.validate', return_value=None)
     def test_commit_message_on_push(self, mocked_workflow_validate):
@@ -1083,7 +1083,7 @@ class PackageTest(QuiltTestCase):
             with open(REMOTE_MANIFEST, encoding='utf-8') as fd:
                 pkg = Package.load(fd)
 
-            pkg.push('Quilt/test_pkg_name', 's3://test-bucket', message='test_message')
+            pkg.push('Quilt/test_pkg_name', 's3://test-bucket', message='test_message', force=True)
             registry = self.S3PackageRegistryDefault(PhysicalKey.from_url('s3://test-bucket'))
             message = 'test_message'
             push_manifest_mock.assert_called_once_with(
@@ -1660,7 +1660,7 @@ class PackageTest(QuiltTestCase):
             with self.subTest(value=val):
                 with pytest.raises(TypeError) as excinfo:
                     pkg.push('foo/bar', registry='s3://test-bucket',
-                             dest=(lambda v: lambda *args, **kwargs: v)(val))
+                             dest=(lambda v: lambda *args, **kwargs: v)(val), force=True)
                 assert 'str is expected' in str(excinfo.value)
 
     @patch('quilt3.workflows.validate', mock.MagicMock(return_value=None))
@@ -1670,13 +1670,13 @@ class PackageTest(QuiltTestCase):
             with self.subTest(value=val):
                 with pytest.raises(quilt3.util.URLParseError):
                     pkg.push('foo/bar', registry='s3://test-bucket',
-                             dest=(lambda v: lambda *args, **kwargs: v)(val))
+                             dest=(lambda v: lambda *args, **kwargs: v)(val), force=True)
 
     @patch('quilt3.workflows.validate', mock.MagicMock(return_value=None))
     def test_push_dest_fn_s3_uri_with_version_id(self):
         pkg = Package().set('foo', DATA_DIR / 'foo.txt')
         with pytest.raises(ValueError) as excinfo:
-            pkg.push('foo/bar', registry='s3://test-bucket', dest=lambda *args, **kwargs: 's3://bucket/ds?versionId=v')
+            pkg.push('foo/bar', registry='s3://test-bucket', dest=lambda *args, **kwargs: 's3://bucket/ds?versionId=v', force=True)
         assert 'URI must not include versionId' in str(excinfo.value)
 
     @patch('quilt3.workflows.validate', mock.MagicMock(return_value=None))
@@ -1703,7 +1703,7 @@ class PackageTest(QuiltTestCase):
         )
         push_manifest_mock = self.patch_s3_registry('push_manifest')
         self.patch_s3_registry('shorten_top_hash', return_value='7a67ff4')
-        pkg.push(pkg_name, registry='s3://test-bucket', dest=dest_fn)
+        pkg.push(pkg_name, registry='s3://test-bucket', dest=dest_fn, force=True)
 
         dest_fn.assert_called_once_with(lk, pkg[lk], mock.sentinel.top_hash)
         push_manifest_mock.assert_called_once_with(pkg_name, mock.sentinel.top_hash, ANY)

--- a/docs/api-reference/Package.md
+++ b/docs/api-reference/Package.md
@@ -311,9 +311,9 @@ __Arguments__
     only push the local file to s3 (instead of pushing all data to the destination bucket).
 * __workflow__:  workflow ID or `None` to skip workflow validation.
     If not specified, the default workflow will be used.
-* __force__:  skip the top hash check and overwrite any existing package
 * __For details see__:  https://docs.quiltdata.com/advanced-usage/workflows
 
+* __force__:  skip the top hash check and overwrite any existing package
 
 __Returns__
 

--- a/docs/api-reference/Package.md
+++ b/docs/api-reference/Package.md
@@ -270,7 +270,7 @@ __Raises__
 * `KeyError`:  when logical_key is not present to be deleted
 
 
-## Package.push(self, name, registry=None, dest=None, message=None, selector\_fn=None, \*, workflow=Ellipsis)  {#Package.push}
+## Package.push(self, name, registry=None, dest=None, message=None, selector\_fn=None, \*, workflow=Ellipsis, force=False)  {#Package.push}
 
 Copies objects to path, then creates a new package that points to those objects.
 Copies each object in this package to path according to logical key structure,
@@ -293,6 +293,9 @@ If `selector_fn('entry_1', pkg["entry_1"]) == False`,
 If `selector_fn('entry_1', pkg["entry_1"]) == True`,
 `new_pkg["entry_1"] = ["s3://bucket/prefix/entry_1.json"]`
 
+By default, push will not overwrite an existing package if its top hash does not match
+the parent hash of the package being pushed. Use `force=True` to skip the check.
+
 __Arguments__
 
 * __name__:  name for package in registry
@@ -308,6 +311,7 @@ __Arguments__
     only push the local file to s3 (instead of pushing all data to the destination bucket).
 * __workflow__:  workflow ID or `None` to skip workflow validation.
     If not specified, the default workflow will be used.
+* __force__:  skip the top hash check and overwrite any existing package
 * __For details see__:  https://docs.quiltdata.com/advanced-usage/workflows
 
 


### PR DESCRIPTION
Make Package.push fail if the destination already contains a package with a top hash that's different from the current package's parent.