### PR TITLE
Normalize case of HTTP headers names passed to lambdas

### DIFF
--- a/lambdas/shared/t4_lambda_shared/decorator.py
+++ b/lambdas/shared/t4_lambda_shared/decorator.py
@@ -27,7 +27,7 @@ class Request:
         self.method = event['httpMethod']
         self.path = event['path']
         self.pathParameters = event.get('pathParameters')
-        self.headers = event['headers'] or {}
+        self.headers = {k.lower(): v for k, v in (event["headers"] or {}).items()}
         self.args = event['queryStringParameters'] or {}
         if event['isBase64Encoded']:
             self.data = b64decode(event['body'])


### PR DESCRIPTION
This is example of headers passed by edge API gateway:
```python
{'Accept': '*/*',
 'Accept-Encoding': 'gzip, deflate, br',
 'Accept-Language': 'en-US,en;q=0.7,ru;q=0.3',
 'cache-control': 'no-cache',
 'CloudFront-Forwarded-Proto': 'https',
 'CloudFront-Is-Desktop-Viewer': 'true',
 'CloudFront-Is-Mobile-Viewer': 'false',
 'CloudFront-Is-SmartTV-Viewer': 'false',
 'CloudFront-Is-Tablet-Viewer': 'false',
 'CloudFront-Viewer-ASN': '16010',
 'CloudFront-Viewer-Country': 'GE',
 'Host': 'b8to03oj99.execute-api.us-east-1.amazonaws.com',
 'origin': 'https://test-sergey-internal.quiltdata-route53.com',
 'pragma': 'no-cache',
 'Referer': 'https://test-sergey-internal.quiltdata-route53.com/',
 'sec-fetch-dest': 'empty',
 'sec-fetch-mode': 'cors',
 'sec-fetch-site': 'cross-site',
 'User-Agent': 'Mozilla/5.0 (X11; Linux x86_64; rv:107.0) Gecko/20100101 Firefox/107.0',
 'Via': '2.0 7ac138eb26fc255f9a664518fcf6f516.cloudfront.net (CloudFront)',
 'X-Amz-Cf-Id': 'Un8-fbG59j9DCqddwbGbzelj_UhEwueRCLtQbfhFR8f1RkYhgLNMJw==',
 'X-Amzn-Trace-Id': 'Root=1-6393462d-7d5f07e55c891db064040c68',
 'X-Forwarded-For': '212.58.121.180, 130.176.33.165',
 'X-Forwarded-Port': '443',
 'X-Forwarded-Proto': 'https'}
```

This is example of headers passed by private API gateway:
```python
{'Accept': '*/*',
 'Accept-Encoding': 'gzip, deflate, br',
 'Accept-Language': 'en-US,en;q=0.7,ru;q=0.3',
 'Cache-Control': 'no-cache',
 'Host': 'b8to03oj99-vpce-02ced35b1061d6ebd.execute-api.us-east-1.amazonaws.com',
 'Origin': 'https://test-sergey-internal.quiltdata-route53.com',
 'Pragma': 'no-cache',
 'Referer': 'https://test-sergey-internal.quiltdata-route53.com/',
 'Sec-Fetch-Dest': 'empty',
 'Sec-Fetch-Mode': 'cors',
 'Sec-Fetch-Site': 'cross-site',
 'User-Agent': 'Mozilla/5.0 (X11; Linux x86_64; rv:107.0) Gecko/20100101 Firefox/107.0',
 'x-amzn-cipher-suite': 'ECDHE-RSA-AES128-GCM-SHA256',
 'x-amzn-tls-version': 'TLSv1.2',
 'x-amzn-vpc-id': 'vpc-0186019080b299258',
 'x-amzn-vpce-config': '1',
 'x-amzn-vpce-id': 'vpce-02ced35b1061d6ebd',
 'X-Forwarded-For': '10.0.128.71'}
```