### PR TITLE
Overwrite AppBar default orange color

### DIFF
--- a/catalog/app/containers/NavBar/NavBar.tsx
+++ b/catalog/app/containers/NavBar/NavBar.tsx
@@ -339,6 +339,7 @@ function SignIn({ error, waiting }: SignInProps) {
 
 const useAppBarStyles = M.makeStyles((t) => ({
   root: {
+    background: t.palette.secondary.dark,
     zIndex: t.zIndex.appBar + 1,
   },
   bgWrapper: {


### PR DESCRIPTION
We use `navTheme.palette.seconday.dark` for color, but AppBar extracts `.main` (so, `<AppBar color="secondary"` doesn't help)
Sometimes, this `primary.main` orange flashes during first load (maybe even once after deploy)