### PR TITLE
Support .tab as .tsv

### DIFF
--- a/catalog/app/components/Preview/loaders/Tabular.tsx
+++ b/catalog/app/components/Preview/loaders/Tabular.tsx
@@ -25,7 +25,7 @@ const isParquet = R.anyPass([
   R.test(/[.-]c\d{3,5}$/gi),
 ])
 
-const isTsv = utils.extIs('.tsv')
+const isTsv = utils.extIn(['.tsv', '.tab'])
 
 const detectBySummarizeType = summarize.detect('perspective')
 


### PR DESCRIPTION
Wikipedia mentions both .tsv and .tab as tab separated values https://en.wikipedia.org/wiki/Tab-separated_values
Gnumeric too https://help.gnome.org/users/gnumeric/stable/gnumeric.html#sect-file-open-formats

I tested with two files found in https://open.quiltdata.com/search?q=ext%3A.tab