### PR TITLE
Add synonym for quilt3 catalog --detailed_help with sane spelling

### DIFF
--- a/api/python/quilt3/main.py
+++ b/api/python/quilt3/main.py
@@ -292,7 +292,7 @@ def create_parser():
             nargs="?"
     )
     catalog_p.add_argument(
-            "--detailed_help",
+            "--detailed-help", "--detailed_help",
             help="Display detailed information about this command and then exit",
             action="store_true",
     )

--- a/docs/api-reference/cli.md
+++ b/docs/api-reference/cli.md
@@ -2,26 +2,27 @@
 
 ## `catalog`
 ```
-usage: quilt3 catalog [-h] [--detailed_help] [--host HOST] [--port PORT]
+usage: quilt3 catalog [-h] [--detailed-help] [--host HOST] [--port PORT]
                       [--no-browser]
                       [navigation_target]
 
 Run Quilt catalog locally
 
 positional arguments:
-  navigation_target  Which page in the local catalog to open. Leave blank to
-                     go to the catalog landing page, pass in an s3 url (e.g.
-                     's3://bucket/myfile.txt') to go to file viewer, or pass
-                     in a package name in the form 'BUCKET:USER/PKG' to go to
-                     the package viewer.
+  navigation_target     Which page in the local catalog to open. Leave blank
+                        to go to the catalog landing page, pass in an s3 url
+                        (e.g. 's3://bucket/myfile.txt') to go to file viewer,
+                        or pass in a package name in the form
+                        'BUCKET:USER/PKG' to go to the package viewer.
 
 optional arguments:
-  -h, --help         show this help message and exit
-  --detailed_help    Display detailed information about this command and then
-                     exit
-  --host HOST        Bind socket to this host
-  --port PORT        Bind to a socket with this port
-  --no-browser       Don't open catalog in a browser after startup
+  -h, --help            show this help message and exit
+  --detailed-help, --detailed_help
+                        Display detailed information about this command and
+                        then exit
+  --host HOST           Bind socket to this host
+  --port PORT           Bind to a socket with this port
+  --no-browser          Don't open catalog in a browser after startup
 ```
 
 Run the Quilt catalog on your machine. Running `quilt3 catalog` launches a

--- a/gendocs/gen_cli_api_reference.sh
+++ b/gendocs/gen_cli_api_reference.sh
@@ -17,7 +17,7 @@ echo "# Quilt3 CLI and environment" >> cli.md
 echo "" >> cli.md
 
 gen_cmd_docs 'catalog'
-quilt3 catalog --detailed_help >> cli.md
+quilt3 catalog --detailed-help >> cli.md
 gen_cmd_docs 'config'
 gen_cmd_docs 'config-default-remote-registry'
 gen_cmd_docs 'disable-telemetry'


### PR DESCRIPTION
IMO we can simply rename it because I think nobody's work depends on the spelling of the flag for showing help message.
