### PR TITLE
doc: fix push args line breaks

### DIFF
--- a/api/python/quilt3/packages.py
+++ b/api/python/quilt3/packages.py
@@ -1324,7 +1324,7 @@ class Package:
         Args:
             name: name for package in registry
             dest: where to copy the objects in the package. Must be either an S3 URI prefix (e.g., s3://$bucket/$key)
-                in the registry bucket, or a callable that takes logical_key, package_entry, and top_hash 
+                in the registry bucket, or a callable that takes logical_key, package_entry, and top_hash
                 and returns an S3 URI.
             registry: registry where to create the new package
             message: the commit message for the new package

--- a/api/python/quilt3/packages.py
+++ b/api/python/quilt3/packages.py
@@ -1323,9 +1323,9 @@ class Package:
 
         Args:
             name: name for package in registry
-            dest: where to copy the objects in the package.
-                Must be either an S3 URI prefix in the registry bucket, or a callable that takes
-                logical_key, package_entry, and top_hash and returns S3 URI. S3 URIs format is s3://$bucket/$key.
+            dest: where to copy the objects in the package. Must be either an S3 URI prefix (e.g., s3://$bucket/$key)
+                in the registry bucket, or a callable that takes logical_key, package_entry, and top_hash 
+                and returns an S3 URI.
             registry: registry where to create the new package
             message: the commit message for the new package
             selector_fn: An optional function that determines which package entries should be copied to S3.

--- a/api/python/quilt3/packages.py
+++ b/api/python/quilt3/packages.py
@@ -1323,7 +1323,7 @@ class Package:
 
         Args:
             name: name for package in registry
-            dest: where to copy the objects in the package
+            dest: where to copy the objects in the package.
                 Must be either an S3 URI prefix in the registry bucket, or a callable that takes
                 logical_key, package_entry, and top_hash and returns S3 URI. S3 URIs format is s3://$bucket/$key.
             registry: registry where to create the new package

--- a/docs/api-reference/Package.md
+++ b/docs/api-reference/Package.md
@@ -299,9 +299,9 @@ the parent hash of the package being pushed. Use `force=True` to skip the check.
 __Arguments__
 
 * __name__:  name for package in registry
-* __dest__:  where to copy the objects in the package
+* __dest__:  where to copy the objects in the package.
     Must be either an S3 URI prefix in the registry bucket, or a callable that takes
-* __logical_key, package_entry, and top_hash and returns S3 URI. S3 URIs format is s3__: //$bucket/$key.
+    logical_key, package_entry, and top_hash and returns S3 URI. S3 URIs format is s3__: //$bucket/$key.
 * __registry__:  registry where to create the new package
 * __message__:  the commit message for the new package
 * __selector_fn__:  An optional function that determines which package entries should be copied to S3.

--- a/docs/api-reference/Package.md
+++ b/docs/api-reference/Package.md
@@ -299,9 +299,9 @@ the parent hash of the package being pushed. Use `force=True` to skip the check.
 __Arguments__
 
 * __name__:  name for package in registry
-* __dest__:  where to copy the objects in the package.
-    Must be either an S3 URI prefix in the registry bucket, or a callable that takes
-    logical_key, package_entry, and top_hash and returns S3 URI. S3 URIs format is s3__: //$bucket/$key.
+* __dest__:  where to copy the objects in the package. Must be either an S3 URI prefix (e.g., s3://$bucket/$key)
+    in the registry bucket, or a callable that takes logical_key, package_entry, and top_hash
+    and returns an S3 URI.
 * __registry__:  registry where to create the new package
 * __message__:  the commit message for the new package
 * __selector_fn__:  An optional function that determines which package entries should be copied to S3.


### PR DESCRIPTION
# Description

Fix incorrect line break in documentation for `push()` args

