### PR TITLE
Workaround to fix us-east-1 S3 signatures

### DIFF
--- a/catalog/app/utils/AWS/S3.js
+++ b/catalog/app/utils/AWS/S3.js
@@ -98,11 +98,15 @@ function useSmartS3() {
               req.httpRequest.path = req.httpRequest.path.replace(`/${b}`, '')
             }
 
+            const signedRegion = req.httpRequest.headers.Host.endsWith('s3.amazonaws.com')
+              ? '-'
+              : req.httpRequest.region
+
             req.httpRequest.endpoint = endpoint
             req.httpRequest.path =
               type === 'select'
                 ? `${basePath}${req.httpRequest.path}`
-                : `${basePath}/${req.httpRequest.region}/${b}${req.httpRequest.path}`
+                : `${basePath}/${signedRegion}/${b}${req.httpRequest.path}`
           })
           req.on(
             'retry',

--- a/catalog/app/utils/AWS/S3.js
+++ b/catalog/app/utils/AWS/S3.js
@@ -98,7 +98,9 @@ function useSmartS3() {
               req.httpRequest.path = req.httpRequest.path.replace(`/${b}`, '')
             }
 
-            const signedRegion = req.httpRequest.headers.Host.endsWith('s3.amazonaws.com')
+            const signedRegion = req.httpRequest.endpoint.host.endsWith(
+              's3.amazonaws.com',
+            )
               ? '-'
               : req.httpRequest.region
 


### PR DESCRIPTION
In us-east-1, the S3 client sometimes uses the `s3.amazonaws.com` hostname, sometimes `s3.us-east-1.amazonaws.com`. We need to use exactly the same one in s3 proxy in order for the signature to work. S3 proxy already supports region-less hostnames - just need to pass "-" as the region.