### PR TITLE
Disable "Blank line inside blockquote" markdownlint rule

### DIFF
--- a/docs/.markdownlint.jsonc
+++ b/docs/.markdownlint.jsonc
@@ -1,3 +1,4 @@
 {
-  "default": true
+  "default": true,
+  "MD028": false
 }

--- a/docs/.markdownlint.jsonc
+++ b/docs/.markdownlint.jsonc
@@ -1,4 +1,4 @@
 {
   "default": true,
-  "MD028": false
+  "no-blanks-blockquote": false
 }


### PR DESCRIPTION
See https://github.com/DavidAnson/markdownlint/blob/main/doc/md028.md

Currently it complains on:

```
> Note 1

> Note 2
```

It works as expected (at least by me) and is displayed as two separate blockquotes both in GitHub and GitBook.