### PR TITLE
Add a region config variable to support GovCloud

### DIFF
--- a/catalog/app/containers/Admin/RolesAndPolicies/shared.ts
+++ b/catalog/app/containers/Admin/RolesAndPolicies/shared.ts
@@ -2,8 +2,8 @@
 export const MAX_POLICIES_PER_ROLE = 5
 
 const IAM_HOME = 'https://console.aws.amazon.com/iam/home'
-const ARN_ROLE_RE = /^arn:aws:iam:[^:]*:[^:]+:role\/(?:.*\/)?(.+)$/
-const ARN_POLICY_RE = /^arn:aws:iam:[^:]*:[^:]+:policy\/(.+)$/
+const ARN_ROLE_RE = /^arn:aws(?:-us-gov)?:iam:[^:]*:[^:]+:role\/(?:.*\/)?(.+)$/
+const ARN_POLICY_RE = /^arn:aws(?:-us-gov)?:iam:[^:]*:[^:]+:policy\/(.+)$/
 
 export function getArnLink(arn: string) {
   const [, role] = arn.match(ARN_ROLE_RE) || []

--- a/catalog/app/utils/AWS/Athena.tsx
+++ b/catalog/app/utils/AWS/Athena.tsx
@@ -1,5 +1,4 @@
 import Athena from 'aws-sdk/clients/athena'
-import * as R from 'ramda'
 import * as React from 'react'
 
 import cfg from 'constants/config'
@@ -8,13 +7,7 @@ import useMemoEqLazy from 'utils/useMemoEqLazy'
 import * as Config from './Config'
 import * as Credentials from './Credentials'
 
-const getRegion: (input: string) => string = R.pipe(
-  R.match(/\.([a-z]{2}-[a-z]+-\d)\.amazonaws\.com/),
-  R.nth(1),
-  R.defaultTo('us-east-1'),
-)
-
-const region = getRegion(cfg.apiGatewayEndpoint)
+const region = cfg.defaultRegion
 
 const AthenaContext = React.createContext<() => Athena | null>(() => null)
 

--- a/catalog/app/utils/AWS/Athena.tsx
+++ b/catalog/app/utils/AWS/Athena.tsx
@@ -7,7 +7,7 @@ import useMemoEqLazy from 'utils/useMemoEqLazy'
 import * as Config from './Config'
 import * as Credentials from './Credentials'
 
-const region = cfg.defaultRegion
+const region = cfg.region
 
 const AthenaContext = React.createContext<() => Athena | null>(() => null)
 

--- a/catalog/app/utils/AWS/S3.js
+++ b/catalog/app/utils/AWS/S3.js
@@ -16,6 +16,7 @@ import * as Credentials from './Credentials'
 const DEFAULT_OPTS = {
   signatureVersion: 'v4',
   s3UsEast1RegionalEndpoint: 'regional',
+  region: cfg.defaultRegion,
 }
 
 const PROXIED = Symbol('proxied')

--- a/catalog/app/utils/AWS/S3.js
+++ b/catalog/app/utils/AWS/S3.js
@@ -16,7 +16,7 @@ import * as Credentials from './Credentials'
 const DEFAULT_OPTS = {
   signatureVersion: 'v4',
   s3UsEast1RegionalEndpoint: 'regional',
-  region: cfg.defaultRegion,
+  region: cfg.region,
 }
 
 const PROXIED = Symbol('proxied')

--- a/catalog/app/utils/Config.ts
+++ b/catalog/app/utils/Config.ts
@@ -11,6 +11,8 @@ type AuthMethodConfig = 'ENABLED' | 'DISABLED' | 'SIGN_IN_ONLY'
 
 // manually synced w/ config-schema.json
 export interface ConfigJson {
+  defaultRegion: string
+
   mode: Mode
   alwaysRequiresAuth: boolean
   desktop?: boolean

--- a/catalog/app/utils/Config.ts
+++ b/catalog/app/utils/Config.ts
@@ -11,7 +11,7 @@ type AuthMethodConfig = 'ENABLED' | 'DISABLED' | 'SIGN_IN_ONLY'
 
 // manually synced w/ config-schema.json
 export interface ConfigJson {
-  defaultRegion: string
+  region: string
 
   mode: Mode
   alwaysRequiresAuth: boolean

--- a/catalog/config-schema.json
+++ b/catalog/config-schema.json
@@ -101,6 +101,7 @@
   "required": [
     "alwaysRequiresAuth",
     "apiGatewayEndpoint",
+    "defaultRegion",
     "mixpanelToken",
     "mode",
     "passwordAuth",

--- a/catalog/config-schema.json
+++ b/catalog/config-schema.json
@@ -17,6 +17,10 @@
       "type": "string",
       "description": "Calendly.com scheduling link (e.g. https://calendly.com/$username/$event) used for meeting scheduling popup aka Talk To Us."
     },
+    "defaultRegion": {
+      "type": "string",
+      "description": "Default region for the S3 client"
+    },
     "intercomAppId": {
       "type": "string",
       "description": "Connects orange chat icon to our Intercom. If absent, icon does not show."

--- a/catalog/config-schema.json
+++ b/catalog/config-schema.json
@@ -17,10 +17,6 @@
       "type": "string",
       "description": "Calendly.com scheduling link (e.g. https://calendly.com/$username/$event) used for meeting scheduling popup aka Talk To Us."
     },
-    "defaultRegion": {
-      "type": "string",
-      "description": "Default region for the S3 client"
-    },
     "intercomAppId": {
       "type": "string",
       "description": "Connects orange chat icon to our Intercom. If absent, icon does not show."
@@ -62,6 +58,10 @@
       "$ref": "#/definitions/AuthMethodConfig",
       "description": "Whether Quilt password authentication is enabled for sign in and sign up."
     },
+    "region": {
+      "type": "string",
+      "description": "Stack's region; used for S3 and Athena. S3 client supports any region, but will try this one first."
+    },
     "registryUrl": {
       "$ref": "#/definitions/Url",
       "description": "Registry your users will use to login and get credentials."
@@ -101,10 +101,10 @@
   "required": [
     "alwaysRequiresAuth",
     "apiGatewayEndpoint",
-    "defaultRegion",
     "mixpanelToken",
     "mode",
     "passwordAuth",
+    "region",
     "registryUrl",
     "s3Proxy",
     "serviceBucket",

--- a/catalog/config.js.example
+++ b/catalog/config.js.example
@@ -1,4 +1,5 @@
 window.QUILT_CATALOG_CONFIG = {
+  "defaultRegion": "us-east-1",
   "registryUrl": "<registry url here>",
   "alwaysRequiresAuth": false,
   "apiGatewayEndpoint": "https://ozj6r9bglc.execute-api.us-east-1.amazonaws.com/prod",

--- a/catalog/config.js.example
+++ b/catalog/config.js.example
@@ -1,5 +1,5 @@
 window.QUILT_CATALOG_CONFIG = {
-  "defaultRegion": "us-east-1",
+  "region": "us-east-1",
   "registryUrl": "<registry url here>",
   "alwaysRequiresAuth": false,
   "apiGatewayEndpoint": "https://ozj6r9bglc.execute-api.us-east-1.amazonaws.com/prod",

--- a/catalog/config.json.tmpl
+++ b/catalog/config.json.tmpl
@@ -1,4 +1,5 @@
 {
+    "defaultRegion": "${DEFAULT_REGION}",
     "apiGatewayEndpoint": "${API_GATEWAY}",
     "alwaysRequiresAuth": ${ALWAYS_REQUIRE_AUTH},
     "noDownload": ${NO_DOWNLOAD},

--- a/catalog/config.json.tmpl
+++ b/catalog/config.json.tmpl
@@ -1,5 +1,5 @@
 {
-    "defaultRegion": "${DEFAULT_REGION}",
+    "region": "${REGION}",
     "apiGatewayEndpoint": "${API_GATEWAY}",
     "alwaysRequiresAuth": ${ALWAYS_REQUIRE_AUTH},
     "noDownload": ${NO_DOWNLOAD},

--- a/catalog/setup-jest.ts
+++ b/catalog/setup-jest.ts
@@ -1,5 +1,5 @@
 ;(window as any).QUILT_CATALOG_CONFIG = {
-  defaultRegion: 'us-east-1',
+  region: 'us-east-1',
   apiGatewayEndpoint: '',
   alwaysRequiresAuth: true,
   s3Proxy: '',

--- a/catalog/setup-jest.ts
+++ b/catalog/setup-jest.ts
@@ -1,4 +1,5 @@
 ;(window as any).QUILT_CATALOG_CONFIG = {
+  defaultRegion: 'us-east-1',
   apiGatewayEndpoint: '',
   alwaysRequiresAuth: true,
   s3Proxy: '',


### PR DESCRIPTION
GovCloud doesn't have us-east-1, so we need to explicitly set a valid region for S3. It's also a potential optimization for any non-us-east-1 stacks (assuming most S3 buckets are in the same region as the stack).

Also use it for Athena: seems less hacky that extracting the region from apiGatewayEndpoint.