### PR TITLE
Fix anyOf|allOf Schema detection and fix enum free form detection in particular

### DIFF
--- a/catalog/app/utils/json-schema/json-schema.ts
+++ b/catalog/app/utils/json-schema/json-schema.ts
@@ -230,6 +230,7 @@ export function makeSchemaValidator(
   const { $id } = schemas[0]
   const options: Options = {
     allErrors: true,
+    allowUnionTypes: true,
     schemaId: '$id',
     schemas,
     useDefaults: true,

--- a/catalog/app/utils/json-schema/json-schema.ts
+++ b/catalog/app/utils/json-schema/json-schema.ts
@@ -134,6 +134,10 @@ function compoundTypeToHumanString(
 export function schemaTypeToHumanString(optSchema?: JsonSchema) {
   if (!optSchema) return ''
   return R.cond<JsonSchema, string>([
+    [isSchemaAnyOf, () => compoundTypeToHumanString(optSchema, 'anyOf', '|')],
+    [isSchemaOneOf, () => compoundTypeToHumanString(optSchema, 'oneOf', '|')],
+    [isSchemaAllOf, () => compoundTypeToHumanString(optSchema, 'allOf', '&')],
+    [isSchemaCompound, () => 'compound'],
     [isSchemaEnum, () => 'enum'],
     [isSchemaConst, () => 'const'],
     [isSchemaBoolean, () => 'boolean'],
@@ -147,10 +151,6 @@ export function schemaTypeToHumanString(optSchema?: JsonSchema) {
           ? optSchema.type.join('|')
           : (optSchema.type as string),
     ],
-    [isSchemaAnyOf, () => compoundTypeToHumanString(optSchema, 'anyOf', '|')],
-    [isSchemaOneOf, () => compoundTypeToHumanString(optSchema, 'oneOf', '|')],
-    [isSchemaAllOf, () => compoundTypeToHumanString(optSchema, 'allOf', '&')],
-    [isSchemaCompound, () => 'compound'],
     [isSchemaReference, () => '$ref'],
     [R.T, () => 'undefined'],
   ])(optSchema)
@@ -174,7 +174,11 @@ function doesTypeMatchCompoundSchema(
 // TODO: rename and redesign function to avoid "if no schema -> return true aka 'type matches schema'"
 export function doesTypeMatchSchema(value: any, optSchema?: JsonSchema): boolean {
   if (!optSchema) return true
+
   return R.cond<JsonSchema, boolean>([
+    [isSchemaAnyOf, () => doesTypeMatchCompoundSchema(value, 'anyOf', optSchema)],
+    [isSchemaOneOf, () => doesTypeMatchCompoundSchema(value, 'oneOf', optSchema)],
+    [isSchemaAllOf, () => doesTypeMatchCompoundSchema(value, 'allOf', optSchema)],
     [
       isSchemaEnum,
       () => {
@@ -194,9 +198,6 @@ export function doesTypeMatchSchema(value: any, optSchema?: JsonSchema): boolean
           doesTypeMatchSchema(value, subSchema),
         ),
     ],
-    [isSchemaAnyOf, () => doesTypeMatchCompoundSchema(value, 'anyOf', optSchema)],
-    [isSchemaOneOf, () => doesTypeMatchCompoundSchema(value, 'oneOf', optSchema)],
-    [isSchemaAllOf, () => doesTypeMatchCompoundSchema(value, 'allOf', optSchema)],
     [isSchemaArray, () => Array.isArray(value)],
     [isSchemaObject, () => R.is(Object, value)],
     [isSchemaString, () => R.is(String, value)],

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -45,6 +45,7 @@
 * [Fixed] Fix editing nested files in packages, fix editing files added from the different location to package ([#3117](https://github.com/quiltdata/quilt/pull/3117))
 * [Fixed] Fix enum detection in `anyOf`, `allOf`, `oneOf`, `not` fields and in arrays in JsonEditor ([#3169](https://github.com/quiltdata/quilt/pull/3169))
 * [Fixed] Fix adding new elements in JsonEditor ([#3169](https://github.com/quiltdata/quilt/pull/3169))
+* [Fixed] Fix enum free form fields ([#3185](https://github.com/quiltdata/quilt/pull/3185))
 * [Changed] Clean up home page ([#2780](https://github.com/quiltdata/quilt/pull/2780)).
 * [Changed] Make `pkgpush` lambda directly invocable, adjust handling of parameters and errors ([#2776](https://github.com/quiltdata/quilt/pull/2776))
 * [Changed] Push packages via GraphQL ([#2768](https://github.com/quiltdata/quilt/pull/2768))


### PR DESCRIPTION
"Free form enum" is a value coverd by Schema `anyOf: [{ type: "string"}, { type: "string", enum: ["one", "two", "three"] }]`

The bug was in the early detection of enum in such Schema, and invalidating a value if it's not equal to one of enum values.

- [x] [Changelog](CHANGELOG.md) entry
