### PR TITLE
Reduce noise in thumbnail lambda tests

### DIFF
--- a/lambdas/thumbnail/tests/conftest.py
+++ b/lambdas/thumbnail/tests/conftest.py
@@ -16,6 +16,15 @@ def pytest_addoption(parser):
 
 
 def pytest_configure(config):
+    # XXX: split into separate PR
+    config.addinivalue_line(
+        "markers", "poppler: mark a test to run only if --poppler is indicated (poppler tools is installed)"
+    )
+    config.addinivalue_line(
+        "markers", "loffice: mark a test to run only if --loffice is indicated (LibreOffice is installed)"
+    )
+    # XXX: /split into separate pr
+
     markers_to_exclude = []
 
     if not config.option.poppler:

--- a/lambdas/thumbnail/tests/conftest.py
+++ b/lambdas/thumbnail/tests/conftest.py
@@ -16,14 +16,12 @@ def pytest_addoption(parser):
 
 
 def pytest_configure(config):
-    # XXX: split into separate PR
     config.addinivalue_line(
         "markers", "poppler: mark a test to run only if --poppler is indicated (poppler tools is installed)"
     )
     config.addinivalue_line(
         "markers", "loffice: mark a test to run only if --loffice is indicated (LibreOffice is installed)"
     )
-    # XXX: /split into separate pr
 
     markers_to_exclude = []
 


### PR DESCRIPTION
# Description
Lambda thumbnail tests were making some noise due to unregistered pytest markers we're using.

This change just registers those markers.

# TODO

<!-- Remove items that are irrelevant to this PR -->

- [x] Unit tests
- [n/a] Automated tests (e.g. Preflight)
- [n/a] Documentation
    - [n/a] [Python: Run `build.py`](../gendocs/build.py) for new docstrings
    - [n/a] JavaScript: basic explanation and screenshot of new features
- [n/a] [Changelog](CHANGELOG.md) entry
