### PR TITLE
Specify condition for rendering Quilt manifests, allowing to render other types of files in `.quilt/packages/`

### DIFF
--- a/catalog/app/components/Preview/loaders/Manifest.tsx
+++ b/catalog/app/components/Preview/loaders/Manifest.tsx
@@ -1,3 +1,5 @@
+import { extname } from 'path'
+
 import hljs from 'highlight.js'
 import * as R from 'ramda'
 import * as React from 'react'
@@ -10,7 +12,9 @@ import { PreviewData, PreviewError } from '../types'
 import * as Text from './Text'
 import * as utils from './utils'
 
-export const detect = R.startsWith('.quilt/packages/')
+const hasNoExt = (key: string) => !extname(key)
+
+export const detect = R.allPass([R.startsWith('.quilt/packages/'), hasNoExt])
 
 const hl = (language: string) => (contents: string) =>
   hljs.highlight(contents, { language }).value

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -51,6 +51,7 @@ Entries inside each section should be ordered by type:
 * [Changed] Unify per-bucket and global search ([#3613](https://github.com/quiltdata/quilt/pull/3613))
 * [Changed] Allow use of <br /> in Markdown ([#3720](https://github.com/quiltdata/quilt/pull/3720))
 * [Changed] Faceted search ([#3712](https://github.com/quiltdata/quilt/pull/3712))
+* [Changed] Specify condition for rendering Quilt manifests, allowing to render other types of files in `.quilt/packages/` ([#3816](https://github.com/quiltdata/quilt/pull/3816))
 
 # 5.3.1 - 2023-05-02
 ## Python API


### PR DESCRIPTION
- [x] [Changelog](../tree/master/docs/CHANGELOG.md) entry (skip if change is not significant to end users, e.g. docs only)
