### PR TITLE
Fix `handle` memoization in Search Results hit

### DIFF
--- a/catalog/app/components/SearchResults/SearchResults.js
+++ b/catalog/app/components/SearchResults/SearchResults.js
@@ -481,7 +481,7 @@ function DirHit({
     bucket,
   },
 }) {
-  const handle = { bucket, key: path }
+  const handle = React.useMemo(() => ({ bucket, key: path }), [bucket, path])
   return (
     <Section
       data-testid="search-hit"

--- a/catalog/app/components/SearchResults/SearchResults.js
+++ b/catalog/app/components/SearchResults/SearchResults.js
@@ -436,7 +436,10 @@ function FileHit({ showBucket, hit: { path, versions, bucket } }) {
   const s3 = AWS.S3.use()
 
   const v = versions[0]
-  const handle = { bucket, key: path, version: v.id }
+  const handle = React.useMemo(
+    () => ({ bucket, key: path, version: v.id }),
+    [bucket, path, v.id],
+  )
 
   const bucketExistenceData = useBucketExistence(bucket)
   const versionExistenceData = Data.use(requests.getObjectExistence, { s3, ...handle })

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -18,6 +18,7 @@ Entries inside each section should be ordered by type:
 * [Added] Add 'ECharts' and 'Text' file type switcher, significantly refactor this switcher ([#3240](https://github.com/quiltdata/quilt/pull/3240))
 * [Added] Add link to file from Athena results ([#3242](https://github.com/quiltdata/quilt/pull/3242))
 * [Added] Add link to package revisions from package list ([#3256](https://github.com/quiltdata/quilt/pull/3256))
+* [Fixed] Fix performance issue (missing memoization) in search results ([#3257](https://github.com/quiltdata/quilt/pull/3257))
 * [Changed] Make file preview wrapper consistently 100% width ([#3245](https://github.com/quiltdata/quilt/pull/3245))
 * [Changed] Rename "Metadata" to "User metadata" ([#3255](https://github.com/quiltdata/quilt/pull/3255))
 


### PR DESCRIPTION
It's relevant for `"ext:.json"` search and Vega results, for example

- [x] [Changelog](CHANGELOG.md) entry (skip if change is not significant to end users, e.g. docs only)