### PR TITLE
Quilt config editor tooltips

### DIFF
--- a/catalog/app/components/JsonEditor/Note.tsx
+++ b/catalog/app/components/JsonEditor/Note.tsx
@@ -29,7 +29,7 @@ function getExamples(examples: JsonValue[]) {
   if (examples.length > 1) return ['Examples:', ...examples]
   const example = examples[0]
   if (typeof example === 'object') return ['Example:', example]
-  return [`Example: ${example}`]
+  return [`Example: ${printObject(example)}`]
 }
 
 function getTypeHelps({ errors, humanReadableSchema, mismatch, schema }: TypeHelpArgs) {

--- a/catalog/app/components/JsonEditor/Note.tsx
+++ b/catalog/app/components/JsonEditor/Note.tsx
@@ -7,6 +7,7 @@ import {
   doesTypeMatchSchema,
   schemaTypeToHumanString,
 } from 'utils/json-schema'
+import { printObject } from 'utils/string'
 
 import {
   JsonValue,
@@ -40,6 +41,14 @@ function getTypeHelps({ errors, humanReadableSchema, mismatch, schema }: TypeHel
 
   if (schema?.description) {
     output.push([`Description: ${schema.description}`])
+  }
+
+  if (schema?.examples && schema.examples.length) {
+    output.push(
+      schema.examples.length > 1
+        ? ['Examples:', ...schema.examples.map(printObject)]
+        : [`Example: ${printObject(schema.examples[0])}`],
+    )
   }
 
   return output

--- a/catalog/app/components/JsonEditor/Note.tsx
+++ b/catalog/app/components/JsonEditor/Note.tsx
@@ -25,6 +25,13 @@ interface TypeHelpArgs {
   schema?: JsonSchema
 }
 
+function getExamples(examples: JsonValue[]) {
+  if (examples.length > 1) return ['Examples:', ...examples]
+  const example = examples[0]
+  if (typeof example === 'object') return ['Example:', example]
+  return [`Example: ${example}`]
+}
+
 function getTypeHelps({ errors, humanReadableSchema, mismatch, schema }: TypeHelpArgs) {
   const output: string[][] = []
 
@@ -45,11 +52,7 @@ function getTypeHelps({ errors, humanReadableSchema, mismatch, schema }: TypeHel
   }
 
   if (schema?.examples && schema.examples.length) {
-    output.push(
-      schema.examples.length > 1
-        ? ['Examples:', ...schema.examples.map(printObject)]
-        : [`Example: ${printObject(schema.examples[0])}`],
-    )
+    output.push(getExamples(schema.examples))
   }
 
   return output
@@ -75,9 +78,14 @@ function TypeHelp({ typeHelps: groups }: TypeHelpProps) {
     <div>
       {groups.map((group, i) => (
         <div className={classes.group} key={`typeHelp_group_${i}`}>
-          {group.map((typeHelp, j) => (
-            <p key={`typeHelp_${i}_${j}`}>{typeHelp}</p>
-          ))}
+          {group.map((typeHelp, j) => {
+            const key = `typeHelp_${i}_${j}`
+            return typeof typeHelp === 'string' ? (
+              <p key={key}>{typeHelp}</p>
+            ) : (
+              <pre key={key}>{printObject(typeHelp)}</pre>
+            )
+          })}
         </div>
       ))}
     </div>

--- a/catalog/app/components/JsonEditor/Note.tsx
+++ b/catalog/app/components/JsonEditor/Note.tsx
@@ -2,6 +2,7 @@ import cx from 'classnames'
 import * as React from 'react'
 import * as M from '@material-ui/core'
 
+import StyledTooltip from 'utils/StyledTooltip'
 import {
   JsonSchema,
   doesTypeMatchSchema,
@@ -57,7 +58,7 @@ function getTypeHelps({ errors, humanReadableSchema, mismatch, schema }: TypeHel
 const useTypeHelpStyles = M.makeStyles((t) => ({
   group: {
     '& + &': {
-      borderTop: `1px solid ${t.palette.common.white}`,
+      borderTop: `1px solid ${t.palette.divider}`,
       marginTop: t.spacing(1),
       paddingTop: t.spacing(1),
     },
@@ -117,7 +118,7 @@ function NoteValue({ errors, schema, value }: NoteValueProps) {
   if (!typeHelps.length) return null
 
   return (
-    <M.Tooltip title={<TypeHelp typeHelps={typeHelps} />}>
+    <StyledTooltip title={<TypeHelp typeHelps={typeHelps} />}>
       <span
         className={cx(classes.default, {
           [classes.mismatch]: mismatch,
@@ -125,7 +126,7 @@ function NoteValue({ errors, schema, value }: NoteValueProps) {
       >
         {<M.Icon>info_outlined</M.Icon>}
       </span>
-    </M.Tooltip>
+    </StyledTooltip>
   )
 }
 

--- a/catalog/app/components/JsonEditor/Note.tsx
+++ b/catalog/app/components/JsonEditor/Note.tsx
@@ -2,6 +2,7 @@ import cx from 'classnames'
 import * as React from 'react'
 import * as M from '@material-ui/core'
 
+import Code from 'components/Code'
 import StyledTooltip from 'utils/StyledTooltip'
 import {
   JsonSchema,
@@ -26,14 +27,16 @@ interface TypeHelpArgs {
 }
 
 function getExamples(examples: JsonValue[]) {
-  if (examples.length > 1) return ['Examples:', ...examples]
-  const example = examples[0]
-  if (typeof example === 'object') return ['Example:', example]
-  return [`Example: ${printObject(example)}`]
+  if (examples.length > 1)
+    return [
+      'Examples:',
+      ...examples.map((example) => <Code>{printObject(example)}</Code>),
+    ]
+  return ['Example:', <Code>{printObject(examples[0])}</Code>]
 }
 
 function getTypeHelps({ errors, humanReadableSchema, mismatch, schema }: TypeHelpArgs) {
-  const output: string[][] = []
+  const output: React.ReactNode[][] = []
 
   if (errors.length) {
     output.push(errors.filter(Boolean).map(({ message }) => message) as string[])
@@ -66,10 +69,13 @@ const useTypeHelpStyles = M.makeStyles((t) => ({
       paddingTop: t.spacing(1),
     },
   },
+  item: {
+    margin: t.spacing(0.5, 0, 0),
+  },
 }))
 
 interface TypeHelpProps {
-  typeHelps: string[][]
+  typeHelps: React.ReactNode[][]
 }
 
 function TypeHelp({ typeHelps: groups }: TypeHelpProps) {
@@ -78,14 +84,11 @@ function TypeHelp({ typeHelps: groups }: TypeHelpProps) {
     <div>
       {groups.map((group, i) => (
         <div className={classes.group} key={`typeHelp_group_${i}`}>
-          {group.map((typeHelp, j) => {
-            const key = `typeHelp_${i}_${j}`
-            return typeof typeHelp === 'string' ? (
-              <p key={key}>{typeHelp}</p>
-            ) : (
-              <pre key={key}>{printObject(typeHelp)}</pre>
-            )
-          })}
+          {group.map((typeHelp, j) => (
+            <p className={classes.item} key={`typeHelp_${i}_${j}`}>
+              {typeHelp}
+            </p>
+          ))}
         </div>
       ))}
     </div>

--- a/catalog/app/utils/StyledTooltip.tsx
+++ b/catalog/app/utils/StyledTooltip.tsx
@@ -1,0 +1,19 @@
+import * as React from 'react'
+import * as M from '@material-ui/core'
+
+const useStyles = M.makeStyles((t) => ({
+  tooltip: {
+    ...t.typography.body1,
+    backgroundColor: t.palette.common.white,
+    border: `1px solid ${t.palette.divider}`,
+    boxShadow: t.shadows[8],
+    color: t.palette.text.primary,
+    maxWidth: t.spacing(30),
+    padding: t.spacing(1),
+  },
+}))
+
+export default function StyledTooltip(props: M.TooltipProps) {
+  const classes = useStyles()
+  return <M.Tooltip classes={classes} {...props} />
+}

--- a/shared/schemas/bucketConfig.yml.json
+++ b/shared/schemas/bucketConfig.yml.json
@@ -4,12 +4,15 @@
   "type": "object",
   "properties": {
     "version": {
-      "const": "1"
+      "const": "1",
+      "examples": ["1"]
     },
     "ui": {
       "type": "object",
+      "description": "Namespace for UI related features",
       "properties": {
         "nav": {
+          "description": "Hide and show bucket tabs",
           "type": "object",
           "properties": {
             "files": {
@@ -31,6 +34,7 @@
         },
         "actions": {
           "type": "object",
+          "description": "Hide and show action buttons",
           "properties": {
             "createPackage": {
               "default": true,
@@ -55,6 +59,7 @@
           }
         },
         "blocks": {
+          "description": "Hide and show UI blocks in package detail page",
           "type": "object",
           "properties": {
             "analytics": {

--- a/shared/schemas/bucketConfig.yml.json
+++ b/shared/schemas/bucketConfig.yml.json
@@ -18,17 +18,20 @@
             "files": {
               "default": true,
               "description": "Hides Files tab",
-              "type": "boolean"
+              "type": "boolean",
+              "examples": [true, false]
             },
             "packages": {
               "default": true,
               "description": "Hides Packages tab",
-              "type": "boolean"
+              "type": "boolean",
+              "examples": [true, false]
             },
             "queries": {
               "default": true,
               "description": "Hides Queries tab",
-              "type": "boolean"
+              "type": "boolean",
+              "examples": [true, false]
             }
           }
         },
@@ -39,22 +42,26 @@
             "createPackage": {
               "default": true,
               "description": "Hides buttons triggering Create Package dialog, both creating package from scratch and from directory",
-              "type": "boolean"
+              "type": "boolean",
+              "examples": [true, false]
             },
             "deleteRevision": {
               "default": true,
               "description": "Hides buttons triggering Delete Package Revision dialog",
-              "type": "boolean"
+              "type": "boolean",
+              "examples": [true, false]
             },
             "revisePackage": {
               "default": true,
               "description": "Hides button triggering Revise Package dialog",
-              "type": "boolean"
+              "type": "boolean",
+              "examples": [true, false]
             },
             "copyPackage": {
               "default": true,
               "description": "Hides button triggering Push to Bucket dialog",
-              "type": "boolean"
+              "type": "boolean",
+              "examples": [true, false]
             }
           }
         },
@@ -65,22 +72,26 @@
             "analytics": {
               "default": true,
               "description": "Show/hide analytics block",
-              "type": "boolean"
+              "type": "boolean",
+              "examples": [true, false]
             },
             "browser": {
               "default": true,
               "description": "Show/hide file browser block",
-              "type": "boolean"
+              "type": "boolean",
+              "examples": [true, false]
             },
             "code": {
               "default": true,
               "description": "Show/hide code block",
-              "type": "boolean"
+              "type": "boolean",
+              "examples": [true, false]
             },
             "meta": {
               "default": true,
               "description": "Show/hide metadata block",
-              "type": "boolean"
+              "type": "boolean",
+              "examples": [true, false]
             }
           }
         },
@@ -97,17 +108,30 @@
             "properties": {
               "message": {
                 "type": "boolean",
-                "description": "Whether to show message or not"
+                "description": "Whether to show message or not",
+                "examples": [true, false]
               },
               "user_meta": {
                 "type": "array",
                 "items": {
                   "type": "string",
-                  "description": "JSONPath to string or array of strings inside user_meta"
+                  "description": "JSONPath to string or array of strings inside user_meta",
+                  "examples": ["$.key", "$.metaKeyParent.metaKeyChild"]
                 }
               }
             }
-          }
+          },
+          "examples": [
+            {
+              "*": {
+                "message": true
+              },
+              "foo/bar": {
+                "message": false,
+                "user_meta": "$.metaKeyParent.metaKeyChild"
+              }
+            }
+          ]
         },
         "sourceBuckets": {
           "type": "object",

--- a/shared/schemas/workflows-config-1.1.0.json
+++ b/shared/schemas/workflows-config-1.1.0.json
@@ -34,16 +34,19 @@
         {
           "$ref": "#/definitions/CompoundVersion"
         }
-      ]
+      ],
+      "examples": ["1.0", { "base": "1", "catalog": "1" }]
     },
     "is_workflow_required": {
       "type": "boolean",
       "description": "If true, users must succeed a workflow in order to push. If false, users may skip workflows altogether.",
-      "default": true
+      "default": true,
+      "examples": [true, false]
     },
     "default_workflow": {
       "type": "string",
-      "description": "The workflow to use if the user doesn't specify a workflow."
+      "description": "The workflow to use if the user doesn't specify a workflow.",
+      "examples": ["foobar"]
     },
     "workflows": {
       "type": "object",
@@ -91,12 +94,30 @@
             "default": false
           }
         }
-      }
+      },
+      "examples": [
+        {
+          "workflowA": {
+            "name": "Workflow A",
+            "metadata_schema": "schemaA"
+          }
+        }
+      ]
     },
     "schemas": {
       "type": "object",
       "description": "JSON Schemas for validating user-supplied metadata and/or package entries.",
       "minProperties": 1,
+      "examples": [
+        {
+          "schemaA": {
+            "url": "s3://foo/bar/.quilt/workflows/schema-a.json"
+          },
+          "schemaB": {
+            "url": "s3://foo/bar/.quilt/workflows/schema-a.json"
+          }
+        }
+      ],
       "additionalProperties": {
         "type": "object",
         "required": ["url"],

--- a/shared/schemas/workflows-config-1.1.0.json
+++ b/shared/schemas/workflows-config-1.1.0.json
@@ -45,7 +45,7 @@
     },
     "default_workflow": {
       "type": "string",
-      "description": "The workflow to use if the user doesn't specify a workflow.",
+      "description": "The workflow to use if the user doesn't specify any.",
       "examples": ["foobar"]
     },
     "workflows": {


### PR DESCRIPTION
* Make tooltips more readable and consistent with the rest of UI
* Show JSON Schema examples in tooltip
* Add `description` and `examples` to config Schemas

![Screenshot from 2022-10-13 13-28-03](https://user-images.githubusercontent.com/533229/195573296-f030c301-81db-4774-8398-21d90b968cfb.png)
![Screenshot from 2022-10-13 13-28-21](https://user-images.githubusercontent.com/533229/195573305-c3475774-b57d-4fd7-81ca-8a13b7382b1c.png)


- [ ] [Changelog](CHANGELOG.md) entry
