### PR TITLE
Hide actions buttons (push, revise etc.) on open.quiltdata.com

### DIFF
--- a/catalog/app/utils/BucketPreferences/OpenProvider.tsx
+++ b/catalog/app/utils/BucketPreferences/OpenProvider.tsx
@@ -1,0 +1,27 @@
+import * as React from 'react'
+
+import * as Sentry from 'utils/Sentry'
+
+import { BucketPreferences, extendDefaults } from './BucketPreferences'
+
+const openModePreferences = {
+  ui: {
+    actions: {
+      copyPackage: false,
+      createPackage: false,
+      deleteRevision: false,
+      revisePackage: false,
+    },
+  },
+}
+
+interface OpenProviderProps {
+  context: React.Context<BucketPreferences | null>
+  children: React.ReactNode
+}
+
+export default function OpenProvider({ context: Ctx, children }: OpenProviderProps) {
+  const sentry = Sentry.use()
+  const value = React.useMemo(() => extendDefaults(openModePreferences, sentry), [sentry])
+  return <Ctx.Provider value={value}>{children}</Ctx.Provider>
+}

--- a/catalog/app/utils/BucketPreferences/Provider.tsx
+++ b/catalog/app/utils/BucketPreferences/Provider.tsx
@@ -11,6 +11,7 @@ import * as requests from 'containers/Bucket/requests'
 
 import { BucketPreferences, SentryInstance, parse } from './BucketPreferences'
 import LocalProvider from './LocalProvider'
+import OpenProvider from './OpenProvider'
 
 const BUCKET_PREFERENCES_PATH = [
   '.quilt/catalog/config.yaml',
@@ -75,6 +76,8 @@ export function Provider({ bucket, children }: ProviderProps) {
   const cfg = Config.use()
   const local = cfg.mode === 'LOCAL'
   if (local) return <LocalProvider context={Ctx}>{children}</LocalProvider>
+  const open = cfg.mode === 'OPEN'
+  if (open) return <OpenProvider context={Ctx}>{children}</OpenProvider>
 
   return <CatalogProvider bucket={bucket}>{children}</CatalogProvider>
 }


### PR DESCRIPTION
Package creation on open.quiltdata.com doesn't work. It's implied users push packages using `quilt3`