### PR TITLE
Fix copying selected text in code samples

### DIFF
--- a/catalog/app/containers/Bucket/CodeSamples/Code.tsx
+++ b/catalog/app/containers/Bucket/CodeSamples/Code.tsx
@@ -32,14 +32,12 @@ const useLineOfCodeStyles = M.makeStyles((t) => ({
     overflowY: 'hidden',
     whiteSpace: 'pre',
     minHeight: t.typography.body2.fontSize,
-    display: 'flex',
-    alignItems: 'flex-end',
     '&:hover $help': {
       opacity: 1,
     },
   },
   help: {
-    display: 'inline-flex',
+    display: 'inline-block',
     marginLeft: t.spacing(0.5),
     opacity: 0.3,
   },

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -27,6 +27,7 @@ Entries inside each section should be ordered by type:
 * [Fixed] Disable opening file picker on metadata click, and fix dropping JSON as metadata ([#3707](https://github.com/quiltdata/quilt/pull/3707))
 * [Fixed] Faceted Search: crash due to infinite recursion on duplicate facets ([#3799](https://github.com/quiltdata/quilt/pull/3799))
 * [Fixed] Hide filters in a sidebar drawer on mobile ([#3801](https://github.com/quiltdata/quilt/pull/3801))
+* [Fixed] Fix copying selected text in code samples ([#3803](https://github.com/quiltdata/quilt/pull/3803))
 * [Added] Add filter for users and buckets tables in Admin dashboards ([#3480](https://github.com/quiltdata/quilt/pull/3480))
 * [Added] Add links to documentation and re-use code samples ([#3496](https://github.com/quiltdata/quilt/pull/3496))
 * [Added] Show S3 Object tags ([#3515](https://github.com/quiltdata/quilt/pull/3515))


### PR DESCRIPTION
Don't use flex which causes `display: block` on children

- [x] [Changelog](CHANGELOG.md) entry (skip if change is not significant to end users, e.g. docs only)
