### PR TITLE
Add link from side navigation and update text

### DIFF
--- a/docs/Catalog/FileBrowser.md
+++ b/docs/Catalog/FileBrowser.md
@@ -1,3 +1,4 @@
+<!--pytest-codeblocks:skipfile-->
 
 Every S3 bucket attached to Quilt has a "Bucket" tab in the Catalog
 that displays all files in the bucket.

--- a/docs/Catalog/FileBrowser.md
+++ b/docs/Catalog/FileBrowser.md
@@ -1,3 +1,4 @@
+
 Every S3 bucket attached to Quilt has a "Bucket" tab in the Catalog
 that displays all files in the bucket.
 

--- a/docs/Catalog/FileBrowser.md
+++ b/docs/Catalog/FileBrowser.md
@@ -1,5 +1,3 @@
-zsh:1: command not found: fm5t
-
 Every S3 bucket attached to Quilt has a "Bucket" tab that displays
 all files in the bucket.
 

--- a/docs/Catalog/FileBrowser.md
+++ b/docs/Catalog/FileBrowser.md
@@ -1,25 +1,25 @@
-# Files manipulation in Catalog
+zsh:1: command not found: fm5t
 
-## Files browser
-
-Every bucket has "Bucket" tab where the user can see all files in his bucket.
+Every S3 bucket attached to Quilt has a "Bucket" tab that displays
+all files in the bucket.
 
 ![Files browser tab](../imgs/catalog-filesbrowser-tab.png)
 
-See also [docs on how to hide this tab](./Preferences.md).
+> If desired, [this tab can be hidden](./Preferences.md).
 
 ## Bookmarks
 
-If you want to create a package including multiple files
-from different directories and even different buckets,
-you can browse files and bookmark needed files. You can select needed files
-and click "Add to bookmarks".
-You can also navigate to a specific file
-and bookmark an individual file from that file's page.
+To create a package that includes multiple files from different
+directories in a single S3 bucket, or even across different S3
+buckets attached to Quilt, you can browse and create a "bookmark"
+of chosen files. Select files by checking the box and clicking "Add
+selected items to bookmarks". You can also navigate to a specific
+file and bookmark an individual file by clicking "Add to bookmarks".
 
 ![Select and add to bookmarks](../imgs/catalog-filesbrowser-addtobookmarks.png)
 
-Then you can open the Bookmarks pane and a create package from all those bookmarks.
+Open the Bookmarks pane (listed in the User account menu) and
+optionally create a new package from the bookmarked files.
 
 ![Open bookmarks](../imgs/catalog-filesbrowser-bookmarksmenu.png)
 
@@ -27,13 +27,15 @@ Then you can open the Bookmarks pane and a create package from all those bookmar
 
 ## Text editor
 
-You can edit plain text, Markdown, JSON and YAML files.
+Inline editing of plain text, Markdown, JSON and YAML file formats
+is supported.
 
 ![Edit button](../imgs/catalog-texteditor-edit.png)
 
-You can also create new files in editable file formats.
-The button for creating text files is located above the file browser,
-in the far right «burger»-menu
+New text files can be created individually in editable file formats.
+To create one, click the «kebab» menu (three vertical dots) located
+in the far-right, above the file browser. Choose a file name and
+format (the default is README.md), enter your content, and click save.
 
 ![Open menu](../imgs/catalog-texteditor-create.png)
 

--- a/docs/Catalog/FileBrowser.md
+++ b/docs/Catalog/FileBrowser.md
@@ -1,5 +1,3 @@
-## Files browser
-
 Every S3 bucket attached to Quilt has a "Bucket" tab in the Catalog
 that displays all files in the bucket.
 

--- a/docs/Catalog/FileBrowser.md
+++ b/docs/Catalog/FileBrowser.md
@@ -1,5 +1,7 @@
-Every S3 bucket attached to Quilt has a "Bucket" tab that displays
-all files in the bucket.
+## Files browser
+
+Every S3 bucket attached to Quilt has a "Bucket" tab in the Catalog
+that displays all files in the bucket.
 
 ![Files browser tab](../imgs/catalog-filesbrowser-tab.png)
 

--- a/docs/Catalog/FileBrowser.md
+++ b/docs/Catalog/FileBrowser.md
@@ -1,4 +1,4 @@
-<!-- markdownlint-disable -->
+<!-- markdownlint-disable-next-line first-line-h1 -->
 Every S3 bucket attached to Quilt has a "Bucket" tab in the Catalog
 that displays all files in the bucket.
 

--- a/docs/Catalog/FileBrowser.md
+++ b/docs/Catalog/FileBrowser.md
@@ -1,5 +1,4 @@
-<!--pytest-codeblocks:skipfile-->
-
+<!-- markdownlint-disable -->
 Every S3 bucket attached to Quilt has a "Bucket" tab in the Catalog
 that displays all files in the bucket.
 

--- a/docs/SUMMARY.md
+++ b/docs/SUMMARY.md
@@ -26,6 +26,7 @@
 ### Catalog
 * [Admin UI](Catalog/Admin.md)
 * [Configuration](Catalog/Preferences.md)
+* [Working with files](Catalog/FileBrowser.md)
 * [Embed](Catalog/Embed.md)
 * [Metadata for teams](Catalog/Metadata.md)
 * [Preview](Catalog/Preview.md)


### PR DESCRIPTION
# TODO

<!-- Remove items that are irrelevant to this PR -->

- [n/a] Unit tests
- [n/a] Automated tests (e.g. Preflight)
- [n/a] Confirm that this change meets security best practices and does not violate the security model
- [X] Documentation
    - [n/a] [Python: Run `build.py`](../gendocs/build.py) for new docstrings
    - [n/a] JavaScript: basic explanation and screenshot of new features
    - [n/a] Markdown somewhere in docs/**/*.md that explains the feature to end users (said .md files should be linked from SUMMARY.md so they appear on https://docs.quiltdata.com)
    - [n/a] Markdown docs for developers
- [n/a] [Changelog](CHANGELOG.md) entry (skip if change is not significant to end users, e.g. docs only)
