### PR TITLE
Add `&referrer=` to the quilt+s3 URI

### DIFF
--- a/catalog/app/containers/Bucket/CodeSamples/Package.tsx
+++ b/catalog/app/containers/Bucket/CodeSamples/Package.tsx
@@ -4,7 +4,6 @@ import * as R from 'ramda'
 import * as React from 'react'
 
 import { docs } from 'constants/urls'
-import * as PackageUri from 'utils/PackageUri'
 import * as s3paths from 'utils/s3paths'
 
 import type { SectionProps } from '../Section'
@@ -84,8 +83,7 @@ export default function PackageCodeSamples({
       },
       {
         label: 'URI',
-        hl: 'uri',
-        contents: PackageUri.stringify({ bucket, name, hash, path }),
+        contents: { bucket, name, hash, path },
       },
     ],
     [bucket, name, hashDisplay, hash, path],

--- a/catalog/app/utils/PackageUri.ts
+++ b/catalog/app/utils/PackageUri.ts
@@ -110,3 +110,10 @@ export function stringify({ bucket, name, hash, tag, path }: PackageUri) {
   const pathPart = path ? `&path=${encodeURIComponent(path)}` : ''
   return `quilt+s3://${bucket}#package=${pkgSpec}${pathPart}`
 }
+
+// TODO: make `referrer` a part of "Standard", or use another approach
+/** @deprecated */
+export function stringifyAndAddReferrer(uri: PackageUri, referrer?: string) {
+  const referrerPart = referrer ? `&referrer=${encodeURIComponent(referrer)}` : ''
+  return `${stringify(uri)}${referrerPart}`
+}

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -24,6 +24,7 @@ Entries inside each section should be ordered by type:
 
 ## Catalog, Lambdas
 * [Added] Support multipart checksums ([#3403](https://github.com/quiltdata/quilt/pull/3403))
+* [Added] Add `&referrer=` to the `quilt+s3` URI ([#3863](https://github.com/quiltdata/quilt/pull/3863))
 * [Fixed] Faceted Search: show helpful message in case of search query syntax errors ([#3821](https://github.com/quiltdata/quilt/pull/3821))
 * [Fixed] JsonEditor: fix changing collections items, that have `.additionalProperties` or `.items` JSON Schema ([#3860](https://github.com/quiltdata/quilt/pull/3860))
 * [Changed] Faceted Search: use non-linear scale for numeric range control ([#3805](https://github.com/quiltdata/quilt/pull/3805))


### PR DESCRIPTION
* Added `&referrer=` to the `quilt+s3://` URI as a string modification, not making at a part of URI struct
* Simplified code by
  * replacing weak assumptions (`if lang == 'uri'`) with types: used `PackageURI` type instead
  * using two components for Uri and code lines, moving parsing lines to that component
* Visually nothing changed and "Copy" button copies URI without `&referrer=`

- [x] [Changelog](../tree/master/docs/CHANGELOG.md) entry (skip if change is not significant to end users, e.g. docs only)
