### PR TITLE
Revert "Quiet meaningless codecov failures (project/auto-lambda) (#3540)

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -18,10 +18,6 @@ flag_management:
       - name_prefix: 'auto-'
         type: patch
   individual_flags:
-    - name: 'auto-lambda'
-    statuses:
-      - type: project
-        threshold: 5
     # Looks like these are left from testing codecov flags,
     # but it's not clear why they are still appear, ignore them.
     - name: 'msys'


### PR DESCRIPTION
Incorrect interpretation of codecov non-blocking error was actually due to canceled test.

This reverts commit 9a9f1275e8c4ae143f49304b5f6c670655bed310.