### PR TITLE
Status Reports UI

### DIFF
--- a/catalog/.graphqlrc.yml
+++ b/catalog/.graphqlrc.yml
@@ -21,3 +21,4 @@ extensions:
             Json: utils/types#Json
             JsonRecord: utils/types#JsonRecord
             PackageContentsFlatMap: model#PackageContentsFlatMap
+            S3ObjectLocation: model/S3#S3ObjectLocation

--- a/catalog/app/components/Preview/loaders/Html.js
+++ b/catalog/app/components/Preview/loaders/Html.js
@@ -2,7 +2,7 @@ import * as React from 'react'
 import * as AWS from 'utils/AWS'
 import AsyncResult from 'utils/AsyncResult'
 import { useIsInStack } from 'utils/BucketConfig'
-import * as Config from 'utils/Config'
+import { useStatusReportsBucket } from 'utils/StatusReportsBucket'
 import useMemoEq from 'utils/useMemoEq'
 
 import { PreviewData } from '../types'
@@ -23,9 +23,8 @@ function IFrameLoader({ handle, children }) {
 
 export const Loader = function HtmlLoader({ handle, children }) {
   const isInStack = useIsInStack()
-  const cfg = Config.useConfig()
-  const inStackOrSpecial = isInStack(handle.bucket) || handle.bucket === cfg.serviceBucket
-  return inStackOrSpecial ? (
+  const statusReportsBucket = useStatusReportsBucket()
+  return isInStack(handle.bucket) || handle.bucket === statusReportsBucket ? (
     <IFrameLoader {...{ handle, children }} />
   ) : (
     <Text.Loader {...{ handle, children }} />

--- a/catalog/app/components/Preview/loaders/Html.js
+++ b/catalog/app/components/Preview/loaders/Html.js
@@ -2,6 +2,7 @@ import * as React from 'react'
 import * as AWS from 'utils/AWS'
 import AsyncResult from 'utils/AsyncResult'
 import { useIsInStack } from 'utils/BucketConfig'
+import * as Config from 'utils/Config'
 import useMemoEq from 'utils/useMemoEq'
 
 import { PreviewData } from '../types'
@@ -22,7 +23,9 @@ function IFrameLoader({ handle, children }) {
 
 export const Loader = function HtmlLoader({ handle, children }) {
   const isInStack = useIsInStack()
-  return isInStack(handle.bucket) ? (
+  const cfg = Config.useConfig()
+  const inStackOrSpecial = isInStack(handle.bucket) || handle.bucket === cfg.serviceBucket
+  return inStackOrSpecial ? (
     <IFrameLoader {...{ handle, children }} />
   ) : (
     <Text.Loader {...{ handle, children }} />

--- a/catalog/app/containers/Admin/Status/Canaries.tsx
+++ b/catalog/app/containers/Admin/Status/Canaries.tsx
@@ -1,0 +1,256 @@
+import * as R from 'ramda'
+import * as React from 'react'
+import type { ResultOf } from '@graphql-typed-document-node/core'
+import * as M from '@material-ui/core'
+import { fade } from '@material-ui/core/styles'
+import * as MDG from '@material-ui/data-grid'
+
+import * as DG from 'components/DataGrid'
+
+import { useDataGridStyles } from './DataGrid'
+import type STATUS_QUERY from './gql/Status.generated'
+
+type StatusResult = NonNullable<ResultOf<typeof STATUS_QUERY>['status']>
+type Canary = StatusResult['canaries'][number]
+
+interface State {
+  rows: {
+    allRows: string[]
+    idRowsLookup: Record<string, Canary>
+  }
+}
+
+const countsByStateSelector = (state: State) =>
+  state.rows.allRows.reduce(
+    (acc, id) => {
+      const prop = {
+        true: 'passed',
+        false: 'failed',
+        null: 'running',
+      }[`${state.rows.idRowsLookup[id].ok}`]
+      return R.evolve({ [prop]: R.inc }, acc)
+    },
+    { passed: 0, failed: 0, running: 0 },
+  )
+
+const useCountsByStateStyles = M.makeStyles((t) => ({
+  root: {
+    display: 'flex',
+    paddingLeft: t.spacing(2),
+  },
+  item: {
+    alignItems: 'center',
+    display: 'flex',
+
+    '& + &': {
+      marginLeft: t.spacing(2),
+    },
+  },
+  count: {
+    marginLeft: t.spacing(1),
+  },
+}))
+
+function CountsByState() {
+  const classes = useCountsByStateStyles()
+  const apiRef = React.useContext(MDG.GridApiContext)
+  const counts = MDG.useGridSelector(apiRef, countsByStateSelector)
+
+  const renderItem = (count: number, label: string, ok: boolean | null) =>
+    !!count && (
+      <M.Tooltip arrow title={label}>
+        <span className={classes.item}>
+          <StateIcon ok={ok} />
+          <span className={classes.count}>{count}</span>
+        </span>
+      </M.Tooltip>
+    )
+
+  return (
+    <div className={classes.root}>
+      {renderItem(counts.failed, 'Failed', false)}
+      {renderItem(counts.running, 'Running', null)}
+      {renderItem(counts.passed, 'Passed', true)}
+    </div>
+  )
+}
+
+const Footer = React.forwardRef<HTMLDivElement, MDG.GridFooterContainerProps>(
+  function Footer(props, ref) {
+    const apiRef = React.useContext(MDG.GridApiContext)
+    const pagination = MDG.useGridSelector(apiRef, MDG.gridPaginationSelector)
+
+    const PaginationComponent =
+      pagination.pageSize != null && apiRef?.current.components.Pagination
+
+    const PaginationElement = PaginationComponent && (
+      <PaginationComponent {...apiRef?.current.componentsProps?.pagination} />
+    )
+
+    return (
+      <MDG.GridFooterContainer ref={ref} {...props}>
+        <CountsByState />
+        {PaginationElement}
+      </MDG.GridFooterContainer>
+    )
+  },
+)
+
+const useStateIconStyles = M.makeStyles((t) => ({
+  ok_true: {
+    color: t.palette.info.main,
+  },
+  ok_false: {
+    color: t.palette.error.main,
+  },
+  ok_null: {
+    color: t.palette.text.secondary,
+  },
+}))
+
+function StateIcon({ ok }: { ok: boolean | null }) {
+  const classes = useStateIconStyles()
+  const icon = { true: 'check', false: 'error', null: 'watch_later' }[`${ok}`]
+  return <M.Icon className={classes[`ok_${ok}`]}>{icon}</M.Icon>
+}
+
+const columns: DG.GridColumns = [
+  {
+    field: 'group',
+    headerName: 'Group',
+    width: 150,
+  },
+  {
+    field: 'title',
+    headerName: 'Title',
+    flex: 1,
+    renderCell: (params: DG.GridCellParams) => {
+      const c = params.row as Canary
+      const url = `https://${c.region}.console.aws.amazon.com/synthetics/cw?region=${c.region}#canary/detail/${c.name}`
+      return (
+        <M.Tooltip
+          arrow
+          title={
+            <>
+              {!!c.description && (
+                <>
+                  {c.description}
+                  <br />
+                  <br />
+                </>
+              )}
+              Click to go to AWS console
+            </>
+          }
+        >
+          <M.Link href={url} rel="noreferrer" target="_blank">
+            {params.value}
+          </M.Link>
+        </M.Tooltip>
+      )
+    },
+  },
+  {
+    field: 'schedule',
+    headerName: 'Schedule',
+    width: 160,
+  },
+  {
+    field: 'ok',
+    headerName: 'State',
+    width: 140,
+    valueGetter: (params) => {
+      const c = params.row as Canary
+      if (c.ok) return 'Passed'
+      if (c.ok === false) return 'Failed'
+      return 'Running'
+    },
+    renderCell: (params: DG.GridCellParams) => {
+      const c = params.row as Canary
+      return (
+        <>
+          <StateIcon ok={c.ok} />
+          <M.Box component="span" ml={1}>
+            {params.value}
+          </M.Box>
+        </>
+      )
+    },
+  },
+  {
+    field: 'lastRun',
+    headerName: 'Last Run',
+    type: 'dateTime',
+    width: 200,
+    align: 'right',
+    renderCell: (params: DG.GridCellParams) => {
+      const c = params.row as Canary
+      return <>{c.lastRun?.toLocaleString() || 'N/A'}</>
+    },
+  },
+]
+
+const useStyles = M.makeStyles((t) => ({
+  rowOk_true: {
+    background: fade(t.palette.info.light, 0.5),
+    '.MuiDataGrid-root &.MuiDataGrid-row:hover': {
+      background: t.palette.info.light,
+    },
+  },
+  rowOk_false: {
+    background: fade(t.palette.error.light, 0.2),
+    '.MuiDataGrid-root &.MuiDataGrid-row:hover': {
+      background: fade(t.palette.error.light, 0.3),
+    },
+  },
+  rowOk_null: {},
+}))
+
+interface CanariesProps {
+  canaries: readonly Canary[]
+}
+
+export default function Canaries({ canaries }: CanariesProps) {
+  const rowClasses = useStyles()
+  const classes = useDataGridStyles()
+
+  const canariesSorted = React.useMemo(
+    () =>
+      R.sortWith(
+        [
+          R.ascend((c) => ({ true: 2, false: 1, null: 0 }[`${c.ok}`])),
+          R.ascend(R.prop('title')),
+        ],
+        canaries,
+      ),
+    [canaries],
+  )
+
+  return (
+    <M.Paper className={classes.root}>
+      <div className={classes.header}>
+        <M.Typography variant="h6">Canaries</M.Typography>
+      </div>
+      <DG.DataGrid
+        className={classes.grid}
+        rows={canariesSorted}
+        columns={columns}
+        getRowId={(r) => r.name}
+        autoHeight
+        components={{ Footer }}
+        getRowClassName={({ row }) => rowClasses[`rowOk_${row.ok as boolean | null}`]}
+        pagination
+        disableSelectionOnClick
+        disableColumnSelector
+        disableColumnResize
+        disableColumnReorder
+        disableMultipleSelection
+        disableMultipleColumnsSorting
+        localeText={{
+          columnMenuSortAsc: 'Sort ascending',
+          columnMenuSortDesc: 'Sort descending',
+        }}
+      />
+    </M.Paper>
+  )
+}

--- a/catalog/app/containers/Admin/Status/Canaries.tsx
+++ b/catalog/app/containers/Admin/Status/Canaries.tsx
@@ -10,7 +10,10 @@ import * as DG from 'components/DataGrid'
 import { useDataGridStyles } from './DataGrid'
 import type STATUS_QUERY from './gql/Status.generated'
 
-type StatusResult = NonNullable<ResultOf<typeof STATUS_QUERY>['status']>
+type StatusResult = Extract<
+  ResultOf<typeof STATUS_QUERY>['status'],
+  { __typename: 'Status' }
+>
 type Canary = StatusResult['canaries'][number]
 
 interface State {

--- a/catalog/app/containers/Admin/Status/DataGrid.ts
+++ b/catalog/app/containers/Admin/Status/DataGrid.ts
@@ -1,0 +1,54 @@
+import * as M from '@material-ui/core'
+import { fade } from '@material-ui/core/styles'
+
+export const useDataGridStyles = M.makeStyles((t) => ({
+  root: {
+    position: 'relative',
+    width: '100%',
+    zIndex: 1, // to prevent receiveing shadow from footer
+  },
+  header: {
+    borderBottom: `1px solid ${t.palette.divider}`,
+    padding: t.spacing(2),
+  },
+  // TODO: move to components/DataGrid
+  '@global': {
+    '.MuiDataGridMenu-root': {
+      zIndex: t.zIndex.modal + 1, // show menu over modals
+    },
+  },
+  grid: {
+    border: 'none',
+
+    '& .MuiDataGrid-overlay': {
+      background: fade(t.palette.background.paper, 0.5),
+      zIndex: 1,
+    },
+    '& .MuiDataGrid-cell': {
+      outline: 'none !important',
+    },
+    '& .MuiDataGrid-colCell': {
+      '& .MuiDataGrid-colCellTitleContainer': {
+        flex: 'none',
+      },
+      '& .MuiDataGrid-sortIcon': {
+        fontSize: 20, // for consistency w/ other icons
+      },
+      '& .MuiDataGrid-columnSeparator': {
+        pointerEvents: 'none',
+      },
+      '&:last-child': {
+        justifyContent: 'flex-end',
+        '& .MuiDataGrid-colCellTitleContainer': {
+          order: 1,
+        },
+        '& .MuiDataGrid-colCellTitle': {
+          order: 1,
+        },
+        '& .MuiDataGrid-columnSeparator': {
+          display: 'none',
+        },
+      },
+    },
+  },
+}))

--- a/catalog/app/containers/Admin/Status/Reports.tsx
+++ b/catalog/app/containers/Admin/Status/Reports.tsx
@@ -1,0 +1,246 @@
+import * as R from 'ramda'
+import * as React from 'react'
+import * as RRDom from 'react-router-dom'
+import * as dateFns from 'date-fns'
+import type { ResultOf } from '@graphql-typed-document-node/core'
+import * as M from '@material-ui/core'
+
+import * as DG from 'components/DataGrid'
+import * as Model from 'model'
+import * as AWS from 'utils/AWS'
+import * as NamedRoutes from 'utils/NamedRoutes'
+import useQuery from 'utils/useQuery'
+
+import { useDataGridStyles } from './DataGrid'
+import REPORTS_QUERY from './gql/Reports.generated'
+import type STATUS_QUERY from './gql/Status.generated'
+
+type StatusResult = NonNullable<ResultOf<typeof STATUS_QUERY>['status']>
+type StatusReport = StatusResult['reports']['page'][number]
+
+interface ReportLinkProps {
+  loc: Model.S3.S3ObjectLocation
+}
+
+function DownloadLink({ loc, ...props }: ReportLinkProps & M.IconButtonProps<'a'>) {
+  const url = AWS.Signer.useDownloadUrl(loc, { filename: loc.key })
+  return (
+    <M.Tooltip title="Download report">
+      <M.IconButton component="a" href={url} rel="noreferrer" target="_blank" {...props}>
+        <M.Icon>save_alt</M.Icon>
+      </M.IconButton>
+    </M.Tooltip>
+  )
+}
+
+function PreviewLink({ loc }: ReportLinkProps) {
+  const { urls } = NamedRoutes.use()
+  const url = urls.bucketFile(loc.bucket, loc.key, { version: loc.version })
+  return (
+    <M.Tooltip title="Preview in catalog">
+      <M.IconButton component={RRDom.Link} to={url}>
+        <M.Icon>visibility</M.Icon>
+      </M.IconButton>
+    </M.Tooltip>
+  )
+}
+
+const columns: DG.GridColumns = [
+  {
+    field: 'timestamp',
+    headerName: 'Timestamp (UTC)',
+    type: 'dateTime',
+    flex: 1,
+    renderCell: (params: DG.GridCellParams) => {
+      const ts = params.value as Date
+      const iso = ts.toISOString()
+      const utcStr = `${iso.substring(0, 10)} ${iso.substring(11, 19)}`
+      return <>{utcStr}</>
+    },
+    filterOperators: DG.getGridDateOperators().filter((op) =>
+      ['onOrAfter', 'onOrBefore', 'is'].includes(op.value),
+    ),
+  },
+  {
+    field: 'renderedReportLocation',
+    headerName: 'Actions',
+    width: 150,
+    disableColumnMenu: true,
+    filterable: false,
+    sortable: false,
+    align: 'right',
+    renderCell: (params: DG.GridCellParams) => {
+      const loc = params.value as Model.S3.S3ObjectLocation
+      return (
+        <>
+          <PreviewLink loc={loc} />
+          <DownloadLink loc={loc} edge="end" />
+        </>
+      )
+    },
+  },
+]
+
+const sortModelToOrder = (sm: DG.GridSortModel): Model.GQLTypes.StatusReportListOrder =>
+  sm[0].sort === 'desc'
+    ? Model.GQLTypes.StatusReportListOrder.NEW_FIRST
+    : Model.GQLTypes.StatusReportListOrder.OLD_FIRST
+
+const filterModelToFilter = ({
+  items: [filterItem],
+}: DG.GridFilterModel): Model.GQLTypes.StatusReportListFilter => {
+  if (!filterItem?.operatorValue || !filterItem?.value)
+    return { timestampFrom: null, timestampTo: null }
+
+  const ts = new Date(filterItem.value)
+  const eod = dateFns.add(ts, { days: 1, seconds: -1 })
+
+  switch (filterItem.operatorValue) {
+    case 'is':
+      return { timestampFrom: ts, timestampTo: eod }
+    case 'onOrAfter':
+      return { timestampFrom: ts, timestampTo: null }
+    case 'onOrBefore':
+      return { timestampFrom: null, timestampTo: eod }
+    default:
+      throw new Error(`Unsupported operator '${filterItem.operatorValue}'`)
+  }
+}
+
+interface ReportsProps {
+  total: number
+  firstPage: readonly StatusReport[]
+  defaultPerPage: number
+  defaultOrder: Model.GQLTypes.StatusReportListOrder
+}
+
+export default function Reports({
+  total,
+  firstPage,
+  defaultPerPage,
+  defaultOrder,
+}: ReportsProps) {
+  const classes = useDataGridStyles()
+
+  const defaults = {
+    page: 1,
+    perPage: defaultPerPage,
+    filter: { timestampFrom: null, timestampTo: null },
+    order: defaultOrder,
+  }
+
+  const { current: fallbacks } = React.useRef({
+    rows: firstPage,
+    rowCount: total,
+  })
+
+  const [sortModel, setSortModel] = React.useState<DG.GridSortModel>(() => [
+    {
+      field: 'timestamp',
+      sort:
+        defaults.order === Model.GQLTypes.StatusReportListOrder.NEW_FIRST
+          ? 'desc'
+          : 'asc',
+    },
+  ])
+  const handleSortModelChange = React.useCallback((params: DG.GridSortModelParams) => {
+    setSortModel(params.sortModel)
+  }, [])
+  const order = React.useMemo(() => sortModelToOrder(sortModel), [sortModel])
+
+  const [filterModel, setFilterModel] = React.useState<DG.GridFilterModel>({ items: [] })
+  const handleFilterModelChange = React.useCallback(
+    (params: DG.GridFilterModelParams) => {
+      setFilterModel(params.filterModel)
+    },
+    [],
+  )
+  const filter = React.useMemo(() => filterModelToFilter(filterModel), [filterModel])
+
+  const [page, setPage] = React.useState(defaults.page)
+  const handlePageChange = React.useCallback((params: DG.GridPageChangeParams) => {
+    setPage(params.page + 1)
+  }, [])
+
+  const [pageSize, setPageSize] = React.useState(defaults.perPage)
+  const handlePageSizeChange = React.useCallback((params: DG.GridPageChangeParams) => {
+    setPageSize(params.pageSize)
+    // reset page when changing page size
+    setPage(1)
+  }, [])
+
+  const variables = {
+    page,
+    perPage: pageSize,
+    filter,
+    order,
+  }
+
+  const pause = R.equals(defaults, variables)
+
+  const data = useQuery({
+    query: REPORTS_QUERY,
+    pause,
+    variables,
+  })
+
+  // console.log('data', data)
+  // TODO: handle data.error
+
+  const rows = (
+    pause ? firstPage : data.data?.status?.reports.page ?? fallbacks.rows
+  ) as StatusReport[]
+  if (rows !== fallbacks.rows) fallbacks.rows = rows
+
+  const isFiltered = !R.equals(defaults.filter, variables.filter)
+
+  const rowCount = isFiltered
+    ? data.data?.status?.reports.total ?? fallbacks.rowCount
+    : total
+  if (rowCount !== fallbacks.rowCount) fallbacks.rowCount = rowCount
+
+  const loading = pause ? false : data.fetching
+
+  return (
+    <M.Paper className={classes.root}>
+      <div className={classes.header}>
+        <M.Typography variant="h6">Reports</M.Typography>
+      </div>
+      <DG.DataGrid
+        className={classes.grid}
+        rows={rows}
+        columns={columns}
+        getRowId={(r) => (r as StatusReport).timestamp.toISOString()}
+        autoHeight
+        disableSelectionOnClick
+        disableColumnSelector
+        disableColumnResize
+        disableColumnReorder
+        disableMultipleSelection
+        disableMultipleColumnsSorting
+        disableMultipleColumnsFiltering
+        localeText={{
+          columnMenuSortAsc: 'Sort ascending',
+          columnMenuSortDesc: 'Sort descending',
+          noRowsLabel: 'No reports',
+          filterOperatorIs: 'is on',
+        }}
+        sortingMode="server"
+        sortingOrder={['desc', 'asc']}
+        sortModel={sortModel}
+        onSortModelChange={handleSortModelChange}
+        filterMode="server"
+        filterModel={filterModel}
+        onFilterModelChange={handleFilterModelChange}
+        pagination
+        paginationMode="server"
+        rowCount={rowCount}
+        onPageChange={handlePageChange}
+        page={page - 1}
+        pageSize={pageSize}
+        onPageSizeChange={handlePageSizeChange}
+        loading={loading}
+      />
+    </M.Paper>
+  )
+}

--- a/catalog/app/containers/Admin/Status/Stats.tsx
+++ b/catalog/app/containers/Admin/Status/Stats.tsx
@@ -1,0 +1,161 @@
+import * as React from 'react'
+import type { ResultOf } from '@graphql-typed-document-node/core'
+import * as M from '@material-ui/core'
+
+import * as Chart from 'components/EChartsChart'
+
+import type STATUS_QUERY from './gql/Status.generated'
+
+type StatusResult = NonNullable<ResultOf<typeof STATUS_QUERY>['status']>
+
+const CHART_COLORS = [M.colors.red[300], M.colors.lightBlue[300], M.colors.grey[400]]
+
+const useStyles = M.makeStyles({
+  root: {
+    display: 'flex',
+    flexWrap: 'wrap',
+    justifyContent: 'center',
+  },
+  donut: {
+    height: '300px',
+    width: '300px',
+  },
+  history: {
+    flex: 1,
+    height: '300px',
+    minWidth: '350px',
+    width: 'calc(100% - 300px)',
+  },
+})
+
+interface StatsProps {
+  latest: StatusResult['latestStats']
+  stats: StatusResult['stats']
+  statsWindow: number
+}
+
+export default function Stats({ latest, stats, statsWindow }: StatsProps) {
+  const classes = useStyles()
+  const t = M.useTheme()
+  const titleTextProps = {
+    textStyle: {
+      fontFamily: t.typography.h6.fontFamily,
+      fontSize: t.typography.h6.fontSize,
+      fontWeight: t.typography.h6.fontWeight,
+    },
+    left: 'center',
+    top: 16,
+  }
+  const total = latest.passed + latest.failed
+
+  const handleInit: Chart.InitHook = (chart) => {
+    // highlight passed tests data by default
+    const passedIndex = 1
+    const hlDefault = () =>
+      chart.dispatchAction({ type: 'highlight', dataIndex: passedIndex })
+
+    hlDefault()
+
+    chart.on('mouseover', (e) => {
+      if (e.dataIndex === passedIndex) return
+      chart.dispatchAction({ type: 'downplay', dataIndex: passedIndex })
+    })
+
+    chart.on('mouseout', hlDefault)
+
+    return () => {
+      chart.off('mouseover')
+      chart.off('mouseout')
+    }
+  }
+
+  return (
+    <M.Paper className={classes.root}>
+      <Chart.Chart
+        className={classes.donut}
+        onInit={handleInit}
+        option={{
+          // @ts-expect-error
+          title: {
+            text: 'Current Operational Status',
+            ...titleTextProps,
+          },
+          color: CHART_COLORS,
+          series: [
+            {
+              type: 'pie',
+              radius: ['30%', '60%'],
+              label: {
+                formatter: `{main|{b}}\n{sub|{c}/${total} tests}`,
+                show: false,
+                position: 'center',
+                fontFamily: t.typography.subtitle1.fontFamily,
+                rich: {
+                  main: {
+                    fontSize: t.typography.subtitle1.fontSize,
+                    // @ts-expect-error
+                    fontWeight: t.typography.subtitle1.fontWeight,
+                    lineHeight: 24,
+                  },
+                  sub: {
+                    fontSize: t.typography.subtitle2.fontSize,
+                    // @ts-expect-error
+                    fontWeight: t.typography.subtitle2.fontWeight,
+                    lineHeight: 16,
+                  },
+                },
+              },
+              emphasis: {
+                label: {
+                  show: true,
+                },
+              },
+              data: [
+                { value: latest.failed, name: 'Failed' },
+                { value: latest.passed, name: 'Passed' },
+                { value: latest.running, name: 'Running' },
+              ],
+            },
+          ],
+        }}
+      />
+      <Chart.Chart
+        className={classes.history}
+        resize
+        option={{
+          // @ts-expect-error
+          title: {
+            text: `Operational Statistics for Past ${statsWindow} Days`,
+            ...titleTextProps,
+          },
+          color: CHART_COLORS,
+          tooltip: { trigger: 'axis' },
+          xAxis: [
+            {
+              data: stats.datetimes.map((d) =>
+                d.toLocaleDateString(undefined, { month: 'short', day: 'numeric' }),
+              ),
+            },
+          ],
+          yAxis: [{ type: 'value' }],
+          series: [
+            {
+              type: 'line',
+              name: 'Failed',
+              stack: 'Total',
+              areaStyle: {},
+              data: stats.failed as number[],
+            },
+            {
+              type: 'line',
+              name: 'Passed',
+              stack: 'Total',
+              areaStyle: {},
+              data: stats.passed as number[],
+            },
+          ],
+        }}
+      />
+    </M.Paper>
+  )
+}

--- a/catalog/app/containers/Admin/Status/Stats.tsx
+++ b/catalog/app/containers/Admin/Status/Stats.tsx
@@ -6,7 +6,10 @@ import * as Chart from 'components/EChartsChart'
 
 import type STATUS_QUERY from './gql/Status.generated'
 
-type StatusResult = NonNullable<ResultOf<typeof STATUS_QUERY>['status']>
+type StatusResult = Extract<
+  ResultOf<typeof STATUS_QUERY>['status'],
+  { __typename: 'Status' }
+>
 
 const CHART_COLORS = [M.colors.red[300], M.colors.lightBlue[300], M.colors.grey[400]]
 

--- a/catalog/app/containers/Admin/Status/Status.tsx
+++ b/catalog/app/containers/Admin/Status/Status.tsx
@@ -1,488 +1,60 @@
-import * as R from 'ramda'
 import * as React from 'react'
-import type { ResultOf } from '@graphql-typed-document-node/core'
 import * as M from '@material-ui/core'
-import { fade } from '@material-ui/core/styles'
-import * as MDG from '@material-ui/data-grid'
 
-import * as Chart from 'components/EChartsChart'
-import * as DG from 'components/DataGrid'
+import * as Model from 'model'
 import MetaTitle from 'utils/MetaTitle'
 import useQuery from 'utils/useQuery'
 
+import Canaries from './Canaries'
+import Reports from './Reports'
+import Stats from './Stats'
 import STATUS_QUERY from './gql/Status.generated'
 
 const STATS_WINDOW = 30
-
-type StatusResult = ResultOf<typeof STATUS_QUERY>['status']
-type Canary = StatusResult['canaries'][number]
-
-interface State {
-  rows: {
-    allRows: string[]
-    idRowsLookup: Record<string, Canary>
-  }
-}
-
-const countsByStateSelector = (state: State) =>
-  state.rows.allRows.reduce(
-    (acc, id) => {
-      const prop = {
-        true: 'passed',
-        false: 'failed',
-        null: 'running',
-      }[`${state.rows.idRowsLookup[id].ok}`]
-      return R.evolve({ [prop]: R.inc }, acc)
-    },
-    { passed: 0, failed: 0, running: 0 },
-  )
-
-const useCountsByStateStyles = M.makeStyles((t) => ({
-  root: {
-    display: 'flex',
-    paddingLeft: t.spacing(2),
-  },
-  item: {
-    alignItems: 'center',
-    display: 'flex',
-
-    '& + &': {
-      marginLeft: t.spacing(2),
-    },
-  },
-  count: {
-    marginLeft: t.spacing(1),
-  },
-}))
-
-function CountsByState() {
-  const classes = useCountsByStateStyles()
-  const apiRef = React.useContext(MDG.GridApiContext)
-  const counts = MDG.useGridSelector(apiRef, countsByStateSelector)
-
-  const renderItem = (count: number, label: string, ok: boolean | null) =>
-    !!count && (
-      <M.Tooltip arrow title={label}>
-        <span className={classes.item}>
-          <StateIcon ok={ok} />
-          <span className={classes.count}>{count}</span>
-        </span>
-      </M.Tooltip>
-    )
-
-  return (
-    <div className={classes.root}>
-      {renderItem(counts.failed, 'Failed', false)}
-      {renderItem(counts.running, 'Running', null)}
-      {renderItem(counts.passed, 'Passed', true)}
-    </div>
-  )
-}
-
-const Footer = React.forwardRef<HTMLDivElement, MDG.GridFooterContainerProps>(
-  function Footer(props, ref) {
-    const apiRef = React.useContext(MDG.GridApiContext)
-    const pagination = MDG.useGridSelector(apiRef, MDG.gridPaginationSelector)
-
-    const PaginationComponent =
-      pagination.pageSize != null && apiRef?.current.components.Pagination
-
-    const PaginationElement = PaginationComponent && (
-      <PaginationComponent {...apiRef?.current.componentsProps?.pagination} />
-    )
-
-    return (
-      <MDG.GridFooterContainer ref={ref} {...props}>
-        <CountsByState />
-        {PaginationElement}
-      </MDG.GridFooterContainer>
-    )
-  },
-)
-
-const useStateIconStyles = M.makeStyles((t) => ({
-  ok_true: {
-    color: t.palette.info.main,
-  },
-  ok_false: {
-    color: t.palette.error.main,
-  },
-  ok_null: {
-    color: t.palette.text.secondary,
-  },
-}))
-
-function StateIcon({ ok }: { ok: boolean | null }) {
-  const classes = useStateIconStyles()
-  const icon = { true: 'check', false: 'error', null: 'watch_later' }[`${ok}`]
-  return <M.Icon className={classes[`ok_${ok}`]}>{icon}</M.Icon>
-}
-
-const columns: DG.GridColumns = [
-  {
-    field: 'group',
-    headerName: 'Group',
-    width: 150,
-  },
-  {
-    field: 'title',
-    headerName: 'Title',
-    flex: 1,
-    renderCell: (params: DG.GridCellParams) => {
-      const c = params.row as Canary
-      const url = `https://${c.region}.console.aws.amazon.com/synthetics/cw?region=${c.region}#canary/detail/${c.name}`
-      return (
-        <M.Tooltip
-          arrow
-          title={
-            <>
-              {!!c.description && (
-                <>
-                  {c.description}
-                  <br />
-                  <br />
-                </>
-              )}
-              Click to go to AWS console
-            </>
-          }
-        >
-          <M.Link href={url} rel="noreferrer" target="_blank">
-            {params.value}
-          </M.Link>
-        </M.Tooltip>
-      )
-    },
-  },
-  {
-    field: 'schedule',
-    headerName: 'Schedule',
-    width: 160,
-  },
-  {
-    field: 'ok',
-    headerName: 'State',
-    width: 140,
-    valueGetter: (params) => {
-      const c = params.row as Canary
-      if (c.ok) return 'Passed'
-      if (c.ok === false) return 'Failed'
-      return 'Running'
-    },
-    renderCell: (params: DG.GridCellParams) => {
-      const c = params.row as Canary
-      return (
-        <>
-          <StateIcon ok={c.ok} />
-          <M.Box component="span" ml={1}>
-            {params.value}
-          </M.Box>
-        </>
-      )
-    },
-  },
-  {
-    field: 'lastRun',
-    headerName: 'Last Run',
-    type: 'dateTime',
-    width: 200,
-    align: 'right',
-    renderCell: (params: DG.GridCellParams) => {
-      const c = params.row as Canary
-      return <>{c.lastRun?.toLocaleString() || 'N/A'}</>
-    },
-  },
-]
-
-const useCanariesStyles = M.makeStyles((t) => ({
-  root: {
-    position: 'relative',
-    width: '100%',
-    zIndex: 1, // to prevent receiveing shadow from footer
-  },
-  header: {
-    borderBottom: `1px solid ${t.palette.divider}`,
-    padding: t.spacing(2),
-  },
-  // TODO: move to components/DataGrid
-  '@global': {
-    '.MuiDataGridMenu-root': {
-      zIndex: t.zIndex.modal + 1, // show menu over modals
-    },
-  },
-  grid: {
-    border: 'none',
-
-    '& .MuiDataGrid-cell': {
-      outline: 'none !important',
-    },
-    '& .MuiDataGrid-colCell': {
-      '& .MuiDataGrid-colCellTitleContainer': {
-        flex: 'none',
-      },
-      '& .MuiDataGrid-sortIcon': {
-        fontSize: 20, // for consistency w/ other icons
-      },
-      '& .MuiDataGrid-columnSeparator': {
-        pointerEvents: 'none',
-      },
-      '&:last-child': {
-        justifyContent: 'flex-end',
-        '& .MuiDataGrid-colCellTitleContainer': {
-          order: 1,
-        },
-        '& .MuiDataGrid-colCellTitle': {
-          order: 1,
-        },
-        '& .MuiDataGrid-columnSeparator': {
-          display: 'none',
-        },
-      },
-    },
-  },
-  rowOk_true: {
-    background: fade(t.palette.info.light, 0.5),
-    '.MuiDataGrid-root &.MuiDataGrid-row:hover': {
-      background: t.palette.info.light,
-    },
-  },
-  rowOk_false: {
-    background: fade(t.palette.error.light, 0.2),
-    '.MuiDataGrid-root &.MuiDataGrid-row:hover': {
-      background: fade(t.palette.error.light, 0.3),
-    },
-  },
-  rowOk_null: {},
-}))
-
-interface CanariesProps {
-  canaries: Canary[]
-}
-
-function Canaries({ canaries }: CanariesProps) {
-  const classes = useCanariesStyles()
-  const canariesSorted = React.useMemo(
-    () =>
-      R.sortWith(
-        [
-          R.ascend((c) => ({ true: 2, false: 1, null: 0 }[`${c.ok}`])),
-          R.ascend(R.prop('title')),
-        ],
-        canaries,
-      ),
-    [canaries],
-  )
-
-  return (
-    <M.Paper className={classes.root}>
-      <div className={classes.header}>
-        <M.Typography variant="h6">Canaries</M.Typography>
-      </div>
-      <DG.DataGrid
-        className={classes.grid}
-        rows={canariesSorted}
-        columns={columns}
-        getRowId={(r) => r.name}
-        autoHeight
-        components={{ Footer }}
-        getRowClassName={({ row }) => classes[`rowOk_${row.ok as boolean | null}`]}
-        pagination
-        disableSelectionOnClick
-        disableColumnSelector
-        disableColumnResize
-        disableColumnReorder
-        disableMultipleSelection
-        disableMultipleColumnsSorting
-        localeText={{
-          columnMenuSortAsc: 'Sort ascending',
-          columnMenuSortDesc: 'Sort descending',
-        }}
-      />
-    </M.Paper>
-  )
-}
-
-const CHART_COLORS = [M.colors.red[300], M.colors.lightBlue[300], M.colors.grey[400]]
-
-const useStatsStyles = M.makeStyles({
-  root: {
-    display: 'flex',
-    flexWrap: 'wrap',
-    justifyContent: 'center',
-  },
-  donut: {
-    height: '300px',
-    width: '300px',
-  },
-  history: {
-    flex: 1,
-    height: '300px',
-    minWidth: '350px',
-    width: 'calc(100% - 300px)',
-  },
-})
-
-interface StatsProps {
-  latest: StatusResult['latestStats']
-  stats: StatusResult['stats']
-}
-
-function Stats({ latest, stats }: StatsProps) {
-  const classes = useStatsStyles()
-  const t = M.useTheme()
-  const titleTextProps = {
-    textStyle: {
-      fontFamily: t.typography.h6.fontFamily,
-      fontSize: t.typography.h6.fontSize,
-      fontWeight: t.typography.h6.fontWeight,
-    },
-    left: 'center',
-    top: 16,
-  }
-  const total = latest.passed + latest.failed
-
-  const handleInit: Chart.InitHook = (chart) => {
-    // highlight passed tests data by default
-    const passedIndex = 1
-    const hlDefault = () =>
-      chart.dispatchAction({ type: 'highlight', dataIndex: passedIndex })
-
-    hlDefault()
-
-    chart.on('mouseover', (e) => {
-      if (e.dataIndex === passedIndex) return
-      chart.dispatchAction({ type: 'downplay', dataIndex: passedIndex })
-    })
-
-    chart.on('mouseout', hlDefault)
-
-    return () => {
-      chart.off('mouseover')
-      chart.off('mouseout')
-    }
-  }
-
-  return (
-    <M.Paper className={classes.root}>
-      <Chart.Chart
-        className={classes.donut}
-        onInit={handleInit}
-        option={{
-          // @ts-expect-error
-          title: {
-            text: 'Current Operational Status',
-            ...titleTextProps,
-          },
-          color: CHART_COLORS,
-          series: [
-            {
-              type: 'pie',
-              radius: ['30%', '60%'],
-              label: {
-                formatter: `{main|{b}}\n{sub|{c}/${total} tests}`,
-                show: false,
-                position: 'center',
-                fontFamily: t.typography.subtitle1.fontFamily,
-                rich: {
-                  main: {
-                    fontSize: t.typography.subtitle1.fontSize,
-                    // @ts-expect-error
-                    fontWeight: t.typography.subtitle1.fontWeight,
-                    lineHeight: 24,
-                  },
-                  sub: {
-                    fontSize: t.typography.subtitle2.fontSize,
-                    // @ts-expect-error
-                    fontWeight: t.typography.subtitle2.fontWeight,
-                    lineHeight: 16,
-                  },
-                },
-              },
-              emphasis: {
-                label: {
-                  show: true,
-                },
-              },
-              data: [
-                { value: latest.failed, name: 'Failed' },
-                { value: latest.passed, name: 'Passed' },
-                { value: latest.running, name: 'Running' },
-              ],
-            },
-          ],
-        }}
-      />
-      <Chart.Chart
-        className={classes.history}
-        resize
-        option={{
-          // @ts-expect-error
-          title: {
-            text: `Operational Statistics for Past ${STATS_WINDOW} Days`,
-            ...titleTextProps,
-          },
-          color: CHART_COLORS,
-          tooltip: { trigger: 'axis' },
-          xAxis: [
-            {
-              data: stats.datetimes.map((d) =>
-                d.toLocaleDateString(undefined, { month: 'short', day: 'numeric' }),
-              ),
-            },
-          ],
-          yAxis: [{ type: 'value' }],
-          series: [
-            {
-              type: 'line',
-              name: 'Failed',
-              stack: 'Total',
-              areaStyle: {},
-              data: stats.failed as number[],
-            },
-            {
-              type: 'line',
-              name: 'Passed',
-              stack: 'Total',
-              areaStyle: {},
-              data: stats.passed as number[],
-            },
-          ],
-        }}
-      />
-    </M.Paper>
-  )
-}
+const DEFAULT_REPORTS_PER_PAGE = 25
+const DEFAULT_REPORTS_ORDER = Model.GQLTypes.StatusReportListOrder.NEW_FIRST
 
 export default function Status() {
-  const query = useQuery({
+  const { status } = useQuery({
     query: STATUS_QUERY,
-    variables: { window: STATS_WINDOW },
+    variables: {
+      statsWindow: STATS_WINDOW,
+      reportsPerPage: DEFAULT_REPORTS_PER_PAGE,
+      reportsOrder: DEFAULT_REPORTS_ORDER,
+    },
     suspend: true,
-  })
+  }).data!
 
   return (
     <M.Box my={2}>
       <MetaTitle>{['Status', 'Admin']}</MetaTitle>
-      {query.case({
-        data: ({ status: s }) =>
-          s.canaries.length ? (
-            <>
-              <Stats latest={s.latestStats} stats={s.stats} />
-              <M.Box pt={2} />
-              <Canaries canaries={s.canaries as Canary[]} />
-            </>
-          ) : (
-            <M.Box py={2}>
-              <M.Typography variant="h4" align="center" gutterBottom>
-                No Data
-              </M.Typography>
-              <M.Typography align="center">
-                Status monitoring is not enabled for this stack
-              </M.Typography>
-            </M.Box>
-          ),
-        fetching: () => null, // doesn't happen bc of suspense
-      })}
+      {status ? (
+        <>
+          <Stats
+            latest={status.latestStats}
+            stats={status.stats}
+            statsWindow={STATS_WINDOW}
+          />
+          <M.Box pt={2} />
+          <Canaries canaries={status.canaries} />
+          <M.Box pt={2} />
+          <Reports
+            total={status.reports.total}
+            firstPage={status.reports.page}
+            defaultPerPage={DEFAULT_REPORTS_PER_PAGE}
+            defaultOrder={DEFAULT_REPORTS_ORDER}
+          />
+        </>
+      ) : (
+        <M.Box py={2}>
+          <M.Typography variant="h4" align="center" gutterBottom>
+            No Data
+          </M.Typography>
+          <M.Typography align="center">
+            Status monitoring is not enabled for this stack
+          </M.Typography>
+        </M.Box>
+      )}
     </M.Box>
   )
 }

--- a/catalog/app/containers/Admin/Status/Status.tsx
+++ b/catalog/app/containers/Admin/Status/Status.tsx
@@ -28,7 +28,7 @@ export default function Status() {
   return (
     <M.Box my={2}>
       <MetaTitle>{['Status', 'Admin']}</MetaTitle>
-      {status ? (
+      {status.__typename === 'Status' ? (
         <>
           <Stats
             latest={status.latestStats}

--- a/catalog/app/containers/Admin/Status/gql/Reports.generated.ts
+++ b/catalog/app/containers/Admin/Status/gql/Reports.generated.ts
@@ -12,21 +12,21 @@ export type containers_Admin_Status_gql_ReportsQueryVariables = Types.Exact<{
 export type containers_Admin_Status_gql_ReportsQuery = {
   readonly __typename: 'Query'
 } & {
-  readonly status: Types.Maybe<
-    { readonly __typename: 'Status' } & {
-      readonly reports: { readonly __typename: 'StatusReportList' } & Pick<
-        Types.StatusReportList,
-        'total'
-      > & {
-          readonly page: ReadonlyArray<
-            { readonly __typename: 'StatusReport' } & Pick<
-              Types.StatusReport,
-              'timestamp' | 'renderedReportLocation'
+  readonly status:
+    | ({ readonly __typename: 'Status' } & {
+        readonly reports: { readonly __typename: 'StatusReportList' } & Pick<
+          Types.StatusReportList,
+          'total'
+        > & {
+            readonly page: ReadonlyArray<
+              { readonly __typename: 'StatusReport' } & Pick<
+                Types.StatusReport,
+                'timestamp' | 'renderedReportLocation'
+              >
             >
-          >
-        }
-    }
-  >
+          }
+      })
+    | { readonly __typename: 'Unavailable' }
 }
 
 export const containers_Admin_Status_gql_ReportsDocument = {
@@ -85,59 +85,78 @@ export const containers_Admin_Status_gql_ReportsDocument = {
             selectionSet: {
               kind: 'SelectionSet',
               selections: [
+                { kind: 'Field', name: { kind: 'Name', value: '__typename' } },
                 {
-                  kind: 'Field',
-                  name: { kind: 'Name', value: 'reports' },
-                  arguments: [
-                    {
-                      kind: 'Argument',
-                      name: { kind: 'Name', value: 'filter' },
-                      value: {
-                        kind: 'Variable',
-                        name: { kind: 'Name', value: 'filter' },
-                      },
-                    },
-                  ],
+                  kind: 'InlineFragment',
+                  typeCondition: {
+                    kind: 'NamedType',
+                    name: { kind: 'Name', value: 'Status' },
+                  },
                   selectionSet: {
                     kind: 'SelectionSet',
                     selections: [
-                      { kind: 'Field', name: { kind: 'Name', value: 'total' } },
                       {
                         kind: 'Field',
-                        name: { kind: 'Name', value: 'page' },
+                        name: { kind: 'Name', value: 'reports' },
                         arguments: [
                           {
                             kind: 'Argument',
-                            name: { kind: 'Name', value: 'number' },
+                            name: { kind: 'Name', value: 'filter' },
                             value: {
                               kind: 'Variable',
-                              name: { kind: 'Name', value: 'page' },
-                            },
-                          },
-                          {
-                            kind: 'Argument',
-                            name: { kind: 'Name', value: 'perPage' },
-                            value: {
-                              kind: 'Variable',
-                              name: { kind: 'Name', value: 'perPage' },
-                            },
-                          },
-                          {
-                            kind: 'Argument',
-                            name: { kind: 'Name', value: 'order' },
-                            value: {
-                              kind: 'Variable',
-                              name: { kind: 'Name', value: 'order' },
+                              name: { kind: 'Name', value: 'filter' },
                             },
                           },
                         ],
                         selectionSet: {
                           kind: 'SelectionSet',
                           selections: [
-                            { kind: 'Field', name: { kind: 'Name', value: 'timestamp' } },
+                            { kind: 'Field', name: { kind: 'Name', value: 'total' } },
                             {
                               kind: 'Field',
-                              name: { kind: 'Name', value: 'renderedReportLocation' },
+                              name: { kind: 'Name', value: 'page' },
+                              arguments: [
+                                {
+                                  kind: 'Argument',
+                                  name: { kind: 'Name', value: 'number' },
+                                  value: {
+                                    kind: 'Variable',
+                                    name: { kind: 'Name', value: 'page' },
+                                  },
+                                },
+                                {
+                                  kind: 'Argument',
+                                  name: { kind: 'Name', value: 'perPage' },
+                                  value: {
+                                    kind: 'Variable',
+                                    name: { kind: 'Name', value: 'perPage' },
+                                  },
+                                },
+                                {
+                                  kind: 'Argument',
+                                  name: { kind: 'Name', value: 'order' },
+                                  value: {
+                                    kind: 'Variable',
+                                    name: { kind: 'Name', value: 'order' },
+                                  },
+                                },
+                              ],
+                              selectionSet: {
+                                kind: 'SelectionSet',
+                                selections: [
+                                  {
+                                    kind: 'Field',
+                                    name: { kind: 'Name', value: 'timestamp' },
+                                  },
+                                  {
+                                    kind: 'Field',
+                                    name: {
+                                      kind: 'Name',
+                                      value: 'renderedReportLocation',
+                                    },
+                                  },
+                                ],
+                              },
                             },
                           ],
                         },

--- a/catalog/app/containers/Admin/Status/gql/Reports.generated.ts
+++ b/catalog/app/containers/Admin/Status/gql/Reports.generated.ts
@@ -1,0 +1,160 @@
+/* eslint-disable @typescript-eslint/naming-convention */
+import type { TypedDocumentNode as DocumentNode } from '@graphql-typed-document-node/core'
+import * as Types from '../../../../model/graphql/types.generated'
+
+export type containers_Admin_Status_gql_ReportsQueryVariables = Types.Exact<{
+  page: Types.Scalars['Int']
+  perPage: Types.Scalars['Int']
+  filter: Types.StatusReportListFilter
+  order: Types.StatusReportListOrder
+}>
+
+export type containers_Admin_Status_gql_ReportsQuery = {
+  readonly __typename: 'Query'
+} & {
+  readonly status: Types.Maybe<
+    { readonly __typename: 'Status' } & {
+      readonly reports: { readonly __typename: 'StatusReportList' } & Pick<
+        Types.StatusReportList,
+        'total'
+      > & {
+          readonly page: ReadonlyArray<
+            { readonly __typename: 'StatusReport' } & Pick<
+              Types.StatusReport,
+              'timestamp' | 'renderedReportLocation'
+            >
+          >
+        }
+    }
+  >
+}
+
+export const containers_Admin_Status_gql_ReportsDocument = {
+  kind: 'Document',
+  definitions: [
+    {
+      kind: 'OperationDefinition',
+      operation: 'query',
+      name: { kind: 'Name', value: 'containers_Admin_Status_gql_Reports' },
+      variableDefinitions: [
+        {
+          kind: 'VariableDefinition',
+          variable: { kind: 'Variable', name: { kind: 'Name', value: 'page' } },
+          type: {
+            kind: 'NonNullType',
+            type: { kind: 'NamedType', name: { kind: 'Name', value: 'Int' } },
+          },
+        },
+        {
+          kind: 'VariableDefinition',
+          variable: { kind: 'Variable', name: { kind: 'Name', value: 'perPage' } },
+          type: {
+            kind: 'NonNullType',
+            type: { kind: 'NamedType', name: { kind: 'Name', value: 'Int' } },
+          },
+        },
+        {
+          kind: 'VariableDefinition',
+          variable: { kind: 'Variable', name: { kind: 'Name', value: 'filter' } },
+          type: {
+            kind: 'NonNullType',
+            type: {
+              kind: 'NamedType',
+              name: { kind: 'Name', value: 'StatusReportListFilter' },
+            },
+          },
+        },
+        {
+          kind: 'VariableDefinition',
+          variable: { kind: 'Variable', name: { kind: 'Name', value: 'order' } },
+          type: {
+            kind: 'NonNullType',
+            type: {
+              kind: 'NamedType',
+              name: { kind: 'Name', value: 'StatusReportListOrder' },
+            },
+          },
+        },
+      ],
+      selectionSet: {
+        kind: 'SelectionSet',
+        selections: [
+          {
+            kind: 'Field',
+            name: { kind: 'Name', value: 'status' },
+            selectionSet: {
+              kind: 'SelectionSet',
+              selections: [
+                {
+                  kind: 'Field',
+                  name: { kind: 'Name', value: 'reports' },
+                  arguments: [
+                    {
+                      kind: 'Argument',
+                      name: { kind: 'Name', value: 'filter' },
+                      value: {
+                        kind: 'Variable',
+                        name: { kind: 'Name', value: 'filter' },
+                      },
+                    },
+                  ],
+                  selectionSet: {
+                    kind: 'SelectionSet',
+                    selections: [
+                      { kind: 'Field', name: { kind: 'Name', value: 'total' } },
+                      {
+                        kind: 'Field',
+                        name: { kind: 'Name', value: 'page' },
+                        arguments: [
+                          {
+                            kind: 'Argument',
+                            name: { kind: 'Name', value: 'number' },
+                            value: {
+                              kind: 'Variable',
+                              name: { kind: 'Name', value: 'page' },
+                            },
+                          },
+                          {
+                            kind: 'Argument',
+                            name: { kind: 'Name', value: 'perPage' },
+                            value: {
+                              kind: 'Variable',
+                              name: { kind: 'Name', value: 'perPage' },
+                            },
+                          },
+                          {
+                            kind: 'Argument',
+                            name: { kind: 'Name', value: 'order' },
+                            value: {
+                              kind: 'Variable',
+                              name: { kind: 'Name', value: 'order' },
+                            },
+                          },
+                        ],
+                        selectionSet: {
+                          kind: 'SelectionSet',
+                          selections: [
+                            { kind: 'Field', name: { kind: 'Name', value: 'timestamp' } },
+                            {
+                              kind: 'Field',
+                              name: { kind: 'Name', value: 'renderedReportLocation' },
+                            },
+                          ],
+                        },
+                      },
+                    ],
+                  },
+                },
+              ],
+            },
+          },
+        ],
+      },
+    },
+  ],
+} as unknown as DocumentNode<
+  containers_Admin_Status_gql_ReportsQuery,
+  containers_Admin_Status_gql_ReportsQueryVariables
+>
+
+export { containers_Admin_Status_gql_ReportsDocument as default }

--- a/catalog/app/containers/Admin/Status/gql/Reports.graphql
+++ b/catalog/app/containers/Admin/Status/gql/Reports.graphql
@@ -5,11 +5,14 @@ query (
   $order: StatusReportListOrder!,
 ) {
   status {
-    reports(filter: $filter) {
-      total
-      page(number: $page, perPage: $perPage, order: $order) {
-        timestamp
-        renderedReportLocation
+    __typename
+    ... on Status {
+      reports(filter: $filter) {
+        total
+        page(number: $page, perPage: $perPage, order: $order) {
+          timestamp
+          renderedReportLocation
+        }
       }
     }
   }

--- a/catalog/app/containers/Admin/Status/gql/Reports.graphql
+++ b/catalog/app/containers/Admin/Status/gql/Reports.graphql
@@ -1,0 +1,16 @@
+query (
+  $page: Int!,
+  $perPage: Int!,
+  $filter: StatusReportListFilter!,
+  $order: StatusReportListOrder!,
+) {
+  status {
+    reports(filter: $filter) {
+      total
+      page(number: $page, perPage: $perPage, order: $order) {
+        timestamp
+        renderedReportLocation
+      }
+    }
+  }
+}

--- a/catalog/app/containers/Admin/Status/gql/Status.generated.ts
+++ b/catalog/app/containers/Admin/Status/gql/Status.generated.ts
@@ -9,42 +9,42 @@ export type containers_Admin_Status_gql_StatusQueryVariables = Types.Exact<{
 }>
 
 export type containers_Admin_Status_gql_StatusQuery = { readonly __typename: 'Query' } & {
-  readonly status: Types.Maybe<
-    { readonly __typename: 'Status' } & {
-      readonly canaries: ReadonlyArray<
-        { readonly __typename: 'Canary' } & Pick<
-          Types.Canary,
-          | 'name'
-          | 'region'
-          | 'group'
-          | 'title'
-          | 'description'
-          | 'schedule'
-          | 'ok'
-          | 'lastRun'
-        >
-      >
-      readonly latestStats: { readonly __typename: 'TestStats' } & Pick<
-        Types.TestStats,
-        'passed' | 'failed' | 'running'
-      >
-      readonly stats: { readonly __typename: 'TestStatsTimeSeries' } & Pick<
-        Types.TestStatsTimeSeries,
-        'datetimes' | 'passed' | 'failed'
-      >
-      readonly reports: { readonly __typename: 'StatusReportList' } & Pick<
-        Types.StatusReportList,
-        'total'
-      > & {
-          readonly page: ReadonlyArray<
-            { readonly __typename: 'StatusReport' } & Pick<
-              Types.StatusReport,
-              'timestamp' | 'renderedReportLocation'
-            >
+  readonly status:
+    | ({ readonly __typename: 'Status' } & {
+        readonly canaries: ReadonlyArray<
+          { readonly __typename: 'Canary' } & Pick<
+            Types.Canary,
+            | 'name'
+            | 'region'
+            | 'group'
+            | 'title'
+            | 'description'
+            | 'schedule'
+            | 'ok'
+            | 'lastRun'
           >
-        }
-    }
-  >
+        >
+        readonly latestStats: { readonly __typename: 'TestStats' } & Pick<
+          Types.TestStats,
+          'passed' | 'failed' | 'running'
+        >
+        readonly stats: { readonly __typename: 'TestStatsTimeSeries' } & Pick<
+          Types.TestStatsTimeSeries,
+          'datetimes' | 'passed' | 'failed'
+        >
+        readonly reports: { readonly __typename: 'StatusReportList' } & Pick<
+          Types.StatusReportList,
+          'total'
+        > & {
+            readonly page: ReadonlyArray<
+              { readonly __typename: 'StatusReport' } & Pick<
+                Types.StatusReport,
+                'timestamp' | 'renderedReportLocation'
+              >
+            >
+          }
+      })
+    | { readonly __typename: 'Unavailable' }
 }
 
 export const containers_Admin_Status_gql_StatusDocument = {
@@ -92,92 +92,114 @@ export const containers_Admin_Status_gql_StatusDocument = {
             selectionSet: {
               kind: 'SelectionSet',
               selections: [
+                { kind: 'Field', name: { kind: 'Name', value: '__typename' } },
                 {
-                  kind: 'Field',
-                  name: { kind: 'Name', value: 'canaries' },
-                  selectionSet: {
-                    kind: 'SelectionSet',
-                    selections: [
-                      { kind: 'Field', name: { kind: 'Name', value: 'name' } },
-                      { kind: 'Field', name: { kind: 'Name', value: 'region' } },
-                      { kind: 'Field', name: { kind: 'Name', value: 'group' } },
-                      { kind: 'Field', name: { kind: 'Name', value: 'title' } },
-                      { kind: 'Field', name: { kind: 'Name', value: 'description' } },
-                      { kind: 'Field', name: { kind: 'Name', value: 'schedule' } },
-                      { kind: 'Field', name: { kind: 'Name', value: 'ok' } },
-                      { kind: 'Field', name: { kind: 'Name', value: 'lastRun' } },
-                    ],
+                  kind: 'InlineFragment',
+                  typeCondition: {
+                    kind: 'NamedType',
+                    name: { kind: 'Name', value: 'Status' },
                   },
-                },
-                {
-                  kind: 'Field',
-                  name: { kind: 'Name', value: 'latestStats' },
                   selectionSet: {
                     kind: 'SelectionSet',
                     selections: [
-                      { kind: 'Field', name: { kind: 'Name', value: 'passed' } },
-                      { kind: 'Field', name: { kind: 'Name', value: 'failed' } },
-                      { kind: 'Field', name: { kind: 'Name', value: 'running' } },
-                    ],
-                  },
-                },
-                {
-                  kind: 'Field',
-                  name: { kind: 'Name', value: 'stats' },
-                  arguments: [
-                    {
-                      kind: 'Argument',
-                      name: { kind: 'Name', value: 'window' },
-                      value: {
-                        kind: 'Variable',
-                        name: { kind: 'Name', value: 'statsWindow' },
-                      },
-                    },
-                  ],
-                  selectionSet: {
-                    kind: 'SelectionSet',
-                    selections: [
-                      { kind: 'Field', name: { kind: 'Name', value: 'datetimes' } },
-                      { kind: 'Field', name: { kind: 'Name', value: 'passed' } },
-                      { kind: 'Field', name: { kind: 'Name', value: 'failed' } },
-                    ],
-                  },
-                },
-                {
-                  kind: 'Field',
-                  name: { kind: 'Name', value: 'reports' },
-                  selectionSet: {
-                    kind: 'SelectionSet',
-                    selections: [
-                      { kind: 'Field', name: { kind: 'Name', value: 'total' } },
                       {
                         kind: 'Field',
-                        name: { kind: 'Name', value: 'page' },
+                        name: { kind: 'Name', value: 'canaries' },
+                        selectionSet: {
+                          kind: 'SelectionSet',
+                          selections: [
+                            { kind: 'Field', name: { kind: 'Name', value: 'name' } },
+                            { kind: 'Field', name: { kind: 'Name', value: 'region' } },
+                            { kind: 'Field', name: { kind: 'Name', value: 'group' } },
+                            { kind: 'Field', name: { kind: 'Name', value: 'title' } },
+                            {
+                              kind: 'Field',
+                              name: { kind: 'Name', value: 'description' },
+                            },
+                            { kind: 'Field', name: { kind: 'Name', value: 'schedule' } },
+                            { kind: 'Field', name: { kind: 'Name', value: 'ok' } },
+                            { kind: 'Field', name: { kind: 'Name', value: 'lastRun' } },
+                          ],
+                        },
+                      },
+                      {
+                        kind: 'Field',
+                        name: { kind: 'Name', value: 'latestStats' },
+                        selectionSet: {
+                          kind: 'SelectionSet',
+                          selections: [
+                            { kind: 'Field', name: { kind: 'Name', value: 'passed' } },
+                            { kind: 'Field', name: { kind: 'Name', value: 'failed' } },
+                            { kind: 'Field', name: { kind: 'Name', value: 'running' } },
+                          ],
+                        },
+                      },
+                      {
+                        kind: 'Field',
+                        name: { kind: 'Name', value: 'stats' },
                         arguments: [
                           {
                             kind: 'Argument',
-                            name: { kind: 'Name', value: 'perPage' },
+                            name: { kind: 'Name', value: 'window' },
                             value: {
                               kind: 'Variable',
-                              name: { kind: 'Name', value: 'reportsPerPage' },
-                            },
-                          },
-                          {
-                            kind: 'Argument',
-                            name: { kind: 'Name', value: 'order' },
-                            value: {
-                              kind: 'Variable',
-                              name: { kind: 'Name', value: 'reportsOrder' },
+                              name: { kind: 'Name', value: 'statsWindow' },
                             },
                           },
                         ],
                         selectionSet: {
                           kind: 'SelectionSet',
                           selections: [
-                            { kind: 'Field', name: { kind: 'Name', value: 'timestamp' } },
+                            { kind: 'Field', name: { kind: 'Name', value: 'datetimes' } },
+                            { kind: 'Field', name: { kind: 'Name', value: 'passed' } },
+                            { kind: 'Field', name: { kind: 'Name', value: 'failed' } },
+                          ],
+                        },
+                      },
+                      {
+                        kind: 'Field',
+                        name: { kind: 'Name', value: 'reports' },
+                        selectionSet: {
+                          kind: 'SelectionSet',
+                          selections: [
+                            { kind: 'Field', name: { kind: 'Name', value: 'total' } },
                             {
                               kind: 'Field',
-                              name: { kind: 'Name', value: 'renderedReportLocation' },
+                              name: { kind: 'Name', value: 'page' },
+                              arguments: [
+                                {
+                                  kind: 'Argument',
+                                  name: { kind: 'Name', value: 'perPage' },
+                                  value: {
+                                    kind: 'Variable',
+                                    name: { kind: 'Name', value: 'reportsPerPage' },
+                                  },
+                                },
+                                {
+                                  kind: 'Argument',
+                                  name: { kind: 'Name', value: 'order' },
+                                  value: {
+                                    kind: 'Variable',
+                                    name: { kind: 'Name', value: 'reportsOrder' },
+                                  },
+                                },
+                              ],
+                              selectionSet: {
+                                kind: 'SelectionSet',
+                                selections: [
+                                  {
+                                    kind: 'Field',
+                                    name: { kind: 'Name', value: 'timestamp' },
+                                  },
+                                  {
+                                    kind: 'Field',
+                                    name: {
+                                      kind: 'Name',
+                                      value: 'renderedReportLocation',
+                                    },
+                                  },
+                                ],
+                              },
                             },
                           ],
                         },

--- a/catalog/app/containers/Admin/Status/gql/Status.generated.ts
+++ b/catalog/app/containers/Admin/Status/gql/Status.generated.ts
@@ -3,33 +3,48 @@ import type { TypedDocumentNode as DocumentNode } from '@graphql-typed-document-
 import * as Types from '../../../../model/graphql/types.generated'
 
 export type containers_Admin_Status_gql_StatusQueryVariables = Types.Exact<{
-  window: Types.Maybe<Types.Scalars['Int']>
+  statsWindow: Types.Scalars['Int']
+  reportsPerPage: Types.Scalars['Int']
+  reportsOrder: Types.StatusReportListOrder
 }>
 
 export type containers_Admin_Status_gql_StatusQuery = { readonly __typename: 'Query' } & {
-  readonly status: { readonly __typename: 'Status' } & {
-    readonly canaries: ReadonlyArray<
-      { readonly __typename: 'Canary' } & Pick<
-        Types.Canary,
-        | 'name'
-        | 'region'
-        | 'group'
-        | 'title'
-        | 'description'
-        | 'schedule'
-        | 'ok'
-        | 'lastRun'
+  readonly status: Types.Maybe<
+    { readonly __typename: 'Status' } & {
+      readonly canaries: ReadonlyArray<
+        { readonly __typename: 'Canary' } & Pick<
+          Types.Canary,
+          | 'name'
+          | 'region'
+          | 'group'
+          | 'title'
+          | 'description'
+          | 'schedule'
+          | 'ok'
+          | 'lastRun'
+        >
       >
-    >
-    readonly latestStats: { readonly __typename: 'TestStats' } & Pick<
-      Types.TestStats,
-      'passed' | 'failed' | 'running'
-    >
-    readonly stats: { readonly __typename: 'TestStatsTimeSeries' } & Pick<
-      Types.TestStatsTimeSeries,
-      'datetimes' | 'passed' | 'failed'
-    >
-  }
+      readonly latestStats: { readonly __typename: 'TestStats' } & Pick<
+        Types.TestStats,
+        'passed' | 'failed' | 'running'
+      >
+      readonly stats: { readonly __typename: 'TestStatsTimeSeries' } & Pick<
+        Types.TestStatsTimeSeries,
+        'datetimes' | 'passed' | 'failed'
+      >
+      readonly reports: { readonly __typename: 'StatusReportList' } & Pick<
+        Types.StatusReportList,
+        'total'
+      > & {
+          readonly page: ReadonlyArray<
+            { readonly __typename: 'StatusReport' } & Pick<
+              Types.StatusReport,
+              'timestamp' | 'renderedReportLocation'
+            >
+          >
+        }
+    }
+  >
 }
 
 export const containers_Admin_Status_gql_StatusDocument = {
@@ -42,8 +57,30 @@ export const containers_Admin_Status_gql_StatusDocument = {
       variableDefinitions: [
         {
           kind: 'VariableDefinition',
-          variable: { kind: 'Variable', name: { kind: 'Name', value: 'window' } },
-          type: { kind: 'NamedType', name: { kind: 'Name', value: 'Int' } },
+          variable: { kind: 'Variable', name: { kind: 'Name', value: 'statsWindow' } },
+          type: {
+            kind: 'NonNullType',
+            type: { kind: 'NamedType', name: { kind: 'Name', value: 'Int' } },
+          },
+        },
+        {
+          kind: 'VariableDefinition',
+          variable: { kind: 'Variable', name: { kind: 'Name', value: 'reportsPerPage' } },
+          type: {
+            kind: 'NonNullType',
+            type: { kind: 'NamedType', name: { kind: 'Name', value: 'Int' } },
+          },
+        },
+        {
+          kind: 'VariableDefinition',
+          variable: { kind: 'Variable', name: { kind: 'Name', value: 'reportsOrder' } },
+          type: {
+            kind: 'NonNullType',
+            type: {
+              kind: 'NamedType',
+              name: { kind: 'Name', value: 'StatusReportListOrder' },
+            },
+          },
         },
       ],
       selectionSet: {
@@ -93,7 +130,7 @@ export const containers_Admin_Status_gql_StatusDocument = {
                       name: { kind: 'Name', value: 'window' },
                       value: {
                         kind: 'Variable',
-                        name: { kind: 'Name', value: 'window' },
+                        name: { kind: 'Name', value: 'statsWindow' },
                       },
                     },
                   ],
@@ -103,6 +140,48 @@ export const containers_Admin_Status_gql_StatusDocument = {
                       { kind: 'Field', name: { kind: 'Name', value: 'datetimes' } },
                       { kind: 'Field', name: { kind: 'Name', value: 'passed' } },
                       { kind: 'Field', name: { kind: 'Name', value: 'failed' } },
+                    ],
+                  },
+                },
+                {
+                  kind: 'Field',
+                  name: { kind: 'Name', value: 'reports' },
+                  selectionSet: {
+                    kind: 'SelectionSet',
+                    selections: [
+                      { kind: 'Field', name: { kind: 'Name', value: 'total' } },
+                      {
+                        kind: 'Field',
+                        name: { kind: 'Name', value: 'page' },
+                        arguments: [
+                          {
+                            kind: 'Argument',
+                            name: { kind: 'Name', value: 'perPage' },
+                            value: {
+                              kind: 'Variable',
+                              name: { kind: 'Name', value: 'reportsPerPage' },
+                            },
+                          },
+                          {
+                            kind: 'Argument',
+                            name: { kind: 'Name', value: 'order' },
+                            value: {
+                              kind: 'Variable',
+                              name: { kind: 'Name', value: 'reportsOrder' },
+                            },
+                          },
+                        ],
+                        selectionSet: {
+                          kind: 'SelectionSet',
+                          selections: [
+                            { kind: 'Field', name: { kind: 'Name', value: 'timestamp' } },
+                            {
+                              kind: 'Field',
+                              name: { kind: 'Name', value: 'renderedReportLocation' },
+                            },
+                          ],
+                        },
+                      },
                     ],
                   },
                 },

--- a/catalog/app/containers/Admin/Status/gql/Status.graphql
+++ b/catalog/app/containers/Admin/Status/gql/Status.graphql
@@ -4,31 +4,34 @@ query (
   $reportsOrder: StatusReportListOrder!,
 ) {
   status {
-    canaries {
-      name
-      region
-      group
-      title
-      description
-      schedule
-      ok
-      lastRun
-    }
-    latestStats {
-      passed
-      failed
-      running
-    }
-    stats(window: $statsWindow) {
-      datetimes
-      passed
-      failed
-    }
-    reports {
-      total
-      page(perPage: $reportsPerPage, order: $reportsOrder) {
-        timestamp
-        renderedReportLocation
+    __typename
+    ... on Status {
+      canaries {
+        name
+        region
+        group
+        title
+        description
+        schedule
+        ok
+        lastRun
+      }
+      latestStats {
+        passed
+        failed
+        running
+      }
+      stats(window: $statsWindow) {
+        datetimes
+        passed
+        failed
+      }
+      reports {
+        total
+        page(perPage: $reportsPerPage, order: $reportsOrder) {
+          timestamp
+          renderedReportLocation
+        }
       }
     }
   }

--- a/catalog/app/containers/Admin/Status/gql/Status.graphql
+++ b/catalog/app/containers/Admin/Status/gql/Status.graphql
@@ -1,4 +1,8 @@
-query ($window: Int) {
+query (
+  $statsWindow: Int!,
+  $reportsPerPage: Int!,
+  $reportsOrder: StatusReportListOrder!,
+) {
   status {
     canaries {
       name
@@ -15,10 +19,17 @@ query ($window: Int) {
       failed
       running
     }
-    stats(window: $window) {
+    stats(window: $statsWindow) {
       datetimes
       passed
       failed
+    }
+    reports {
+      total
+      page(perPage: $reportsPerPage, order: $reportsOrder) {
+        timestamp
+        renderedReportLocation
+      }
     }
   }
 }

--- a/catalog/app/model/S3.ts
+++ b/catalog/app/model/S3.ts
@@ -1,0 +1,5 @@
+export interface S3ObjectLocation {
+  bucket: string
+  key: string
+  version?: string
+}

--- a/catalog/app/model/graphql/schema.generated.ts
+++ b/catalog/app/model/graphql/schema.generated.ts
@@ -2671,12 +2671,9 @@ export default {
           {
             name: 'status',
             type: {
-              kind: 'NON_NULL',
-              ofType: {
-                kind: 'OBJECT',
-                name: 'Status',
-                ofType: null,
-              },
+              kind: 'OBJECT',
+              name: 'Status',
+              ofType: null,
             },
             args: [],
           },
@@ -3042,6 +3039,10 @@ export default {
         interfaces: [],
       },
       {
+        kind: 'SCALAR',
+        name: 'S3ObjectLocation',
+      },
+      {
         kind: 'OBJECT',
         name: 'SnsInvalid',
         fields: [
@@ -3108,6 +3109,127 @@ export default {
                   kind: 'SCALAR',
                   name: 'Int',
                   ofType: null,
+                },
+              },
+            ],
+          },
+          {
+            name: 'reports',
+            type: {
+              kind: 'NON_NULL',
+              ofType: {
+                kind: 'OBJECT',
+                name: 'StatusReportList',
+                ofType: null,
+              },
+            },
+            args: [
+              {
+                name: 'filter',
+                type: {
+                  kind: 'SCALAR',
+                  name: 'Any',
+                },
+              },
+            ],
+          },
+        ],
+        interfaces: [],
+      },
+      {
+        kind: 'OBJECT',
+        name: 'StatusReport',
+        fields: [
+          {
+            name: 'timestamp',
+            type: {
+              kind: 'NON_NULL',
+              ofType: {
+                kind: 'SCALAR',
+                name: 'Datetime',
+                ofType: null,
+              },
+            },
+            args: [],
+          },
+          {
+            name: 'renderedReportLocation',
+            type: {
+              kind: 'NON_NULL',
+              ofType: {
+                kind: 'SCALAR',
+                name: 'S3ObjectLocation',
+                ofType: null,
+              },
+            },
+            args: [],
+          },
+        ],
+        interfaces: [],
+      },
+      {
+        kind: 'OBJECT',
+        name: 'StatusReportList',
+        fields: [
+          {
+            name: 'total',
+            type: {
+              kind: 'NON_NULL',
+              ofType: {
+                kind: 'SCALAR',
+                name: 'Int',
+                ofType: null,
+              },
+            },
+            args: [],
+          },
+          {
+            name: 'page',
+            type: {
+              kind: 'NON_NULL',
+              ofType: {
+                kind: 'LIST',
+                ofType: {
+                  kind: 'NON_NULL',
+                  ofType: {
+                    kind: 'OBJECT',
+                    name: 'StatusReport',
+                    ofType: null,
+                  },
+                },
+              },
+            },
+            args: [
+              {
+                name: 'number',
+                type: {
+                  kind: 'NON_NULL',
+                  ofType: {
+                    kind: 'SCALAR',
+                    name: 'Int',
+                    ofType: null,
+                  },
+                },
+              },
+              {
+                name: 'perPage',
+                type: {
+                  kind: 'NON_NULL',
+                  ofType: {
+                    kind: 'SCALAR',
+                    name: 'Int',
+                    ofType: null,
+                  },
+                },
+              },
+              {
+                name: 'order',
+                type: {
+                  kind: 'NON_NULL',
+                  ofType: {
+                    kind: 'SCALAR',
+                    name: 'Any',
+                  },
                 },
               },
             ],

--- a/catalog/app/model/graphql/schema.generated.ts
+++ b/catalog/app/model/graphql/schema.generated.ts
@@ -2671,9 +2671,12 @@ export default {
           {
             name: 'status',
             type: {
-              kind: 'OBJECT',
-              name: 'Status',
-              ofType: null,
+              kind: 'NON_NULL',
+              ofType: {
+                kind: 'UNION',
+                name: 'StatusResult',
+                ofType: null,
+              },
             },
             args: [],
           },
@@ -3238,6 +3241,20 @@ export default {
         interfaces: [],
       },
       {
+        kind: 'UNION',
+        name: 'StatusResult',
+        possibleTypes: [
+          {
+            kind: 'OBJECT',
+            name: 'Status',
+          },
+          {
+            kind: 'OBJECT',
+            name: 'Unavailable',
+          },
+        ],
+      },
+      {
         kind: 'OBJECT',
         name: 'TestStats',
         fields: [
@@ -3335,6 +3352,22 @@ export default {
                   },
                 },
               },
+            },
+            args: [],
+          },
+        ],
+        interfaces: [],
+      },
+      {
+        kind: 'OBJECT',
+        name: 'Unavailable',
+        fields: [
+          {
+            name: '_',
+            type: {
+              kind: 'SCALAR',
+              name: 'Boolean',
+              ofType: null,
             },
             args: [],
           },

--- a/catalog/app/model/graphql/schema.generated.ts
+++ b/catalog/app/model/graphql/schema.generated.ts
@@ -3136,6 +3136,18 @@ export default {
               },
             ],
           },
+          {
+            name: 'reportsBucket',
+            type: {
+              kind: 'NON_NULL',
+              ofType: {
+                kind: 'SCALAR',
+                name: 'String',
+                ofType: null,
+              },
+            },
+            args: [],
+          },
         ],
         interfaces: [],
       },

--- a/catalog/app/model/graphql/types.generated.ts
+++ b/catalog/app/model/graphql/types.generated.ts
@@ -1,5 +1,6 @@
 import type { Json, JsonRecord } from 'utils/types'
 import type { PackageContentsFlatMap } from 'model'
+import type { S3ObjectLocation } from 'model/S3'
 
 export type Maybe<T> = T | null
 export type Exact<T extends { [key: string]: unknown }> = { [K in keyof T]: T[K] }
@@ -20,6 +21,7 @@ export interface Scalars {
   Json: Json
   JsonRecord: JsonRecord
   PackageContentsFlatMap: PackageContentsFlatMap
+  S3ObjectLocation: S3ObjectLocation
 }
 
 export interface AccessCountForDate {
@@ -562,7 +564,7 @@ export interface Query {
   readonly roles: ReadonlyArray<Role>
   readonly role: Maybe<Role>
   readonly defaultRole: Maybe<Role>
-  readonly status: Status
+  readonly status: Maybe<Status>
 }
 
 export interface QuerybucketConfigArgs {
@@ -690,10 +692,43 @@ export interface Status {
   readonly canaries: ReadonlyArray<Canary>
   readonly latestStats: TestStats
   readonly stats: TestStatsTimeSeries
+  readonly reports: StatusReportList
 }
 
 export interface StatusstatsArgs {
   window?: Maybe<Scalars['Int']>
+}
+
+export interface StatusreportsArgs {
+  filter: Maybe<StatusReportListFilter>
+}
+
+export interface StatusReport {
+  readonly __typename: 'StatusReport'
+  readonly timestamp: Scalars['Datetime']
+  readonly renderedReportLocation: Scalars['S3ObjectLocation']
+}
+
+export interface StatusReportList {
+  readonly __typename: 'StatusReportList'
+  readonly total: Scalars['Int']
+  readonly page: ReadonlyArray<StatusReport>
+}
+
+export interface StatusReportListpageArgs {
+  number?: Scalars['Int']
+  perPage?: Scalars['Int']
+  order?: StatusReportListOrder
+}
+
+export interface StatusReportListFilter {
+  readonly timestampFrom: Maybe<Scalars['Datetime']>
+  readonly timestampTo: Maybe<Scalars['Datetime']>
+}
+
+export enum StatusReportListOrder {
+  NEW_FIRST = 'NEW_FIRST',
+  OLD_FIRST = 'OLD_FIRST',
 }
 
 export interface TestStats {

--- a/catalog/app/model/graphql/types.generated.ts
+++ b/catalog/app/model/graphql/types.generated.ts
@@ -693,6 +693,7 @@ export interface Status {
   readonly latestStats: TestStats
   readonly stats: TestStatsTimeSeries
   readonly reports: StatusReportList
+  readonly reportsBucket: Scalars['String']
 }
 
 export interface StatusstatsArgs {

--- a/catalog/app/model/graphql/types.generated.ts
+++ b/catalog/app/model/graphql/types.generated.ts
@@ -564,7 +564,7 @@ export interface Query {
   readonly roles: ReadonlyArray<Role>
   readonly role: Maybe<Role>
   readonly defaultRole: Maybe<Role>
-  readonly status: Maybe<Status>
+  readonly status: StatusResult
 }
 
 export interface QuerybucketConfigArgs {
@@ -731,6 +731,8 @@ export enum StatusReportListOrder {
   OLD_FIRST = 'OLD_FIRST',
 }
 
+export type StatusResult = Status | Unavailable
+
 export interface TestStats {
   readonly __typename: 'TestStats'
   readonly passed: Scalars['Int']
@@ -743,6 +745,11 @@ export interface TestStatsTimeSeries {
   readonly datetimes: ReadonlyArray<Scalars['Datetime']>
   readonly passed: ReadonlyArray<Scalars['Int']>
   readonly failed: ReadonlyArray<Scalars['Int']>
+}
+
+export interface Unavailable {
+  readonly __typename: 'Unavailable'
+  readonly _: Maybe<Scalars['Boolean']>
 }
 
 export interface UnmanagedPolicyInput {

--- a/catalog/app/model/index.ts
+++ b/catalog/app/model/index.ts
@@ -7,6 +7,8 @@ import * as GQLTypes from './graphql/types.generated'
 
 export * as GQLTypes from './graphql/types.generated'
 
+export * as S3 from './S3'
+
 export const BucketPermissionLevel = Types.enum(
   GQLTypes.BucketPermissionLevel,
   'BucketPermissionLevel',

--- a/catalog/app/utils/AWS/S3.js
+++ b/catalog/app/utils/AWS/S3.js
@@ -6,6 +6,7 @@ import * as redux from 'react-redux'
 import * as authSelectors from 'containers/Auth/selectors'
 import * as BucketConfig from 'utils/BucketConfig'
 import { useConfig } from 'utils/Config'
+import { useStatusReportsBucket } from 'utils/StatusReportsBucket'
 import useConstant from 'utils/useConstant'
 import useMemoEqLazy from 'utils/useMemoEqLazy'
 
@@ -39,6 +40,7 @@ function useSmartS3() {
   const selectEndpoint = `${cfg.binaryApiGatewayEndpoint}/s3select/`
   const isAuthenticated = useTracking(redux.useSelector(authSelectors.authenticated))
   const isInStack = useTrackingFn(BucketConfig.useIsInStack())
+  const statusReportsBucket = useStatusReportsBucket()
 
   return useConstant(() => {
     class SmartS3 extends S3 {
@@ -52,8 +54,8 @@ function useSmartS3() {
             // sign if operation is not bucket-specific
             // (not sure if there are any such operations that can be used from the browser)
             !bucket ||
-            (cfg.analyticsBucket && cfg.analyticsBucket === bucket) ||
-            (cfg.serviceBucket && cfg.serviceBucket === bucket) ||
+            cfg.analyticsBucket === bucket ||
+            statusReportsBucket === bucket ||
             (cfg.mode !== 'OPEN' && isInStack(bucket))
           ) {
             return 'signed'

--- a/catalog/app/utils/AWS/Signer.js
+++ b/catalog/app/utils/AWS/Signer.js
@@ -4,6 +4,7 @@ import * as redux from 'react-redux'
 import * as authSelectors from 'containers/Auth/selectors'
 import * as BucketConfig from 'utils/BucketConfig'
 import * as Config from 'utils/Config'
+import { useStatusReportsBucket } from 'utils/StatusReportsBucket'
 import { handleToHttpsUri } from 'utils/s3paths'
 
 import * as Credentials from './Credentials'
@@ -22,10 +23,11 @@ export function useS3Signer({ urlExpiration: exp, forceProxy = false } = {}) {
   const authenticated = redux.useSelector(authSelectors.authenticated)
   const cfg = Config.useConfig()
   const isInStack = BucketConfig.useIsInStack()
+  const statusReportsBucket = useStatusReportsBucket()
   const s3 = S3.use()
   const inStackOrSpecial = React.useCallback(
-    (b) => isInStack(b) || cfg.analyticsBucket === b || cfg.serviceBucket === b,
-    [isInStack, cfg.analyticsBucket, cfg.serviceBucket],
+    (b) => isInStack(b) || cfg.analyticsBucket === b || statusReportsBucket === b,
+    [isInStack, cfg.analyticsBucket, statusReportsBucket],
   )
   return React.useCallback(
     ({ bucket, key, version }, opts) =>

--- a/catalog/app/utils/AWS/Signer.js
+++ b/catalog/app/utils/AWS/Signer.js
@@ -20,12 +20,17 @@ export function useS3Signer({ urlExpiration: exp, forceProxy = false } = {}) {
   const urlExpiration = exp || ctx.urlExpiration
   Credentials.use().suspend()
   const authenticated = redux.useSelector(authSelectors.authenticated)
-  const { mode } = Config.useConfig()
+  const cfg = Config.useConfig()
   const isInStack = BucketConfig.useIsInStack()
   const s3 = S3.use()
+  const inStackOrSpecial = React.useCallback(
+    (b) => isInStack(b) || cfg.analyticsBucket === b || cfg.serviceBucket === b,
+    [isInStack, cfg.analyticsBucket, cfg.serviceBucket],
+  )
   return React.useCallback(
     ({ bucket, key, version }, opts) =>
-      mode !== 'OPEN' && (mode === 'LOCAL' || (isInStack(bucket) && authenticated))
+      cfg.mode !== 'OPEN' &&
+      (cfg.mode === 'LOCAL' || (inStackOrSpecial(bucket) && authenticated))
         ? s3.getSignedUrl('getObject', {
             Bucket: bucket,
             Key: key,
@@ -35,7 +40,7 @@ export function useS3Signer({ urlExpiration: exp, forceProxy = false } = {}) {
             ...opts,
           })
         : handleToHttpsUri({ bucket, key, version }), // TODO: handle ResponseContentDisposition for unsigned case
-    [mode, isInStack, authenticated, s3, urlExpiration, forceProxy],
+    [cfg.mode, inStackOrSpecial, authenticated, s3, urlExpiration, forceProxy],
   )
 }
 
@@ -52,12 +57,13 @@ function usePolling(callback, { interval = POLL_INTERVAL } = {}) {
   }, [interval])
 }
 
-export function useDownloadUrl(handle) {
+export function useDownloadUrl(handle, { filename } = {}) {
   const { urlExpiration } = React.useContext(Ctx)
   const sign = useS3Signer()
+  const filenameSuffix = filename ? `; filename="${filename}"` : ''
   const doSign = () => ({
     url: sign(handle, {
-      ResponseContentDisposition: 'attachment',
+      ResponseContentDisposition: `attachment${filenameSuffix}`,
       ResponseContentType: 'binary/octet-stream',
     }),
     ts: Date.now(),

--- a/catalog/app/utils/AWS/Signer.js
+++ b/catalog/app/utils/AWS/Signer.js
@@ -59,14 +59,14 @@ function usePolling(callback, { interval = POLL_INTERVAL } = {}) {
   }, [interval])
 }
 
-export function useDownloadUrl(handle, { filename } = {}) {
+export function useDownloadUrl(handle, { filename = '', contentType = '' } = {}) {
   const { urlExpiration } = React.useContext(Ctx)
   const sign = useS3Signer()
   const filenameSuffix = filename ? `; filename="${filename}"` : ''
   const doSign = () => ({
     url: sign(handle, {
       ResponseContentDisposition: `attachment${filenameSuffix}`,
-      ResponseContentType: 'binary/octet-stream',
+      ResponseContentType: contentType || 'binary/octet-stream',
     }),
     ts: Date.now(),
   })

--- a/catalog/app/utils/GraphQL.tsx
+++ b/catalog/app/utils/GraphQL.tsx
@@ -100,6 +100,7 @@ export function GraphQLProvider({ children }: React.PropsWithChildren<{}>) {
           PackageDir: () => null,
           PackageFile: () => null,
           PackageList: () => null,
+          // XXX: is r.modified a string here?
           PackageRevision: (r) =>
             r.hash ? `${r.hash}:${r.modified?.valueOf() || ''}` : null,
           PackageRevisionList: () => null,
@@ -109,6 +110,8 @@ export function GraphQLProvider({ children }: React.PropsWithChildren<{}>) {
           RoleBucketPermission: (p: any) =>
             p.bucket?.name && p.role?.id ? `${p.bucket.name}/${p.role.id}` : null,
           Status: () => null,
+          StatusReport: (r) => (typeof r.timestamp === 'string' ? r.timestamp : null),
+          StatusReportList: () => null,
           TestStats: () => null,
           TestStatsTimeSeries: () => null,
         },

--- a/catalog/app/utils/StatusReportsBucket.generated.ts
+++ b/catalog/app/utils/StatusReportsBucket.generated.ts
@@ -1,0 +1,57 @@
+/* eslint-disable @typescript-eslint/naming-convention */
+import type { TypedDocumentNode as DocumentNode } from '@graphql-typed-document-node/core'
+import * as Types from '../model/graphql/types.generated'
+
+export type utils_StatusReportsBucketQueryVariables = Types.Exact<{
+  [key: string]: never
+}>
+
+export type utils_StatusReportsBucketQuery = { readonly __typename: 'Query' } & {
+  readonly status:
+    | ({ readonly __typename: 'Status' } & Pick<Types.Status, 'reportsBucket'>)
+    | { readonly __typename: 'Unavailable' }
+}
+
+export const utils_StatusReportsBucketDocument = {
+  kind: 'Document',
+  definitions: [
+    {
+      kind: 'OperationDefinition',
+      operation: 'query',
+      name: { kind: 'Name', value: 'utils_StatusReportsBucket' },
+      selectionSet: {
+        kind: 'SelectionSet',
+        selections: [
+          {
+            kind: 'Field',
+            name: { kind: 'Name', value: 'status' },
+            selectionSet: {
+              kind: 'SelectionSet',
+              selections: [
+                { kind: 'Field', name: { kind: 'Name', value: '__typename' } },
+                {
+                  kind: 'InlineFragment',
+                  typeCondition: {
+                    kind: 'NamedType',
+                    name: { kind: 'Name', value: 'Status' },
+                  },
+                  selectionSet: {
+                    kind: 'SelectionSet',
+                    selections: [
+                      { kind: 'Field', name: { kind: 'Name', value: 'reportsBucket' } },
+                    ],
+                  },
+                },
+              ],
+            },
+          },
+        ],
+      },
+    },
+  ],
+} as unknown as DocumentNode<
+  utils_StatusReportsBucketQuery,
+  utils_StatusReportsBucketQueryVariables
+>
+
+export { utils_StatusReportsBucketDocument as default }

--- a/catalog/app/utils/StatusReportsBucket.graphql
+++ b/catalog/app/utils/StatusReportsBucket.graphql
@@ -1,0 +1,8 @@
+query {
+  status {
+    __typename
+    ... on Status {
+      reportsBucket
+    }
+  }
+}

--- a/catalog/app/utils/StatusReportsBucket.tsx
+++ b/catalog/app/utils/StatusReportsBucket.tsx
@@ -1,0 +1,15 @@
+import invariant from 'invariant'
+
+import useQuery from 'utils/useQuery'
+
+import STATUS_REPORTS_BUCKET_QUERY from './StatusReportsBucket.generated'
+
+export function useStatusReportsBucket() {
+  const result = useQuery({
+    query: STATUS_REPORTS_BUCKET_QUERY,
+    suspend: true,
+  })
+  invariant(result.data, 'No data')
+  const { status } = result.data
+  return status.__typename === 'Status' ? status.reportsBucket : null
+}

--- a/catalog/app/utils/StatusReportsBucket.tsx
+++ b/catalog/app/utils/StatusReportsBucket.tsx
@@ -1,5 +1,3 @@
-import invariant from 'invariant'
-
 import useQuery from 'utils/useQuery'
 
 import STATUS_REPORTS_BUCKET_QUERY from './StatusReportsBucket.generated'
@@ -9,7 +7,7 @@ export function useStatusReportsBucket() {
     query: STATUS_REPORTS_BUCKET_QUERY,
     suspend: true,
   })
-  invariant(result.data, 'No data')
+  if (!result.data) return null
   const { status } = result.data
   return status.__typename === 'Status' ? status.reportsBucket : null
 }

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -30,6 +30,7 @@
 * [Added] Add "Create text file" menu ([#3017](https://github.com/quiltdata/quilt/pull/3017))
 * [Added] Redirect to last selected Athena workgroup ([#3067](https://github.com/quiltdata/quilt/pull/3067))
 * [Added] `status_reports` lambda ([#2989](https://github.com/quiltdata/quilt/pull/2989))
+* [Added] Stack Status Admin UI: reports ([#3068](https://github.com/quiltdata/quilt/pull/3068))
 * [Fixed] Fix package creation in S3 buckets with SSE-KMS enabled ([#2754](https://github.com/quiltdata/quilt/pull/2754))
 * [Fixed] Fix creation of packages with large (4+ GiB) files ([#2933](https://github.com/quiltdata/quilt/pull/2933))
 * [Changed] Clean up home page ([#2780](https://github.com/quiltdata/quilt/pull/2780)).

--- a/shared/graphql/schema.graphql
+++ b/shared/graphql/schema.graphql
@@ -32,6 +32,10 @@ type Ok {
   _: Boolean
 }
 
+type Unavailable {
+  _: Boolean
+}
+
 type ContentIndexingSettings {
   extensions: [String!]!
   bytesDefault: Int!
@@ -97,6 +101,8 @@ type Status {
   stats(window: Int = 30): TestStatsTimeSeries!
   reports(filter: StatusReportListFilter): StatusReportList!
 }
+
+union StatusResult = Status | Unavailable
 
 type Collaborator {
   email: String!
@@ -268,7 +274,7 @@ type Query {
   roles: [Role!]! @admin
   role(id: ID!): Role @admin
   defaultRole: Role @admin
-  status: Status @admin
+  status: StatusResult! @admin
 }
 
 input BucketAddInput {

--- a/shared/graphql/schema.graphql
+++ b/shared/graphql/schema.graphql
@@ -8,6 +8,9 @@ scalar JsonRecord
 
 scalar PackageContentsFlatMap
 
+# bucket + key + version (aka physical key)
+scalar S3ObjectLocation
+
 type OperationError {
   message: String!
   name: String!
@@ -64,10 +67,35 @@ type TestStatsTimeSeries {
   failed: [Int!]!
 }
 
+type StatusReport {
+  timestamp: Datetime! # can be used as id / cache key
+  renderedReportLocation: S3ObjectLocation!
+}
+
+enum StatusReportListOrder {
+  NEW_FIRST
+  OLD_FIRST
+}
+
+type StatusReportList {
+  total: Int!
+  page(
+    number: Int! = 1
+    perPage: Int! = 25
+    order: StatusReportListOrder! = NEW_FIRST
+  ): [StatusReport!]!
+}
+
+input StatusReportListFilter {
+  timestampFrom: Datetime
+  timestampTo: Datetime
+}
+
 type Status {
   canaries: [Canary!]!
   latestStats: TestStats!
   stats(window: Int = 30): TestStatsTimeSeries!
+  reports(filter: StatusReportListFilter): StatusReportList!
 }
 
 type Collaborator {
@@ -240,7 +268,7 @@ type Query {
   roles: [Role!]! @admin
   role(id: ID!): Role @admin
   defaultRole: Role @admin
-  status: Status! @admin
+  status: Status @admin
 }
 
 input BucketAddInput {

--- a/shared/graphql/schema.graphql
+++ b/shared/graphql/schema.graphql
@@ -100,6 +100,7 @@ type Status {
   latestStats: TestStats!
   stats(window: Int = 30): TestStatsTimeSeries!
   reports(filter: StatusReportListFilter): StatusReportList!
+  reportsBucket: String!
 }
 
 union StatusResult = Status | Unavailable


### PR DESCRIPTION
# Description

Add status reports datagrid (sortable, filterable, paginated) to admin/status screen (plus related graphql changes and some utility adjustments):

<img width="1287" alt="Screenshot 2022-09-02 at 15 15 48" src="https://user-images.githubusercontent.com/122294/188118331-8507eb4a-4b92-4877-8f1d-6e884ecf883b.png">


# TODO

- [x] [Changelog](CHANGELOG.md) entry

Depends on related registry / lambda / deployment changes (tho *should* gracefully degrade even without them)