### PR TITLE
S3 proxy: Use path-style requests for buckets containing dots

### DIFF
--- a/s3-proxy/nginx.conf
+++ b/s3-proxy/nginx.conf
@@ -49,15 +49,24 @@ http {
                 return 200;
             }
 
-            set $s3_host '$s3_bucket.s3.$s3_region.amazonaws.com';
+            # Add a region if it's not "-".
+            set $s3_host_suffix 's3.$s3_region.amazonaws.com';
             if ($s3_region = '-') {
-                set $s3_host '$s3_bucket.s3.amazonaws.com';
+                set $s3_host_suffix 's3.amazonaws.com';
             }
 
-            # Proxy everything else to S3.
+            # Use virtual hosts by default, but path-style for buckets with dots.
+            set $s3_host '$s3_bucket.$s3_host_suffix';
+            set $s3_path_prefix '';
+            if ($s3_bucket ~ "\.") {
+                set $s3_host '$s3_host_suffix';
+                set $s3_path_prefix '$s3_bucket/';
+            }
+
+            # Proxy the request to S3.
             # Use $request_uri rather than $s3_path because it needs to stay encoded.
             if ($request_uri ~ "^/[^/?]+/[^/?]+/?(.*)") {
-                proxy_pass 'https://$s3_host/$1';
+                proxy_pass 'https://$s3_host/$s3_path_prefix$1';
             }
 
             # Remove any existing CORS headers from the response to avoid duplicates.


### PR DESCRIPTION
Virtual host style does not support dots because sub-subdomains are not allowed by wildcard SSL certificates. The AWS console uses path-style in those cases, so let's do the same thing in the S3 proxy.