### PR TITLE
Fix access counts position when there is metadata

### DIFF
--- a/catalog/app/containers/Bucket/PackageRevisions/PackageRevisions.tsx
+++ b/catalog/app/containers/Bucket/PackageRevisions/PackageRevisions.tsx
@@ -168,6 +168,11 @@ const useRevisionLayoutStyles = M.makeStyles((t) => ({
       marginTop: t.spacing(1),
     },
   },
+  base: {
+    [t.breakpoints.up('sm')]: {
+      position: 'relative',
+    },
+  },
 }))
 
 interface RevisionLayoutProps {
@@ -189,12 +194,24 @@ function RevisionLayout({ link, msg, meta, hash, stats, counts }: RevisionLayout
   const sparklineH = xs ? 32 : 48
   return (
     <M.Paper className={classes.root}>
-      <M.Box pt={2} pl={2} pr={25}>
-        {link}
-      </M.Box>
-      <M.Box py={1} pl={2} pr={xs ? 2 : Math.ceil(sparklineW / t.spacing(1) + 1)}>
-        {msg}
-      </M.Box>
+      <div className={classes.base}>
+        <M.Box pt={2} pl={2} pr={25}>
+          {link}
+        </M.Box>
+        <M.Box py={1} pl={2} pr={xs ? 2 : Math.ceil(sparklineW / t.spacing(1) + 1)}>
+          {msg}
+        </M.Box>
+        <M.Box
+          position="absolute"
+          right={0}
+          bottom={0}
+          top={{ xs: 'auto', sm: 16 }}
+          height={{ xs: 64, sm: 'auto' }}
+          width={sparklineW}
+        >
+          {counts({ sparklineW, sparklineH })}
+        </M.Box>
+      </div>
       {!!meta && (
         <M.Hidden xsDown>
           <M.Divider />
@@ -224,16 +241,6 @@ function RevisionLayout({ link, msg, meta, hash, stats, counts }: RevisionLayout
         color="text.secondary"
       >
         {stats}
-      </M.Box>
-      <M.Box
-        position="absolute"
-        right={0}
-        bottom={{ xs: 0, sm: 49 }}
-        top={{ xs: 'auto', sm: 16 }}
-        height={{ xs: 64, sm: 'auto' }}
-        width={sparklineW}
-      >
-        {counts({ sparklineW, sparklineH })}
       </M.Box>
     </M.Paper>
   )


### PR DESCRIPTION
Added wrapper "anchored" access count chart instead of positioning it with pixels

Before:

![Screenshot from 2022-07-21 16-13-05](https://user-images.githubusercontent.com/533229/180222177-96ad3d23-f7e3-411d-a914-c17d94807fce.png)

After;
![Screenshot from 2022-07-21 16-13-15](https://user-images.githubusercontent.com/533229/180222186-f5e89a04-0f0d-4e1b-9435-c2b2501d150b.png)
