### PR TITLE
Bump mod_zip: allow empty zip files

### DIFF
--- a/s3-proxy/Dockerfile
+++ b/s3-proxy/Dockerfile
@@ -22,7 +22,7 @@ RUN set -x \
     && curl -L http://nginx.org/download/nginx-${NGINX_VERSION}.tar.gz | tar zx \
     && cd nginx-${NGINX_VERSION} \
     && mkdir mod_zip \
-    && curl -L https://api.github.com/repos/quiltdata/mod_zip/tarball/1b6813a030d71ee1279e3cb87e87516875e7c08e | tar zx --strip-components 1 --directory mod_zip \
+    && curl -L https://api.github.com/repos/quiltdata/mod_zip/tarball/979314cca0507a59071310f09401861cced73ccb | tar zx --strip-components 1 --directory mod_zip \
     && ./configure \
         --prefix=/etc/nginx \
         --sbin-path=/usr/sbin/nginx \


### PR DESCRIPTION
See https://github.com/quiltdata/mod_zip/commit/979314cca0507a59071310f09401861cced73ccb

Will make the registry code simpler.
