### PR TITLE
Athena: Remove duplicate first row

### DIFF
--- a/catalog/app/containers/Bucket/Queries/Athena/Athena.tsx
+++ b/catalog/app/containers/Bucket/Queries/Athena/Athena.tsx
@@ -182,7 +182,7 @@ function ResultsContainer({
         workgroup={workgroup}
       >
         {!!queryResults.rows.length && (
-          <CreatePackage bucket={bucket} rows={queryResults.rows} />
+          <CreatePackage bucket={bucket} queryResults={queryResults} />
         )}
       </ResultsBreadcrumbs>
       {/* eslint-disable-next-line no-nested-ternary */}

--- a/catalog/app/containers/Bucket/Queries/Athena/Results.tsx
+++ b/catalog/app/containers/Bucket/Queries/Athena/Results.tsx
@@ -32,19 +32,19 @@ interface ResultsProps {
 
 export default function Results({ columns, rows, onLoadMore }: ResultsProps) {
   const classes = useResultsStyles()
-  const data = React.useMemo(
-    () =>
-      rows.map((row) =>
-        row.reduce(
-          (memo, item, index) => ({
-            ...memo,
-            [columns[index]?.name || 'Unknown']: item,
-          }),
-          {},
-        ),
+  const data = React.useMemo(() => {
+    // TODO: move to `athena.fetchQueryResults`
+    const isHeadColumns = columns.every(({ name }, index) => name === rows[0][index])
+    return (isHeadColumns ? rows.slice(1) : rows).map((row) =>
+      row.reduce(
+        (memo, item, index) => ({
+          ...memo,
+          [columns[index]?.name || 'Unknown']: item,
+        }),
+        {},
       ),
-    [columns, rows],
-  )
+    )
+  }, [columns, rows])
 
   if (!data.length) return <Empty />
 

--- a/catalog/app/containers/Bucket/Queries/Athena/Results.tsx
+++ b/catalog/app/containers/Bucket/Queries/Athena/Results.tsx
@@ -32,19 +32,19 @@ interface ResultsProps {
 
 export default function Results({ columns, rows, onLoadMore }: ResultsProps) {
   const classes = useResultsStyles()
-  const data = React.useMemo(() => {
-    // TODO: move to `athena.fetchQueryResults`
-    const isHeadColumns = columns.every(({ name }, index) => name === rows[0][index])
-    return (isHeadColumns ? rows.slice(1) : rows).map((row) =>
-      row.reduce(
-        (memo, item, index) => ({
-          ...memo,
-          [columns[index]?.name || 'Unknown']: item,
-        }),
-        {},
+  const data = React.useMemo(
+    () =>
+      rows.map((row) =>
+        row.reduce(
+          (memo, item, index) => ({
+            ...memo,
+            [columns[index]?.name || 'Unknown']: item,
+          }),
+          {},
+        ),
       ),
-    )
-  }, [columns, rows])
+    [columns, rows],
+  )
 
   if (!data.length) return <Empty />
 

--- a/catalog/app/containers/Bucket/Queries/requests/athena.ts
+++ b/catalog/app/containers/Bucket/Queries/requests/athena.ts
@@ -374,8 +374,9 @@ async function fetchQueryResults({
           type: Type,
         }),
       ) || emptyColumns
+    const isHeadColumns = columns.every(({ name }, index) => name === rows[0][index])
     return {
-      rows,
+      rows: isHeadColumns ? rows.slice(1) : rows,
       columns,
       next: queryResultsOutput.NextToken,
       queryExecution,

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -32,6 +32,7 @@
 * [Added] `status_reports` lambda ([#2989](https://github.com/quiltdata/quilt/pull/2989), [#3088](https://github.com/quiltdata/quilt/pull/3088))
 * [Added] Stack Status Admin UI: reports ([#3068](https://github.com/quiltdata/quilt/pull/3068))
 * [Added] Edit button for text files in packages ([#3070](https://github.com/quiltdata/quilt/pull/3070))
+* [Added] Add execution context for Athena query execution ([#3062](https://github.com/quiltdata/quilt/pull/3062))
 * [Fixed] Fix package creation in S3 buckets with SSE-KMS enabled ([#2754](https://github.com/quiltdata/quilt/pull/2754))
 * [Fixed] Fix creation of packages with large (4+ GiB) files ([#2933](https://github.com/quiltdata/quilt/pull/2933))
 * [Fixed] Fix pre-popullation of default dates when using "dateformat" + {"format": "date"} ([3082](https://github.com/quiltdata/quilt/pull/3082))
@@ -42,6 +43,7 @@
 * [Changed] Rework package indexing: now package indexes have documents only for current versions of package pointer objects, documents for 'latest' pointers have `package_hash`, `package_stats`, `comment`, `metadata` fields properly populated ([#2897](https://github.com/quiltdata/quilt/pull/2897))
 * [Changed] Remove ClientRequestToken (idempotency token) for making Athena queries ([#2992](https://github.com/quiltdata/quilt/pull/2992))
 * [Changed] Fixed config and docs mistyping: `ui.athena.defaultWorkflow` should be `ui.athena.defaultWorkgroup` ([#3067](https://github.com/quiltdata/quilt/pull/3067))
+* [Changed] Use dedicated columns field instead of first row, fix duplicated first row in table results ([#3101](https://github.com/quiltdata/quilt/pull/3101))
 
 ## Docs
 * [Added] Fix four-deep headers so auto-link generation works ([#3100](https://github.com/quiltdata/quilt/pull/3100))


### PR DESCRIPTION
Practically found that first row have column names always, but didn't find that in documentation or on StackOverflow (only questions on how to skip first row when **create** table)
* So, I check if first row have column names, then skip. I have dedicated columns field already
* Replaced use of first row for checking if table have package manifest with use of columns