### PR TITLE
File edit as text

### DIFF
--- a/catalog/app/components/FileEditor/Controls.tsx
+++ b/catalog/app/components/FileEditor/Controls.tsx
@@ -25,6 +25,7 @@ interface ButtonControlProps {
   variant?: 'outlined' | 'contained'
 }
 
+// TODO: use components/Buttons/ShrinkedIconButton
 function ButtonControl({
   disabled,
   className,
@@ -79,8 +80,14 @@ export function Controls({
   const [anchorEl, setAnchorEl] = React.useState<HTMLElement | null>(null)
   const disabled = saving
   const handleEditClick = React.useCallback(
-    (event) => setAnchorEl(event.currentTarget),
-    [],
+    (event) => {
+      if (types.length === 1) {
+        onEdit(types[0])
+      } else {
+        setAnchorEl(event.currentTarget)
+      }
+    },
+    [onEdit, types],
   )
   const handleTypeClick = React.useCallback(
     (type) => {

--- a/catalog/app/components/FileEditor/Controls.tsx
+++ b/catalog/app/components/FileEditor/Controls.tsx
@@ -79,12 +79,13 @@ export function Controls({
 }: ControlsProps) {
   const [anchorEl, setAnchorEl] = React.useState<HTMLElement | null>(null)
   const disabled = saving
+  const hasMultipleChoices = types.length > 1
   const handleEditClick = React.useCallback(
     (event) => {
-      if (types.length === 1) {
-        onEdit(types[0])
-      } else {
+      if (hasMultipleChoices) {
         setAnchorEl(event.currentTarget)
+      } else {
+        onEdit(types[0])
       }
     },
     [onEdit, types],
@@ -106,13 +107,15 @@ export function Controls({
           label="Edit"
           onClick={handleEditClick}
         />
-        <M.Menu open={!!anchorEl} anchorEl={anchorEl} onClose={() => setAnchorEl(null)}>
-          {types.map((type) => (
-            <M.MenuItem onClick={() => handleTypeClick(type)} key={type.brace}>
-              Edit as {type.title || type.brace}
-            </M.MenuItem>
-          ))}
-        </M.Menu>
+        {hasMultipleChoices && (
+          <M.Menu open={!!anchorEl} anchorEl={anchorEl} onClose={() => setAnchorEl(null)}>
+            {types.map((type) => (
+              <M.MenuItem onClick={() => handleTypeClick(type)} key={type.brace}>
+                Edit as {type.title || type.brace}
+              </M.MenuItem>
+            ))}
+          </M.Menu>
+        )}
       </>
     )
   return (

--- a/catalog/app/components/FileEditor/Controls.tsx
+++ b/catalog/app/components/FileEditor/Controls.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react'
 import * as M from '@material-ui/core'
 
-import { EditorInputType } from './types'
+import { EditorState } from './State'
 
 interface AddFileButtonProps {
   onClick: () => void
@@ -63,26 +63,21 @@ function ButtonControl({
   )
 }
 
-interface ControlsProps {
-  disabled?: boolean
+interface ControlsProps extends EditorState {
   className?: string
-  editing: boolean
-  onEdit: (type: EditorInputType | null) => void
-  onSave: () => void
-  onCancel: () => void
-  types: EditorInputType[]
 }
 
 export function Controls({
-  disabled,
   className,
   editing,
-  onEdit,
-  onSave,
   onCancel,
+  onEdit,
+  saving,
+  onSave,
   types,
 }: ControlsProps) {
   const [anchorEl, setAnchorEl] = React.useState<HTMLElement | null>(null)
+  const disabled = saving
   const handleEditClick = React.useCallback(
     (event) => setAnchorEl(event.currentTarget),
     [],
@@ -106,7 +101,7 @@ export function Controls({
         />
         <M.Menu open={!!anchorEl} anchorEl={anchorEl} onClose={() => setAnchorEl(null)}>
           {types.map((type) => (
-            <M.MenuItem onClick={() => handleTypeClick(type)}>
+            <M.MenuItem onClick={() => handleTypeClick(type)} key={type.brace}>
               Edit as {type.title || type.brace}
             </M.MenuItem>
           ))}

--- a/catalog/app/components/FileEditor/Controls.tsx
+++ b/catalog/app/components/FileEditor/Controls.tsx
@@ -1,6 +1,8 @@
 import * as React from 'react'
 import * as M from '@material-ui/core'
 
+import { EditorInputType } from './types'
+
 interface AddFileButtonProps {
   onClick: () => void
 }
@@ -19,7 +21,7 @@ interface ButtonControlProps {
   color?: 'primary'
   icon: string
   label: string
-  onClick: () => void
+  onClick: (event: React.MouseEvent) => void
   variant?: 'outlined' | 'contained'
 }
 
@@ -65,9 +67,10 @@ interface ControlsProps {
   disabled?: boolean
   className?: string
   editing: boolean
-  onEdit: () => void
+  onEdit: (type: EditorInputType | null) => void
   onSave: () => void
   onCancel: () => void
+  types: EditorInputType[]
 }
 
 export function Controls({
@@ -77,16 +80,38 @@ export function Controls({
   onEdit,
   onSave,
   onCancel,
+  types,
 }: ControlsProps) {
+  const [anchorEl, setAnchorEl] = React.useState<HTMLElement | null>(null)
+  const handleEditClick = React.useCallback(
+    (event) => setAnchorEl(event.currentTarget),
+    [],
+  )
+  const handleTypeClick = React.useCallback(
+    (type) => {
+      onEdit(type)
+      setAnchorEl(null)
+    },
+    [onEdit],
+  )
   if (!editing)
     return (
-      <ButtonControl
-        className={className}
-        disabled={disabled}
-        icon="edit"
-        label="Edit"
-        onClick={onEdit}
-      />
+      <>
+        <ButtonControl
+          className={className}
+          disabled={disabled}
+          icon="edit"
+          label="Edit"
+          onClick={handleEditClick}
+        />
+        <M.Menu open={!!anchorEl} anchorEl={anchorEl} onClose={() => setAnchorEl(null)}>
+          {types.map((type) => (
+            <M.MenuItem onClick={() => handleTypeClick(type)}>
+              Edit as {type.title || type.brace}
+            </M.MenuItem>
+          ))}
+        </M.Menu>
+      </>
     )
   return (
     <M.ButtonGroup disabled={disabled} className={className} size="small">

--- a/catalog/app/components/FileEditor/FileEditor.tsx
+++ b/catalog/app/components/FileEditor/FileEditor.tsx
@@ -1,101 +1,17 @@
 import * as React from 'react'
-import * as RRDom from 'react-router-dom'
 
 import * as PreviewUtils from 'components/Preview/loaders/utils'
 import PreviewDisplay from 'components/Preview/Display'
-import type * as Model from 'model'
-import * as AddToPackage from 'containers/AddToPackage'
 import AsyncResult from 'utils/AsyncResult'
-import * as NamedRoutes from 'utils/NamedRoutes'
-import parseSearch from 'utils/parseSearch'
 import type { S3HandleBase } from 'utils/s3paths'
 
 import Skeleton from './Skeleton'
 import TextEditor from './TextEditor'
 import QuiltConfigEditor from './QuiltConfigEditor'
-import { detect, loadMode, useWriteData } from './loader'
+import { loadMode } from './loader'
 import { EditorInputType } from './types'
 
 export { detect, isSupportedFileType } from './loader'
-
-function useRedirect() {
-  const addToPackage = AddToPackage.use()
-  const history = RRDom.useHistory()
-  const { urls } = NamedRoutes.use()
-  const location = RRDom.useLocation()
-  const { add, next } = parseSearch(location.search, true)
-  return React.useCallback(
-    ({ bucket, key, size, version }: Model.S3File) => {
-      if (add && addToPackage?.append) {
-        addToPackage.append(add, { bucket, key, size, version })
-      }
-      history.push(next || urls.bucketFile(bucket, key, { version }))
-    },
-    [history, next, addToPackage, add, urls],
-  )
-}
-
-interface EditorState {
-  editing: EditorInputType | null
-  error: Error | null
-  onCancel: () => void
-  onChange: (value: string) => void
-  onEdit: (type: EditorInputType | null) => void
-  onSave: () => Promise<Model.S3File | void>
-  types: EditorInputType[]
-  value?: string
-}
-
-// TODO: use Provider
-export function useState(handle: S3HandleBase): EditorState {
-  const types = React.useMemo(() => detect(handle.key), [handle.key])
-  const location = RRDom.useLocation()
-  const { edit } = parseSearch(location.search, true)
-  const [error, setError] = React.useState<Error | null>(null)
-  const [value, setValue] = React.useState<string | undefined>()
-  const [editing, setEditing] = React.useState<EditorInputType | null>(
-    edit ? types[0] : null,
-  )
-  const [saving, setSaving] = React.useState<boolean>(false)
-  const writeFile = useWriteData(handle)
-  const redirect = useRedirect()
-  const onSave = React.useCallback(async () => {
-    // XXX: implement custom MUI Dialog-based confirm?
-    // eslint-disable-next-line no-restricted-globals, no-alert
-    if (!value && !window.confirm('You are about to save empty file')) return
-    setSaving(true)
-    try {
-      setError(null)
-      const h = await writeFile(value || '')
-      setEditing(null)
-      setSaving(false)
-      redirect(h)
-      return h
-    } catch (e) {
-      const err = e instanceof Error ? e : new Error(`${e}`)
-      setError(err)
-      setSaving(false)
-    }
-  }, [redirect, value, writeFile])
-  const onCancel = React.useCallback(() => {
-    setEditing(null)
-    setError(null)
-  }, [])
-  return React.useMemo(
-    () => ({
-      editing,
-      error,
-      onCancel,
-      onChange: setValue,
-      onEdit: setEditing,
-      onSave,
-      saving,
-      types,
-      value,
-    }),
-    [editing, error, onCancel, onSave, saving, types, value],
-  )
-}
 
 interface EditorProps {
   disabled?: boolean

--- a/catalog/app/components/FileEditor/FileEditor.tsx
+++ b/catalog/app/components/FileEditor/FileEditor.tsx
@@ -6,6 +6,7 @@ import AsyncResult from 'utils/AsyncResult'
 import type { S3HandleBase } from 'utils/s3paths'
 
 import Skeleton from './Skeleton'
+import { EditorState } from './State'
 import TextEditor from './TextEditor'
 import QuiltConfigEditor from './QuiltConfigEditor'
 import { loadMode } from './loader'
@@ -13,23 +14,21 @@ import { EditorInputType } from './types'
 
 export { detect, isSupportedFileType } from './loader'
 
-interface EditorProps {
-  disabled?: boolean
-  empty?: boolean
-  error: Error | null
-  handle: S3HandleBase
-  onChange: (value: string) => void
+interface EditorProps extends EditorState {
   editing: EditorInputType
+  empty?: boolean
+  handle: S3HandleBase
 }
 
 function EditorSuspended({
-  disabled,
+  saving,
   empty,
   error,
   handle,
   onChange,
   editing,
 }: EditorProps) {
+  const disabled = saving
   if (editing.brace !== '__quiltConfig') {
     loadMode(editing.brace || 'plain_text') // TODO: loaders#typeText.brace
   }

--- a/catalog/app/components/FileEditor/State.tsx
+++ b/catalog/app/components/FileEditor/State.tsx
@@ -27,13 +27,14 @@ function useRedirect() {
   )
 }
 
-interface EditorState {
+export interface EditorState {
   editing: EditorInputType | null
   error: Error | null
   onCancel: () => void
   onChange: (value: string) => void
   onEdit: (type: EditorInputType | null) => void
   onSave: () => Promise<Model.S3File | void>
+  saving: boolean
   types: EditorInputType[]
   value?: string
 }

--- a/catalog/app/components/FileEditor/State.tsx
+++ b/catalog/app/components/FileEditor/State.tsx
@@ -1,0 +1,90 @@
+import * as React from 'react'
+import * as RRDom from 'react-router-dom'
+
+import type * as Model from 'model'
+import * as AddToPackage from 'containers/AddToPackage'
+import * as NamedRoutes from 'utils/NamedRoutes'
+import parseSearch from 'utils/parseSearch'
+import type { S3HandleBase } from 'utils/s3paths'
+
+import { detect, useWriteData } from './loader'
+import { EditorInputType } from './types'
+
+function useRedirect() {
+  const addToPackage = AddToPackage.use()
+  const history = RRDom.useHistory()
+  const { urls } = NamedRoutes.use()
+  const location = RRDom.useLocation()
+  const { add, next } = parseSearch(location.search, true)
+  return React.useCallback(
+    ({ bucket, key, size, version }: Model.S3File) => {
+      if (add && addToPackage?.append) {
+        addToPackage.append(add, { bucket, key, size, version })
+      }
+      history.push(next || urls.bucketFile(bucket, key, { version }))
+    },
+    [history, next, addToPackage, add, urls],
+  )
+}
+
+interface EditorState {
+  editing: EditorInputType | null
+  error: Error | null
+  onCancel: () => void
+  onChange: (value: string) => void
+  onEdit: (type: EditorInputType | null) => void
+  onSave: () => Promise<Model.S3File | void>
+  types: EditorInputType[]
+  value?: string
+}
+
+// TODO: use Provider
+export function useState(handle: S3HandleBase): EditorState {
+  const types = React.useMemo(() => detect(handle.key), [handle.key])
+  const location = RRDom.useLocation()
+  const { edit } = parseSearch(location.search, true)
+  const [error, setError] = React.useState<Error | null>(null)
+  const [value, setValue] = React.useState<string | undefined>()
+  const [editing, setEditing] = React.useState<EditorInputType | null>(
+    edit ? types[0] : null,
+  )
+  const [saving, setSaving] = React.useState<boolean>(false)
+  const writeFile = useWriteData(handle)
+  const redirect = useRedirect()
+  const onSave = React.useCallback(async () => {
+    // XXX: implement custom MUI Dialog-based confirm?
+    // eslint-disable-next-line no-restricted-globals, no-alert
+    if (!value && !window.confirm('You are about to save empty file')) return
+    setSaving(true)
+    try {
+      setError(null)
+      const h = await writeFile(value || '')
+      setEditing(null)
+      setSaving(false)
+      redirect(h)
+      return h
+    } catch (e) {
+      const err = e instanceof Error ? e : new Error(`${e}`)
+      setError(err)
+      setSaving(false)
+    }
+  }, [redirect, value, writeFile])
+  const onCancel = React.useCallback(() => {
+    setEditing(null)
+    setError(null)
+  }, [])
+  return React.useMemo(
+    () => ({
+      editing,
+      error,
+      onCancel,
+      onChange: setValue,
+      onEdit: setEditing,
+      onSave,
+      saving,
+      types,
+      value,
+    }),
+    [editing, error, onCancel, onSave, saving, types, value],
+  )
+}

--- a/catalog/app/components/FileEditor/index.ts
+++ b/catalog/app/components/FileEditor/index.ts
@@ -1,3 +1,4 @@
 export * from './Controls'
 export * from './CreateFile'
 export * from './FileEditor'
+export * from './State'

--- a/catalog/app/components/FileEditor/loader.ts
+++ b/catalog/app/components/FileEditor/loader.ts
@@ -25,6 +25,7 @@ export const loadMode = (mode: Mode) => {
 const isQuiltConfig = (path: string) =>
   quiltConfigs.all.some((quiltConfig) => quiltConfig.includes(path))
 const typeQuiltConfig: EditorInputType = {
+  title: 'Quilt config helper',
   brace: '__quiltConfig',
 }
 
@@ -44,11 +45,13 @@ const typeMarkdown: EditorInputType = {
 
 const isText = PreviewUtils.extIn(['.txt', ''])
 const typeText: EditorInputType = {
+  title: 'Plain text',
   brace: 'plain_text',
 }
 
 const isYaml = PreviewUtils.extIn(['.yaml', '.yml'])
 const typeYaml: EditorInputType = {
+  title: 'YAML',
   brace: 'yaml',
 }
 
@@ -56,22 +59,22 @@ const typeNone: EditorInputType = {
   brace: null,
 }
 
-export const detect: (path: string) => EditorInputType = R.pipe(
+export const detect: (path: string) => EditorInputType[] = R.pipe(
   PreviewUtils.stripCompression,
   R.cond([
-    [isQuiltConfig, R.always(typeQuiltConfig)],
-    [isCsv, R.always(typeCsv)],
-    [isJson, R.always(typeJson)],
-    [isMarkdown, R.always(typeMarkdown)],
-    [isText, R.always(typeText)],
-    [isYaml, R.always(typeYaml)],
-    [R.T, R.always(typeNone)],
+    [isQuiltConfig, R.always([typeQuiltConfig, typeYaml])],
+    [isCsv, R.always([typeCsv])],
+    [isJson, R.always([typeJson])],
+    [isMarkdown, R.always([typeMarkdown])],
+    [isText, R.always([typeText])],
+    [isYaml, R.always([typeYaml])],
+    [R.T, R.always([typeNone])],
   ]),
 )
 
 export const isSupportedFileType: (path: string) => boolean = R.pipe(
   detect,
-  R.prop('brace'),
+  R.path([0, 'brace']),
   Boolean,
 )
 

--- a/catalog/app/components/FileEditor/types.ts
+++ b/catalog/app/components/FileEditor/types.ts
@@ -1,5 +1,6 @@
 export type Mode = '__quiltConfig' | 'less' | 'json' | 'markdown' | 'plain_text' | 'yaml'
 
 export interface EditorInputType {
+  title?: string
   brace: Mode | null
 }

--- a/catalog/app/containers/Bucket/File.js
+++ b/catalog/app/containers/Bucket/File.js
@@ -521,10 +521,10 @@ export default function File({
               {editorState.editing ? (
                 <Section icon="text_fields" heading="Edit content" defaultExpanded>
                   <FileEditor.Editor
+                    handle={handle}
                     disabled={editorState.saving}
                     editing={editorState.editing}
                     error={editorState.error}
-                    handle={handle}
                     onChange={editorState.onChange}
                     types={editorState.types}
                   />

--- a/catalog/app/containers/Bucket/File.js
+++ b/catalog/app/containers/Bucket/File.js
@@ -477,14 +477,15 @@ export default function File({
               onChange={onViewModeChange}
             />
           )}
-          {!!editorState.type.brace && (
+          {FileEditor.isSupportedFileType(handle.key) && (
             <FileEditor.Controls
+              className={classes.button}
               disabled={editorState.saving}
               editing={editorState.editing}
-              className={classes.button}
-              onSave={handleEditorSave}
               onCancel={editorState.onCancel}
               onEdit={editorState.onEdit}
+              onSave={handleEditorSave}
+              types={editorState.types}
             />
           )}
           <FileView.AdaptiveButtonLayout
@@ -525,10 +526,11 @@ export default function File({
                 <Section icon="text_fields" heading="Edit content" defaultExpanded>
                   <FileEditor.Editor
                     disabled={editorState.saving}
+                    editing={editorState.editing}
                     error={editorState.error}
                     handle={handle}
                     onChange={editorState.onChange}
-                    type={editorState.type}
+                    types={editorState.types}
                   />
                 </Section>
               ) : (

--- a/catalog/app/containers/Bucket/File.js
+++ b/catalog/app/containers/Bucket/File.js
@@ -479,13 +479,9 @@ export default function File({
           )}
           {FileEditor.isSupportedFileType(handle.key) && (
             <FileEditor.Controls
+              {...editorState}
               className={classes.button}
-              disabled={editorState.saving}
-              editing={editorState.editing}
-              onCancel={editorState.onCancel}
-              onEdit={editorState.onEdit}
               onSave={handleEditorSave}
-              types={editorState.types}
             />
           )}
           <FileView.AdaptiveButtonLayout

--- a/catalog/app/containers/Bucket/File.js
+++ b/catalog/app/containers/Bucket/File.js
@@ -520,14 +520,7 @@ export default function File({
               )}
               {editorState.editing ? (
                 <Section icon="text_fields" heading="Edit content" defaultExpanded>
-                  <FileEditor.Editor
-                    handle={handle}
-                    disabled={editorState.saving}
-                    editing={editorState.editing}
-                    error={editorState.error}
-                    onChange={editorState.onChange}
-                    types={editorState.types}
-                  />
+                  <FileEditor.Editor {...editorState} handle={handle} />
                 </Section>
               ) : (
                 <Section icon="remove_red_eye" heading="Preview" defaultExpanded>
@@ -547,14 +540,7 @@ export default function File({
           _: () =>
             editorState.editing ? (
               <Section icon="text_fields" heading="Edit content" defaultExpanded>
-                <FileEditor.Editor
-                  disabled={editorState.saving}
-                  error={editorState.error}
-                  type={editorState.type}
-                  empty
-                  handle={handle}
-                  onChange={editorState.onChange}
-                />
+                <FileEditor.Editor {...editorState} empty handle={handle} />
               </Section>
             ) : (
               <>

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -33,6 +33,7 @@ Entries inside each section should be ordered by type:
 * [Changed] Rename "Metadata" to "User metadata" ([#3255](https://github.com/quiltdata/quilt/pull/3255))
 * [Changed] Show selective metadata for packages as JSON ([#3259](https://github.com/quiltdata/quilt/pull/3259))
 * [Changed] Show selective metadata on one line and optionaly on multiple lines ([#3284](https://github.com/quiltdata/quilt/pull/3284))
+* [Changed] Edit .quilt/config files with text editor ([#3306](https://github.com/quiltdata/quilt/pull/3306))
 
 # 5.1.0 - 2022-12-09
 ## Python API


### PR DESCRIPTION
Main change is in FileEditor/loader.ts - detected type changed from single value to array 
* If there are multiple detected types to edit, then there is a menu to select which type to use
* Refactored state, `types` stores detected type, `editing` converted from boolean (is editing or not) to file type (if editing then with what type)
* Move state to separate module and re-used state type instead of creating type individually for every component

- [x] [Changelog](CHANGELOG.md) entry (skip if change is not significant to end users, e.g. docs only)
