### PR TITLE
Robots.txt by default for catalog deployments

### DIFF
--- a/catalog/firebase.json
+++ b/catalog/firebase.json
@@ -10,7 +10,10 @@
         "destination": "/index.html"
       }
     ],
-    "ignore": ["**/.*"],
+    "ignore": [
+        "**/.*",
+        "robots.txt"
+    ],
     "headers": [
       {
         "source": "**/*.@(jpg|jpeg|gif|png)",

--- a/catalog/static/robots.txt
+++ b/catalog/static/robots.txt
@@ -1,0 +1,3 @@
+User-agent: *
+Disallow: /
+


### PR DESCRIPTION
* No robots.txt to be served from open (separate deployment PR)
* No robots.txt to be served from quiltdata.com (see firebase.json)
* Serve robots.txt in all other cases