### PR TITLE
add extension

### DIFF
--- a/catalog/internals/webpack/webpack.base.js
+++ b/catalog/internals/webpack/webpack.base.js
@@ -138,7 +138,7 @@ module.exports = (options) => ({
     }),
 
     new webpack.ProvidePlugin({
-      process: 'process/browser',
+      process: 'process/browser.js',
     }),
 
     new PerspectivePlugin(),


### PR DESCRIPTION
https://nodejs.org/api/esm.html#esm_mandatory_file_extensions

https://webpack.js.org/blog/2020-10-10-webpack-5-release/#externals

There are no problems in master. But there is an error if update `xlsx`:

```
ERROR in ./node_modules/xlsx/xlsx.mjs 127:88-95
Module not found: Error: Can't resolve 'process/browser' in '/home/fiskus/reps/quilt/catalog/node_modules/xlsx'
Did you mean 'browser.js'?
BREAKING CHANGE: The request 'process/browser' failed to resolve only because it was resolved as fully specified
(probably because the origin is strict EcmaScript Module, e. g. a module with javascript mimetype, a '*.mjs' file, or a '*.js' file where the package.json contains '"type": "module"').
The extension in the request is mandatory for it to be fully specified.
Add the extension to the request.
resolve 'process/browser' in '/home/fiskus/reps/quilt/catalog/node_modules/xlsx'
```