### PR TITLE
Fix URL encoding in s3 proxy

### DIFF
--- a/s3-proxy/nginx.conf
+++ b/s3-proxy/nginx.conf
@@ -65,21 +65,16 @@ http {
                 set $s3_path_sep '/';
             }
 
-            set $s3_path_suffix '';
-            # Use $request_uri rather than $s3_path because it needs to stay encoded.
-            if ($request_uri ~ "^/[^/?]+/[^/?]+/?(.*)") {
-                set $s3_path_suffix "$1";
-            }
-
             # Don't add a slash if there's no more path segments
-            if ($s3_path_suffix !~ '^[^?]') {
+            if ($s3_path = '') {
                 set $s3_path_sep '';
             }
 
-            set $s3_full_path '$s3_path_prefix$s3_path_sep$s3_path_suffix';
-
-            # Proxy the request to S3.
-            proxy_pass 'https://$s3_host/$s3_full_path';
+            # Proxy the request to S3. It *MUST* be done inside an "if", using "$1" -
+            # calling "set" causes the URL to be decoded, breaking paths with spaces, etc.
+            if ($request_uri ~ "^/[^/?]+/[^/?]+/?(.*)") {
+                proxy_pass 'https://$s3_host/$s3_path_prefix$s3_path_sep$1';
+            }
 
             # Remove any existing CORS headers from the response to avoid duplicates.
             proxy_hide_header 'Access-Control-Allow-Headers';


### PR DESCRIPTION
Using "set" causes the URL to be decoded - likely an Nginx bug. We have to use "$1" immediately, without storing it in a variable.

We already have an "s3_path" variable we can use for the "/" logic, though, so that makes it simpler.