### PR TITLE
Add a robots.txt to the catalog

### DIFF
--- a/catalog/firebase.json
+++ b/catalog/firebase.json
@@ -10,7 +10,7 @@
         "destination": "/index.html"
       }
     ],
-    "ignore": ["**/.*"],
+    "ignore": ["**/.*", "robots.txt"],
     "headers": [
       {
         "source": "**/*.@(jpg|jpeg|gif|png)",

--- a/catalog/static/robots.txt
+++ b/catalog/static/robots.txt
@@ -1,0 +1,2 @@
+User-agent: *
+Disallow: /


### PR DESCRIPTION
Block all indexing in private catalog deployments.

CloudFront deployments will exclude /robots.txt.
