### PR TITLE
indexer lambda: bump botocore

### DIFF
--- a/lambdas/indexer/requirements.txt
+++ b/lambdas/indexer/requirements.txt
@@ -1,7 +1,7 @@
 attrs==19.1.0
 aws-requests-auth==0.4.2
-boto3==1.17.100
-botocore==1.20.100
+boto3==1.34.41
+botocore==1.34.41
 certifi==2023.7.22
 cffi==1.15.1
 chardet==3.0.4
@@ -35,7 +35,7 @@ python-dateutil==2.8.0
 python-pptx==0.6.21
 pytz==2019.2
 requests==2.31.0
-s3transfer==0.4.2
+s3transfer==0.10.0
 six==1.12.0
 sortedcontainers==2.4.0
 strict-rfc3339==0.7


### PR DESCRIPTION
This drops installed size of botocore from 60 to 24 MiB and should fix deployment.
See https://github.com/boto/botocore/issues/2365#issuecomment-1813447304.