### PR TITLE
Use "S3 Metadata" title

### DIFF
--- a/catalog/app/containers/Bucket/Meta.tsx
+++ b/catalog/app/containers/Bucket/Meta.tsx
@@ -142,13 +142,14 @@ export function PackageMetaSection({ meta, preferences }: PackageMetaSectionProp
 }
 
 interface ObjectMetaSectionProps {
+  title?: string
   meta?: JsonRecord | null
 }
 
-export function ObjectMetaSection({ meta }: ObjectMetaSectionProps) {
+export function ObjectMetaSection({ meta, title = 'Metadata' }: ObjectMetaSectionProps) {
   if (!meta || R.isEmpty(meta)) return null
   return (
-    <Section icon="list" heading="Metadata" defaultExpanded>
+    <Section icon="list" heading={title} defaultExpanded>
       {/* @ts-expect-error */}
       <JsonDisplay value={meta} defaultExpanded={1} />
     </Section>
@@ -166,7 +167,7 @@ export function ObjectMeta({ handle }: ObjectMetaProps) {
     handle,
   })
   return metaData.case({
-    Ok: (meta?: JsonRecord) => <ObjectMetaSection meta={meta} />,
+    Ok: (meta?: JsonRecord) => <ObjectMetaSection meta={meta} title="S3 Metadata" />,
     Err: errorHandler,
     _: noop,
   })


### PR DESCRIPTION
Use "S3 Metadata" for object-level s3 metadata. And "Metadata" for object-level quilt metadata.
![Screenshot from 2023-08-10 15-50-59](https://github.com/quiltdata/quilt/assets/533229/9e3ff1f8-aaa5-4449-a074-aee344d54def)
![Screenshot from 2023-08-10 15-51-02](https://github.com/quiltdata/quilt/assets/533229/2646d8ae-18e9-402a-9b4f-d4b2cce513df)
