### PR TITLE
Metadata dropzone: disable click, fix JSON drop

### DIFF
--- a/catalog/app/containers/Bucket/PackageDialog/MetaInput.tsx
+++ b/catalog/app/containers/Bucket/PackageDialog/MetaInput.tsx
@@ -284,7 +284,7 @@ export const MetaInput = React.forwardRef<HTMLDivElement, MetaInputProps>(
               onChange(contents)
             } else {
               try {
-                JSON.parse(contents as string)
+                onChange(JSON.parse(contents as string))
               } catch (e) {
                 notify('The file does not contain valid JSON')
               }
@@ -318,7 +318,11 @@ export const MetaInput = React.forwardRef<HTMLDivElement, MetaInputProps>(
 
     const isDragging = useDragging()
 
-    const { getRootProps, isDragActive } = useDropzone({ onDrop })
+    const { getRootProps, isDragActive } = useDropzone({
+      onDrop,
+      noClick: true,
+      noKeyboard: true,
+    })
 
     return (
       <div className={className}>

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -25,6 +25,7 @@ Entries inside each section should be ordered by type:
 * [Fixed] Fix Header's orange flash on load ([#3487](https://github.com/quiltdata/quilt/pull/3487))
 * [Fixed] Fix code sample for package push ([#3499](https://github.com/quiltdata/quilt/pull/3499))
 * [Fixed] Make bookmarks optional (and fix Embed listings broken in #3697) ([#3705](https://github.com/quiltdata/quilt/pull/3705))
+* [Fixed] Disable opening file picker on metadata click ([#3707](https://github.com/quiltdata/quilt/pull/3707))
 * [Added] Add filter for users and buckets tables in Admin dashboards ([#3480](https://github.com/quiltdata/quilt/pull/3480))
 * [Added] Add links to documentation and re-use code samples ([#3496](https://github.com/quiltdata/quilt/pull/3496))
 * [Added] Show S3 Object tags ([#3515](https://github.com/quiltdata/quilt/pull/3515))

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -25,7 +25,7 @@ Entries inside each section should be ordered by type:
 * [Fixed] Fix Header's orange flash on load ([#3487](https://github.com/quiltdata/quilt/pull/3487))
 * [Fixed] Fix code sample for package push ([#3499](https://github.com/quiltdata/quilt/pull/3499))
 * [Fixed] Make bookmarks optional (and fix Embed listings broken in #3697) ([#3705](https://github.com/quiltdata/quilt/pull/3705))
-* [Fixed] Disable opening file picker on metadata click ([#3707](https://github.com/quiltdata/quilt/pull/3707))
+* [Fixed] Disable opening file picker on metadata click, and fix dropping JSON as metadata ([#3707](https://github.com/quiltdata/quilt/pull/3707))
 * [Added] Add filter for users and buckets tables in Admin dashboards ([#3480](https://github.com/quiltdata/quilt/pull/3480))
 * [Added] Add links to documentation and re-use code samples ([#3496](https://github.com/quiltdata/quilt/pull/3496))
 * [Added] Show S3 Object tags ([#3515](https://github.com/quiltdata/quilt/pull/3515))


### PR DESCRIPTION
Click bug introduced in https://github.com/quiltdata/quilt/pull/3647
And JSON drop bug introduced in https://github.com/quiltdata/quilt/pull/2510

- [x] [Changelog](CHANGELOG.md) entry (skip if change is not significant to end users, e.g. docs only)
