### PR TITLE
Fix fallback component syntax

### DIFF
--- a/catalog/app/components/Preview/loaders/Notebook.tsx
+++ b/catalog/app/components/Preview/loaders/Notebook.tsx
@@ -55,7 +55,7 @@ export const Loader = function WrappedNotebookLoader({
   children,
 }: NotebookLoaderProps) {
   return (
-    <React.Suspense fallback={() => children(AsyncResult.Pending())}>
+    <React.Suspense fallback={<>{children(AsyncResult.Pending())}</>}>
       <NotebookLoader {...{ handle, children }} />
     </React.Suspense>
   )


### PR DESCRIPTION
Fixes warning in console:
> Warning: Functions are not valid as a React child. This may happen if you return a Component instead of <Component /> from render. Or maybe you meant to call this function rather than return it.