### PR TITLE
s3-proxy: return the original Content-Length in a custom header

### DIFF
--- a/s3-proxy/nginx.conf
+++ b/s3-proxy/nginx.conf
@@ -42,7 +42,11 @@ http {
             add_header 'Access-Control-Allow-Methods' $http_access_control_request_method always;
             add_header 'Access-Control-Allow-Origin' '*' always;
             add_header 'Access-Control-Max-Age' '3000' always;
-            add_header 'Access-Control-Expose-Headers' 'Content-Length, Content-Range, ETag, x-amz-meta-helium, x-amz-bucket-region, x-amz-delete-marker, x-amz-request-id, x-amz-version-id, x-amz-storage-class' always;
+            add_header 'Access-Control-Expose-Headers' 'Content-Length, Content-Range, ETag, x-amz-meta-helium, x-amz-bucket-region, x-amz-delete-marker, x-amz-request-id, x-amz-version-id, x-amz-storage-class, x-quilt-size' always;
+
+            # When compression is used, the original Content-Length header gets removed.
+            # The original file size may still be useful, so return it in a custom header.
+            add_header 'x-quilt-size' $upstream_http_content_length;
 
             # Return success on OPTIONS.
             if ($request_method = 'OPTIONS') {


### PR DESCRIPTION
When compression is used, the Content-Length header gets removed. The original file size can still be useful for e.g. the catalog, so return it in a custom header.