### PR TITLE
Fix code sample for package push

### DIFF
--- a/catalog/app/containers/Bucket/PackageTree/PackageTree.tsx
+++ b/catalog/app/containers/Bucket/PackageTree/PackageTree.tsx
@@ -85,7 +85,7 @@ function PkgCode({ bucket, name, hash, hashOrTag, path }: PkgCodeProps) {
         # or whole directories
         p.set_dir("subdir", "subdir")
         # and push changes
-        q3.Package.push("${name}", registry="s3://${bucket}", message="Hello World")
+        p.push("${name}", registry="s3://${bucket}", message="Hello World")
 
         # Download (be mindful of large packages)
         q3.Package.install("${name}"${pathPy}${hashPy}, registry="s3://${bucket}", dest=".")

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -23,6 +23,7 @@ Entries inside each section should be ordered by type:
 * [Fixed] Fixed file preview header layout ([#3454](https://github.com/quiltdata/quilt/pull/3454))
 * [Fixed] Fix getting custom styles and options for files listed in quilt_summarize.json ([#3485](https://github.com/quiltdata/quilt/pull/3485))
 * [Fixed] Fix Header's orange flash on load ([#3487](https://github.com/quiltdata/quilt/pull/3487))
+* [Fixed] Fix code sample for package push ([#3499](https://github.com/quiltdata/quilt/pull/3499))
 * [Added] Add filter for users and buckets tables in Admin dashboards ([#3480](https://github.com/quiltdata/quilt/pull/3480))
 * [Changed] Enable user selection in perspective grids ([#3453](https://github.com/quiltdata/quilt/pull/3453))
 


### PR DESCRIPTION
Extracted from https://github.com/quiltdata/quilt/pull/3496, because this one is more important than the rest.

https://docs.quiltdata.com/api-reference/package#package.push (`push` not a static method, but instance's method)