### PR TITLE
Disable upload optimization for objects with SSE-KMS

### DIFF
--- a/api/python/quilt3/data_transfer.py
+++ b/api/python/quilt3/data_transfer.py
@@ -486,7 +486,7 @@ def _upload_or_copy_file(ctx, size, src_path, dest_bucket, dest_path):
             dest_size = resp['ContentLength']
             dest_etag = resp['ETag']
             dest_version_id = resp.get('VersionId')
-            if size == dest_size:
+            if size == dest_size and resp.get('ServerSideEncryption') != 'aws:kms':
                 src_etag = _calculate_etag(src_path)
                 if src_etag == dest_etag:
                     # Nothing more to do. We should not attempt to copy the object because

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -8,6 +8,7 @@
 !-->
 ## Python API
 * [Fixed] Fix check to determine if a file is a tempfile in Windows with Python 3.8+ ([#2900](https://github.com/quiltdata/quilt/pull/2900))
+* [Changed] Disable upload optimization for objects with SSE-KMS ([#2790](https://github.com/quiltdata/quilt/pull/2790))
 
 ## Catalog, Lambdas
 * [Added] Use `quilt_summarize.json` to control Perspective menu ([#2744](https://github.com/quiltdata/quilt/pull/2744))


### PR DESCRIPTION
# Description
https://docs.aws.amazon.com/AmazonS3/latest/API/RESTCommonResponseHeaders.html
> Objects encrypted by SSE-C or SSE-KMS have ETags that are not an MD5 digest
> of their object data.

For example:
```
In [109]: def get_data(key):
     ...:     resp = s3.head_object(Bucket='quilt-test-sse-kms', Key=key, ChecksumMode='Enabled')
     ...:     return (resp['ContentLength'], resp['ChecksumSHA256'], resp['ETag'])
     ...: 

In [110]: get_data('test/test1.txt'), get_data('test/test2.txt')
Out[110]: 
((3,
  'CEx5nNVR3R2NXF+aXVk7LpMfXjYSLuXHk8HQihmDnMA=',
  '"9ba4961d25d575a71aa2904c95b2c7c4"'),
 (3,
  'CEx5nNVR3R2NXF+aXVk7LpMfXjYSLuXHk8HQihmDnMA=',
  '"c8dc0d14c1d6b8837c78281df9823375"')
```
These objects have same size and SHA256 (because they contains the same data), but still have different ETags.

# TODO

<!-- Use <del></del> for items that are not required for this PR -->

- [x] [Changelog](CHANGELOG.md) entry
