### PR TITLE
catalog push limits (to review)

### DIFF
--- a/docs/api-reference/limitations.md
+++ b/docs/api-reference/limitations.md
@@ -11,15 +11,15 @@ To ensure usability and quick package pushes, the Quilt web catalog imposes the
 following limits on pushes (which vary depending on whether the chunked checksums
 are enabled on the stack). These limits do not apply to the `quilt3` Python API.
 
- Dimension                                                  | Max (classic / chunked checksums)
-------------------------------------------------------------|--------
- Package manifest size (metadata)                           | 100 MiB
- Package size (data; via promotion or from an S3 directory) | 100 GiB / 5 TiB
- Total size of uploaded files (soft limit)                  | 20 GB
- Total size of files from S3 (soft limit)                   | 50 GB / 5 TB
- Maximum file size                                          | 10 GiB / 5 TiB
- Maximum number of files per push (soft limit)              | 1,000
- Maximum number of files per push (hard limit)              | 5,000
+    Dimension                                                  | Max (classic / chunked checksums)
+    ------------------------------------------------------------|--------
+    Package manifest size (metadata)                           | 100 MiB
+    Package size (data; via promotion or from an S3 directory) | 100 GiB / 5 TiB
+    Total size of uploaded files (soft limit)                  | 20 GB
+    Total size of files from S3 (soft limit)                   | 50 GB / 5 TB
+    Maximum file size                                          | 10 GiB / 5 TiB
+    Maximum number of files per push (soft limit)              | 1,000
+    Maximum number of files per push (hard limit)              | 5,000
 
 ### API
 


### PR DESCRIPTION
Are the limits  on `number of files` still accurate?

```markdown
    Maximum number of files per push (soft limit)              | 1,000
    Maximum number of files per push (hard limit)              | 5,000
```

Do NOT spend more than 15 minutes on this, but if you have a quick answer please let us know.

This matters [because](https://quiltdata.slack.com/archives/C03RRFEAVLY/p1709319449267729?thread_ts=1709319337.460759&cid=C03RRFEAVLY):

> Not only the total file size but the number of files (catalog hard limit of 5K) is a usage-stopping issue for Customers and causes them to do weird things like zipping up files before syncing to S3 so they are within Quilt file size limits. That's an example where Quilt is hurting data liquidity.