### PR TITLE
Fix four levels deep of heading to three

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -44,6 +44,7 @@
 * [Changed] Fixed config and docs mistyping: `ui.athena.defaultWorkflow` should be `ui.athena.defaultWorkgroup` ([#3067](https://github.com/quiltdata/quilt/pull/3067))
 
 ## Docs
+* [Added] Fix four-deep headers so auto-link generation works ([#3100](https://github.com/quiltdata/quilt/pull/3100))
 * [Added] Object deletion example ([#3097](https://github.com/quiltdata/quilt/pull/3097))
 * [Added] Using R with Quilt ([#3089](https://github.com/quiltdata/quilt/pull/3089))
 * [Added] Querying metadata with Athena ([#2901](https://github.com/quiltdata/quilt/pull/2901))

--- a/docs/technical-reference.md
+++ b/docs/technical-reference.md
@@ -36,7 +36,7 @@ only allowing necessary traffic.
 ### Sizing
 The Quilt CloudFormation template will automatically configure appropriate instance sizes for RDS, ECS (Fargate), Lambda and Elasticsearch Service. Some users may choose to adjust the size and configuration of their Elasticsearch cluster. All other services should use the default settings.
 
-#### Elasticsearch Service Configuration
+### Elasticsearch Service Configuration
 By default, Quilt configures an Elasticsearch cluster with 3 master nodes and 2 data nodes. Please contact the Quilt support team before adjusting the size and configuration of your cluster to avoid disruption.
 
 ### Cost
@@ -55,7 +55,7 @@ The infrastructure costs of running a Quilt stack vary with usage. Baseline infr
 ### Health and Monitoring
 To check the status of your Quilt stack after bring-up or update, check the stack health in the CloudFormation console.
 
-#### Elasticsearch Cluster
+### Elasticsearch Cluster
 If you notice slow or incomplete search results, check the status of the Quilt Elasticsearch cluster. To find the Quilt search cluster from CloudFormation, click on the Quilt stack, then "Resources." Click on the "Search" resource.
 
 If your cluster status is not "Green" (healthy), please contact Quilt support. Causes of unhealthy search clusters include:
@@ -249,9 +249,9 @@ users to be able to sign up.
 ![](imgs/default-role.png)
 
 
-### Single sign-on (SSO)
+## Single sign-on (SSO)
 
-#### Google
+### Google
 
 You can enable users on your Google domain to sign in to Quilt.
 Refer to [Google's instructions on OAuth2 user agents](https://developers.google.com/identity/protocols/OAuth2UserAgent)
@@ -263,7 +263,7 @@ In the template menu (CloudFormation or Service Catalog), select Google under *U
 
 ![](./imgs/google_auth.png)
 
-#### Active Directory
+### Active Directory
 
 1. Go to Azure Portal > Active Directory > App Registrations
 1. Click New Registration
@@ -285,7 +285,7 @@ and hybrid flows, and check the box to issue ID tokens
 
 ![](./imgs/active-directory.png)
 
-#### Okta
+### Okta
 
 1. Go to Okta > Admin > Applications
 1. Click `Add Application`
@@ -306,7 +306,7 @@ and hybrid flows, and check the box to issue ID tokens
 
 ![](./imgs/okta-sso-general.png)
 
-#### OneLogin
+### OneLogin
 
 1. Go to Administration : Applications > Custom Connectors
 1. Click `New Connector`
@@ -327,7 +327,7 @@ Quilt
 ![](./imgs/onelogin-sso.png)
 ![](./imgs/onelogin-users.png)
 
-#### Enabling SSO in CloudFormation
+### Enabling SSO in CloudFormation
 
 Now you can connect Quilt to your SSO provider.
 In the Quilt template


### PR DESCRIPTION
# Description
Fix Gitbook `h4` headers (not supported that deep) to `h3` so auto-links work once again

# TODO

<!-- Remove items that are irrelevant to this PR -->

- [ x ] [Changelog](CHANGELOG.md) entry
