### PR TITLE
Summarize mobile view fixes

### DIFF
--- a/catalog/app/containers/Bucket/Listing.tsx
+++ b/catalog/app/containers/Bucket/Listing.tsx
@@ -775,6 +775,9 @@ const useStyles = M.makeStyles((t) => ({
   root: {
     position: 'relative',
     zIndex: 1, // to prevent receiveing shadow from footer
+    [t.breakpoints.down('xs')]: {
+      borderRadius: 0,
+    },
   },
   grid: {
     border: 'none',

--- a/catalog/app/containers/Bucket/Summarize.tsx
+++ b/catalog/app/containers/Bucket/Summarize.tsx
@@ -124,6 +124,10 @@ const useSectionStyles = M.makeStyles((t) => ({
       ...t.typography.h5,
     },
   },
+  headingText: {
+    overflow: 'hidden',
+    textOverflow: 'ellipsis',
+  },
   headingAction: {
     marginLeft: 'auto',
   },
@@ -148,7 +152,7 @@ export function Section({
     <M.Paper className={cx(classes.root, classes[ft])} {...props}>
       {!!heading && (
         <div className={classes.heading}>
-          {heading}
+          <div className={classes.headingText}>{heading}</div>
           {handle && <DownloadButton className={classes.headingAction} handle={handle} />}
         </div>
       )}

--- a/catalog/app/containers/Bucket/Summary.js
+++ b/catalog/app/containers/Bucket/Summary.js
@@ -35,7 +35,14 @@ const extractSummary = R.applySpec({
 })
 
 const Container = M.styled(M.Card)(({ theme: t }) => ({
-  marginTop: t.spacing(2),
+  position: 'relative',
+  zIndex: 1,
+  [t.breakpoints.down('xs')]: {
+    borderRadius: 0,
+  },
+  [t.breakpoints.up('sm')]: {
+    marginTop: t.spacing(2),
+  },
 }))
 
 const Header = ({ children }) => (


### PR DESCRIPTION
* Removed border-radius at files listing
* Removed border-radius and margin at thumbnails block (similar to files previews)
* Cut with ellipsis long unbreakable file names

![Screenshot from 2022-04-01 11-45-30](https://user-images.githubusercontent.com/533229/161228963-e5642c43-caf8-4698-871f-c6007a1d4c79.png)
![Screenshot from 2022-04-01 11-45-53](https://user-images.githubusercontent.com/533229/161228966-4580892f-fcf2-44c8-8840-45acaa9ff5ab.png)
![Screenshot from 2022-04-01 11-46-52](https://user-images.githubusercontent.com/533229/161228969-27371b1c-6e26-4988-b181-125e99712d63.png)
