### PR TITLE
Perspective Safari bugs

### DIFF
--- a/catalog/app/components/Preview/renderers/Perspective/Perspective.tsx
+++ b/catalog/app/components/Preview/renderers/Perspective/Perspective.tsx
@@ -152,15 +152,18 @@ function TruncatedWarning({ className, onLoadMore, table }: TruncatedWarningProp
 
 const useStyles = M.makeStyles((t) => ({
   root: {
+    overflow: 'scroll',
+    // NOTE: padding is required because perspective-viewer covers resize handle
+    padding: '0 0 4px',
+    resize: 'vertical',
     width: '100%',
   },
   meta: {
     marginBottom: t.spacing(1),
   },
   viewer: {
-    height: t.spacing(80),
-    overflow: 'auto',
-    resize: 'vertical',
+    height: '100%',
+    minHeight: t.spacing(80),
     zIndex: 1,
   },
   warning: {

--- a/catalog/app/utils/perspective.ts
+++ b/catalog/app/utils/perspective.ts
@@ -1,3 +1,4 @@
+import cx from 'classnames'
 import * as React from 'react'
 
 import 'utils/perspective-pollution'
@@ -18,7 +19,8 @@ export function renderViewer(
 ): HTMLPerspectiveViewerElement {
   const element = document.createElement('perspective-viewer')
   if (className) {
-    element.className = className
+    // NOTE: safari needs `.perspective-viewer-material` instead of custom tagName
+    element.className = cx(className, 'perspective-viewer-material')
   }
   parentNode.appendChild(element)
   return element

--- a/catalog/app/utils/perspective.ts
+++ b/catalog/app/utils/perspective.ts
@@ -18,10 +18,8 @@ export function renderViewer(
   { className }: React.HTMLAttributes<HTMLDivElement>,
 ): HTMLPerspectiveViewerElement {
   const element = document.createElement('perspective-viewer')
-  if (className) {
-    // NOTE: safari needs `.perspective-viewer-material` instead of custom tagName
-    element.className = cx(className, 'perspective-viewer-material')
-  }
+  // NOTE: safari needs `.perspective-viewer-material` instead of custom tagName
+  element.className = cx('perspective-viewer-material', className)
   parentNode.appendChild(element)
   return element
 }


### PR DESCRIPTION
1. CSS variables weren't applied. Adding className besides `perspective-viewer` tag name fixed that. CSS code looks like this:
```css
perspective-viewer, .perspective-viewer-material {
  --variableA: 'one'
  --variableB: 'two'
}
```
2. `perspecttive-viewer`'s shadow HTML was covering resize handle in Safari, so I moved resize handle to outer wrapper and added small bottom padding