### PR TITLE
Update example S3 bucket policy to include GetObjectTagging

### DIFF
--- a/docs/CrossAccount.md
+++ b/docs/CrossAccount.md
@@ -35,6 +35,7 @@ following to buckets in your *DataAccount*.
             },
             "Action": [
                 "s3:GetObject",
+                "s3:GetObjectTagging",
                 "s3:GetObjectVersion",
                 "s3:ListBucket",
                 "s3:ListBucketVersions",


### PR DESCRIPTION
# Description
Add `s3:GetObjectTagging` to the example IAM S3 bucket policy for correct cross account access