### PR TITLE
pkgpush lambda: always generate URLs using v4 signer

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -8,6 +8,7 @@
 !-->
 ## Catalog, Lambdas
 * [Added] Use `quilt_summarize.json` to control Perspective menu ([#2744](https://github.com/quiltdata/quilt/pull/2744))
+* [Fixed] Fix package creation in S3 buckets with SSE-KMS enabled ([#2754](https://github.com/quiltdata/quilt/pull/2754))
 
 # 5.0.0 - 2022-03-14
 ## CLI

--- a/lambdas/pkgpush/src/t4_lambda_pkgpush/__init__.py
+++ b/lambdas/pkgpush/src/t4_lambda_pkgpush/__init__.py
@@ -14,6 +14,7 @@ import traceback
 from http import HTTPStatus
 
 import boto3
+import botocore.client
 from botocore.exceptions import ClientError
 from jsonschema import Draft7Validator
 
@@ -206,7 +207,7 @@ def calculate_pkg_hashes(boto_session, pkg):
 
     @functools.lru_cache(maxsize=None)
     def get_s3_client_for_region(region: str):
-        return boto_session.client("s3", region_name=region)
+        return boto_session.client("s3", region_name=region, config=botocore.client.Config(signature_version="s3v4"))
 
     def get_client_for_bucket(bucket: str):
         return get_s3_client_for_region(get_region_for_bucket(bucket))


### PR DESCRIPTION
This is required for S3 buckets using SSE-KMS.

# Description
- [x] [Changelog](CHANGELOG.md) entry
