### PR TITLE
Remove workarounds for connecting to an ELB

### DIFF
--- a/s3-proxy/Dockerfile
+++ b/s3-proxy/Dockerfile
@@ -13,14 +13,13 @@ ENV NGINX_VERSION=1.24.0
 # Download and compile Nginx.
 # Dependencies:
 # - pcre: runtime dependency for nginx
-# - awscli: aws used by run-nginx.sh
 # - gettext: envsubst used by run-nginx.sh
 # - shadow-utils: useradd
 # - tar, gzip: download the source
 # - gcc, make, *-devel: compile nginx
 RUN set -x \
     && dnf -y upgrade \
-    && dnf -y install --setopt=install_weak_deps=False pcre awscli gettext shadow-utils tar gzip gcc make openssl-devel pcre-devel zlib-devel \
+    && dnf -y install --setopt=install_weak_deps=False pcre gettext shadow-utils tar gzip gcc make openssl-devel pcre-devel zlib-devel \
     && cd /root \
     && curl -L http://nginx.org/download/nginx-${NGINX_VERSION}.tar.gz | tar zx \
     && cd nginx-${NGINX_VERSION} \

--- a/s3-proxy/nginx.conf
+++ b/s3-proxy/nginx.conf
@@ -31,7 +31,7 @@ http {
             proxy_request_buffering off;
             proxy_ssl_verify on;
             proxy_ssl_verify_depth 5;
-            proxy_ssl_trusted_certificate /etc/nginx/certs.pem;
+            proxy_ssl_trusted_certificate /etc/ssl/cert.pem;
 
             # Add CORS headers.
             add_header 'Access-Control-Allow-Headers' $http_access_control_request_headers always;
@@ -87,12 +87,6 @@ http {
             proxy_pass $registry;
             proxy_http_version 1.1;
             proxy_buffering off;
-            proxy_ssl_verify on;
-            proxy_ssl_verify_depth 5;
-            proxy_ssl_trusted_certificate /etc/nginx/certs.pem;
-            proxy_ssl_name $REGISTRY_HOST;
-
-            proxy_set_header Host $REGISTRY_HOST;
 
             # mod_zip cannot handle compressed output from the upstream.
             proxy_set_header Accept-Encoding '';
@@ -106,12 +100,6 @@ http {
             proxy_pass $registry;
             proxy_http_version 1.1;
             proxy_buffering off;
-            proxy_ssl_verify on;
-            proxy_ssl_verify_depth 5;
-            proxy_ssl_trusted_certificate /etc/nginx/certs.pem;
-            proxy_ssl_name $REGISTRY_HOST;
-
-            proxy_set_header Host $REGISTRY_HOST;
 
             proxy_intercept_errors on;
             error_page 301 302 307 = @handle_redirect;

--- a/s3-proxy/run-nginx.sh
+++ b/s3-proxy/run-nginx.sh
@@ -13,12 +13,6 @@ then
     exit 1
 fi
 
-cp /etc/ssl/cert.pem /etc/nginx/certs.pem
-if [ $CERTIFICATE_ARN ]
-then
-    aws --region $(echo $CERTIFICATE_ARN | cut -d ":" -f 4) acm get-certificate --certificate-arn $CERTIFICATE_ARN --output text --query "join('', [Certificate, CertificateChain])" >> /etc/nginx/certs.pem
-fi
-
 INTERNAL_REGISTRY_URL=${INTERNAL_REGISTRY_URL%%/} # Remove a trailing slash.
 
 # Get the DNS server from /etc/resolv.conf
@@ -32,6 +26,6 @@ fi
 
 export NAMESERVER=$nameserver
 
-envsubst '$REGISTRY_HOST $INTERNAL_REGISTRY_URL $NAMESERVER' < /root/nginx.conf.tmpl > /etc/nginx/nginx.conf
+envsubst '$INTERNAL_REGISTRY_URL $NAMESERVER' < /root/nginx.conf.tmpl > /etc/nginx/nginx.conf
 
 exec nginx -g 'daemon off;'


### PR DESCRIPTION
No longer needed, since s3-proxy will be connecting to the registry directly.