### PR TITLE
Update base Docker images, use versioned tags and digests

### DIFF
--- a/catalog/Dockerfile
+++ b/catalog/Dockerfile
@@ -1,4 +1,4 @@
-FROM nginx:1.18.0
+FROM nginx:1.21.1@sha256:77e8d894dd80c62dafed1ba880954ff707bf0053710aeca2b639258cd6314f2f
 MAINTAINER Quilt Data, Inc. contact@quiltdata.io
 
 # Set up nginx

--- a/lambdas/molecule/Dockerfile
+++ b/lambdas/molecule/Dockerfile
@@ -1,7 +1,8 @@
-ARG base_image="python:3.7-slim-bullseye"
 ARG FUNCTION_DIR="/function"
 
-FROM ${base_image} as build-image
+FROM python:3.7-slim-bullseye@sha256:179b9df027ec92091d44f9d9429b0127f513d1ca47815db6164ec271ebc3f42f AS base-image
+
+FROM base-image as build-image
 
 # Include global arg in this stage of the build
 ARG FUNCTION_DIR
@@ -21,7 +22,7 @@ COPY shared/ /src/shared/
 COPY molecule/ /src/molecule/
 RUN pip install --target /lambda --no-deps /src/shared/ /src/molecule/
 
-FROM ${base_image}
+FROM base-image
 
 RUN apt-get update && \
     apt-get install -y --no-install-recommends \

--- a/lambdas/thumbnail/Dockerfile
+++ b/lambdas/thumbnail/Dockerfile
@@ -1,7 +1,8 @@
-ARG base_image="debian:bullseye-slim"
 ARG FUNCTION_DIR="/function"
 
-FROM ${base_image} as build-image
+FROM debian:bullseye-20230227-slim@sha256:77f46c1cf862290e750e913defffb2828c889d291a93bdd10a7a0597720948fc as base-image
+
+FROM base-image as build-image
 
 # Include global arg in this stage of the build
 ARG FUNCTION_DIR
@@ -25,7 +26,7 @@ COPY shared/ /src/shared/
 COPY thumbnail/ /src/thumbnail/
 RUN pip install --target /lambda --no-deps /src/shared/ /src/thumbnail/
 
-FROM ${base_image}
+FROM base-image
 
 RUN apt-get update && \
     apt-get install -y --no-install-recommends\

--- a/s3-proxy/Dockerfile
+++ b/s3-proxy/Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:buster-slim
+FROM debian:bullseye-20230227-slim@sha256:77f46c1cf862290e750e913defffb2828c889d291a93bdd10a7a0597720948fc
 MAINTAINER Quilt Data, Inc. contact@quiltdata.io
 
 # Based on:


### PR DESCRIPTION
Also do not specify base image as ARG as it's not supported by dependabot.