### PR TITLE
Use Event data shape containing value instead of plain value

### DIFF
--- a/catalog/app/components/JsonValidationErrors/JsonValidationErrors.tsx
+++ b/catalog/app/components/JsonValidationErrors/JsonValidationErrors.tsx
@@ -58,11 +58,11 @@ export default function JsonValidationErrors({
   return (
     <div className={className}>
       {Array.isArray(error) ? (
-        error.map((e) => (
+        error.map((e, index) => (
           <SingleError
             className={classes.item}
             error={e}
-            key={(e as ErrorObject).instancePath + e.message}
+            key={(e as ErrorObject).instancePath + e.message + index}
           />
         ))
       ) : (

--- a/catalog/app/containers/Bucket/PackageDialog/MetaInput.tsx
+++ b/catalog/app/containers/Bucket/PackageDialog/MetaInput.tsx
@@ -240,7 +240,10 @@ export const MetaInput = React.forwardRef<HTMLDivElement, MetaInputProps>(
     const onChangeFullscreen = React.useCallback(
       (json: JsonRecord) => {
         setJsonInlineEditorKey(R.inc)
-        onChange(json)
+        // NOTE: `json` may have `target` field and make react-final-form think it's an event not value
+        //       so, let's create "event" voluntarily
+        //       https://final-form.org/docs/react-final-form/types/FieldRenderProps#inputonchange
+        onChange({ target: { value: json } })
       },
       [onChange],
     )
@@ -248,7 +251,10 @@ export const MetaInput = React.forwardRef<HTMLDivElement, MetaInputProps>(
     const onChangeInline = React.useCallback(
       (json: JsonRecord) => {
         setJsonFullscreenEditorKey(R.inc)
-        onChange(json)
+        // NOTE: `json` may have `target` field and make react-final-form think it's an event not value
+        //       so, let's create "event" voluntarily
+        //       https://final-form.org/docs/react-final-form/types/FieldRenderProps#inputonchange
+        onChange({ target: { value: json } })
       },
       [onChange],
     )


### PR DESCRIPTION
`react-final-form` erases value when this value contains `{ "target": … }` value because it tries to extract value from the event. So, I use event instead of plane value then.

Link to associated code https://github.com/final-form/react-final-form/blob/147bd62fc86b9cf7e0e7300605a5ff0be2f90e2d/src/useField.js#L213