### PR TITLE
Docs: Add link to RODA example & add PFS acronym

### DIFF
--- a/docs/Catalog/Preview.md
+++ b/docs/Catalog/Preview.md
@@ -38,12 +38,12 @@ The following file formats are supported:
 * .ipynb (Jupyter and Voila dashboards)
 * .parquet
 
-## Advanced
+## Advanced: Quilt Package File Server
 
-The Quilt catalog supports secure, custom Javascript-enabled visualizations and
-dashboards embedded inside iframes.
-It is at your discretion which JS library (or libraries) you wish to import in
-your HTML file.
+The Quilt Catalog supports secure, custom Javascript-enabled
+visualizations and dashboards embedded inside iframes (Package
+File Server). It is at your discretion which JS library (or libraries)
+you wish to import in your HTML file.
 
 To enable "permissive" visualizations, check the `Enable permissive HTML
 rendering` checkbox in [Bucket settings](Admin.md#buckets). Please note
@@ -66,3 +66,8 @@ session, although all session traffic _remains encrypted_.
 > **All files in the same package** are made temporarily publicly-available (for
 > lifetime of the session) under `/temporary-session-id`, even if not explicitly
 referenced in `report.html`.
+
+### Live packages
+
+- [Dynamic visualizations; interactive IGV dashboard; Perspective datagrids with
+images](https://open.quiltdata.com/b/quilt-example/packages/examples/package-file-server)

--- a/docs/Catalog/Preview.md
+++ b/docs/Catalog/Preview.md
@@ -69,5 +69,5 @@ referenced in `report.html`.
 
 ### Live packages
 
-- [Dynamic visualizations; interactive IGV dashboard; Perspective datagrids with
+* [Dynamic visualizations; interactive IGV dashboard; Perspective datagrids with
 images](https://open.quiltdata.com/b/quilt-example/packages/examples/package-file-server)


### PR DESCRIPTION
# TODO

<!-- Remove items that are irrelevant to this PR -->

- [n/a] Unit tests
- [n/a] Automated tests (e.g. Preflight)
- [X] Confirm that this change meets security best practices and does not violate the security model
- [X] Documentation
    - [n/a] [Python: Run `build.py`](../gendocs/build.py) for new docstrings
    - [n/a] JavaScript: basic explanation and screenshot of new features
    - [n/a] Markdown somewhere in docs/**/*.md that explains the feature to end users (said .md files should be linked from SUMMARY.md so they appear on https://docs.quiltdata.com)
    - [n/a] Markdown docs for developers
- [n/a] [Changelog](CHANGELOG.md) entry (skip if change is not significant to end users, e.g. docs only)
