### PR TITLE
Successors only config

### DIFF
--- a/catalog/app/utils/workflows.ts
+++ b/catalog/app/utils/workflows.ts
@@ -187,6 +187,10 @@ function validateConfigCompoundVersion(
 
 function validateConfig(data: unknown): asserts data is WorkflowsYaml {
   const objectVersion = (data as WorkflowsYaml).version
+  if (!objectVersion)
+    throw new bucketErrors.WorkflowsConfigInvalid({
+      errors: [new Error('Provide the config version')],
+    })
   const workflowsConfigValidator = (objectVersion as WorkflowsVersion).catalog
     ? makeSchemaValidator(workflowsCatalogConfigSchema, [workflowsConfigSchema])
     : makeSchemaValidator(workflowsConfigSchema)

--- a/docs/advanced-features/workflows.md
+++ b/docs/advanced-features/workflows.md
@@ -370,6 +370,11 @@ The catalog's
 feature can be enabled by adding a `successors` property to the config.
 A *successor* is a destination bucket. 
 ```yaml
+version:
+  base: "1"
+workflows:
+  dummy:
+    name: Dummy
 successors:
   s3://bucket1:
     title: Staging


### PR DESCRIPTION
* Added error missed when config.yml doesn't have `version`
* FIlled example such way user can copy-paste if he just wants `successors`