### PR TITLE
Add no-undef rule for .js files

### DIFF
--- a/catalog/.eslintrc.js
+++ b/catalog/.eslintrc.js
@@ -81,4 +81,12 @@ module.exports = {
       version: 'detect',
     },
   },
+  overrides: [
+    {
+      files: ['.js'],
+      rules: {
+        'no-undef': 2,
+      },
+    },
+  ],
 }

--- a/catalog/.eslintrc.js
+++ b/catalog/.eslintrc.js
@@ -83,7 +83,7 @@ module.exports = {
   },
   overrides: [
     {
-      files: ['.js'],
+      files: ['*.js'],
       rules: {
         'no-undef': 2,
       },


### PR DESCRIPTION
Typescript can handle use of variables that are not defined, much better than ESLint. That's why `no-undef` rule is turned off by default.
But we need to check variables in JavaScript code still.