### PR TITLE
Merge pylint/pycodestyle and isort

### DIFF
--- a/.github/workflows/py-ci.yml
+++ b/.github/workflows/py-ci.yml
@@ -10,25 +10,13 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip setuptools
-          python -m pip install 'pylint==2.10.2' 'pycodestyle>=2.6.1'
+          python -m pip install 'pylint==2.10.2' 'pycodestyle>=2.6.1' isort
       - name: Run pylint
         run: |
           pylint $(find -name '*.py')
       - name: Run pycodestyle
         run: |
           pycodestyle $(find -name '*.py')
-
-  isort:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
-        with:
-          python-version: '3.7'
-      - name: Install dependencies
-        run: |
-          python -m pip install --upgrade pip setuptools
-          python -m pip install isort
       - name: Run isort
         run: |
           isort --check --diff .


### PR DESCRIPTION
No reason why pylint/pycodestyle should be one job, but isort should be separate.