### PR TITLE
Collaborators avatars narrow layout

### DIFF
--- a/catalog/app/components/Collaborators/Avatars.tsx
+++ b/catalog/app/components/Collaborators/Avatars.tsx
@@ -92,19 +92,17 @@ export default function Avatars({ className, collaborators, onClick }: AvatarsPr
   const potentialCollaborators = collaborators.filter(
     ({ permissionLevel }) => !permissionLevel,
   )
-  const hasUnmanagedRole = !!potentialCollaborators.length
 
   const avatars = React.useMemo(() => {
     if (!potentialCollaborators.length) return knownCollaborators.slice(0, 5)
     return [potentialCollaborators[0], ...knownCollaborators.slice(0, 4)]
   }, [knownCollaborators, potentialCollaborators])
-  const avatarsLength = avatars.length
 
   const classes = useStyles()
-  const more = React.useMemo(() => {
-    const num = collaborators.length - avatarsLength
-    return hasUnmanagedRole ? `${num}+ more` : `${num} more`
-  }, [avatarsLength, collaborators, hasUnmanagedRole])
+  const moreNum = React.useMemo(
+    () => collaborators.length - avatars.length,
+    [avatars, collaborators],
+  )
 
   return (
     <div className={cx(classes.root, className)} onClick={onClick}>
@@ -121,10 +119,10 @@ export default function Avatars({ className, collaborators, onClick }: AvatarsPr
           </div>
         ),
         <>
-          {collaborators.length > avatarsLength && (
+          {moreNum > 0 && (
             <div className={classes.avatarWrapper}>
               <M.Tooltip title="Click to see more collaborators">
-                <span className={classes.more}>{more}</span>
+                <span className={classes.more}>{moreNum}+</span>
               </M.Tooltip>
             </div>
           )}

--- a/catalog/app/components/Collaborators/Avatars.tsx
+++ b/catalog/app/components/Collaborators/Avatars.tsx
@@ -41,18 +41,19 @@ function Avatar({ className, email, index }: AvatarProps) {
 
 const useStyles = M.makeStyles((t) => ({
   root: {
-    cursor: 'pointer',
-    display: 'flex',
-    height: '36px',
-    position: 'relative',
-  },
-  more: {
-    color: t.palette.common.white,
     // NOTE: base background color should be the same as NavBar bg
     background: `linear-gradient(to left, ${fade(
       '#2a2d69',
       0,
     )} 0, #2a2d69 32px, #2a2d69 100%)`,
+    cursor: 'pointer',
+    display: 'flex',
+    height: '36px',
+    position: 'relative',
+    zIndex: 1,
+  },
+  more: {
+    color: t.palette.common.white,
     lineHeight: '36px',
     marginLeft: '12px',
     padding: '0 16px 0 0',


### PR DESCRIPTION
1. `+` meant unmanaged role, but we already show `( ? )` avatar. So, "+" can be used as "more"
2. Fixed gradient: it was under Search :man_facepalming:. Also, gradient can cover all avatars background

![Screenshot from 2022-04-28 23-00-53](https://user-images.githubusercontent.com/533229/165835893-1f3251aa-38d5-424a-81a5-9c044fa71087.png)
