### PR TITLE
Remove Warning for multiple molecules from a single SDF file

### DIFF
--- a/docs/Catalog/Preview.md
+++ b/docs/Catalog/Preview.md
@@ -24,11 +24,6 @@ The following file formats are supported:
 * .ent
 * .pdb
 
-### ⚠ Warning: Previewing multiple molecules from a single .sdf file
-
-Currently, the Quilt catalog does not support visualization of
-multiple molecules with titles from a single .sdf file.
-
 ## Binary and special file format previews
 * Excel (.xls, .xlsx)
 * FCS Flow Cytometry files (.fcs)


### PR DESCRIPTION
# Description
Remove warning text string for lack of support of multiple molecules (with titles) from a single SDF file