### PR TITLE
Add provider-specific OAuth2 overrides to ask for refresh tokens

### DIFF
--- a/catalog/app/containers/Auth/SSOAzure.js
+++ b/catalog/app/containers/Auth/SSOAzure.js
@@ -21,6 +21,10 @@ export default function SSOAzure({ mutex, next, ...props }) {
   const authenticate = OIDC.use({
     provider,
     popupParams: 'width=500,height=700',
+    overrides: {
+      // Make sure we get a refresh_token.
+      scope: 'openid email offline_access',
+    },
   })
 
   const sentry = Sentry.use()

--- a/catalog/app/containers/Auth/SSOGoogle.js
+++ b/catalog/app/containers/Auth/SSOGoogle.js
@@ -20,6 +20,12 @@ export default function SSOGoogle({ mutex, ...props }) {
   const authenticate = OIDC.use({
     provider,
     popupParams: 'width=600,height=600',
+    overrides: {
+      // Make sure we get a refresh_token.
+      access_type: 'offline',
+      // Make sure we get it every time, not just during the first login.
+      prompt: 'consent',
+    },
   })
 
   const sentry = Sentry.use()

--- a/catalog/app/containers/Auth/SSOOkta.js
+++ b/catalog/app/containers/Auth/SSOOkta.js
@@ -21,6 +21,10 @@ export default function SSOOkta({ mutex, next, ...props }) {
   const authenticate = OIDC.use({
     provider,
     popupParams: 'width=400,height=600',
+    overrides: {
+      // Make sure we get a refresh_token.
+      scope: 'openid email offline_access',
+    },
   })
 
   const sentry = Sentry.use()

--- a/catalog/app/embed/debug-harness.js
+++ b/catalog/app/embed/debug-harness.js
@@ -41,6 +41,10 @@ function Embedder() {
   const authenticate = OIDC.use({
     provider: 'okta',
     popupParams: 'width=400,height=600',
+    overrides: {
+      // Make sure we get a refresh_token.
+      scope: 'openid email offline_access',
+    },
   })
 
   const iframeRef = React.useRef(null)

--- a/catalog/app/utils/OIDC.js
+++ b/catalog/app/utils/OIDC.js
@@ -12,7 +12,7 @@ export class OIDCError extends BaseError {
   }
 }
 
-export function useOIDC({ provider, popupParams }) {
+export function useOIDC({ provider, popupParams, overrides = {} }) {
   return React.useCallback(
     () =>
       new Promise((resolve, reject) => {
@@ -22,6 +22,7 @@ export function useOIDC({ provider, popupParams }) {
           response_type: 'code',
           scope: 'openid email',
           state,
+          ...overrides,
         })
         const url = `${cfg.registryUrl}/oidc-authorize/${provider}${query}`
         const popup = window.open(url, `quilt_${provider}_popup`, popupParams)
@@ -65,7 +66,7 @@ export function useOIDC({ provider, popupParams }) {
         window.addEventListener('message', handleMessage)
         popup.focus()
       }),
-    [provider, popupParams],
+    [provider, popupParams, overrides],
   )
 }
 


### PR DESCRIPTION
Currently, we're getting ID tokens and access tokens, but not refresh tokens (which aren't used yet, but will be soon).

It appears that requesting a refresh token is not standardized, and different providers do it in different, incompatible ways:
- Google needs `access_type=offline`, and will actively reject anything unexpected
- Okta and Azure need `scope=offline_access`, and will also reject anything unexpected
- OneLogin doesn't need anything, but will reject parameters required by the other providers
