### PR TITLE
quilt3: make write_yaml() constistent across platforms to fix tests

### DIFF
--- a/api/python/quilt3/util.py
+++ b/api/python/quilt3/util.py
@@ -297,7 +297,8 @@ def write_yaml(data, yaml_path, keep_backup=False):
 
     try:
         if path.exists():
-            path.rename(backup_path)
+            # TODO: use something from tempfile to make sure backup_path doesn't exist.
+            path.replace(backup_path)
         path.parent.mkdir(parents=True, exist_ok=True)
         with path.open('w') as config_file:
             yaml.dump(data, config_file)


### PR DESCRIPTION
os.rename() raises if dst exists on Win, but not on Linux or MacOS. This leads to transient test failures on Win, especially because it looks like it has relatively low time resolution.