### PR TITLE
Add option switcher JSON → ECharts

### DIFF
--- a/catalog/app/components/Preview/loaders/Json.js
+++ b/catalog/app/components/Preview/loaders/Json.js
@@ -103,7 +103,6 @@ function JsonLoader({ gated, handle, children }) {
   )
 }
 
-// TODO: !Igv.detect(key, options) && !Echarts.detect(key, options)
 export const detect = utils.extIs('.json')
 
 function findLoader(mode, firstBytes) {

--- a/catalog/app/components/Preview/loaders/Json.js
+++ b/catalog/app/components/Preview/loaders/Json.js
@@ -5,7 +5,8 @@ import * as React from 'react'
 import AsyncResult from 'utils/AsyncResult'
 
 import { PreviewData, PreviewError } from '../types'
-import * as IgvLoader from './Igv'
+import * as Igv from './Igv'
+import * as Echarts from './Echarts'
 import useSignObjectUrls from './useSignObjectUrls'
 
 import * as Text from './Text'
@@ -109,8 +110,10 @@ function findLoader(mode, firstBytes) {
   switch (mode) {
     case 'json':
       return JsonLoader
+    case 'echarts':
+      return Echarts.Loader
     case 'igv':
-      return IgvLoader.Loader
+      return Igv.Loader
     default:
       return detectSchema(firstBytes) ? VegaLoader : JsonLoader
   }

--- a/catalog/app/components/Preview/renderers/ECharts.tsx
+++ b/catalog/app/components/Preview/renderers/ECharts.tsx
@@ -5,6 +5,7 @@ import * as echarts from 'echarts'
 const useStyles = M.makeStyles({
   root: {
     height: '400px',
+    width: '100%',
   },
 })
 

--- a/catalog/app/containers/Bucket/viewModes.ts
+++ b/catalog/app/containers/Bucket/viewModes.ts
@@ -10,6 +10,7 @@ import { PackageHandle } from 'utils/packageHandle'
 import { JsonRecord } from 'utils/types'
 
 const MODES = {
+  echarts: 'ECharts',
   igv: 'IGV',
   json: 'JSON',
   jupyter: 'Jupyter',
@@ -19,7 +20,10 @@ const MODES = {
 
 export type ViewMode = keyof typeof MODES
 
-const isIgvTracks = (json: JsonRecord) => Array.isArray(json?.tracks)
+const isIgvTracks = (json?: JsonRecord) => Array.isArray(json?.tracks)
+
+const isEchartsDatasource = (json?: JsonRecord) =>
+  !!json?.dataset || Array.isArray(json?.series)
 
 const isVegaSchema = (schema: string) => {
   if (!schema) return false
@@ -70,6 +74,7 @@ export function useViewModes(
             Json: (json: any) => {
               if (isVegaSchema(json.rendered?.$schema)) return ['vega', 'json']
               if (isIgvTracks(json.rendered)) return ['json', 'igv']
+              if (isEchartsDatasource(json.rendered)) return ['json', 'echarts']
               return []
             },
             _: () => [],


### PR DESCRIPTION
Unfortunately, there is no required properties for ECharts we can check for, but I believe `.series` or `dataset` are most used properties.