### PR TITLE
Bump mistune and nbconvert in preview lambda

### DIFF
--- a/lambdas/preview/requirements.txt
+++ b/lambdas/preview/requirements.txt
@@ -14,8 +14,8 @@ Jinja2==3.1.2
 jsonschema==3.2.0
 jupyter-core==4.11.2
 MarkupSafe==2.1.1
-mistune==0.8.4
-nbconvert==6.5.1
+mistune==2.0.5
+nbconvert==7.2.9
 nbformat==5.4.0
 numpy==1.21.5
 openpyxl==3.0.7


### PR DESCRIPTION
This is for security, see https://github.com/quiltdata/quilt/pull/2964.
(For some reason dependabot thinks mistune is already updated)