### PR TITLE
Allow same-origin for Browsable iframes

### DIFF
--- a/catalog/app/components/Preview/loaders/IFrame/LoaderBrowsable.tsx
+++ b/catalog/app/components/Preview/loaders/IFrame/LoaderBrowsable.tsx
@@ -184,6 +184,7 @@ export default function BrowsableLoader({ handle, children }: BrowsableLoaderPro
           PreviewData.IFrame({
             src: `${cfg.s3Proxy}/browse/${sessionId}/${handle.logicalKey}`,
             modes: [FileType.Html, FileType.Text],
+            sandbox: 'allow-scripts allow-same-origin',
           }),
       },
       sessionData,


### PR DESCRIPTION
* Iframe hosted on the different host origin, so it's safe to set "allow-same-origin"
* Perspective worker (and inline WebWorkers in general) doesn't work in Chrome without "allow-same-origin"