### PR TITLE
Rob documentation buildrefs s3filenames

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -61,6 +61,7 @@
 * [Changed] Initialize Catalog configuration synchronously from `QUILT_CATALOG_CONFIG` global var ([#3166](https://github.com/quiltdata/quilt/pull/3166))
 
 ## Docs
+* [Added] Add number of IPs used; S3 filename limitations; multi-molecule SDF support ([#3180](https://github.com/quiltdata/quilt/pull/3180))
 * [Removed] Delete out-of-date Roadmap section ([#3177](https://github.com/quiltdata/quilt/pull/3177))
 * [Fixed] Meeting scheduling link, mailto, package deletion ([#3161](https://github.com/quiltdata/quilt/pull/3161))
 * [Added] Add Quilt and Nextflow integration ([#3136](https://github.com/quiltdata/quilt/pull/3136))

--- a/docs/Catalog/Preview.md
+++ b/docs/Catalog/Preview.md
@@ -24,6 +24,11 @@ The following file formats are supported:
 * .ent
 * .pdb
 
+### ⚠ Warning: Previewing multiple molecules from a single .sdf file
+
+Currently, the Quilt catalog does not support visualization of
+multiple molecules with titles from a single .sdf file.
+
 ## Binary and special file format previews
 * Excel (.xls, .xlsx)
 * FCS Flow Cytometry files (.fcs)

--- a/docs/FAQ.md
+++ b/docs/FAQ.md
@@ -53,7 +53,7 @@ quilt3 --version
 1. Copy the row labeled TemplateBuildMetadata
 1. "git_revision" is your template version
 
-## Hashing takes a long time. Can I speed it up?
+## Hashing during `push` takes a long time. Can I speed it up?
 
 Yes. Follow these steps:
 

--- a/docs/FAQ.md
+++ b/docs/FAQ.md
@@ -155,3 +155,30 @@ when writing Amazon Athena queries.
 * [SQL reference for Amazon Athena](https://docs.aws.amazon.com/athena/latest/ug/ddl-sql-reference.html)
 * [Functions in Amazon Athena](https://docs.aws.amazon.com/athena/latest/ug/presto-functions.html)
 
+## Are there any limitations on characters in Quilt filenames?
+
+Yes. Quilt is built on top of Amazon S3, and has the same character limitations.
+Although any UTF-8 character is supported in an object key
+name (filename), using certain characters can result in problems with some
+applications and protocols. The following guideline will help you
+maximize compliance. For a comprehensive list of safe characters, characters
+that might require special handling, and characters to avoid, please
+review the official Amazon S3 documentation linked below.
+
+### List of safe characters
+* Alphanumeric characters:
+  * 0-9
+  * a-z
+  * A-Z
+* Special characters:
+  * Exclamation point (`!`)
+  * Hyphen (`-`)
+  * Underscore (`_`)
+  * Period (`.`)
+  * Asterisk (`*`)
+  * Single quote (`'`)
+  * Open parenthesis (`(`)
+  * Close parenthesis (`)`)
+
+### References
+* [Creating object key names](https://docs.aws.amazon.com/AmazonS3/latest/userguide/object-keys.html)

--- a/docs/FAQ.md
+++ b/docs/FAQ.md
@@ -182,3 +182,11 @@ review the official Amazon S3 documentation linked below.
 
 ### References
 * [Creating object key names](https://docs.aws.amazon.com/AmazonS3/latest/userguide/object-keys.html)
+
+## How many IPs does a standard Quilt stack require?
+
+Currently, a full size, multi-Availability Zone deployment (without
+[Voila](https://docs.quiltdata.com/catalog/visualizationdashboards#voila))
+requires at least 256 IPs. This means a minimum CIDR block of `/24`.
+
+Optional additional features (such as automated data packaging) require additional IPs.


### PR DESCRIPTION
# Description
Documentation fixes:
- Number of IPs Quilt uses
- Characters to avoid in S3 filenames
- Limitation on multi-molecule SDF files
- Reword hashing latency title for clarity 

# TODO
- [ ] [Changelog](CHANGELOG.md) entry
