### PR TITLE
Add note about set_dir() and metadata

### DIFF
--- a/docs/Troubleshooting.md
+++ b/docs/Troubleshooting.md
@@ -37,9 +37,9 @@ changes will be lost the next time that you update Quilt
 
 ## Missing metadata when working with data packages via the API
 
-If you are browsing and pushing a package using the Python `quilt3`
-API be careful to note that `Package.set_dir()` on the root path
-(`.`) currently sets metadata to `None`:
+> `Package.set_dir()` on the package root (".") overrides package-level metadata.
+> If you do not provide `set_dir(".", foo, meta=baz)` with a value for `meta=`,
+> `set_dir` will set package-level metadata to `None`.
 
 > This is because _folder-level_ metadata overrides _package-level_ metadata.
 

--- a/docs/Troubleshooting.md
+++ b/docs/Troubleshooting.md
@@ -43,9 +43,10 @@ changes will be lost the next time that you update Quilt
 
 > This is because _folder-level_ metadata overrides _package-level_ metadata.
 
-A common development pattern is to `Package.browse()` to get the most recent
-version of a package, and then `Package.push()` updates. Be sure
-to add any **existing package metadata** to ensure the metadata is not replaced:
+A common pattern is to `Package.browse()` to get the most recent
+version of a package, and then `Package.push()` updates.
+You can preserve package-level metadata when calling `set_dir(".", ...)`
+as follows:
 
 <!--pytest.mark.skip-->
 ```python

--- a/docs/Troubleshooting.md
+++ b/docs/Troubleshooting.md
@@ -52,20 +52,15 @@ as follows:
 ```python
 import quilt3
 
-p = quilt3.Package()
-p.browse(
-    name=f"user-packages/{package_name}", 
-    registry=f"s3://{bucket}"
+p = quilt3.Package.browse(
+    f"user-packages/{package_name}", 
+    f"s3://{bucket}"
 )
 
-# Get existing package-level metadata
-metadata = p.meta
-
-# Add all files from path to the package and preserve existing metadata
 p.set_dir(
-    lkey=".",
-    path=f"s3://{bucket}/user-packages/{package_name}/",
-    meta=metadata
+    ".",
+    f"s3://{bucket}/user-packages/{package_name}/",
+    meta=p.meta
 )
 
 # Push changes to the S3 registry

--- a/docs/Troubleshooting.md
+++ b/docs/Troubleshooting.md
@@ -35,7 +35,7 @@ any issues
 1. It is not recommended that you adjust ElasticSearch via Edit domain, as these
 changes will be lost the next time that you update Quilt
 
-## Missing metadata when working with data packages via the API
+## Missing metadata when working with Quilt packages via the API
 
 > `Package.set_dir()` on the package root (".") overrides package-level metadata.
 > If you do not provide `set_dir(".", foo, meta=baz)` with a value for `meta=`,

--- a/docs/Troubleshooting.md
+++ b/docs/Troubleshooting.md
@@ -34,3 +34,46 @@ any issues
 1. Send screenshots to [Quilt support](mailto:support@quiltdata.io).
 1. It is not recommended that you adjust ElasticSearch via Edit domain, as these
 changes will be lost the next time that you update Quilt
+
+## Missing metadata when working with data packages via the API
+
+If you are browsing and pushing a package using the Python `quilt3`
+API be careful to note that `Package.set_dir()` on the root path
+(`.`) currently sets metadata to `None`:
+
+> This is because _folder-level_ metadata overrides _package-level_ metadata.
+
+A common development pattern is to `Package.browse()` to get the most recent
+version of a package, and then `Package.push()` updates. Be sure
+to add any **existing package metadata** to ensure the metadata is not replaced:
+
+<!--pytest.mark.skip-->
+```python
+import quilt3
+
+p = quilt3.Package()
+p.browse(
+    name=f"user-packages/{package_name}", 
+    registry=f"s3://{bucket}"
+)
+
+# Get existing package-level metadata
+metadata = p.meta
+
+# Add all files from path to the package and preserve existing metadata
+p.set_dir(
+    lkey=".",
+    path=f"s3://{bucket}/user-packages/{package_name}/",
+    meta=metadata
+)
+
+# Push changes to the S3 registry
+p.push(
+    name=f"user-packages/{package_name}",
+    registry=f"s3://{bucket}",
+    message=f"Updating package {package_name}",
+    workflow="default"
+)
+```
+
+- [Reference](https://docs.quiltdata.com/api-reference/package#package.set_dir).

--- a/docs/Troubleshooting.md
+++ b/docs/Troubleshooting.md
@@ -52,7 +52,7 @@ import quilt3
 
 p = quilt3.Package.browse(
     "user-packages/geodata", 
-    "s3://bucket_1"
+    registry="s3://bucket_1"
 )
 
 p.set_dir(
@@ -64,7 +64,7 @@ p.set_dir(
 # Push changes to the S3 registry
 p.push(
     "user-packages/geodata",
-    "s3://bucket_1",
+    registry="s3://bucket_1",
     message="Updating package geodata source data"
 )
 ```

--- a/docs/Troubleshooting.md
+++ b/docs/Troubleshooting.md
@@ -41,8 +41,6 @@ changes will be lost the next time that you update Quilt
 > If you do not provide `set_dir(".", foo, meta=baz)` with a value for `meta=`,
 > `set_dir` will set package-level metadata to `None`.
 
-> This is because _folder-level_ metadata overrides _package-level_ metadata.
-
 A common pattern is to `Package.browse()` to get the most recent
 version of a package, and then `Package.push()` updates.
 You can preserve package-level metadata when calling `set_dir(".", ...)`

--- a/docs/Troubleshooting.md
+++ b/docs/Troubleshooting.md
@@ -69,10 +69,9 @@ p.set_dir(
 
 # Push changes to the S3 registry
 p.push(
-    name=f"user-packages/{package_name}",
-    registry=f"s3://{bucket}",
-    message=f"Updating package {package_name}",
-    workflow="default"
+    f"user-packages/{package_name}",
+    f"s3://{bucket}",
+    message=f"Updating package {package_name}"
 )
 ```
 

--- a/docs/Troubleshooting.md
+++ b/docs/Troubleshooting.md
@@ -51,21 +51,21 @@ as follows:
 import quilt3
 
 p = quilt3.Package.browse(
-    f"user-packages/{package_name}", 
-    f"s3://{bucket}"
+    "user-packages/geodata", 
+    "s3://bucket_1"
 )
 
 p.set_dir(
     ".",
-    f"s3://{bucket}/user-packages/{package_name}/",
+    "s3://bucket_2/path/to/new/geofiles",
     meta=p.meta
 )
 
 # Push changes to the S3 registry
 p.push(
-    f"user-packages/{package_name}",
-    f"s3://{bucket}",
-    message=f"Updating package {package_name}"
+    "user-packages/geodata",
+    "s3://bucket_1",
+    message="Updating package geodata source data"
 )
 ```
 


### PR DESCRIPTION
# Description
Add a new entry to Troubleshooting about using `set_dir()` at the root path of a package.

# TODO
- [n/a] Unit tests
- [n/a] Automated tests (e.g. Preflight)
- [X] Documentation
    - [n/a] [Python: Run `build.py`](../gendocs/build.py) for new docstrings
    - [n/a] JavaScript: basic explanation and screenshot of new features
- [n/a] [Changelog](CHANGELOG.md) entry (skip if change is not significant to end users, e.g. docs only)
