### PR TITLE
Fix search in Python client

### DIFF
--- a/api/python/quilt3/api.py
+++ b/api/python/quilt3/api.py
@@ -197,5 +197,5 @@ def search(query, limit=10):
     """
     # force a call to configure_from_default if no config exists
     _config()
-    raw_results = search_api(query, '*', limit)
+    raw_results = search_api(query, '_all', limit)
     return raw_results['hits']['hits']

--- a/api/python/quilt3/api.py
+++ b/api/python/quilt3/api.py
@@ -178,22 +178,7 @@ def search(query, limit=10):
 
 
     Returns:
-        a list of objects with the following structure:
-        ```
-        [{
-            "_id": <document unique id>
-            "_index": <source index>,
-            "_score": <relevance score>
-            "_source":
-                "key": <key of the object>,
-                "size": <size of object in bytes>,
-                "user_meta": <user metadata from meta= via quilt3>,
-                "last_modified": <timestamp from ElasticSearch>,
-                "updated": <object timestamp from S3>,
-                "version_id": <version_id of object version>
-            "_type": <document type>
-        }, ...]
-        ```
+        a list of dicts
     """
     # force a call to configure_from_default if no config exists
     _config()

--- a/api/python/quilt3/api.py
+++ b/api/python/quilt3/api.py
@@ -171,7 +171,7 @@ def search(query: T.Union[str, dict], limit: int = 10) -> T.List[dict]:
     Execute a search against the configured search endpoint.
 
     Args:
-        query: query string to search if passed as `str`, ES query body if passed as `dict`
+        query: query string to query if passed as `str`, DSL query body if passed as `dict`
         limit: maximum number of results to return. Defaults to 10
 
     Query Syntax:

--- a/api/python/quilt3/api.py
+++ b/api/python/quilt3/api.py
@@ -166,21 +166,21 @@ def _disable_telemetry():
 
 
 @ApiTelemetry("api.search")
-def search(query: str, limit: int = 10) -> T.List[dict]:
+def search(query: T.Union[str, dict], limit: int = 10) -> T.List[dict]:
     """
     Execute a search against the configured search endpoint.
 
     Args:
-        query (str): query string to search
-        limit (number): maximum number of results to return. Defaults to 10
+        query: query string to search if passed as `str`, ES query body if passed as `dict`
+        limit: maximum number of results to return. Defaults to 10
 
     Query Syntax:
-        [simple query string query](
-            https://www.elastic.co/guide/en/elasticsearch/reference/6.8/query-dsl-simple-query-string-query.html)
-
+        [Query String Query](
+            https://www.elastic.co/guide/en/elasticsearch/reference/6.8/query-dsl-query-string-query.html)
+        [Query DSL](https://www.elastic.co/guide/en/elasticsearch/reference/6.8/query-dsl.html)
 
     Returns:
-        a list of dicts
+        search results
     """
     # force a call to configure_from_default if no config exists
     _config()

--- a/api/python/quilt3/api.py
+++ b/api/python/quilt3/api.py
@@ -1,3 +1,5 @@
+import typing as T
+
 from .backends import get_package_registry
 from .data_transfer import copy_file
 from .search_util import search_api
@@ -164,7 +166,7 @@ def _disable_telemetry():
 
 
 @ApiTelemetry("api.search")
-def search(query, limit=10):
+def search(query: str, limit: int = 10) -> T.List[dict]:
     """
     Execute a search against the configured search endpoint.
 

--- a/api/python/quilt3/bucket.py
+++ b/api/python/quilt3/bucket.py
@@ -51,19 +51,7 @@ class Bucket:
             The syntax for field match is `user_meta.$field_name:"exact_match"`.
 
         Returns:
-            a list of objects with the following structure:
-            ```
-            [{
-                "key": <key of the object>,
-                "version_id": <version_id of object version>,
-                "operation": <"Create" or "Delete">,
-                "meta": <metadata attached to object>,
-                "size": <size of object in bytes>,
-                "text": <indexed text of object>,
-                "source": <source document for object (what is actually stored in ElasticSeach)>,
-                "time": <timestamp for operation>,
-            }...]
-            ```
+            a list of dicts
         """
         return search_api(query, index=self._pk.bucket, limit=limit)
 

--- a/api/python/quilt3/bucket.py
+++ b/api/python/quilt3/bucket.py
@@ -37,17 +37,18 @@ class Bucket:
         if self._pk.path or self._pk.version_id is not None:
             raise QuiltException("Bucket URI shouldn't contain a path or a version ID")
 
-    def search(self, query: str, limit: int = 10) -> T.List[dict]:
+    def search(self, query: T.Union[str, dict], limit: int = 10) -> T.List[dict]:
         """
         Execute a search against the configured search endpoint.
 
         Args:
-            query: query string to search
+            query: query string to search if passed as `str`, ES query body if passed as `dict`
             limit: maximum number of results to return. Defaults to 10
 
         Query Syntax:
-            [simple query string query](
-                https://www.elastic.co/guide/en/elasticsearch/reference/6.8/query-dsl-simple-query-string-query.html)
+            [Query String Query](
+                https://www.elastic.co/guide/en/elasticsearch/reference/6.8/query-dsl-query-string-query.html)
+            [Query DSL](https://www.elastic.co/guide/en/elasticsearch/reference/6.8/query-dsl.html)
 
         Returns:
             search results

--- a/api/python/quilt3/bucket.py
+++ b/api/python/quilt3/bucket.py
@@ -5,6 +5,7 @@ Contains the Bucket class, which provides several useful functions
     over an s3 bucket.
 """
 import pathlib
+import typing as T
 
 from .data_transfer import (
     copy_file,
@@ -36,24 +37,22 @@ class Bucket:
         if self._pk.path or self._pk.version_id is not None:
             raise QuiltException("Bucket URI shouldn't contain a path or a version ID")
 
-    def search(self, query, limit=10):
+    def search(self, query: str, limit: int = 10) -> T.List[dict]:
         """
         Execute a search against the configured search endpoint.
 
         Args:
-            query (str): query string to search
-            limit (number): maximum number of results to return. Defaults to 10
+            query: query string to search
+            limit: maximum number of results to return. Defaults to 10
 
         Query Syntax:
-            By default, a normal plaintext search will be executed over the query string.
-            You can use field-match syntax to filter on exact matches for fields in
-                your metadata.
-            The syntax for field match is `user_meta.$field_name:"exact_match"`.
+            [simple query string query](
+                https://www.elastic.co/guide/en/elasticsearch/reference/6.8/query-dsl-simple-query-string-query.html)
 
         Returns:
-            a list of dicts
+            search results
         """
-        return search_api(query, index=self._pk.bucket, limit=limit)
+        return search_api(query, index=f"{self._pk.bucket},{self._pk.bucket}_packages", limit=limit)["hits"]["hits"]
 
     def put_file(self, key, path):
         """

--- a/api/python/quilt3/bucket.py
+++ b/api/python/quilt3/bucket.py
@@ -42,7 +42,7 @@ class Bucket:
         Execute a search against the configured search endpoint.
 
         Args:
-            query: query string to search if passed as `str`, ES query body if passed as `dict`
+            query: query string to query if passed as `str`, DSL query body if passed as `dict`
             limit: maximum number of results to return. Defaults to 10
 
         Query Syntax:

--- a/api/python/quilt3/search_util.py
+++ b/api/python/quilt3/search_util.py
@@ -3,29 +3,7 @@ search_util.py
 
 Contains search-related glue code
 """
-from aws_requests_auth.aws_auth import AWSRequestsAuth
-
 from . import session
-from .session import create_botocore_session
-
-
-def search_credentials(host, region, service):
-    credentials = create_botocore_session().get_credentials()
-    if credentials:
-        # use registry-provided credentials if present, otherwise
-        # standard boto credentials
-        creds = credentials.get_frozen_credentials()
-        auth = AWSRequestsAuth(aws_access_key=creds.access_key,
-                               aws_secret_access_key=creds.secret_key,
-                               aws_host=host,
-                               aws_region=region,
-                               aws_service=service,
-                               aws_token=creds.token,
-                               )
-    else:
-        auth = None
-
-    return auth
 
 
 def search_api(query, index, limit=10):

--- a/api/python/quilt3/search_util.py
+++ b/api/python/quilt3/search_util.py
@@ -3,14 +3,10 @@ search_util.py
 
 Contains search-related glue code
 """
-import re
-from urllib.parse import quote, urlencode, urlparse
-
-import requests
 from aws_requests_auth.aws_auth import AWSRequestsAuth
 
+from . import session
 from .session import create_botocore_session
-from .util import QuiltException, get_from_config
 
 
 def search_credentials(host, region, service):
@@ -37,19 +33,8 @@ def search_api(query, index, limit=10):
     Sends a query to the search API (supports simple search
     queries only)
     """
-    api_gateway = get_from_config('apiGatewayEndpoint')
-    api_gateway_host = urlparse(api_gateway).hostname
-    match = re.match(r".*\.([a-z]{2}-[a-z]+-\d)\.amazonaws\.com$", api_gateway_host)
-    region = match.groups()[0]
-    auth = search_credentials(api_gateway_host, region, 'execute-api')
-    # Encode the parameters manually because AWS Auth requires spaces to be encoded as '%20' rather than '+'.
-    encoded_params = urlencode(dict(index=index, action='search', query=query), quote_via=quote)
-    response = requests.get(
-        f"{api_gateway}/search?{encoded_params}",
-        auth=auth
+    response = session.get_session().get(
+        f"{session.get_registry_url()}/api/search",
+        params=dict(index=index, action='search', query=query, size=limit),
     )
-
-    if not response.ok:
-        raise QuiltException(response.text)
-
     return response.json()

--- a/api/python/quilt3/search_util.py
+++ b/api/python/quilt3/search_util.py
@@ -3,16 +3,22 @@ search_util.py
 
 Contains search-related glue code
 """
+import json
+import typing as T
+
 from . import session
 
 
-def search_api(query, index, limit=10):
+def search_api(query: T.Union[str, dict], index: str, limit: int = 10):
     """
-    Sends a query to the search API (supports simple search
-    queries only)
+    Send a query to the search API
     """
+    if isinstance(query, dict):
+        params = dict(index=index, action="freeform", body=json.dumps(query), size=limit)
+    else:
+        params = dict(index=index, action="search", query=query, size=limit)
     response = session.get_session().get(
         f"{session.get_registry_url()}/api/search",
-        params=dict(index=index, action='search', query=query, size=limit),
+        params=params,
     )
     return response.json()

--- a/api/python/setup.py
+++ b/api/python/setup.py
@@ -58,7 +58,6 @@ setup(
     keywords='',
     install_requires=[
         'platformdirs>=2',
-        'aws-requests-auth>=0.4.2',
         'boto3>=1.21.7',
         'jsonlines==1.2.0',
         'PyYAML>=5.1',

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -16,6 +16,8 @@ Entries inside each section should be ordered by type:
 !-->
 # unreleased - YYYY-MM-DD
 ## Python API
+* [Added] `quilt3.search()` and `quilt3.Bucket.search()` now accept custom Elasticsearch queries ([#3448](https://github.com/quiltdata/quilt/pull/3448))
+* [Fixed] `quilt3.search()` and `quilt3.Bucket.search()` now work with 2022+ Quilt stacks ([#3448](https://github.com/quiltdata/quilt/pull/3448))
 
 ## CLI
 

--- a/docs/api-reference/Bucket.md
+++ b/docs/api-reference/Bucket.md
@@ -20,7 +20,7 @@ Execute a search against the configured search endpoint.
 
 __Arguments__
 
-* __query__:  query string to search if passed as `str`, ES query body if passed as `dict`
+* __query__:  query string to query if passed as `str`, DSL query body if passed as `dict`
 * __limit__:  maximum number of results to return. Defaults to 10
 
 Query Syntax:

--- a/docs/api-reference/Bucket.md
+++ b/docs/api-reference/Bucket.md
@@ -14,36 +14,23 @@ __Returns__
 
 A new Bucket
 
-## Bucket.search(self, query, limit=10)  {#Bucket.search}
+## Bucket.search(self, query: Union[str, dict], limit: int = 10) -> List[dict]  {#Bucket.search}
 
 Execute a search against the configured search endpoint.
 
 __Arguments__
 
-* __query (str)__:  query string to search
-* __limit (number)__:  maximum number of results to return. Defaults to 10
+* __query__:  query string to search if passed as `str`, ES query body if passed as `dict`
+* __limit__:  maximum number of results to return. Defaults to 10
 
 Query Syntax:
-    By default, a normal plaintext search will be executed over the query string.
-    You can use field-match syntax to filter on exact matches for fields in
-        your metadata.
-    The syntax for field match is `user_meta.$field_name:"exact_match"`.
+    [Query String Query](
+        https://www.elastic.co/guide/en/elasticsearch/reference/6.8/query-dsl-query-string-query.html)
+    [Query DSL](https://www.elastic.co/guide/en/elasticsearch/reference/6.8/query-dsl.html)
 
 __Returns__
 
-a list of objects with the following structure:
-```
-[{
-`"key"`: <key of the object>,
-`"version_id"`: <version_id of object version>,
-`"operation"`: <"Create" or "Delete">,
-`"meta"`: <metadata attached to object>,
-`"size"`: <size of object in bytes>,
-`"text"`: <indexed text of object>,
-`"source"`: <source document for object (what is actually stored in ElasticSeach)>,
-`"time"`: <timestamp for operation>,
-}...]
-```
+search results
 
 
 ## Bucket.put\_file(self, key, path)  {#Bucket.put\_file}

--- a/docs/api-reference/api.md
+++ b/docs/api-reference/api.md
@@ -93,36 +93,21 @@ Launches a web browser and asks the user for a token.
 Do not use Quilt credentials. Useful if you have existing AWS credentials.
 
 
-## search(query, limit=10)  {#search}
+## search(query: Union[str, dict], limit: int = 10) -> List[dict]  {#search}
 
 Execute a search against the configured search endpoint.
 
 __Arguments__
 
-* __query (str)__:  query string to search
-* __limit (number)__:  maximum number of results to return. Defaults to 10
+* __query__:  query string to search if passed as `str`, ES query body if passed as `dict`
+* __limit__:  maximum number of results to return. Defaults to 10
 
 Query Syntax:
-    [simple query string query](
-        https://www.elastic.co/guide/en/elasticsearch/reference/6.8/query-dsl-simple-query-string-query.html)
-
+    [Query String Query](
+        https://www.elastic.co/guide/en/elasticsearch/reference/6.8/query-dsl-query-string-query.html)
+    [Query DSL](https://www.elastic.co/guide/en/elasticsearch/reference/6.8/query-dsl.html)
 
 __Returns__
 
-a list of objects with the following structure:
-```
-[{
-`"_id"`: <document unique id>
-`"_index"`: <source index>,
-`"_score"`: <relevance score>
-    "_source":
-`"key"`: <key of the object>,
-`"size"`: <size of object in bytes>,
-`"user_meta"`: <user metadata from meta= via quilt3>,
-`"last_modified"`: <timestamp from ElasticSearch>,
-`"updated"`: <object timestamp from S3>,
-`"version_id"`: <version_id of object version>
-`"_type"`: <document type>
-}, ...]
-```
+search results
 

--- a/docs/api-reference/api.md
+++ b/docs/api-reference/api.md
@@ -99,7 +99,7 @@ Execute a search against the configured search endpoint.
 
 __Arguments__
 
-* __query__:  query string to search if passed as `str`, ES query body if passed as `dict`
+* __query__:  query string to query if passed as `str`, DSL query body if passed as `dict`
 * __limit__:  maximum number of results to return. Defaults to 10
 
 Query Syntax:


### PR DESCRIPTION
# Description

* use registry for search API because it's removed from API gateway at least since 60113c5816b845e8f9005aaaf3b1ca131ad4ca21
* allow using custom ES queries additionally to query string queries 
* align what we return in `quilt3.Bucket.search()` with docstring  and `quilt3.search()`, it's kinda breaking, but it could be considered already broken since return type didn't match docstring
* remove description of result entries shape because it was incorrect and I don't think we should make it part of contract
* I don't like that we return mix of object and package results and don't provide a clear way to check it it's one or another, but I gave up on this, since nobody wants spend time on it  

# TODO

<!-- Remove items that are irrelevant to this PR -->

- [x] `limit` doesn't really work
- [x] `api.search()` returns both objects and packages indexes, `Bucket.search()` returns only objects (both APIs returns mix of object and package results)
- [x] check docstrings re what is returned
- [x] Unit tests
- [x] Documentation
    - [x] [Python: Run `build.py`](../gendocs/build.py) for new docstrings
- [x] [Changelog](CHANGELOG.md) entry (skip if change is not significant to end users, e.g. docs only)
