### PR TITLE
lambdas/thumbnail update to scipy==1.7.3

### DIFF
--- a/lambdas/thumbnail/requirements.txt
+++ b/lambdas/thumbnail/requirements.txt
@@ -12,7 +12,7 @@ psutil==5.7.0
 pyrsistent==0.14.11
 python-pptx==0.6.21
 requests==2.26.0
-scipy==1.7.1
+scipy==1.7.3
 tifffile==0.15.1
 six==1.12.0
 urllib3==1.26.5


### PR DESCRIPTION
# Description
### Issue
`scipy` limits its versions to specific `Python` binary version ranges.  Thus, when using a Python 3.10 environment (my system),
`pip install requirements.txt` fails due to upper-bound python version of `<3.10`

Solution: Bump scipy version to one that doesn't need `python<3.10`

# TODO

<!-- Remove items that are irrelevant to this PR -->

- [ ] Unit tests
- [ ] Automated tests (e.g. Preflight)
- [ ] Documentation
    - [ ] [Python: Run `build.py`](../gendocs/build.py) for new docstrings
    - [ ] JavaScript: basic explanation and screenshot of new features
- [ ] [Changelog](CHANGELOG.md) entry
