### PR TITLE
Rewrite hostname and region logic in S3 proxy

### DIFF
--- a/catalog/app/utils/AWS/S3.js
+++ b/catalog/app/utils/AWS/S3.js
@@ -83,26 +83,23 @@ function useSmartS3() {
           )
           req.on('sign', () => {
             if (req.httpRequest[PRESIGN]) return
+
             // Monkey-patch the request object after it has been signed and save the original
             // values in case of retry.
+            const origEndpoint = req.httpRequest.endpoint
+            const origPath = req.httpRequest.path
+
             req.httpRequest[PROXIED] = {
-              endpoint: req.httpRequest.endpoint,
-              path: req.httpRequest.path,
+              endpoint: origEndpoint,
+              path: origPath,
             }
             const basePath = endpoint.path.replace(/\/$/, '')
-            // handle buckets with dots in their names
-            if (
-              req.httpRequest.path.startsWith(`/${b}`) &&
-              !req.httpRequest.endpoint.host.startsWith(`${b}.`)
-            ) {
-              req.httpRequest.path = req.httpRequest.path.replace(`/${b}`, '')
-            }
 
             req.httpRequest.endpoint = endpoint
             req.httpRequest.path =
               type === 'select'
-                ? `${basePath}${req.httpRequest.path}`
-                : `${basePath}/${req.httpRequest.region}/${b}${req.httpRequest.path}`
+                ? `${basePath}${origPath}`
+                : `${basePath}/${origEndpoint.host}${origPath}`
           })
           req.on(
             'retry',

--- a/s3-proxy/nginx.conf
+++ b/s3-proxy/nginx.conf
@@ -23,7 +23,7 @@ http {
         listen 3333 default_server;
         listen [::]:3333 default_server;
 
-        location ~ ^/(?<s3_region>[^/]+)/(?<s3_bucket>[^/]+)(/(?<s3_path>.*))? {
+        location ~ ^/(?<s3_host>[^/]+\.amazonaws\.com)(?<s3_path>/.*) {
             client_max_body_size 10G;
 
             proxy_http_version 1.1;
@@ -45,31 +45,10 @@ http {
                 return 200;
             }
 
-            # Add a region if it's not "-".
-            set $s3_host_suffix 's3.$s3_region.amazonaws.com';
-            if ($s3_region = '-') {
-                set $s3_host_suffix 's3.amazonaws.com';
-            }
-
-            # Use virtual hosts by default, but path-style for buckets with dots.
-            set $s3_host '$s3_bucket.$s3_host_suffix';
-            set $s3_path_prefix '';
-            set $s3_path_sep '';
-            if ($s3_bucket ~ "\.") {
-                set $s3_host '$s3_host_suffix';
-                set $s3_path_prefix '$s3_bucket';
-                set $s3_path_sep '/';
-            }
-
-            # Don't add a slash if there's no more path segments
-            if ($s3_path = '') {
-                set $s3_path_sep '';
-            }
-
             # Proxy the request to S3. It *MUST* be done inside an "if", using "$1" -
             # calling "set" causes the URL to be decoded, breaking paths with spaces, etc.
-            if ($request_uri ~ "^/[^/?]+/[^/?]+/?(.*)") {
-                proxy_pass 'https://$s3_host/$s3_path_prefix$s3_path_sep$1';
+            if ($request_uri ~ "^/[^/?]+(.*)") {
+                proxy_pass 'https://$s3_host$1';
             }
 
             # Remove any existing CORS headers from the response to avoid duplicates.
@@ -78,6 +57,12 @@ http {
             proxy_hide_header 'Access-Control-Allow-Origin';
             proxy_hide_header 'Access-Control-Max-age';
             proxy_hide_header 'Access-Control-Expose-Headers';
+        }
+
+        location ~ ^/(?<s3_host>[^/]+)/.* {
+            # Hostname doesn't end in amazonaws.com; return a helpful error just for debugging.
+            add_header 'Content-Type' 'text/plain' always;
+            return 400 'Unexpected host: $s3_host';
         }
 
         location = / {


### PR DESCRIPTION
Instead of passing the region, S3 bucket name, and S3 path just pass the original HTTP hostname and path.

It simplifies the logic quite a bit and lets us not worry about things like:
- Virtual hosts vs path-style (aka bucket names with dots problems)
- `s3.amazonaws.com` vs `s3.us-east-1.amazonaws.com`