### PR TITLE
Fix scroll on homepage when there are few buckets

### DIFF
--- a/catalog/app/components/Layout/Layout.tsx
+++ b/catalog/app/components/Layout/Layout.tsx
@@ -7,6 +7,7 @@ import * as NavBar from 'containers/NavBar'
 const useRootStyles = M.makeStyles({
   root: {
     overflowX: 'hidden',
+    position: 'relative',
   },
 })
 

--- a/catalog/app/utils/perspective.ts
+++ b/catalog/app/utils/perspective.ts
@@ -1,5 +1,4 @@
 import cx from 'classnames'
-import * as R from 'ramda'
 import * as React from 'react'
 
 import 'utils/perspective-pollution'

--- a/catalog/app/website/pages/Landing/Buckets/Buckets.js
+++ b/catalog/app/website/pages/Landing/Buckets/Buckets.js
@@ -6,6 +6,7 @@ import { fade } from '@material-ui/core/styles'
 
 import Pagination from 'components/Pagination2'
 import * as BucketConfig from 'utils/BucketConfig'
+import * as Config from 'utils/Config'
 import * as NamedRoutes from 'utils/NamedRoutes'
 import useDebouncedInput from 'utils/useDebouncedInput'
 import usePrevious from 'utils/usePrevious'
@@ -31,6 +32,10 @@ const useStyles = M.makeStyles((t) => ({
     [t.breakpoints.up('sm')]: {
       maxWidth: 360,
     },
+  },
+  backlight: {
+    bottom: ({ isProduct }) => (isProduct ? 0 : undefined),
+    opacity: 0.5,
   },
   controls: {
     display: 'flex',
@@ -62,7 +67,8 @@ const useStyles = M.makeStyles((t) => ({
 }))
 
 export default function Buckets({ query: filter } = { query: '' }) {
-  const classes = useStyles()
+  const cfg = Config.useConfig()
+  const classes = useStyles({ isProduct: cfg.mode === 'PRODUCT' })
   // XXX: consider using graphql directly
   const buckets = BucketConfig.useRelevantBucketConfigs()
   const { urls } = NamedRoutes.use()
@@ -126,7 +132,7 @@ export default function Buckets({ query: filter } = { query: '' }) {
 
   return (
     <div className={classes.root}>
-      <Backlight style={{ height: '1200px', opacity: 0.5 }} />
+      <Backlight className={classes.backlight} />
       <M.Container maxWidth="lg" className={classes.container}>
         <div ref={scrollRef} style={{ position: 'relative', top: -72 }} />
         <M.Typography variant="h1" color="textPrimary">

--- a/catalog/app/website/pages/Landing/Landing.js
+++ b/catalog/app/website/pages/Landing/Landing.js
@@ -32,7 +32,7 @@ export default function Landing({ location }) {
         <LinkedData.CatalogData />
       </React.Suspense>
       {cfg.mode !== 'LOCAL' && (
-        <Dots style={{ height: cfg.mode === 'PRODUCT' ? '1109px' : undefined }} />
+        <Dots style={{ bottom: cfg.mode === 'PRODUCT' ? 0 : undefined }} />
       )}
       {cfg.mode === 'PRODUCT' && <Buckets query={query} />}
       {cfg.mode === 'LOCAL' && <LocalMode />}


### PR DESCRIPTION
Instead of hardcoding height, I stuck the background element to parent's bottom. It's possible because for product mode there are fewer blocks.