### PR TITLE
Add docs section on running quilt3 in Databricks

### DIFF
--- a/docs/SUMMARY.md
+++ b/docs/SUMMARY.md
@@ -43,7 +43,7 @@
 * [Workflows](advanced-features/workflows.md)
 * [Enterprise install](technical-reference.md)
 * [S3 Events, EventBridge](EventBridge.md)
-* [Running Quilt in Databricks](databricks.md)
+* [Databricks](databricks.md)
 
 ### More
 * [Frequently Asked Questions](FAQ.md)

--- a/docs/SUMMARY.md
+++ b/docs/SUMMARY.md
@@ -43,6 +43,7 @@
 * [Workflows](advanced-features/workflows.md)
 * [Enterprise install](technical-reference.md)
 * [S3 Events, EventBridge](EventBridge.md)
+* [Running Quilt in Databricks](databricks.md)
 
 ### More
 * [Frequently Asked Questions](FAQ.md)

--- a/docs/databricks.md
+++ b/docs/databricks.md
@@ -1,4 +1,5 @@
 # Running Quilt in Databricks
+Many Databricks workloads consume input data from S3 and write output data to S3. Quilt packages provide a logical structure to data in S3, connecting related files, metadata, and documentation into a logical view that's available in code and in an online catalog. Databricks users can use the `quilt3` Python API to create and browse data packages in their Python notebooks.
 
 ## Install `quilt3` on Your Cluster
 Before using `quilt3` in your Databricks notebooks, you'll need to install it on your cluster. Find your cluster from the __Compute__ tab. From your Cluster overview, click on the __Libraries__ tab, then click the "Install new" button. Select PyPI under Library Source and enter `quilt3` for the Package.

--- a/docs/databricks.md
+++ b/docs/databricks.md
@@ -1,0 +1,6 @@
+# Running Quilt in Databricks
+
+## Install `quilt3` on Your Cluster
+Before using `quilt3` in your Databricks notebooks, you'll need to install it on your cluster. Find your cluster from the __Compute__ tab. From your Cluster overview, click on the __Libraries__ tab, then click the "Install new" button. Select PyPI under Library Source and enter `quilt3` for the Package.
+
+For more details, see the Databricks [documentation on libraries](https://docs.databricks.com/libraries/index.html).


### PR DESCRIPTION
# Description

Adding a docs section under Advanced on running Quilt in Databricks. The first topic is how to install quilt3 on a Databricks cluster. Future topics might include:
* S3 permissions
* packaging parquet files

# TODO

<!-- Use <del></del> for items that are not required for this PR -->

<del>
- [ ] Unit tests
- [ ] Automated tests (e.g. Preflight)
- [ ] Documentation
    - [ ] [Python: Run `build.py`](../gendocs/build.py) for new docstrings
    - [ ] JavaScript: basic explanation and screenshot of new features
- [ ] [Changelog](CHANGELOG.md) entry
</del>