### PR TITLE
Render status report if no `bucketConfig`

### DIFF
--- a/catalog/app/components/Preview/loaders/Html.js
+++ b/catalog/app/components/Preview/loaders/Html.js
@@ -40,8 +40,8 @@ export const Loader = function HtmlLoader({ handle, children }) {
   return bucketData.case({
     fetching: () => children(AsyncResult.Pending()),
     error: (e) => children(AsyncResult.Err(e)),
-    data: ({ bucketConfig: { browsable } }) =>
-      browsable && inPackage ? (
+    data: ({ bucketConfig }) =>
+      bucketConfig?.browsable && inPackage ? (
         <IFrame.LoaderBrowsable {...{ handle, children }} />
       ) : (
         <IFrame.LoaderSigned {...{ handle, children }} />


### PR DESCRIPTION
I don't know why, but there is no `bucketConfig` for bucket with status reports

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1204325167861344