### PR TITLE
Show Athena query content on error

### DIFF
--- a/catalog/app/containers/Bucket/Queries/Athena/Athena.tsx
+++ b/catalog/app/containers/Bucket/Queries/Athena/Athena.tsx
@@ -172,6 +172,11 @@ function ResultsContainer({
               />
             )
           }
+          if (queryResults.queryExecution.error) {
+            return makeAsyncDataErrorHandler('Query Results Data')(
+              queryResults.queryExecution.error,
+            )
+          }
           if (queryResults.queryExecution) {
             return (
               <History

--- a/catalog/app/containers/Bucket/Queries/requests/athena.ts
+++ b/catalog/app/containers/Bucket/Queries/requests/athena.ts
@@ -262,13 +262,13 @@ async function waitForQueryStatus(
     // eslint-disable-next-line no-await-in-loop
     const statusData = await athena.getQueryExecution({ QueryExecutionId }).promise()
     const status = statusData?.QueryExecution?.Status?.State
-    const reason = statusData?.QueryExecution?.Status?.StateChangeReason || ''
     const parsed = statusData?.QueryExecution
       ? parseQueryExecution(statusData?.QueryExecution)
       : {
           id: QueryExecutionId,
         }
     if (status === 'FAILED' || status === 'CANCELLED') {
+      const reason = statusData?.QueryExecution?.Status?.StateChangeReason || ''
       return {
         ...parsed,
         error: new Error(`${status}: ${reason}`),

--- a/catalog/app/containers/Bucket/Queries/requests/athena.ts
+++ b/catalog/app/containers/Bucket/Queries/requests/athena.ts
@@ -235,7 +235,7 @@ export function useQueryExecutions(
 async function waitForQueryStatus(
   athena: Athena,
   QueryExecutionId: string,
-): Promise<Athena.QueryExecution | null> {
+): Promise<QueryExecution> {
   // eslint-disable-next-line no-constant-condition
   while (true) {
     // NOTE: await is used to intentionally pause loop and make requests in series
@@ -243,16 +243,27 @@ async function waitForQueryStatus(
     const statusData = await athena.getQueryExecution({ QueryExecutionId }).promise()
     const status = statusData?.QueryExecution?.Status?.State
     const reason = statusData?.QueryExecution?.Status?.StateChangeReason || ''
+    const parsed = statusData?.QueryExecution
+      ? parseQueryExecution(statusData?.QueryExecution)
+      : {
+          id: QueryExecutionId,
+        }
     if (status === 'FAILED' || status === 'CANCELLED') {
-      throw new Error(`${status}: ${reason}`)
+      return {
+        ...parsed,
+        error: new Error(`${status}: ${reason}`),
+      }
     }
 
     if (!status) {
-      throw new Error('Unknown query execution status')
+      return {
+        ...parsed,
+        error: new Error('Unknown query execution status'),
+      }
     }
 
     if (status === 'SUCCEEDED') {
-      return statusData?.QueryExecution || null
+      return parsed
     }
 
     // eslint-disable-next-line no-await-in-loop
@@ -274,7 +285,7 @@ export type QueryResultsRows = Row[]
 export interface QueryResultsResponse {
   columns: QueryResultsColumns
   next?: string
-  queryExecution: QueryExecution | null
+  queryExecution: QueryExecution
   rows: QueryResultsRows
 }
 
@@ -294,29 +305,47 @@ async function fetchQueryResults({
   prev,
 }: QueryResultsArgs): Promise<QueryResultsResponse> {
   const queryExecution = await waitForQueryStatus(athena, queryExecutionId)
+  if (queryExecution.error) {
+    return {
+      rows: emptyList,
+      columns: emptyColumns,
+      queryExecution,
+    }
+  }
 
-  const queryResultsOutput = await athena
-    .getQueryResults({
-      QueryExecutionId: queryExecutionId,
-      NextToken: prev?.next,
-    })
-    .promise()
-  const parsed =
-    queryResultsOutput.ResultSet?.Rows?.map(
-      (row) => row?.Data?.map((item) => item?.VarCharValue || '') || emptyRow,
-    ) || emptyList
-  const rows = [...(prev?.rows || emptyList), ...parsed]
-  return {
-    rows,
-    columns:
-      queryResultsOutput.ResultSet?.ResultSetMetadata?.ColumnInfo?.map(
-        ({ Name, Type }) => ({
-          name: Name,
-          type: Type,
-        }),
-      ) || emptyColumns,
-    next: queryResultsOutput.NextToken,
-    queryExecution: queryExecution ? parseQueryExecution(queryExecution) : null,
+  try {
+    const queryResultsOutput = await athena
+      .getQueryResults({
+        QueryExecutionId: queryExecutionId,
+        NextToken: prev?.next,
+      })
+      .promise()
+    const parsed =
+      queryResultsOutput.ResultSet?.Rows?.map(
+        (row) => row?.Data?.map((item) => item?.VarCharValue || '') || emptyRow,
+      ) || emptyList
+    const rows = [...(prev?.rows || emptyList), ...parsed]
+    return {
+      rows,
+      columns:
+        queryResultsOutput.ResultSet?.ResultSetMetadata?.ColumnInfo?.map(
+          ({ Name, Type }) => ({
+            name: Name,
+            type: Type,
+          }),
+        ) || emptyColumns,
+      next: queryResultsOutput.NextToken,
+      queryExecution,
+    }
+  } catch (error) {
+    return {
+      rows: emptyList,
+      columns: emptyColumns,
+      queryExecution: {
+        ...queryExecution,
+        error: error instanceof Error ? error : new Error(`${error}`),
+      },
+    }
   }
 }
 


### PR DESCRIPTION
Before:
* If query results return error, then UI doesn't have info about query content, only error message

After:
* Instead of `QueryExecution | Error` I always return `QueryExecution` with `error?` field if needed
* Query content filled on error and user can change it and submit edited query

![Screenshot from 2022-08-30 16-06-04](https://user-images.githubusercontent.com/533229/187444365-560d8758-3b4a-4f21-b479-f728feac1dcb.png)
