### PR TITLE
Fix "`name.replaceAll` is not a function" error

### DIFF
--- a/catalog/app/containers/Bucket/Listing.tsx
+++ b/catalog/app/containers/Bucket/Listing.tsx
@@ -1050,7 +1050,7 @@ export function Listing({
           toolbar: { truncated, locked, loadMore, items, children: toolbarContents },
           footer: { truncated, locked, loadMore, items },
         }}
-        getRowId={(row) => row.name.replaceAll("'", "\\'")}
+        getRowId={(row) => row.name?.replaceAll("'", "\\'") || row.id}
         pagination
         pageSize={pageSize}
         onPageSizeChange={handlePageSizeChange}


### PR DESCRIPTION
I don't know how to reproduce it, but I saw these errors in Sentry