### PR TITLE
Set wrapper for previews 100% width

### DIFF
--- a/catalog/app/components/Preview/renderers/DataFrame.js
+++ b/catalog/app/components/Preview/renderers/DataFrame.js
@@ -1,13 +1,9 @@
-import cx from 'classnames'
 import * as React from 'react'
 import * as M from '@material-ui/core'
 
 import { renderWarnings } from './util'
 
 const useStyles = M.makeStyles((t) => ({
-  root: {
-    width: '100%',
-  },
   wrapper: {
     overflow: 'auto',
 
@@ -38,7 +34,7 @@ const useStyles = M.makeStyles((t) => ({
 function DataFrame({ children, className, note, warnings, ...props } = {}) {
   const classes = useStyles()
   return (
-    <div className={cx(className, classes.root)} {...props}>
+    <div className={className} {...props}>
       {renderWarnings(warnings)}
       <div
         title={note}
@@ -50,6 +46,7 @@ function DataFrame({ children, className, note, warnings, ...props } = {}) {
   )
 }
 
+// TODO: it is unused, remove it
 export default ({ preview, note, warnings }, props) => (
   <DataFrame {...{ note, warnings }} {...props}>
     {preview}

--- a/catalog/app/components/Preview/renderers/DataFrame.js
+++ b/catalog/app/components/Preview/renderers/DataFrame.js
@@ -46,7 +46,7 @@ function DataFrame({ children, className, note, warnings, ...props } = {}) {
   )
 }
 
-// TODO: it is unused, remove it
+// TODO: this loader is unused, remove it
 export default ({ preview, note, warnings }, props) => (
   <DataFrame {...{ note, warnings }} {...props}>
     {preview}

--- a/catalog/app/components/Preview/renderers/ECharts.tsx
+++ b/catalog/app/components/Preview/renderers/ECharts.tsx
@@ -5,7 +5,6 @@ import * as echarts from 'echarts'
 const useStyles = M.makeStyles({
   root: {
     height: '400px',
-    width: '100%',
   },
 })
 

--- a/catalog/app/components/Preview/renderers/Fcs.js
+++ b/catalog/app/components/Preview/renderers/Fcs.js
@@ -1,4 +1,3 @@
-import cx from 'classnames'
 import * as React from 'react'
 import * as M from '@material-ui/core'
 
@@ -7,9 +6,6 @@ import JsonDisplay from 'components/JsonDisplay'
 import { renderWarnings } from './util'
 
 const useStyles = M.makeStyles((t) => ({
-  root: {
-    width: '100%',
-  },
   dataframe: {
     overflow: 'auto',
     paddingTop: t.spacing(2),
@@ -40,7 +36,7 @@ const useStyles = M.makeStyles((t) => ({
 function Fcs({ className, preview, metadata, note, warnings, ...props }) {
   const classes = useStyles()
   return (
-    <div className={cx(className, classes.root)} {...props}>
+    <div className={className} {...props}>
       {renderWarnings(warnings)}
       {!!metadata && <JsonDisplay name="Metadata" value={metadata} />}
       {!!preview && (

--- a/catalog/app/components/Preview/renderers/IFrame.tsx
+++ b/catalog/app/components/Preview/renderers/IFrame.tsx
@@ -5,7 +5,6 @@ const useStyles = M.makeStyles({
   root: {
     border: 'none',
     height: '90vh',
-    width: '100%',
   },
 })
 

--- a/catalog/app/components/Preview/renderers/Image.js
+++ b/catalog/app/components/Preview/renderers/Image.js
@@ -20,7 +20,6 @@ function Image({ handle, className, ...props }) {
       size="lg"
       className={cx(className, classes.root)}
       alt=""
-      skeletonProps={{ width: '100%' }}
       {...props}
     />
   )

--- a/catalog/app/components/Preview/renderers/NamedPackage.tsx
+++ b/catalog/app/components/Preview/renderers/NamedPackage.tsx
@@ -1,4 +1,3 @@
-import cx from 'classnames'
 import 'highlight.js/styles/default.css'
 import * as React from 'react'
 import * as M from '@material-ui/core'
@@ -9,9 +8,6 @@ import StyledLink from 'utils/StyledLink'
 import { renderWarnings } from './util'
 
 const useStyles = M.makeStyles((t) => ({
-  root: {
-    width: '100%',
-  },
   text: {
     fontFamily: (t.typography as $TSFixMe).monospace.fontFamily,
     overflow: 'auto',
@@ -38,7 +34,7 @@ function NamedPackage({
   const { urls } = NamedRoutes.use()
   const classes = useStyles()
   return (
-    <div className={cx(className, classes.root)} {...props}>
+    <div className={className} {...props}>
       <StyledLink to={urls.bucketFile(bucket, `.quilt/packages/${hash}`)}>
         {hash}
       </StyledLink>

--- a/catalog/app/components/Preview/renderers/Ngl/index.tsx
+++ b/catalog/app/components/Preview/renderers/Ngl/index.tsx
@@ -21,7 +21,6 @@ const Ngl: React.FC<NglProps> = RT.mkLazy(() => import('./Ngl'), SuspensePlaceho
 const useStyles = M.makeStyles((t) => ({
   root: {
     flexDirection: 'column',
-    width: '100%',
   },
   item: {
     '& + &': {

--- a/catalog/app/components/Preview/renderers/Notebook.js
+++ b/catalog/app/components/Preview/renderers/Notebook.js
@@ -22,9 +22,6 @@ const renderMath = (el) => {
 }
 
 const useStyles = M.makeStyles({
-  root: {
-    width: '100%',
-  },
   contents: {
     // workaround to speed-up browser rendering / compositing
     '& pre': {
@@ -37,7 +34,7 @@ const useStyles = M.makeStyles({
 function Notebook({ children, className, note, warnings, ...props } = {}) {
   const classes = useStyles()
   return (
-    <div className={cx(classes.root, className)} {...props}>
+    <div className={className} {...props}>
       {renderWarnings(warnings)}
       <div
         title={note}

--- a/catalog/app/components/Preview/renderers/Pdf.js
+++ b/catalog/app/components/Preview/renderers/Pdf.js
@@ -53,7 +53,6 @@ const useStyles = M.makeStyles((t) => ({
     flexDirection: 'column',
     position: 'relative',
     alignItems: 'center',
-    width: '100%',
   },
   btn: {
     marginBottom: -12,

--- a/catalog/app/components/Preview/renderers/Perspective/Perspective.tsx
+++ b/catalog/app/components/Preview/renderers/Perspective/Perspective.tsx
@@ -193,7 +193,6 @@ const useStyles = M.makeStyles((t) => ({
     // NOTE: padding is required because perspective-viewer covers resize handle
     padding: '0 0 8px',
     resize: 'vertical',
-    width: '100%',
   },
   meta: {
     marginBottom: t.spacing(1),

--- a/catalog/app/components/Preview/renderers/Text.js
+++ b/catalog/app/components/Preview/renderers/Text.js
@@ -1,4 +1,3 @@
-import cx from 'classnames'
 import 'highlight.js/styles/default.css'
 import * as React from 'react'
 import * as M from '@material-ui/core'
@@ -6,9 +5,6 @@ import * as M from '@material-ui/core'
 import { renderWarnings } from './util'
 
 const useStyles = M.makeStyles((t) => ({
-  root: {
-    width: '100%',
-  },
   text: {
     fontFamily: t.typography.monospace.fontFamily,
     overflow: 'auto',
@@ -19,7 +15,7 @@ const useStyles = M.makeStyles((t) => ({
 function Text({ className, children, note, warnings, ...props }) {
   const classes = useStyles()
   return (
-    <div className={cx(className, classes.root)} {...props}>
+    <div className={className} {...props}>
       {renderWarnings(warnings)}
       <div title={note} className={classes.text}>
         {children}

--- a/catalog/app/components/Preview/renderers/Vcf.js
+++ b/catalog/app/components/Preview/renderers/Vcf.js
@@ -5,9 +5,6 @@ import * as M from '@material-ui/core'
 import { renderWarnings } from './util'
 
 const useStyles = M.makeStyles((t) => ({
-  root: {
-    width: '100%',
-  },
   tableWrapper: {
     overflow: 'auto',
   },
@@ -61,7 +58,7 @@ function Vcf({ meta, header, data, variants, note, warnings }) {
       )
 
   return (
-    <div className={classes.root}>
+    <>
       {renderWarnings(warnings)}
       <div className={classes.tableWrapper}>
         <M.Table className={classes.table}>
@@ -107,7 +104,7 @@ function Vcf({ meta, header, data, variants, note, warnings }) {
           <div className={classes.variants}>{variants.join(' ')}</div>
         </M.Box>
       )}
-    </div>
+    </>
   )
 }
 

--- a/catalog/app/containers/Bucket/File.js
+++ b/catalog/app/containers/Bucket/File.js
@@ -319,6 +319,9 @@ const useStyles = M.makeStyles((t) => ({
     display: 'flex',
     marginBottom: t.spacing(2),
   },
+  preview: {
+    width: '100%',
+  },
 }))
 
 export default function File({
@@ -530,13 +533,15 @@ export default function File({
                 </Section>
               ) : (
                 <Section icon="remove_red_eye" heading="Preview" defaultExpanded>
-                  {versionExistsData.case({
-                    _: () => <CenteredProgress />,
-                    Err: (e) => {
-                      throw e
-                    },
-                    Ok: withPreview(renderPreview(viewModes.handlePreviewResult)),
-                  })}
+                  <div className={classes.preview}>
+                    {versionExistsData.case({
+                      _: () => <CenteredProgress />,
+                      Err: (e) => {
+                        throw e
+                      },
+                      Ok: withPreview(renderPreview(viewModes.handlePreviewResult)),
+                    })}
+                  </div>
                 </Section>
               )}
             </>

--- a/catalog/app/containers/Bucket/PackageTree/PackageTree.tsx
+++ b/catalog/app/containers/Bucket/PackageTree/PackageTree.tsx
@@ -570,6 +570,9 @@ const useFileDisplayStyles = M.makeStyles((t) => ({
       marginBottom: '3px',
     },
   },
+  preview: {
+    width: '100%',
+  },
 }))
 
 interface FileDisplayProps extends FileDisplayQueryProps {
@@ -693,12 +696,14 @@ function FileDisplay({
                 <FileView.ObjectMeta data={AsyncResult.Ok(file.metadata)} />
               )}
               <Section icon="remove_red_eye" heading="Preview" expandable={false}>
-                {withPreview(
-                  { archived, deleted },
-                  handle,
-                  viewModes.mode,
-                  renderPreview(viewModes.handlePreviewResult),
-                )}
+                <div className={classes.preview}>
+                  {withPreview(
+                    { archived, deleted },
+                    handle,
+                    viewModes.mode,
+                    renderPreview(viewModes.handlePreviewResult),
+                  )}
+                </div>
               </Section>
             </>
           ),

--- a/catalog/app/embed/File.js
+++ b/catalog/app/embed/File.js
@@ -343,6 +343,9 @@ const useStyles = M.makeStyles((t) => ({
   button: {
     marginLeft: t.spacing(2),
   },
+  preview: {
+    width: '100%',
+  },
 }))
 
 const previewOptions = { context: Preview.CONTEXT.FILE }
@@ -475,13 +478,15 @@ export default function File({
                 <Analytics {...{ bucket, path }} />
               )}
               <Section icon="remove_red_eye" heading="Preview" defaultExpanded>
-                {versionExistsData.case({
-                  _: () => <CenteredProgress />,
-                  Err: (e) => {
-                    throw e
-                  },
-                  Ok: withPreview(renderPreview()),
-                })}
+                <div className={classes.preview}>
+                  {versionExistsData.case({
+                    _: () => <CenteredProgress />,
+                    Err: (e) => {
+                      throw e
+                    },
+                    Ok: withPreview(renderPreview()),
+                  })}
+                </div>
               </Section>
               <Meta bucket={bucket} path={path} version={version} />
             </>

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -16,6 +16,7 @@ Entries inside each section should be ordered by type:
 !-->
 ## Catalog, Lambdas
 * [Added] Add 'ECharts' and 'Text' file type switcher, significantly refactor this switcher ([#3240](https://github.com/quiltdata/quilt/pull/3240))
+* [Changed] Make file preview wrapper consistently 100% width ([#3245](https://github.com/quiltdata/quilt/pull/3245))
 
 # 5.1.0 - 2022-12-09
 ## Python API


### PR DESCRIPTION
Before:
![Screenshot from 2022-12-28 14-05-54](https://user-images.githubusercontent.com/533229/209809735-5f05ee06-351d-4691-9eaf-5ebfd0d45b36.png)
![Screenshot from 2022-12-28 13-55-52](https://user-images.githubusercontent.com/533229/209809733-14c4255c-6c23-4d90-8268-ed78c6894845.png)

After:
![Screenshot from 2022-12-28 14-05-31](https://user-images.githubusercontent.com/533229/209811151-c121de16-95a7-4eee-a126-34c8b792ba65.png)
![Screenshot from 2022-12-28 14-18-28](https://user-images.githubusercontent.com/533229/209811157-16884b1e-c92d-4983-be23-d023f1a643b5.png)

- [ ] [Changelog](CHANGELOG.md) entry (skip if change is not significant to end users, e.g. docs only)
