### PR TITLE
Split .sdf files containing multiple molecules

### DIFF
--- a/catalog/app/components/Preview/loaders/Ngl.spec.ts
+++ b/catalog/app/components/Preview/loaders/Ngl.spec.ts
@@ -3,8 +3,7 @@ import { parseResponse } from './Ngl'
 const fileA = `fileA.sdf
 Molecule A description
 
-1 2 3 4 V2000
-`
+1 2 3 4 V2000`
 
 const fileB = `fileB.sdf
 Molecule B description
@@ -12,8 +11,7 @@ Molecule B description
 0 0 0 0 0 999 V3000
 M V30 BEGIN CTAB
 M V30 END CTAB
-M END
-`
+M END`
 
 const fileBConverted = `
 Actelion Java MolfileCreator 1.0
@@ -25,8 +23,7 @@ M  END
 const fileC = `fileC.sdf
 Molecule C description
 
-1 2 3 4 V2000
-`
+1 2 3 4 V2000`
 
 const compoundFile = `${fileA}
 $$$$
@@ -42,7 +39,7 @@ describe('components/Preview/loaders/Ngl', () => {
     it('parses single file', async () => {
       const result = [
         {
-          file: `${fileA}$$$$\n`,
+          file: fileA,
           ext: 'sdf',
         },
       ]
@@ -50,21 +47,24 @@ describe('components/Preview/loaders/Ngl', () => {
         result,
       )
       expect(
+        await parseResponse(`${fileA}\n$$$$\n`, { bucket: '', key: 'fileA.sdf' }),
+      ).toMatchObject(result)
+      expect(
         await parseResponse(Buffer.from(fileA), { bucket: '', key: 'fileA.sdf' }),
       ).toMatchObject(result)
     })
     it('parses multiple files', async () => {
       const result = [
         {
-          file: `${fileA}$$$$\n`,
+          file: fileA,
           ext: 'sdf',
         },
         {
-          file: `${fileBConverted}`,
+          file: fileBConverted,
           ext: 'mol',
         },
         {
-          file: `${fileC}$$$$\n`,
+          file: fileC,
           ext: 'sdf',
         },
       ]

--- a/catalog/app/components/Preview/loaders/Ngl.spec.ts
+++ b/catalog/app/components/Preview/loaders/Ngl.spec.ts
@@ -1,0 +1,82 @@
+import { parseResponse } from './Ngl'
+
+const fileA = `fileA.sdf
+Molecule A description
+
+1 2 3 4 V2000
+`
+
+const fileB = `fileB.sdf
+Molecule B description
+
+0 0 0 0 0 999 V3000
+M V30 BEGIN CTAB
+M V30 END CTAB
+M END
+`
+
+const fileBConverted = `
+Actelion Java MolfileCreator 1.0
+
+  0  0  0  0  0  0  0  0  0  0999 V2000
+M  END
+`
+
+const fileC = `fileC.sdf
+Molecule C description
+
+1 2 3 4 V2000
+`
+
+const compoundFile = `${fileA}
+$$$$
+
+${fileB}
+
+$$$$
+${fileC}
+$$$$`
+
+describe('components/Preview/loaders/Ngl', () => {
+  describe('parseResponse', () => {
+    it('parses single file', async () => {
+      const result = [
+        {
+          file: `${fileA}$$$$\n`,
+          ext: 'sdf',
+        },
+      ]
+      expect(await parseResponse(fileA, { bucket: '', key: 'fileA.sdf' })).toMatchObject(
+        result,
+      )
+      expect(
+        await parseResponse(Buffer.from(fileA), { bucket: '', key: 'fileA.sdf' }),
+      ).toMatchObject(result)
+    })
+    it('parses multiple files', async () => {
+      const result = [
+        {
+          file: `${fileA}$$$$\n`,
+          ext: 'sdf',
+        },
+        {
+          file: `${fileBConverted}`,
+          ext: 'mol',
+        },
+        {
+          file: `${fileC}$$$$\n`,
+          ext: 'sdf',
+        },
+      ]
+      expect(
+        await parseResponse(compoundFile, { bucket: '', key: 'fileCompound.sdf' }),
+      ).toMatchObject(result)
+      expect(
+        await parseResponse(Buffer.from(compoundFile), {
+          bucket: '',
+          key: 'fileCompound.sdf',
+        }),
+      ).toMatchObject(result)
+    })
+  })
+})

--- a/catalog/app/components/Preview/loaders/Ngl.tsx
+++ b/catalog/app/components/Preview/loaders/Ngl.tsx
@@ -32,21 +32,26 @@ export async function parseResponse(
   handle: S3HandleBase,
 ): Promise<{ file: ResponseFile; ext: string }[]> {
   const ext = extname(utils.stripCompression(handle.key)).substring(1)
-  if (ext !== 'sdf' && ext !== 'mol' && ext !== 'mol2')
-    return [
-      {
-        ext,
-        file,
-      },
-    ]
-  return Promise.all(
-    file
-      .toString()
-      .split('$$$$')
-      .map((x) => x.trim())
-      .filter(Boolean)
-      .map((part) => parseMol(part, ext)),
-  )
+  switch (ext) {
+    case 'sdf':
+    case 'mol':
+    case 'mol2':
+      return Promise.all(
+        file
+          .toString()
+          .split('$$$$')
+          .map((x) => x.trim())
+          .filter(Boolean)
+          .map((part) => parseMol(part, ext)),
+      )
+    default:
+      return [
+        {
+          ext,
+          file,
+        },
+      ]
+  }
 }
 
 export const detect = R.pipe(

--- a/catalog/app/components/Preview/loaders/Ngl.tsx
+++ b/catalog/app/components/Preview/loaders/Ngl.tsx
@@ -27,7 +27,7 @@ async function parseMol(
   }
 }
 
-async function parseResponse(
+export async function parseResponse(
   file: ResponseFile,
   handle: S3HandleBase,
 ): Promise<{ file: ResponseFile; ext: string }[]> {

--- a/catalog/app/components/Preview/loaders/Ngl.tsx
+++ b/catalog/app/components/Preview/loaders/Ngl.tsx
@@ -17,14 +17,13 @@ type ResponseFile = string | Uint8Array
 
 async function parseMol(
   content: string,
-  file: ResponseFile,
   ext: string,
 ): Promise<{ file: ResponseFile; ext: string }> {
-  // if (content.indexOf('V3000') === -1) return { ext, file: content }
+  if (content.indexOf('V3000') === -1) return { ext, file: content }
   const { Molecule } = await openchem
   return {
     ext: 'mol',
-    file: Molecule.fromMolfile(content).toMolfile(),
+    file: Molecule.fromMolfile(content.trim()).toMolfile(),
   }
 }
 
@@ -44,8 +43,9 @@ async function parseResponse(
     file
       .toString()
       .split('$$$$')
-      .filter((x) => !!x.trim())
-      .map((part) => parseMol(part + '$$$$', file, ext)),
+      .map((x) => x.trim())
+      .filter(Boolean)
+      .map((part) => parseMol(`${part}\n$$$$\n`, ext)),
   )
 }
 

--- a/catalog/app/components/Preview/loaders/Ngl.tsx
+++ b/catalog/app/components/Preview/loaders/Ngl.tsx
@@ -45,7 +45,7 @@ export async function parseResponse(
       .split('$$$$')
       .map((x) => x.trim())
       .filter(Boolean)
-      .map((part) => parseMol(`${part}\n$$$$\n`, ext)),
+      .map((part) => parseMol(part, ext)),
   )
 }
 

--- a/catalog/app/components/Preview/loaders/Ngl.tsx
+++ b/catalog/app/components/Preview/loaders/Ngl.tsx
@@ -9,23 +9,10 @@ import type { S3HandleBase } from 'utils/s3paths'
 
 import { PreviewData } from '../types'
 
+import mol from './formatters/mol'
 import * as utils from './utils'
 
-const openchem = import('openchemlib/minimal')
-
 type ResponseFile = string | Uint8Array
-
-async function parseMol(
-  content: string,
-  ext: string,
-): Promise<{ file: ResponseFile; ext: string }> {
-  if (content.indexOf('V3000') === -1) return { ext, file: content }
-  const { Molecule } = await openchem
-  return {
-    ext: 'mol',
-    file: Molecule.fromMolfile(content.trim()).toMolfile(),
-  }
-}
 
 export async function parseResponse(
   file: ResponseFile,
@@ -36,14 +23,7 @@ export async function parseResponse(
     case 'sdf':
     case 'mol':
     case 'mol2':
-      return Promise.all(
-        file
-          .toString()
-          .split('$$$$')
-          .map((x) => x.trim())
-          .filter(Boolean)
-          .map((part) => parseMol(part, ext)),
-      )
+      return mol(file, ext)
     default:
       return [
         {

--- a/catalog/app/components/Preview/loaders/formatters/mol.ts
+++ b/catalog/app/components/Preview/loaders/formatters/mol.ts
@@ -1,0 +1,29 @@
+const openchem = import('openchemlib/minimal')
+
+type ResponseFile = string | Uint8Array
+
+async function parseMolItem(
+  content: string,
+  ext: string,
+): Promise<{ file: ResponseFile; ext: string }> {
+  if (content.indexOf('V3000') === -1) return { ext, file: content }
+  const { Molecule } = await openchem
+  return {
+    ext: 'mol',
+    file: Molecule.fromMolfile(content.trim()).toMolfile(),
+  }
+}
+
+export default async function parseMol(
+  file: ResponseFile,
+  ext: string,
+): Promise<{ file: ResponseFile; ext: string }[]> {
+  return Promise.all(
+    file
+      .toString()
+      .split('$$$$')
+      .map((x) => x.trim())
+      .filter(Boolean)
+      .map((part) => parseMolItem(part, ext)),
+  )
+}

--- a/catalog/app/components/Preview/loaders/formatters/mol.ts
+++ b/catalog/app/components/Preview/loaders/formatters/mol.ts
@@ -2,22 +2,41 @@ const openchem = import('openchemlib/minimal')
 
 type ResponseFile = string | Uint8Array
 
-async function parseMolItem(
-  content: string,
-  ext: string,
-): Promise<{ file: ResponseFile; ext: string }> {
-  if (content.indexOf('V3000') === -1) return { ext, file: content }
+export interface MolMeta {
+  title: string
+  source: string
+  comment: string
+}
+
+interface Molecule {
+  file: string
+  ext: string
+  meta: MolMeta
+}
+
+const readLines = (x: string) => x.split('\n')
+
+function getMeta(content: string): MolMeta {
+  const [title, source, comment] = readLines(content)
+  return {
+    title,
+    source,
+    comment,
+  }
+}
+
+async function parseMolItem(content: string, ext: string): Promise<Molecule> {
+  const meta = getMeta(content)
+  if (content.indexOf('V3000') === -1) return { ext, file: content, meta }
   const { Molecule } = await openchem
   return {
     ext: 'mol',
     file: Molecule.fromMolfile(content.trim()).toMolfile(),
+    meta,
   }
 }
 
-export default async function parseMol(
-  file: ResponseFile,
-  ext: string,
-): Promise<{ file: ResponseFile; ext: string }[]> {
+export async function parse(file: ResponseFile, ext: string): Promise<Molecule[]> {
   return Promise.all(
     file
       .toString()

--- a/catalog/app/components/Preview/renderers/Ngl/Meta.tsx
+++ b/catalog/app/components/Preview/renderers/Ngl/Meta.tsx
@@ -17,7 +17,8 @@ interface MetaProps {
 export default function Meta({ meta }: MetaProps) {
   const classes = useStyles()
   const entries = React.useMemo(
-    () => Object.entries(meta).filter(([key, value]) => !!value),
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    () => Object.entries(meta).filter(([_1, value]) => !!value),
     [meta],
   )
   return (

--- a/catalog/app/components/Preview/renderers/Ngl/Meta.tsx
+++ b/catalog/app/components/Preview/renderers/Ngl/Meta.tsx
@@ -1,0 +1,37 @@
+import * as React from 'react'
+import * as M from '@material-ui/core'
+
+import { JsonRecord } from 'utils/types'
+
+const useStyles = M.makeStyles(() => ({
+  root: {
+    tableLayout: 'fixed',
+    width: 'auto',
+  },
+}))
+
+interface MetaProps {
+  meta: JsonRecord
+}
+
+export default function Meta({ meta }: MetaProps) {
+  const classes = useStyles()
+  const entries = React.useMemo(
+    () => Object.entries(meta).filter(([key, value]) => !!value),
+    [meta],
+  )
+  return (
+    <M.Table className={classes.root} size="small">
+      <M.TableBody>
+        {entries.map(([key, value]) => (
+          <M.TableRow key={key + value}>
+            <M.TableCell>
+              <strong>{key}:</strong>
+            </M.TableCell>
+            <M.TableCell>{value}</M.TableCell>
+          </M.TableRow>
+        ))}
+      </M.TableBody>
+    </M.Table>
+  )
+}

--- a/catalog/app/components/Preview/renderers/Ngl/Ngl.tsx
+++ b/catalog/app/components/Preview/renderers/Ngl/Ngl.tsx
@@ -27,10 +27,13 @@ const useStyles = M.makeStyles((t) => ({
   },
 }))
 
-export interface NglProps extends React.HTMLAttributes<HTMLDivElement> {
+export interface NglFile {
   blob: Blob
   ext: string
 }
+
+// type NglProps = NglFile & React.HTMLAttributes<HTMLDivElement>
+interface NglProps extends NglFile, React.HTMLAttributes<HTMLDivElement> {}
 
 export default function Ngl({ blob, ext, ...props }: NglProps) {
   const classes = useStyles()

--- a/catalog/app/components/Preview/renderers/Ngl/Ngl.tsx
+++ b/catalog/app/components/Preview/renderers/Ngl/Ngl.tsx
@@ -2,6 +2,10 @@ import * as React from 'react'
 import * as M from '@material-ui/core'
 import type { Stage } from 'ngl'
 
+import { JsonRecord } from 'utils/types'
+
+import Meta from './Meta'
+
 const NGLLibrary = import('ngl')
 
 async function renderNgl(blob: Blob, ext: string, wrapperEl: HTMLDivElement, t: M.Theme) {
@@ -20,6 +24,18 @@ async function renderNgl(blob: Blob, ext: string, wrapperEl: HTMLDivElement, t: 
 
 const useStyles = M.makeStyles((t) => ({
   root: {
+    position: 'relative',
+  },
+  meta: {
+    left: t.spacing(0),
+    opacity: 0.7,
+    position: 'absolute',
+    top: t.spacing(2),
+    '&:hover': {
+      opacity: 1,
+    },
+  },
+  wrapper: {
     height: t.spacing(50),
     overflow: 'auto',
     resize: 'vertical',
@@ -30,12 +46,14 @@ const useStyles = M.makeStyles((t) => ({
 export interface NglFile {
   blob: Blob
   ext: string
+  meta?: JsonRecord
 }
 
 // type NglProps = NglFile & React.HTMLAttributes<HTMLDivElement>
 interface NglProps extends NglFile, React.HTMLAttributes<HTMLDivElement> {}
 
-export default function Ngl({ blob, ext, ...props }: NglProps) {
+export default function Ngl({ blob, ext, meta, ...props }: NglProps) {
+  console.log('NGL', meta, JSON.stringify(meta))
   const classes = useStyles()
 
   const t = M.useTheme()
@@ -67,5 +85,14 @@ export default function Ngl({ blob, ext, ...props }: NglProps) {
 
   if (error) throw error
 
-  return <div ref={viewport} className={classes.root} {...props} />
+  return (
+    <div className={classes.root}>
+      <div ref={viewport} className={classes.wrapper} {...props} />
+      {!!meta && (
+        <M.Paper className={classes.meta}>
+          <Meta meta={meta} />
+        </M.Paper>
+      )}
+    </div>
+  )
 }

--- a/catalog/app/components/Preview/renderers/Ngl/Ngl.tsx
+++ b/catalog/app/components/Preview/renderers/Ngl/Ngl.tsx
@@ -1,3 +1,4 @@
+import cx from 'classnames'
 import * as React from 'react'
 import * as M from '@material-ui/core'
 import type { Stage } from 'ngl'
@@ -49,10 +50,11 @@ export interface NglFile {
   meta?: JsonRecord
 }
 
-// type NglProps = NglFile & React.HTMLAttributes<HTMLDivElement>
-interface NglProps extends NglFile, React.HTMLAttributes<HTMLDivElement> {}
+export interface NglProps extends NglFile {
+  className: string
+}
 
-export default function Ngl({ blob, ext, meta, ...props }: NglProps) {
+export default function Ngl({ blob, className, ext, meta }: NglProps) {
   const classes = useStyles()
 
   const t = M.useTheme()
@@ -85,8 +87,8 @@ export default function Ngl({ blob, ext, meta, ...props }: NglProps) {
   if (error) throw error
 
   return (
-    <div className={classes.root}>
-      <div ref={viewport} className={classes.wrapper} {...props} />
+    <div className={cx(classes.root, className)}>
+      <div ref={viewport} className={classes.wrapper} />
       {!!meta && (
         <M.Paper className={classes.meta}>
           <Meta meta={meta} />

--- a/catalog/app/components/Preview/renderers/Ngl/Ngl.tsx
+++ b/catalog/app/components/Preview/renderers/Ngl/Ngl.tsx
@@ -53,7 +53,6 @@ export interface NglFile {
 interface NglProps extends NglFile, React.HTMLAttributes<HTMLDivElement> {}
 
 export default function Ngl({ blob, ext, meta, ...props }: NglProps) {
-  console.log('NGL', meta, JSON.stringify(meta))
   const classes = useStyles()
 
   const t = M.useTheme()

--- a/catalog/app/components/Preview/renderers/Ngl/index.tsx
+++ b/catalog/app/components/Preview/renderers/Ngl/index.tsx
@@ -18,13 +18,25 @@ const SuspensePlaceholder = () => <Placeholder color="text.secondary" />
 
 const Ngl = RT.mkLazy(() => import('./Ngl'), SuspensePlaceholder)
 
-export default (
+const useStyles = M.makeStyles({
+  root: {
+    flexDirection: 'column',
+    width: '100%',
+  },
+})
+
+export default function NglWrapper(
   data: { files: NglFile[] },
   props: React.HTMLAttributes<HTMLDivElement>,
-) => (
-  <ErrorBoundary>
-    {data.files.map((file, index) => (
-      <Ngl key={`nlg_${index}`} {...file} {...props} />
-    ))}
-  </ErrorBoundary>
-)
+) {
+  const classes = useStyles()
+  return (
+    <ErrorBoundary>
+      <div className={classes.root}>
+        {data.files.map((file, index) => (
+          <Ngl key={`nlg_${index}`} {...file} {...props} />
+        ))}
+      </div>
+    </ErrorBoundary>
+  )
+}

--- a/catalog/app/components/Preview/renderers/Ngl/index.tsx
+++ b/catalog/app/components/Preview/renderers/Ngl/index.tsx
@@ -18,12 +18,17 @@ const SuspensePlaceholder = () => <Placeholder color="text.secondary" />
 
 const Ngl = RT.mkLazy(() => import('./Ngl'), SuspensePlaceholder)
 
-const useStyles = M.makeStyles({
+const useStyles = M.makeStyles((t) => ({
   root: {
     flexDirection: 'column',
     width: '100%',
+    '& > div+div': {
+      borderTop: `1px solid ${t.palette.divider}`,
+      marginTop: t.spacing(2),
+      paddingTop: t.spacing(2),
+    },
   },
-})
+}))
 
 function Wrapper({ children }: React.PropsWithChildren<{}>) {
   const classes = useStyles()

--- a/catalog/app/components/Preview/renderers/Ngl/index.tsx
+++ b/catalog/app/components/Preview/renderers/Ngl/index.tsx
@@ -25,18 +25,22 @@ const useStyles = M.makeStyles({
   },
 })
 
+function Wrapper({ children }: React.PropsWithChildren<{}>) {
+  const classes = useStyles()
+  return <div className={classes.root}>{children}</div>
+}
+
 export default function NglWrapper(
   data: { files: NglFile[] },
   props: React.HTMLAttributes<HTMLDivElement>,
 ) {
-  const classes = useStyles()
   return (
     <ErrorBoundary>
-      <div className={classes.root}>
+      <Wrapper>
         {data.files.map((file, index) => (
           <Ngl key={`nlg_${index}`} {...file} {...props} />
         ))}
-      </div>
+      </Wrapper>
     </ErrorBoundary>
   )
 }

--- a/catalog/app/components/Preview/renderers/Ngl/index.tsx
+++ b/catalog/app/components/Preview/renderers/Ngl/index.tsx
@@ -5,7 +5,7 @@ import { createBoundary } from 'utils/ErrorBoundary'
 import Placeholder from 'components/Placeholder'
 import * as RT from 'utils/reactTools'
 
-import type { NglProps } from './Ngl'
+import type { NglFile } from './Ngl'
 
 function NglError() {
   // TODO: <a href={docs}>Learn more</a>
@@ -18,8 +18,13 @@ const SuspensePlaceholder = () => <Placeholder color="text.secondary" />
 
 const Ngl = RT.mkLazy(() => import('./Ngl'), SuspensePlaceholder)
 
-export default (data: NglProps, props: NglProps) => (
+export default (
+  data: { files: NglFile[] },
+  props: React.HTMLAttributes<HTMLDivElement>,
+) => (
   <ErrorBoundary>
-    <Ngl {...data} {...props} />
+    {data.files.map((file, index) => (
+      <Ngl key={`nlg_${index}`} {...file} {...props} />
+    ))}
   </ErrorBoundary>
 )

--- a/catalog/app/components/Preview/renderers/Ngl/index.tsx
+++ b/catalog/app/components/Preview/renderers/Ngl/index.tsx
@@ -5,7 +5,7 @@ import { createBoundary } from 'utils/ErrorBoundary'
 import Placeholder from 'components/Placeholder'
 import * as RT from 'utils/reactTools'
 
-import type { NglFile } from './Ngl'
+import type { NglFile, NglProps } from './Ngl'
 
 function NglError() {
   // TODO: <a href={docs}>Learn more</a>
@@ -16,13 +16,15 @@ const ErrorBoundary = createBoundary(() => () => <NglError />)
 
 const SuspensePlaceholder = () => <Placeholder color="text.secondary" />
 
-const Ngl = RT.mkLazy(() => import('./Ngl'), SuspensePlaceholder)
+const Ngl: React.FC<NglProps> = RT.mkLazy(() => import('./Ngl'), SuspensePlaceholder)
 
 const useStyles = M.makeStyles((t) => ({
   root: {
     flexDirection: 'column',
     width: '100%',
-    '& > div+div': {
+  },
+  item: {
+    '& + &': {
       borderTop: `1px solid ${t.palette.divider}`,
       marginTop: t.spacing(2),
       paddingTop: t.spacing(2),
@@ -30,9 +32,19 @@ const useStyles = M.makeStyles((t) => ({
   },
 }))
 
-function Wrapper({ children }: React.PropsWithChildren<{}>) {
+interface NglWrapperProps extends React.HTMLAttributes<HTMLDivElement> {
+  files: NglFile[]
+}
+
+function NglRenderer({ files, className, ...props }: NglWrapperProps) {
   const classes = useStyles()
-  return <div className={classes.root}>{children}</div>
+  return (
+    <div className={classes.root} {...props}>
+      {files.map((file, index) => (
+        <Ngl {...file} className={classes.item} key={`nlg_${index}`} />
+      ))}
+    </div>
+  )
 }
 
 export default function NglWrapper(
@@ -41,11 +53,7 @@ export default function NglWrapper(
 ) {
   return (
     <ErrorBoundary>
-      <Wrapper>
-        {data.files.map((file, index) => (
-          <Ngl key={`nlg_${index}`} {...file} {...props} />
-        ))}
-      </Wrapper>
+      <NglRenderer files={data.files} {...props} />
     </ErrorBoundary>
   )
 }

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -59,6 +59,7 @@
 * [Changed] Support dots in bucket names while using S3 proxy ([#3147](https://github.com/quiltdata/quilt/pull/3147))
 * [Changed] Support `additonalProperties` and `items` in JsonEditor ([#3144](https://github.com/quiltdata/quilt/pull/3144))
 * [Changed] Initialize Catalog configuration synchronously from `QUILT_CATALOG_CONFIG` global var ([#3166](https://github.com/quiltdata/quilt/pull/3166))
+* [Changed] Handle rendering multiple molecules in one .sdf file ([#3179](https://github.com/quiltdata/quilt/pull/3179))
 
 ## Docs
 * [Fixed] Meeting scheduling link, mailto, package deletion ([#3161](https://github.com/quiltdata/quilt/pull/3161))


### PR DESCRIPTION
Split .sdf files containing multiple molecules into multiple .sdf files and render them separately

![Screenshot from 2022-11-13 11-53-41](https://user-images.githubusercontent.com/533229/201516008-c9fa624d-ffe8-4f41-9156-f370e696d0b2.png)

- [x] Unit tests
- [x] [Changelog](CHANGELOG.md) entry