### PR TITLE
Bucket preferences iteration

### DIFF
--- a/catalog/app/utils/BucketPreferences/BucketPreferences.spec.ts
+++ b/catalog/app/utils/BucketPreferences/BucketPreferences.spec.ts
@@ -1,3 +1,5 @@
+import dedent from 'dedent'
+
 import { parse } from './BucketPreferences'
 
 const sentryMock = () => {}
@@ -31,6 +33,30 @@ describe('utils/BucketPreferences', () => {
   describe('parse', () => {
     test('Empty config returns default preferences', () => {
       expect(parse('', sentryMock)).toMatchObject(expectedDefaults)
+    })
+
+    test('If one action is overwritten, others should be default', () => {
+      const config = dedent`
+            ui:
+                actions:
+                    copyPackage: False
+      `
+      const result = parse(config, sentryMock)
+      expect(result.ui.actions.copyPackage).toBe(false)
+      expect(result.ui.actions.createPackage).toBe(true)
+      expect(result.ui.actions.deleteRevision).toBe(false)
+    })
+
+    test('If one block is overwritten, others should be default', () => {
+      const config = dedent`
+            ui:
+                blocks:
+                    analytics: False
+      `
+      const result = parse(config, sentryMock)
+      expect(result.ui.blocks.analytics).toBe(false)
+      expect(result.ui.blocks.browser).toBe(true)
+      expect(result.ui.blocks.code).toBe(true)
     })
   })
 

--- a/catalog/app/utils/BucketPreferences/BucketPreferences.spec.ts
+++ b/catalog/app/utils/BucketPreferences/BucketPreferences.spec.ts
@@ -41,10 +41,10 @@ describe('utils/BucketPreferences', () => {
                 actions:
                     copyPackage: False
       `
-      const result = parse(config, sentryMock)
-      expect(result.ui.actions.copyPackage).toBe(false)
-      expect(result.ui.actions.createPackage).toBe(true)
-      expect(result.ui.actions.deleteRevision).toBe(false)
+      expect(parse(config, sentryMock).ui.actions).toMatchObject({
+        ...expectedDefaults.ui.actions,
+        copyPackage: false,
+      })
     })
 
     test('If one block is overwritten, others should be default', () => {
@@ -53,10 +53,40 @@ describe('utils/BucketPreferences', () => {
                 blocks:
                     analytics: False
       `
-      const result = parse(config, sentryMock)
-      expect(result.ui.blocks.analytics).toBe(false)
-      expect(result.ui.blocks.browser).toBe(true)
-      expect(result.ui.blocks.code).toBe(true)
+      expect(parse(config, sentryMock).ui.blocks).toMatchObject({
+        ...expectedDefaults.ui.blocks,
+        analytics: false,
+      })
+    })
+
+    test('If one nav is overwritten, others should be default', () => {
+      const config = dedent`
+            ui:
+                nav:
+                    queries: False
+      `
+      expect(parse(config, sentryMock).ui.nav).toMatchObject({
+        ...expectedDefaults.ui.nav,
+        queries: false,
+      })
+    })
+
+    test('Additional config structures returns defaults', () => {
+      const config = dedent`
+            ui:
+                blocks:
+                    queries: QUERY
+      `
+      expect(parse(config, sentryMock)).toMatchObject(expectedDefaults)
+    })
+
+    test('Invalid config values throws error', () => {
+      const config = dedent`
+            ui:
+                nav:
+                    queries: QUERY
+      `
+      expect(() => parse(config, sentryMock)).toThrowError()
     })
   })
 
@@ -69,28 +99,42 @@ describe('utils/BucketPreferences', () => {
       const config = {
         ui: {
           actions: {
-            copyPackage: false,
+            deleteRevision: true,
           },
         },
       }
-      const result = extendDefaults(config, sentryMock)
-      expect(result.ui.actions.copyPackage).toBe(false)
-      expect(result.ui.actions.createPackage).toBe(true)
-      expect(result.ui.actions.deleteRevision).toBe(false)
+      expect(extendDefaults(config, sentryMock).ui.actions).toMatchObject({
+        ...expectedDefaults.ui.actions,
+        deleteRevision: true,
+      })
     })
 
     test('If one block is overwritten, others should be default', () => {
       const config = {
         ui: {
           blocks: {
-            analytics: false,
+            browser: false,
           },
         },
       }
-      const result = extendDefaults(config, sentryMock)
-      expect(result.ui.blocks.analytics).toBe(false)
-      expect(result.ui.blocks.browser).toBe(true)
-      expect(result.ui.blocks.code).toBe(true)
+      expect(extendDefaults(config, sentryMock).ui.blocks).toMatchObject({
+        ...expectedDefaults.ui.blocks,
+        browser: false,
+      })
+    })
+
+    test('If one nav is overwritten, others should be default', () => {
+      const config = {
+        ui: {
+          nav: {
+            files: false,
+          },
+        },
+      }
+      expect(extendDefaults(config, sentryMock).ui.nav).toMatchObject({
+        ...expectedDefaults.ui.nav,
+        files: false,
+      })
     })
   })
 })

--- a/catalog/app/utils/BucketPreferences/BucketPreferences.spec.ts
+++ b/catalog/app/utils/BucketPreferences/BucketPreferences.spec.ts
@@ -90,7 +90,7 @@ describe('utils/BucketPreferences', () => {
     })
   })
 
-  describe('extendUiDefaults', () => {
+  describe('extendDefaults', () => {
     test('Empty config returns default preferences', () => {
       expect(extendDefaults({}, sentryMock)).toMatchObject(expectedDefaults)
     })

--- a/catalog/app/utils/BucketPreferences/BucketPreferences.spec.ts
+++ b/catalog/app/utils/BucketPreferences/BucketPreferences.spec.ts
@@ -1,6 +1,6 @@
 import dedent from 'dedent'
 
-import { parse } from './BucketPreferences'
+import { extendDefaults, parse } from './BucketPreferences'
 
 const sentryMock = () => {}
 
@@ -60,5 +60,37 @@ describe('utils/BucketPreferences', () => {
     })
   })
 
-  describe.skip('extend', () => {})
+  describe('extendUiDefaults', () => {
+    test('Empty config returns default preferences', () => {
+      expect(extendDefaults({}, sentryMock)).toMatchObject(expectedDefaults)
+    })
+
+    test('If one action is overwritten, others should be default', () => {
+      const config = {
+        ui: {
+          actions: {
+            copyPackage: false,
+          },
+        },
+      }
+      const result = extendDefaults(config, sentryMock)
+      expect(result.ui.actions.copyPackage).toBe(false)
+      expect(result.ui.actions.createPackage).toBe(true)
+      expect(result.ui.actions.deleteRevision).toBe(false)
+    })
+
+    test('If one block is overwritten, others should be default', () => {
+      const config = {
+        ui: {
+          blocks: {
+            analytics: false,
+          },
+        },
+      }
+      const result = extendDefaults(config, sentryMock)
+      expect(result.ui.blocks.analytics).toBe(false)
+      expect(result.ui.blocks.browser).toBe(true)
+      expect(result.ui.blocks.code).toBe(true)
+    })
+  })
 })

--- a/catalog/app/utils/BucketPreferences/BucketPreferences.spec.ts
+++ b/catalog/app/utils/BucketPreferences/BucketPreferences.spec.ts
@@ -1,0 +1,38 @@
+import { parse } from './BucketPreferences'
+
+const sentryMock = () => {}
+
+const expectedDefaults = {
+  ui: {
+    actions: {
+      copyPackage: true,
+      createPackage: true,
+      deleteRevision: false,
+      revisePackage: true,
+    },
+    blocks: {
+      analytics: true,
+      browser: true,
+      code: true,
+      meta: true,
+    },
+    nav: {
+      files: true,
+      packages: true,
+      queries: true,
+    },
+    sourceBuckets: {
+      list: [],
+    },
+  },
+}
+
+describe('utils/BucketPreferences', () => {
+  describe('parse', () => {
+    test('Empty config returns default preferences', () => {
+      expect(parse('', sentryMock)).toMatchObject(expectedDefaults)
+    })
+  })
+
+  describe.skip('extend', () => {})
+})

--- a/catalog/app/utils/BucketPreferences/BucketPreferences.ts
+++ b/catalog/app/utils/BucketPreferences/BucketPreferences.ts
@@ -8,12 +8,12 @@ import yaml from 'utils/yaml'
 
 export type SentryInstance = (command: 'captureMessage', message: string) => void
 
-export type ActionPreferences = Record<
+type ActionPreferences = Record<
   'copyPackage' | 'createPackage' | 'deleteRevision' | 'revisePackage',
   boolean
 >
 
-export type BlocksPreferences = Record<'analytics' | 'browser' | 'code' | 'meta', boolean>
+type BlocksPreferences = Record<'analytics' | 'browser' | 'code' | 'meta', boolean>
 
 export type NavPreferences = Record<'files' | 'packages' | 'queries', boolean>
 

--- a/catalog/app/utils/BucketPreferences/BucketPreferences.ts
+++ b/catalog/app/utils/BucketPreferences/BucketPreferences.ts
@@ -93,6 +93,7 @@ function parseSourceBuckets(
       if (defaultSourceBucket) {
         const found = list.find((name) => name === defaultSourceBucket)
         if (found) return found
+        // TODO: use more civilized logger, log all similar configuration errors
         sentry(
           'captureMessage',
           `defaultSourceBucket ${defaultSourceBucket} is incorrect`,
@@ -119,6 +120,21 @@ export function parse(
       blocks: R.mergeRight(defaultPreferences.ui.blocks, data?.ui?.blocks || {}),
       nav: R.mergeRight(defaultPreferences.ui.nav, data?.ui?.nav || {}),
       sourceBuckets: parseSourceBuckets(sentry, data?.ui),
+    },
+  }
+}
+
+interface BucketPreferencesExtensions {
+  ui: Partial<UiPreferences>
+}
+
+export function extendDefaults(
+  preferences: BucketPreferencesExtensions,
+): BucketPreferences {
+  return {
+    ui: {
+      ...defaultPreferences.ui,
+      ...preferences.ui,
     },
   }
 }

--- a/catalog/app/utils/BucketPreferences/BucketPreferences.ts
+++ b/catalog/app/utils/BucketPreferences/BucketPreferences.ts
@@ -1,18 +1,12 @@
 import * as R from 'ramda'
-import * as React from 'react'
 
 import bucketPreferencesSchema from 'schemas/bucketConfig.yml.json'
 
-import * as AWS from 'utils/AWS'
-import * as Config from 'utils/Config'
-import { useData } from 'utils/Data'
-import * as Sentry from 'utils/Sentry'
+import * as bucketErrors from 'containers/Bucket/errors'
 import { makeSchemaValidator } from 'utils/json-schema'
 import yaml from 'utils/yaml'
-import * as bucketErrors from 'containers/Bucket/errors'
-import * as requests from 'containers/Bucket/requests'
 
-type SentryInstance = (command: 'captureMessage', message: string) => void
+export type SentryInstance = (command: 'captureMessage', message: string) => void
 
 export type ActionPreferences = Record<
   'copyPackage' | 'createPackage' | 'deleteRevision' | 'revisePackage',
@@ -47,11 +41,11 @@ interface BucketPreferencesYaml {
   ui?: UiPreferencesYaml
 }
 
-interface BucketPreferences {
+export interface BucketPreferences {
   ui: UiPreferences
 }
 
-const defaultPreferences: BucketPreferences = {
+export const defaultPreferences: BucketPreferences = {
   ui: {
     actions: {
       copyPackage: true,
@@ -77,28 +71,9 @@ const defaultPreferences: BucketPreferences = {
   },
 }
 
-const localModePreferences: BucketPreferences = {
-  ui: {
-    ...defaultPreferences.ui,
-    actions: {
-      copyPackage: false,
-      createPackage: false,
-      deleteRevision: false,
-      revisePackage: false,
-    },
-    blocks: {
-      analytics: true,
-      browser: true,
-      code: true,
-      meta: true,
-    },
-    nav: {
-      files: true,
-      packages: true,
-      queries: false,
-    },
-  },
-}
+const S3_PREFIX = 's3://'
+const normalizeBucketName = (input: string) =>
+  input.startsWith(S3_PREFIX) ? input.slice(S3_PREFIX.length) : input
 
 const bucketPreferencesValidator = makeSchemaValidator(bucketPreferencesSchema)
 
@@ -106,10 +81,6 @@ function validate(data: unknown): asserts data is BucketPreferencesYaml {
   const errors = bucketPreferencesValidator(data)
   if (errors.length) throw new bucketErrors.BucketPreferencesInvalid({ errors })
 }
-
-const S3_PREFIX = 's3://'
-const normalizeBucketName = (input: string) =>
-  input.startsWith(S3_PREFIX) ? input.slice(S3_PREFIX.length) : input
 
 function parseSourceBuckets(
   sentry: SentryInstance,
@@ -133,7 +104,10 @@ function parseSourceBuckets(
   }
 }
 
-function parse(bucketPreferencesYaml: string, sentry: SentryInstance): BucketPreferences {
+export function parse(
+  bucketPreferencesYaml: string,
+  sentry: SentryInstance,
+): BucketPreferences {
   const data = yaml(bucketPreferencesYaml)
   if (!data) return defaultPreferences
 
@@ -148,68 +122,3 @@ function parse(bucketPreferencesYaml: string, sentry: SentryInstance): BucketPre
     },
   }
 }
-
-const BUCKET_PREFERENCES_PATH = [
-  '.quilt/catalog/config.yaml',
-  '.quilt/catalog/config.yml',
-]
-
-interface FetchBucketPreferencesArgs {
-  s3: $TSFixMe
-  bucket: string
-  sentry: SentryInstance
-  local: boolean
-}
-
-async function fetchBucketPreferences({
-  s3,
-  sentry,
-  bucket,
-  local,
-}: FetchBucketPreferencesArgs) {
-  if (local) return localModePreferences
-  try {
-    const response = await requests.fetchFile({
-      s3,
-      bucket,
-      path: BUCKET_PREFERENCES_PATH,
-    })
-    return parse(response.Body.toString('utf-8'), sentry)
-  } catch (e) {
-    if (
-      e instanceof bucketErrors.FileNotFound ||
-      e instanceof bucketErrors.VersionNotFound
-    )
-      return defaultPreferences
-
-    // eslint-disable-next-line no-console
-    console.log('Unable to fetch')
-    // eslint-disable-next-line no-console
-    console.error(e)
-    throw e
-  }
-}
-
-const Ctx = React.createContext<BucketPreferences | null>(null)
-
-type ProviderProps = React.PropsWithChildren<{ bucket: string }>
-
-export function Provider({ bucket, children }: ProviderProps) {
-  const cfg = Config.use()
-  const local = cfg.mode === 'LOCAL'
-  const sentry = Sentry.use()
-  const s3 = AWS.S3.use()
-  const data = useData(fetchBucketPreferences, { s3, sentry, bucket, local })
-
-  // XXX: consider returning AsyncResult or using Suspense
-  const preferences = data.case({
-    Ok: R.identity,
-    Err: () => defaultPreferences,
-    _: () => null,
-  })
-  return <Ctx.Provider value={preferences}>{children}</Ctx.Provider>
-}
-
-export const useBucketPreferences = () => React.useContext(Ctx)
-
-export const use = useBucketPreferences

--- a/catalog/app/utils/BucketPreferences/BucketPreferences.ts
+++ b/catalog/app/utils/BucketPreferences/BucketPreferences.ts
@@ -48,7 +48,7 @@ export interface BucketPreferences {
   ui: UiPreferences
 }
 
-export const defaultPreferences: BucketPreferences = {
+const defaultPreferences: BucketPreferences = {
   ui: {
     actions: {
       copyPackage: true,

--- a/catalog/app/utils/BucketPreferences/BucketPreferences.ts
+++ b/catalog/app/utils/BucketPreferences/BucketPreferences.ts
@@ -109,20 +109,10 @@ function parseSourceBuckets(
   }
 }
 
-function extendUiDefaults(
-  preferences?: UiPreferencesInput,
-): Omit<UiPreferences, 'sourceBuckets'> {
-  return {
-    actions: R.mergeRight(defaultPreferences.ui.actions, preferences?.actions || {}),
-    blocks: R.mergeRight(defaultPreferences.ui.blocks, preferences?.blocks || {}),
-    nav: R.mergeRight(defaultPreferences.ui.nav, preferences?.nav || {}),
-  }
-}
-
 export function extendDefaults(data: BucketPreferencesInput, sentry: SentryInstance) {
   return {
     ui: {
-      ...extendUiDefaults(data?.ui || {}),
+      ...R.mergeDeepRight(defaultPreferences.ui, data?.ui || {}),
       sourceBuckets: parseSourceBuckets(
         sentry,
         data?.ui?.sourceBuckets,

--- a/catalog/app/utils/BucketPreferences/BucketPreferences.ts
+++ b/catalog/app/utils/BucketPreferences/BucketPreferences.ts
@@ -34,10 +34,10 @@ type DefaultSourceBucketYaml = string
 type SourceBucketsYaml = Record<string, null>
 
 interface UiPreferencesYaml {
-  actions?: ActionPreferences
-  blocks?: BlocksPreferences
+  actions?: Partial<ActionPreferences>
+  blocks?: Partial<BlocksPreferences>
   defaultSourceBucket?: DefaultSourceBucketYaml
-  nav?: NavPreferences
+  nav?: Partial<NavPreferences>
   sourceBuckets?: SourceBucketsYaml
 }
 
@@ -47,19 +47,6 @@ interface BucketPreferencesYaml {
 
 export interface BucketPreferences {
   ui: UiPreferences
-}
-
-type RecursivePartial<T> = {
-  [P in keyof T]?: RecursivePartial<T[P]>
-}
-
-// NOTE: `sourceBuckets` is special because null (from type) and undefined(from Partial) incompatible
-type UiToExtend = RecursivePartial<Omit<UiPreferencesYaml, 'sourceBuckets'>>
-
-interface PreferencesToExtend {
-  ui?: UiToExtend & {
-    sourceBuckets?: SourceBucketsYaml
-  }
 }
 
 export const defaultPreferences: BucketPreferences = {
@@ -124,7 +111,7 @@ function parseSourceBuckets(
 }
 
 function extendUiDefaults(
-  preferences?: UiToExtend,
+  preferences?: UiPreferencesYaml,
 ): Omit<UiPreferences, 'sourceBuckets'> {
   return {
     actions: R.mergeRight(defaultPreferences.ui.actions, preferences?.actions || {}),
@@ -133,7 +120,7 @@ function extendUiDefaults(
   }
 }
 
-export function extendDefaults(data: PreferencesToExtend, sentry: SentryInstance) {
+export function extendDefaults(data: BucketPreferencesYaml, sentry: SentryInstance) {
   return {
     ui: {
       ...extendUiDefaults(data?.ui || {}),

--- a/catalog/app/utils/BucketPreferences/LocalProvider.tsx
+++ b/catalog/app/utils/BucketPreferences/LocalProvider.tsx
@@ -1,8 +1,10 @@
 import * as React from 'react'
 
+import * as Sentry from 'utils/Sentry'
+
 import { BucketPreferences, extendDefaults } from './BucketPreferences'
 
-const localModePreferences: BucketPreferences = extendDefaults({
+const localModePreferences = {
   ui: {
     actions: {
       copyPackage: false,
@@ -22,7 +24,7 @@ const localModePreferences: BucketPreferences = extendDefaults({
       queries: false,
     },
   },
-})
+}
 
 interface LocalProviderProps {
   context: React.Context<BucketPreferences | null>
@@ -30,5 +32,10 @@ interface LocalProviderProps {
 }
 
 export default function LocalProvider({ context: Ctx, children }: LocalProviderProps) {
-  return <Ctx.Provider value={localModePreferences}>{children}</Ctx.Provider>
+  const sentry = Sentry.use()
+  const value = React.useMemo(
+    () => extendDefaults(localModePreferences, sentry),
+    [sentry],
+  )
+  return <Ctx.Provider value={value}>{children}</Ctx.Provider>
 }

--- a/catalog/app/utils/BucketPreferences/LocalProvider.tsx
+++ b/catalog/app/utils/BucketPreferences/LocalProvider.tsx
@@ -12,15 +12,7 @@ const localModePreferences = {
       deleteRevision: false,
       revisePackage: false,
     },
-    blocks: {
-      analytics: true,
-      browser: true,
-      code: true,
-      meta: true,
-    },
     nav: {
-      files: true,
-      packages: true,
       queries: false,
     },
   },

--- a/catalog/app/utils/BucketPreferences/LocalProvider.tsx
+++ b/catalog/app/utils/BucketPreferences/LocalProvider.tsx
@@ -1,0 +1,34 @@
+import * as React from 'react'
+
+import { BucketPreferences, extendDefaults } from './BucketPreferences'
+
+const localModePreferences: BucketPreferences = extendDefaults({
+  ui: {
+    actions: {
+      copyPackage: false,
+      createPackage: false,
+      deleteRevision: false,
+      revisePackage: false,
+    },
+    blocks: {
+      analytics: true,
+      browser: true,
+      code: true,
+      meta: true,
+    },
+    nav: {
+      files: true,
+      packages: true,
+      queries: false,
+    },
+  },
+})
+
+interface LocalProviderProps {
+  context: React.Context<BucketPreferences | null>
+  children: React.ReactNode
+}
+
+export default function LocalProvider({ context: Ctx, children }: LocalProviderProps) {
+  return <Ctx.Provider value={localModePreferences}>{children}</Ctx.Provider>
+}

--- a/catalog/app/utils/BucketPreferences/Provider.tsx
+++ b/catalog/app/utils/BucketPreferences/Provider.tsx
@@ -70,7 +70,7 @@ function CatalogProvider({ bucket, children }: ProviderProps) {
 export function Provider({ bucket, children }: ProviderProps) {
   const cfg = Config.use()
   const local = cfg.mode === 'LOCAL'
-  if (!local) return <LocalProvider context={Ctx}>{children}</LocalProvider>
+  if (local) return <LocalProvider context={Ctx}>{children}</LocalProvider>
 
   return <CatalogProvider bucket={bucket}>{children}</CatalogProvider>
 }

--- a/catalog/app/utils/BucketPreferences/Provider.tsx
+++ b/catalog/app/utils/BucketPreferences/Provider.tsx
@@ -1,0 +1,105 @@
+import * as R from 'ramda'
+import * as React from 'react'
+
+import * as AWS from 'utils/AWS'
+import * as Config from 'utils/Config'
+import { useData } from 'utils/Data'
+import * as Sentry from 'utils/Sentry'
+import * as bucketErrors from 'containers/Bucket/errors'
+import * as requests from 'containers/Bucket/requests'
+
+import {
+  BucketPreferences,
+  SentryInstance,
+  defaultPreferences,
+  parse,
+} from './BucketPreferences'
+
+const localModePreferences: BucketPreferences = {
+  ui: {
+    ...defaultPreferences.ui,
+    actions: {
+      copyPackage: false,
+      createPackage: false,
+      deleteRevision: false,
+      revisePackage: false,
+    },
+    blocks: {
+      analytics: true,
+      browser: true,
+      code: true,
+      meta: true,
+    },
+    nav: {
+      files: true,
+      packages: true,
+      queries: false,
+    },
+  },
+}
+
+const BUCKET_PREFERENCES_PATH = [
+  '.quilt/catalog/config.yaml',
+  '.quilt/catalog/config.yml',
+]
+
+interface FetchBucketPreferencesArgs {
+  s3: $TSFixMe
+  bucket: string
+  sentry: SentryInstance
+  local: boolean
+}
+
+async function fetchBucketPreferences({
+  s3,
+  sentry,
+  bucket,
+  local,
+}: FetchBucketPreferencesArgs) {
+  if (local) return localModePreferences
+  try {
+    const response = await requests.fetchFile({
+      s3,
+      bucket,
+      path: BUCKET_PREFERENCES_PATH,
+    })
+    return parse(response.Body.toString('utf-8'), sentry)
+  } catch (e) {
+    if (
+      e instanceof bucketErrors.FileNotFound ||
+      e instanceof bucketErrors.VersionNotFound
+    )
+      return defaultPreferences
+
+    // eslint-disable-next-line no-console
+    console.log('Unable to fetch')
+    // eslint-disable-next-line no-console
+    console.error(e)
+    throw e
+  }
+}
+
+const Ctx = React.createContext<BucketPreferences | null>(null)
+
+type ProviderProps = React.PropsWithChildren<{ bucket: string }>
+
+// TODO: ProviderWrapper LocalProvider
+export function Provider({ bucket, children }: ProviderProps) {
+  const cfg = Config.use()
+  const local = cfg.mode === 'LOCAL'
+  const sentry = Sentry.use()
+  const s3 = AWS.S3.use()
+  const data = useData(fetchBucketPreferences, { s3, sentry, bucket, local })
+
+  // XXX: consider returning AsyncResult or using Suspense
+  const preferences = data.case({
+    Ok: R.identity,
+    Err: () => defaultPreferences,
+    _: () => null,
+  })
+  return <Ctx.Provider value={preferences}>{children}</Ctx.Provider>
+}
+
+export const useBucketPreferences = () => React.useContext(Ctx)
+
+export const use = useBucketPreferences

--- a/catalog/app/utils/BucketPreferences/index.ts
+++ b/catalog/app/utils/BucketPreferences/index.ts
@@ -1,2 +1,6 @@
-export * from './BucketPreferences'
+export type {
+  BucketPreferences,
+  NavPreferences,
+  SourceBuckets,
+} from './BucketPreferences'
 export * from './Provider'

--- a/catalog/app/utils/BucketPreferences/index.ts
+++ b/catalog/app/utils/BucketPreferences/index.ts
@@ -1,0 +1,2 @@
+export * from './BucketPreferences'
+export * from './Provider'


### PR DESCRIPTION
* Splited BucketPrefences module into React specific and data-focused
* Use one way to extend preferences for both yaml config and local stack
* Added tests for data