### PR TITLE
s3hash: always stream bytes in legacy mode

### DIFF
--- a/lambdas/s3hash/CHANGELOG.md
+++ b/lambdas/s3hash/CHANGELOG.md
@@ -16,6 +16,7 @@ where verb is one of
 
 ## Changes
 
+- [Changed] Always stream bytes in legacy mode ([#3903](https://github.com/quiltdata/quilt/pull/3903))
 - [Changed] Compute chunked checksums, adhere to the spec ([#3889](https://github.com/quiltdata/quilt/pull/3889))
 - [Added] Lambda handler for file copy ([#3884](https://github.com/quiltdata/quilt/pull/3884))
 - [Changed] Compute multipart checksums ([#3402](https://github.com/quiltdata/quilt/pull/3402))

--- a/lambdas/s3hash/src/t4_lambda_s3hash/__init__.py
+++ b/lambdas/s3hash/src/t4_lambda_s3hash/__init__.py
@@ -383,11 +383,11 @@ async def compute_checksum(location: S3ObjectSource) -> ChecksumResult:
     if total_size == 0:
         return ChecksumResult(checksum=Checksum.empty())
 
-    if not CHUNKED_CHECKSUMS and total_size > MAX_PART_SIZE:
+    if not CHUNKED_CHECKSUMS:
         checksum = await compute_checksum_legacy(location)
         return ChecksumResult(checksum=checksum)
 
-    part_defs = get_parts_for_size(total_size) if CHUNKED_CHECKSUMS else PARTS_SINGLE
+    part_defs = get_parts_for_size(total_size)
 
     async with create_mpu(MPU_DST) as mpu:
         part_checksums = await compute_part_checksums(
@@ -397,7 +397,7 @@ async def compute_checksum(location: S3ObjectSource) -> ChecksumResult:
             part_defs,
         )
 
-    checksum = Checksum.for_parts(part_checksums) if CHUNKED_CHECKSUMS else Checksum.sha256(part_checksums[0])
+    checksum = Checksum.for_parts(part_checksums)
     return ChecksumResult(checksum=checksum)
 
 


### PR DESCRIPTION
to prevent cross-region vpc endpoint issue
