### PR TITLE
Tabular data default to .csv

### DIFF
--- a/catalog/app/components/Preview/loaders/Tabular.tsx
+++ b/catalog/app/components/Preview/loaders/Tabular.tsx
@@ -34,7 +34,7 @@ export const detect = R.pipe(
   R.anyPass([isCsv, isExcel, isJsonl, isParquet, isTsv]),
 )
 
-type TabularType = 'csv' | 'jsonl' | 'excel' | 'parquet' | 'tsv' | 'txt'
+type TabularType = 'csv' | 'jsonl' | 'excel' | 'parquet' | 'tsv'
 
 const detectTabularType: (type: string) => TabularType = R.pipe(
   utils.stripCompression,
@@ -44,7 +44,7 @@ const detectTabularType: (type: string) => TabularType = R.pipe(
     [isJsonl, R.always('jsonl')],
     [isParquet, R.always('parquet')],
     [isTsv, R.always('tsv')],
-    [R.T, R.always('txt')],
+    [R.T, R.always('csv')],
   ]),
 )
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -27,6 +27,7 @@ Entries inside each section should be ordered by type:
 * [Changed] Edit .quilt/config files with text editor ([#3306](https://github.com/quiltdata/quilt/pull/3306))
 * [Changed] Refactoring of buttons adapted to page width ([#3300](https://github.com/quiltdata/quilt/pull/3300))
 * [Changed] Restrict editing `user_meta` field only for object-level metadata ([#3337](https://github.com/quiltdata/quilt/pull/3337))
+* [Changed] Tabular format defaults to .csv ([#3382](https://github.com/quiltdata/quilt/pull/3382))
 
 # 5.1.1 - 2023-01-25
 ## Python API


### PR DESCRIPTION
* Tabular lambda doesn't accept .txt type anyway
* At least one customer place CSV into .data file

After this change, if users set `type: [perspective]` in quilt_summarize, and file doesn't have extension .csv, .xlsx, .xls, .jsonl, .pq, .parquet, .tsv, .tab, then we try to render it as .csv.