### PR TITLE
Revert "Localstack s3 support (#3505)"

### DIFF
--- a/api/python/quilt3/data_transfer.py
+++ b/api/python/quilt3/data_transfer.py
@@ -172,8 +172,7 @@ class S3ClientProvider:
 
     def _build_client(self, get_config):
         session = self.get_boto_session()
-        endpoint_url = os.environ.get('ENDPOINT_URL') or None
-        return session.client('s3', config=get_config(session), endpoint_url=endpoint_url)
+        return session.client('s3', config=get_config(session))
 
     def _build_standard_client(self):
         s3_client = self._build_client(


### PR DESCRIPTION
This reverts commit 049421c7fdc263cdf201aa4a6683222889359112.

With boto3>=1.28.0 AWS_ENDPOINT_URL_S3 can be used instead.
See https://docs.aws.amazon.com/sdkref/latest/guide/feature-ss-endpoints.html.
