### PR TITLE
Rebase the catalog Docker image from "nginx" to "amazonlinux"

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -24,13 +24,6 @@ updates:
     directory: "/catalog"
     schedule:
       interval: "daily"
-    ignore:
-      - dependency-name: "nginx"
-        # Prefer stable over mainline. See
-        # https://www.nginx.com/blog/nginx-1-6-1-7-released/ for explanation.
-        # There is no way to specify stable versions, so just ignore latest
-        # mainline.
-        versions: ["~> 1.25.0"]
 
   - package-ecosystem: "docker"
     directory: "/s3-proxy"

--- a/catalog/Dockerfile
+++ b/catalog/Dockerfile
@@ -5,7 +5,7 @@ ENV LC_ALL=C.UTF-8
 ENV LANG=C.UTF-8
 
 RUN amazon-linux-extras enable nginx1 && \
-    yum -y upgrade && yum -y install gettext nginx && \
+    yum -y upgrade && yum -y install gettext nginx && \  # envsubst requires gettext
     yum clean all
 
 # Make logs show up in Docker output

--- a/catalog/Dockerfile
+++ b/catalog/Dockerfile
@@ -1,7 +1,18 @@
-FROM nginx:1.24.0@sha256:73341830a31bf12a44c846b6b323dd8a4fab7668e72c16e9124913ff097c9536
+FROM amazonlinux:2.0.20230912.0
 MAINTAINER Quilt Data, Inc. contact@quiltdata.io
 
+ENV LC_ALL=C.UTF-8
+ENV LANG=C.UTF-8
+
+RUN amazon-linux-extras enable nginx1 && \
+    yum -y update && yum -y install gettext nginx
+
+# Make logs show up in Docker output
+RUN ln -sf /dev/stdout /var/log/nginx/access.log && \
+    ln -sf /dev/stderr /var/log/nginx/error.log
+
 # Set up nginx
+COPY nginx.conf /etc/nginx/nginx.conf
 COPY nginx-web.conf /etc/nginx/conf.d/default.conf
 
 # Copy pre-built catalog assets to nginx
@@ -10,6 +21,9 @@ COPY build /usr/share/nginx/html
 
 # Copy config file
 COPY config.json.tmpl config.json.tmpl
+
+# Use SIGQUIT for a "graceful" shutdown
+STOPSIGNAL SIGQUIT
 
 # Substitute environment variables into config.json and generate config.js based on that before starting nginx.
 # Note: use "exec" because otherwise the shell will catch Ctrl-C and other signals.

--- a/catalog/Dockerfile
+++ b/catalog/Dockerfile
@@ -1,4 +1,4 @@
-FROM amazonlinux:2.0.20230912.0
+FROM amazonlinux:2023.2.20230920.1
 MAINTAINER Quilt Data, Inc. contact@quiltdata.io
 
 ENV LC_ALL=C.UTF-8
@@ -6,9 +6,7 @@ ENV LANG=C.UTF-8
 
 # Upgrade and install dependencies
 # gettext is required by envsubst
-RUN amazon-linux-extras enable nginx1 && \
-    yum -y upgrade && yum -y install gettext nginx && \
-    yum clean all
+RUN dnf -y upgrade && dnf -y install gettext nginx && dnf -y clean all
 
 # Make logs show up in Docker output
 RUN ln -sf /dev/stdout /var/log/nginx/access.log && \

--- a/catalog/Dockerfile
+++ b/catalog/Dockerfile
@@ -5,7 +5,8 @@ ENV LC_ALL=C.UTF-8
 ENV LANG=C.UTF-8
 
 RUN amazon-linux-extras enable nginx1 && \
-    yum -y update && yum -y install gettext nginx
+    yum -y upgrade && yum -y install gettext nginx && \
+    yum clean all
 
 # Make logs show up in Docker output
 RUN ln -sf /dev/stdout /var/log/nginx/access.log && \

--- a/catalog/Dockerfile
+++ b/catalog/Dockerfile
@@ -4,8 +4,10 @@ MAINTAINER Quilt Data, Inc. contact@quiltdata.io
 ENV LC_ALL=C.UTF-8
 ENV LANG=C.UTF-8
 
+# Upgrade and install dependencies
+# gettext is required by envsubst
 RUN amazon-linux-extras enable nginx1 && \
-    yum -y upgrade && yum -y install gettext nginx && \  # envsubst requires gettext
+    yum -y upgrade && yum -y install gettext nginx && \
     yum clean all
 
 # Make logs show up in Docker output

--- a/catalog/nginx-web.conf
+++ b/catalog/nginx-web.conf
@@ -1,5 +1,3 @@
-server_tokens off;
-
 server {
     listen 80 default_server;
     listen [::]:80 default_server;

--- a/catalog/nginx.conf
+++ b/catalog/nginx.conf
@@ -1,0 +1,28 @@
+user  nginx;
+worker_processes  auto;
+
+error_log  /var/log/nginx/error.log notice;
+pid        /var/run/nginx.pid;
+
+events {
+    worker_connections  1024;
+}
+
+http {
+    include       /etc/nginx/mime.types;
+    default_type  application/octet-stream;
+
+    log_format  main  '$remote_addr - $remote_user [$time_local] "$request" '
+                      '$status $body_bytes_sent "$http_referer" '
+                      '"$http_user_agent" "$http_x_forwarded_for"';
+
+    access_log  /var/log/nginx/access.log  main;
+
+    sendfile on;
+    tcp_nopush on;
+    tcp_nodelay on;
+    keepalive_timeout 65;
+    server_tokens off;
+
+    include /etc/nginx/conf.d/*.conf;
+}

--- a/catalog/nginx.conf
+++ b/catalog/nginx.conf
@@ -22,6 +22,7 @@ http {
     tcp_nopush on;
     tcp_nodelay on;
     keepalive_timeout 65;
+    types_hash_max_size 4096;
     server_tokens off;
 
     include /etc/nginx/conf.d/*.conf;


### PR DESCRIPTION
This fixes vulnerabilities found by the ECR scanner.

The nginx base image contains a production-ready nginx.conf that sets a few sane defaults and loads everything else from the "conf.d" dir. The default nginx.conf, on the other hand, configures a server on port 80 that displays "Welcome to nginx". Therefore, we're now overwriting nginx.conf, too, in addition to adding the catalog config.

"server_tokens off;" is moved to the main config where it actually belongs.

A few things are added to the Dockerfile that the nginx base image Dockerfile used to do.
