### PR TITLE
S3 Proxy: fix support for buckets with dots

### DIFF
--- a/s3-proxy/docker-compose.yml
+++ b/s3-proxy/docker-compose.yml
@@ -1,0 +1,8 @@
+services:
+  s3proxy:
+    build: .
+    environment:
+      - REGISTRY_HOST
+      - INTERNAL_REGISTRY_URL
+    ports:
+      - "5002:80"

--- a/s3-proxy/nginx.conf
+++ b/s3-proxy/nginx.conf
@@ -60,13 +60,29 @@ http {
             set $s3_path_prefix '';
             if ($s3_bucket ~ "\.") {
                 set $s3_host '$s3_host_suffix';
-                set $s3_path_prefix '$s3_bucket/';
+                set $s3_path_prefix '$s3_bucket';
+            }
+
+            set $s3_path_suffix '';
+            # Use $request_uri rather than $s3_path because it needs to stay encoded.
+            if ($request_uri ~ "^/[^/?]+/[^/?]+/?(.*)") {
+                set $s3_path_suffix "$1";
+            }
+
+            set $slash_needed '';
+            if ($s3_path_prefix) {
+                set $slash_needed '${slash_needed}1';
+            }
+            if ($s3_path_suffix ~ '^[^?]+') {
+                set $slash_needed '${slash_needed}1';
+            }
+            if ($slash_needed = '11') {
+                set $s3_path_prefix '$s3_path_prefix/';
             }
 
             # Proxy the request to S3.
-            # Use $request_uri rather than $s3_path because it needs to stay encoded.
-            if ($request_uri ~ "^/[^/?]+/[^/?]+/?(.*)") {
-                proxy_pass 'https://$s3_host/$s3_path_prefix$1';
+            if ($s3_path_suffix) {
+                proxy_pass 'https://$s3_host/$s3_path_prefix$s3_path_suffix';
             }
 
             # Remove any existing CORS headers from the response to avoid duplicates.

--- a/s3-proxy/nginx.conf
+++ b/s3-proxy/nginx.conf
@@ -72,7 +72,7 @@ http {
             }
 
             # Don't add a slash if there's no more path segments
-            if ($s3_path_suffix !~ '^[^?]+') {
+            if ($s3_path_suffix !~ '^[^?]') {
                 set $s3_path_sep '';
             }
 

--- a/s3-proxy/nginx.conf
+++ b/s3-proxy/nginx.conf
@@ -58,9 +58,11 @@ http {
             # Use virtual hosts by default, but path-style for buckets with dots.
             set $s3_host '$s3_bucket.$s3_host_suffix';
             set $s3_path_prefix '';
+            set $s3_path_sep '';
             if ($s3_bucket ~ "\.") {
                 set $s3_host '$s3_host_suffix';
                 set $s3_path_prefix '$s3_bucket';
+                set $s3_path_sep '/';
             }
 
             set $s3_path_suffix '';
@@ -69,21 +71,15 @@ http {
                 set $s3_path_suffix "$1";
             }
 
-            set $slash_needed '';
-            if ($s3_path_prefix) {
-                set $slash_needed '${slash_needed}1';
-            }
-            if ($s3_path_suffix ~ '^[^?]+') {
-                set $slash_needed '${slash_needed}1';
-            }
-            if ($slash_needed = '11') {
-                set $s3_path_prefix '$s3_path_prefix/';
+            # Don't add a slash if there's no more path segments
+            if ($s3_path_suffix !~ '^[^?]+') {
+                set $s3_path_sep '';
             }
 
+            set $s3_full_path '$s3_path_prefix$s3_path_sep$s3_path_suffix';
+
             # Proxy the request to S3.
-            if ($s3_path_suffix) {
-                proxy_pass 'https://$s3_host/$s3_path_prefix$s3_path_suffix';
-            }
+            proxy_pass 'https://$s3_host/$s3_full_path';
 
             # Remove any existing CORS headers from the response to avoid duplicates.
             proxy_hide_header 'Access-Control-Allow-Headers';


### PR DESCRIPTION
Add slash after the bucket name conditionally (only when there's more path segments after it), so that the operations on the bucket itself (head bucket, list objects in the root) don't lead to signature mismatch errors.