### PR TITLE
Load perspective lazily

### DIFF
--- a/catalog/app/components/Preview/renderers/Perspective/Perspective.tsx
+++ b/catalog/app/components/Preview/renderers/Perspective/Perspective.tsx
@@ -5,11 +5,11 @@ import * as M from '@material-ui/core'
 
 import JsonDisplay from 'components/JsonDisplay'
 import * as perspective from 'utils/perspective'
-import type { S3HandleBase } from 'utils/s3paths'
 
-import { ParquetMetadata } from '../loaders/Tabular'
+import { ParquetMetadata } from '../../loaders/Tabular'
+import { CONTEXT } from '../../types'
 
-import { CONTEXT } from '../types'
+import { PerspectiveProps } from './types'
 
 const useParquetMetaStyles = M.makeStyles((t) => ({
   root: {
@@ -144,16 +144,7 @@ const useStyles = M.makeStyles((t) => ({
   },
 }))
 
-interface PerspectiveProps extends React.HTMLAttributes<HTMLDivElement> {
-  context: 'file' | 'listing'
-  data: string | ArrayBuffer
-  meta: ParquetMetadata
-  handle: S3HandleBase
-  onLoadMore: () => void
-  truncated: boolean
-}
-
-function Perspective({
+export default function Perspective({
   children,
   className,
   context,
@@ -184,7 +175,3 @@ function Perspective({
     </div>
   )
 }
-
-export default (data: PerspectiveProps, props: PerspectiveProps) => (
-  <Perspective {...data} {...props} />
-)

--- a/catalog/app/components/Preview/renderers/Perspective/index.tsx
+++ b/catalog/app/components/Preview/renderers/Perspective/index.tsx
@@ -1,0 +1,14 @@
+import * as React from 'react'
+
+import Placeholder from 'components/Placeholder'
+import * as RT from 'utils/reactTools'
+
+import { PerspectiveProps } from './types'
+
+const SuspensePlaceholder = () => <Placeholder color="text.secondary" />
+
+const Perspective = RT.mkLazy(() => import('./Perspective'), SuspensePlaceholder)
+
+export default (data: PerspectiveProps, props: PerspectiveProps) => (
+  <Perspective {...data} {...props} />
+)

--- a/catalog/app/components/Preview/renderers/Perspective/types.ts
+++ b/catalog/app/components/Preview/renderers/Perspective/types.ts
@@ -1,0 +1,14 @@
+import type * as React from 'react'
+
+import type { S3HandleBase } from 'utils/s3paths'
+
+import { ParquetMetadata } from '../../loaders/Tabular'
+
+export interface PerspectiveProps extends React.HTMLAttributes<HTMLDivElement> {
+  context: 'file' | 'listing'
+  data: string | ArrayBuffer
+  meta: ParquetMetadata
+  handle: S3HandleBase
+  onLoadMore: () => void
+  truncated: boolean
+}


### PR DESCRIPTION
I checked the bucket overview page: the size of js files decreased in 650Kb