### PR TITLE
Throw error if JSON schema invalid

### DIFF
--- a/catalog/app/containers/Bucket/requests/requestsUntyped.js
+++ b/catalog/app/containers/Bucket/requests/requestsUntyped.js
@@ -248,19 +248,8 @@ export const metadataSchema = async ({ s3, schemaUrl }) => {
 
   const { bucket, key, version } = s3paths.parseS3Url(schemaUrl)
 
-  try {
-    const response = await fetchFile({ s3, bucket, path: key, version })
-    return JSON.parse(response.Body.toString('utf-8'))
-  } catch (e) {
-    if (e instanceof errors.FileNotFound || e instanceof errors.VersionNotFound) throw e
-
-    // eslint-disable-next-line no-console
-    console.log('Unable to fetch')
-    // eslint-disable-next-line no-console
-    console.error(e)
-  }
-
-  return null
+  const response = await fetchFile({ s3, bucket, path: key, version })
+  return JSON.parse(response.Body.toString('utf-8'))
 }
 
 const WORKFLOWS_CONFIG_PATH = '.quilt/workflows/config.yml'


### PR DESCRIPTION
Don't remember if there is a reason for not throwing an error. Probably, I just copied the way other functions silently catch errors

![Screenshot from 2022-07-20 19-17-10](https://user-images.githubusercontent.com/533229/180032683-0183f9bd-2d87-4672-85f6-a88da5f70ed9.png)
