### PR TITLE
Faceted Search: show helpful message in case of search query syntax errors

### DIFF
--- a/catalog/app/components/SearchResults/SearchResults.tsx
+++ b/catalog/app/components/SearchResults/SearchResults.tsx
@@ -26,7 +26,7 @@ import * as requests from 'containers/Bucket/requests'
 const PER_PAGE = 10
 const ES_V = '6.8'
 const ES_REF = `https://www.elastic.co/guide/en/elasticsearch/reference/${ES_V}`
-const ES_REF_SYNTAX = `${ES_REF}/query-dsl-query-string-query.html#query-string-syntax`
+export const ES_REF_SYNTAX = `${ES_REF}/query-dsl-query-string-query.html#query-string-syntax`
 const ES_REF_WILDCARDS = `${ES_REF}/query-dsl-query-string-query.html#_wildcards`
 
 const CrumbLink = M.styled(StyledLink)({ wordBreak: 'break-word' })

--- a/catalog/app/containers/Search/Results.tsx
+++ b/catalog/app/containers/Search/Results.tsx
@@ -112,7 +112,7 @@ const useEmptyResultsStyles = M.makeStyles((t) => ({
 interface EmptyResultsProps {
   className?: string
   clearTitle?: string
-  description?: string
+  description?: string | React.ReactNode
   image?: 'not-found' | 'error'
   title?: string
 }

--- a/catalog/app/containers/Search/Search.tsx
+++ b/catalog/app/containers/Search/Search.tsx
@@ -10,6 +10,7 @@ import Skeleton from 'components/Skeleton'
 import * as GQL from 'utils/GraphQL'
 import * as JSONPointer from 'utils/JSONPointer'
 import MetaTitle from 'utils/MetaTitle'
+import StyledLink from 'utils/StyledLink'
 import assertNever from 'utils/assertNever'
 import * as Format from 'utils/format'
 
@@ -1139,12 +1140,38 @@ function ResultsInner({ className }: ResultsInnerProps) {
         case 'EmptySearchResultSet':
           return <EmptyResults className={className} />
         case 'InvalidInput':
+          const [err] = r.data.errors
+          const title =
+            err.name === 'QuerySyntaxError' ? 'Query syntax error' : `Invalid input`
+          const description =
+            err.name === 'QuerySyntaxError' ? (
+              <>
+                Oops, couldn&apos;t parse that search.
+                <br />
+                Try quoting your query or read about{' '}
+                <StyledLink href={SearchResults.ES_REF_SYNTAX} target="_blank">
+                  supported query syntax
+                </StyledLink>
+                .
+                <br />
+                <br />
+                Error details:
+                <br />
+                {err.message}
+              </>
+            ) : (
+              <>
+                Invalid input at <code>{err.path}</code>: {err.name}
+                <br />
+                {err.message}
+              </>
+            )
           return (
             <EmptyResults
               className={className}
-              description={r.data.errors[0].message}
+              description={description}
               image="error"
-              title="Invalid input"
+              title={title}
             />
           )
         case 'ObjectsSearchResultSet':

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -21,6 +21,7 @@ Entries inside each section should be ordered by type:
 ## CLI
 
 ## Catalog, Lambdas
+* [Fixed] Faceted Search: show helpful message in case of search query syntax errors ([#3821](https://github.com/quiltdata/quilt/pull/3821))
 * [Changed] Faceted Search: use non-linear scale for numeric range control ([#3805](https://github.com/quiltdata/quilt/pull/3805))
 * [Changed] Faceted Search: reliably find metadata facets ([#3809](https://github.com/quiltdata/quilt/pull/3809))
 


### PR DESCRIPTION
# Description

<img width="783" alt="Screenshot 2023-12-19 at 14 44 36" src="https://github.com/quiltdata/quilt/assets/122294/674c0e25-d62a-41b3-838c-c3ffb8bccd8d">

# TODO

- [x] Confirm that this change meets security best practices and does not violate the security model
- [x] [Changelog](../tree/master/docs/CHANGELOG.md) entry (skip if change is not significant to end users, e.g. docs only)
