### PR TITLE
Fix docs for quilt3.config() autoconfiguration call

### DIFF
--- a/api/python/quilt3/api.py
+++ b/api/python/quilt3/api.py
@@ -97,7 +97,7 @@ def config(*catalog_url, **config_values):
     To trigger autoconfiguration, call with just the navigator URL:
 
         import quilt3
-        quilt3.config(navigator_url='https://example.com')
+        quilt3.config('https://example.com')
 
     To set config values, call with one or more key=value pairs:
 

--- a/api/python/quilt3/api.py
+++ b/api/python/quilt3/api.py
@@ -97,7 +97,7 @@ def config(*catalog_url, **config_values):
     To trigger autoconfiguration, call with just the navigator URL:
 
         import quilt3
-        quilt3.config('https://example.com')
+        quilt3.config('https://YOUR-CATALOG-URL.com')
 
     To set config values, call with one or more key=value pairs:
 

--- a/docs/api-reference/api.md
+++ b/docs/api-reference/api.md
@@ -13,7 +13,7 @@ To retrieve the current config, call directly, without arguments:
 To trigger autoconfiguration, call with just the navigator URL:
 
     import quilt3
-    quilt3.config('https://example.com')
+    quilt3.config('https://YOUR-CATALOG-URL.com')
 
 To set config values, call with one or more key=value pairs:
 

--- a/docs/api-reference/api.md
+++ b/docs/api-reference/api.md
@@ -13,7 +13,7 @@ To retrieve the current config, call directly, without arguments:
 To trigger autoconfiguration, call with just the navigator URL:
 
     import quilt3
-    quilt3.config(navigator_url='https://example.com')
+    quilt3.config('https://example.com')
 
 To set config values, call with one or more key=value pairs:
 


### PR DESCRIPTION
Was broken in d6d9bdc44a9458789d66a050b3001f0243bf9e7e
