### PR TITLE
Use ResizeObserver third-party hook

### DIFF
--- a/catalog/app/components/JsonDisplay/JsonDisplay.js
+++ b/catalog/app/components/JsonDisplay/JsonDisplay.js
@@ -1,6 +1,7 @@
 import cx from 'classnames'
 import * as R from 'ramda'
 import * as React from 'react'
+import useResizeObserver from 'use-resize-observer'
 import * as M from '@material-ui/core'
 
 import * as NamedRoutes from 'utils/NamedRoutes'
@@ -307,21 +308,6 @@ function JsonDisplayInner(props) {
   return <Component />
 }
 
-function useElementWidth(ref) {
-  const [width, setWidth] = React.useState(0)
-  React.useEffect(() => {
-    const wrapper = ref.current
-    if (!wrapper) return
-    const resizeObserver = new window.ResizeObserver(() => {
-      if (!wrapper) return
-      setWidth(wrapper.clientWidth)
-    })
-    resizeObserver.observe(ref.current)
-    return () => resizeObserver.unobserve(wrapper)
-  }, [ref])
-  return width
-}
-
 export default function JsonDisplay({
   name,
   value,
@@ -336,7 +322,7 @@ export default function JsonDisplay({
 }) {
   const ref = React.useRef(null)
   const classes = useStyles()
-  const currentBPWidth = useElementWidth(ref)
+  const { width: currentBPWidth } = useResizeObserver({ ref })
   const computedKeys = React.useMemo(() => {
     if (showKeysWhenCollapsed === true) return Number.POSITIVE_INFINITY
     if (showKeysWhenCollapsed === false) return Number.POSITIVE_INFINITY

--- a/catalog/app/containers/Bucket/PackageCopyDialog.tsx
+++ b/catalog/app/containers/Bucket/PackageCopyDialog.tsx
@@ -2,6 +2,7 @@ import * as FF from 'final-form'
 import * as R from 'ramda'
 import * as React from 'react'
 import * as RF from 'react-final-form'
+import useResizeObserver from 'use-resize-observer'
 import * as M from '@material-ui/core'
 
 import * as Intercom from 'components/Intercom'
@@ -111,7 +112,6 @@ function DialogForm({
   const nameValidator = PD.useNameValidator(selectedWorkflow)
   const nameExistence = PD.useNameExistence(successor.slug)
   const [nameWarning, setNameWarning] = React.useState<React.ReactNode>('')
-  const [metaHeight, setMetaHeight] = React.useState(0)
   const classes = useStyles()
   const validateWorkflow = PD.useWorkflowValidator(workflowsConfig)
 
@@ -191,14 +191,6 @@ function DialogForm({
   )
 
   const [editorElement, setEditorElement] = React.useState<HTMLDivElement | null>(null)
-  const resizeObserver = React.useMemo(
-    () =>
-      new window.ResizeObserver((entries) => {
-        const { height } = entries[0].contentRect
-        setMetaHeight(height)
-      }),
-    [setMetaHeight],
-  )
 
   // HACK: FIXME: it triggers name validation with correct workflow
   const [hideMeta, setHideMeta] = React.useState(false)
@@ -220,13 +212,7 @@ function DialogForm({
     [handleNameChange, selectedWorkflow, setWorkflow],
   )
 
-  React.useEffect(() => {
-    if (editorElement) resizeObserver.observe(editorElement)
-    return () => {
-      if (editorElement) resizeObserver.unobserve(editorElement)
-    }
-  }, [editorElement, resizeObserver])
-
+  const { height: metaHeight = 0 } = useResizeObserver({ ref: editorElement })
   const dialogContentClasses = PD.useContentStyles({ metaHeight })
 
   return (

--- a/catalog/app/containers/Bucket/PackageDialog/PackageCreationForm.tsx
+++ b/catalog/app/containers/Bucket/PackageDialog/PackageCreationForm.tsx
@@ -5,6 +5,7 @@ import * as FP from 'fp-ts'
 import * as R from 'ramda'
 import * as React from 'react'
 import * as RF from 'react-final-form'
+import useResizeObserver from 'use-resize-observer'
 import * as M from '@material-ui/core'
 
 import * as Intercom from 'components/Intercom'
@@ -213,8 +214,9 @@ function PackageCreationForm({
   const nameValidator = PD.useNameValidator(selectedWorkflow)
   const nameExistence = PD.useNameExistence(successor.slug)
   const [nameWarning, setNameWarning] = React.useState<React.ReactNode>('')
-  const [metaHeight, setMetaHeight] = React.useState(0)
   const classes = useStyles()
+  const [editorElement, setEditorElement] = React.useState<HTMLDivElement | null>(null)
+  const { height: metaHeight = 0 } = useResizeObserver({ ref: editorElement })
   const dialogContentClasses = PD.useContentStyles({ metaHeight })
   const validateWorkflow = PD.useWorkflowValidator(workflowsConfig)
 
@@ -436,15 +438,6 @@ function PackageCreationForm({
     [nameWarning, nameExistence],
   )
 
-  const [editorElement, setEditorElement] = React.useState<HTMLDivElement | null>(null)
-  const resizeObserver = React.useMemo(
-    () =>
-      new window.ResizeObserver((entries) => {
-        const { height } = entries[0]!.contentRect
-        setMetaHeight(height)
-      }),
-    [setMetaHeight],
-  )
   const [filesDisabled, setFilesDisabled] = React.useState(false)
   const onFormChange = React.useCallback(
     ({ dirtyFields, values }) => {
@@ -452,13 +445,6 @@ function PackageCreationForm({
     },
     [handleNameChange],
   )
-
-  React.useEffect(() => {
-    if (editorElement) resizeObserver.observe(editorElement)
-    return () => {
-      if (editorElement) resizeObserver.unobserve(editorElement)
-    }
-  }, [editorElement, resizeObserver])
 
   const validateFiles = React.useCallback(
     async (files: FI.FilesState) => {


### PR DESCRIPTION
It fixes some edge cases, when ResizeObserver emits error.

I can consistently reproduce this error: open file with metadata (JsonDisplay should be there), scroll back and forth while page is loading (it is not required to do actual scroll, just scroll events by mousewheel).

We can fix this in our code, or just use that library, that we already use for Status page.