### PR TITLE
Add filter to Policies and Roles tables, refactor filter

### DIFF
--- a/catalog/app/containers/Admin/Buckets/Buckets.tsx
+++ b/catalog/app/containers/Admin/Buckets/Buckets.tsx
@@ -29,7 +29,6 @@ import { useTracker } from 'utils/tracking'
 import * as Types from 'utils/types'
 import * as validators from 'utils/validators'
 
-import Filter from '../Filter'
 import * as Form from '../Form'
 import * as Table from '../Table'
 
@@ -1186,7 +1185,7 @@ function CustomBucketIcon({ src }: CustomBucketIconProps) {
   return <BucketIcon alt="" classes={classes} src={src} title="Default icon" />
 }
 
-const columns = [
+const columns: Table.Column<BucketConfig>[] = [
   {
     id: 'name',
     label: 'Name (relevance)',
@@ -1272,17 +1271,14 @@ interface CRUDProps {
 
 function CRUD({ bucketName }: CRUDProps) {
   const { bucketConfigs: rows } = GQL.useQueryS(BUCKET_CONFIGS_QUERY)
-  const [filter, setFilter] = React.useState('')
-  const filtered = React.useMemo(
-    () =>
-      filter
-        ? rows.filter(({ name, title }) =>
-            (name + title).toLowerCase().includes(filter.toLowerCase()),
-          )
-        : rows,
-    [filter, rows],
-  )
-  const ordering = Table.useOrdering({ rows: filtered, column: columns[0] })
+  const filtering = Table.useFiltering({
+    rows,
+    filterBy: ({ name, title }) => name + title,
+  })
+  const ordering = Table.useOrdering({
+    rows: filtering.filtered,
+    column: columns[0],
+  })
   const pagination = Pagination.use(ordering.ordered, {
     // @ts-expect-error
     getItemId: R.prop('name'),
@@ -1346,8 +1342,7 @@ function CRUD({ bucketName }: CRUDProps) {
       </M.Dialog>
 
       <Table.Toolbar heading="Buckets" actions={toolbarActions}>
-        {/* @ts-expect-error */}
-        <Filter value={filter} onChange={setFilter} />
+        <Table.Filter {...filtering} />
       </Table.Toolbar>
       <Table.Wrapper>
         <M.Table size="small">
@@ -1361,9 +1356,7 @@ function CRUD({ bucketName }: CRUDProps) {
                 style={{ cursor: 'pointer' }}
               >
                 {columns.map((col) => (
-                  // @ts-expect-error
                   <M.TableCell key={col.id} align={col.align} {...col.props}>
-                    {/* @ts-expect-error */}
                     {(col.getDisplay || R.identity)(col.getValue(i), i)}
                   </M.TableCell>
                 ))}

--- a/catalog/app/containers/Admin/RolesAndPolicies/AssociatedRoles.tsx
+++ b/catalog/app/containers/Admin/RolesAndPolicies/AssociatedRoles.tsx
@@ -1,9 +1,12 @@
 import * as React from 'react'
+import * as R from 'ramda'
 import * as RF from 'react-final-form'
 import * as M from '@material-ui/core'
 
 import * as GQL from 'utils/GraphQL'
 
+import * as Table from '../Table'
+import Filter from './Filter'
 import { MAX_POLICIES_PER_ROLE } from './shared'
 
 import ROLES_QUERY from './gql/Roles.generated'
@@ -45,12 +48,26 @@ function RoleSelectionDialog({
     [setSelected],
   )
 
+  const filtering = Table.useFiltering({
+    rows: roles,
+    filterBy: ({ name }: ManagedRole) => name,
+  })
+  const ordered = React.useMemo(
+    () => R.sortBy(({ name }: ManagedRole) => name, filtering.filtered),
+    [filtering.filtered],
+  )
+
   return (
     <M.Dialog maxWidth="xs" open={open} onClose={onClose} onExited={handleExited}>
       <M.DialogTitle>Attach policy to roles</M.DialogTitle>
+      {roles.length && (
+        <M.Box ml={3} mr={1.5}>
+          <Filter {...filtering} />
+        </M.Box>
+      )}
       <M.DialogContent dividers>
-        {roles.length ? (
-          roles.map((role) => (
+        {ordered.length ? (
+          ordered.map((role) => (
             <M.FormControlLabel
               key={role.id}
               style={{ display: 'flex', marginRight: 0 }}
@@ -73,7 +90,11 @@ function RoleSelectionDialog({
             />
           ))
         ) : (
-          <M.Typography>No more roles to attach this policy to</M.Typography>
+          <M.Typography>
+            {filtering.value
+              ? 'No roles found, try resetting filter'
+              : 'No more roles to attach this policy to'}
+          </M.Typography>
         )}
       </M.DialogContent>
       <M.DialogActions>

--- a/catalog/app/containers/Admin/RolesAndPolicies/Filter.tsx
+++ b/catalog/app/containers/Admin/RolesAndPolicies/Filter.tsx
@@ -1,0 +1,26 @@
+import * as React from 'react'
+import * as M from '@material-ui/core'
+
+interface FilterProps {
+  value: string
+  onChange: (v: string) => void
+}
+
+export default function Filter({ value, onChange }: FilterProps) {
+  return (
+    <M.InputBase
+      endAdornment={
+        value && (
+          <M.IconButton onClick={() => onChange('')}>
+            <M.Icon fontSize="small">clear</M.Icon>
+          </M.IconButton>
+        )
+      }
+      fullWidth
+      onChange={(event) => onChange(event.target.value)}
+      placeholder="Filter"
+      startAdornment={<M.Icon fontSize="small">search</M.Icon>}
+      value={value}
+    />
+  )
+}

--- a/catalog/app/containers/Admin/RolesAndPolicies/Roles.tsx
+++ b/catalog/app/containers/Admin/RolesAndPolicies/Roles.tsx
@@ -29,7 +29,7 @@ import ROLE_DELETE_MUTATION from './gql/RoleDelete.generated'
 import ROLE_SET_DEFAULT_MUTATION from './gql/RoleSetDefault.generated'
 import { RoleSelectionFragment as Role } from './gql/RoleSelection.generated'
 
-const columns = [
+const columns: Table.Column<Role>[] = [
   {
     id: 'name',
     label: 'Name',
@@ -694,7 +694,14 @@ export default function Roles() {
   const rows = data.roles
   const defaultRoleId = data.defaultRole?.id
 
-  const ordering = Table.useOrdering({ rows, column: columns[0] })
+  const filtering = Table.useFiltering({
+    rows,
+    filterBy: ({ name }) => name,
+  })
+  const ordering = Table.useOrdering({
+    rows: filtering.filtered,
+    column: columns[0],
+  })
   const dialogs = Dialogs.use()
 
   const toolbarActions = [
@@ -709,11 +716,11 @@ export default function Roles() {
 
   const inlineActions = (role: Role) => [
     role.arn
-      ? {
+      ? ({
           title: 'Open AWS Console',
           icon: <M.Icon>launch</M.Icon>,
           href: getArnLink(role.arn),
-        }
+        } as Table.Action)
       : null,
     {
       title: 'Edit',
@@ -742,7 +749,9 @@ export default function Roles() {
     >
       <M.Paper>
         {dialogs.render({ fullWidth: true, maxWidth: 'sm' })}
-        <Table.Toolbar heading="Roles" actions={toolbarActions} />
+        <Table.Toolbar heading="Roles" actions={toolbarActions}>
+          <Table.Filter {...filtering} />
+        </Table.Toolbar>
         <Table.Wrapper>
           <M.Table>
             <Table.Head columns={columns} ordering={ordering} withInlineActions />
@@ -750,9 +759,7 @@ export default function Roles() {
               {ordering.ordered.map((i: Role) => (
                 <M.TableRow hover key={i.id}>
                   {columns.map((col) => (
-                    // @ts-expect-error
                     <M.TableCell key={col.id} {...col.props}>
-                      {/* @ts-expect-error */}
                       {(col.getDisplay || R.identity)(col.getValue(i), i, {
                         defaultRoleId,
                       })}
@@ -760,7 +767,6 @@ export default function Roles() {
                   ))}
                   <M.TableCell align="right" padding="none">
                     <Table.InlineActions actions={inlineActions(i)}>
-                      {/* @ts-expect-error */}
                       <SettingsMenu role={i} openDialog={dialogs.open} />
                     </Table.InlineActions>
                   </M.TableCell>

--- a/catalog/app/containers/Admin/Table/Filter.tsx
+++ b/catalog/app/containers/Admin/Table/Filter.tsx
@@ -29,6 +29,7 @@ function ClearButton({ onClick }: ClearButtonProps) {
 const useFilterStyles = M.makeStyles({
   root: {
     animation: `$expand ${ANIMATION_DURATION}ms ease-out`,
+    flexShrink: 0,
     width: '40vw',
   },
   collapsing: {

--- a/catalog/app/containers/Admin/Table/index.js
+++ b/catalog/app/containers/Admin/Table/index.js
@@ -1,0 +1,3 @@
+export * from './untyped'
+export * from './Table'
+export { default as Filter } from './Filter'

--- a/catalog/app/containers/Admin/Table/untyped.js
+++ b/catalog/app/containers/Admin/Table/untyped.js
@@ -1,0 +1,72 @@
+import * as React from 'react'
+import * as M from '@material-ui/core'
+
+export function Head({
+  columns,
+  selection: sel = undefined,
+  ordering: ord,
+  withInlineActions = false,
+}) {
+  return (
+    <M.TableHead>
+      <M.TableRow>
+        {!!sel && (
+          <M.TableCell padding="checkbox" onClick={sel.toggleAll}>
+            <M.Checkbox
+              indeterminate={sel.selected.size > 0 && sel.selected.size < sel.all.size}
+              checked={sel.selected.equals(sel.all)}
+            />
+          </M.TableCell>
+        )}
+        {columns.map((col) => (
+          <M.TableCell
+            key={col.id}
+            sortDirection={ord.column === col ? ord.direction : false}
+            align={col.align}
+          >
+            {col.sortable === false ? (
+              col.label
+            ) : (
+              <M.Tooltip
+                title={col.hint || 'Sort'}
+                placement="bottom-start"
+                enterDelay={300}
+              >
+                <M.TableSortLabel
+                  active={ord.column === col}
+                  direction={ord.direction}
+                  onClick={() => ord.change(col)}
+                >
+                  {col.label}
+                </M.TableSortLabel>
+              </M.Tooltip>
+            )}
+          </M.TableCell>
+        ))}
+        {withInlineActions && <M.TableCell align="right">Actions</M.TableCell>}
+      </M.TableRow>
+    </M.TableHead>
+  )
+}
+
+const usePaginationStyles = M.makeStyles((t) => ({
+  toolbar: {
+    paddingRight: [t.spacing(1), '!important'],
+  },
+}))
+
+export function Pagination({ pagination, ...rest }) {
+  const classes = usePaginationStyles()
+  return (
+    <M.TablePagination
+      classes={classes}
+      component="div"
+      count={pagination.total}
+      rowsPerPage={pagination.perPage}
+      page={pagination.page - 1}
+      onChangePage={(e, page) => pagination.goToPage(page + 1)}
+      onChangeRowsPerPage={(e) => pagination.setPerPage(e.target.value)}
+      {...rest}
+    />
+  )
+}

--- a/catalog/app/containers/Admin/Users/Users.js
+++ b/catalog/app/containers/Admin/Users/Users.js
@@ -14,7 +14,6 @@ import * as Cache from 'utils/ResourceCache'
 import * as Format from 'utils/format'
 import * as validators from 'utils/validators'
 
-import Filter from '../Filter'
 import * as Form from '../Form'
 import * as Table from '../Table'
 import * as data from '../data'
@@ -677,15 +676,14 @@ export default function Users({ users }) {
     [roles, openDialog, setIsActive, setRole],
   )
 
-  const [filter, setFilter] = React.useState('')
-  const filtered = React.useMemo(
-    () =>
-      filter
-        ? rows.filter(({ email, username }) => (email + username).includes(filter))
-        : rows,
-    [filter, rows],
-  )
-  const ordering = Table.useOrdering({ rows: filtered, column: columns[0] })
+  const filtering = Table.useFiltering({
+    rows,
+    filterBy: ({ email, username }) => email + username,
+  })
+  const ordering = Table.useOrdering({
+    rows: filtering.filtered,
+    column: columns[0],
+  })
   const pagination = Pagination.use(ordering.ordered, {
     getItemId: R.prop('username'),
   })
@@ -722,7 +720,7 @@ export default function Users({ users }) {
       <M.Paper>
         {dialogs.render({ maxWidth: 'xs', fullWidth: true })}
         <Table.Toolbar heading="Users" actions={toolbarActions}>
-          <Filter value={filter} onChange={setFilter} />
+          <Table.Filter {...filtering} />
         </Table.Toolbar>
         <Table.Wrapper>
           <M.Table size="small">

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -28,6 +28,7 @@ Entries inside each section should be ordered by type:
 * [Added] Add links to documentation and re-use code samples ([#3496](https://github.com/quiltdata/quilt/pull/3496))
 * [Added] Show S3 Object tags ([#3515](https://github.com/quiltdata/quilt/pull/3515))
 * [Added] Indexer lambda now indexes S3 Object tags ([#3691](https://github.com/quiltdata/quilt/pull/3691))
+* [Added] Add filters to Roles and Permissions in Admin dashboards ([#3690](https://github.com/quiltdata/quilt/pull/3690))
 * [Added] Add download and bookmarks button to file listings ([#3697](https://github.com/quiltdata/quilt/pull/3697))
 * [Changed] Enable user selection in perspective grids ([#3453](https://github.com/quiltdata/quilt/pull/3453))
 * [Changed] Hide columns without values in files listings ([#3512](https://github.com/quiltdata/quilt/pull/3512))


### PR DESCRIPTION
* ~Moved repeatable filter code to `Table.useOrdering`~ Created `Table.useFiltering`
* Converted the most of the `Table` to Typescript (splitted code to typed.tsx and untyped.js)
* Moved `<Filter />` to `<Table.Filter />` and used it as one of toolbar `actions`
* Added filter for list of attached policies, associated roles, buckets. Re-use `Table.useFiltering` for these components

![Screenshot from 2023-08-15 16-28-26](https://github.com/quiltdata/quilt/assets/533229/4460f960-54e3-42fe-925a-12df52b08c4b)
![Screenshot from 2023-08-15 16-30-20](https://github.com/quiltdata/quilt/assets/533229/feec5f29-c7c9-4d91-9fcc-816c3e163c64)
![Screenshot from 2023-08-15 16-30-47](https://github.com/quiltdata/quilt/assets/533229/62c3ee4f-6ef5-4c13-b5ed-3c67a9e7bbd5)
![Screenshot from 2023-08-15 16-31-01](https://github.com/quiltdata/quilt/assets/533229/cbffb64a-0a9c-4496-bc11-26283852fd65)

- [x] [Changelog](CHANGELOG.md) entry (skip if change is not significant to end users, e.g. docs only)
