### PR TITLE
py-shared: cross-region chunksums support (pass scratch bucket map to lambdas)

### DIFF
--- a/py-shared/CHANGELOG.md
+++ b/py-shared/CHANGELOG.md
@@ -16,5 +16,7 @@ where verb is one of
 
 ## Changes
 
+- [Changed] **BREAKING**: Add `scratch_buckets` required field to `S3HashLambdaParams` ([#3922](https://github.com/quiltdata/quilt/pull/3922))
+- [Added] Introduce `PackageConstructParams` ([#3922](https://github.com/quiltdata/quilt/pull/3922))
 - [Changed] Tweak checksum types ([#3888](https://github.com/quiltdata/quilt/pull/3888))
 - [Added] Bootstrap `quilt_shared` package ([#3849](https://github.com/quiltdata/quilt/pull/3849))

--- a/py-shared/src/quilt_shared/pkgpush.py
+++ b/py-shared/src/quilt_shared/pkgpush.py
@@ -62,6 +62,7 @@ class S3ObjectDestination(pydantic.BaseModel):
 
 class S3HashLambdaParams(pydantic.BaseModel):
     credentials: AWSCredentials
+    scratch_buckets: T.Dict[str, str]
     location: S3ObjectSource
 
 
@@ -144,6 +145,10 @@ class PackagePromoteSource(pydantic.BaseModel):
 
 class PackagePromoteParams(PackagePushParams):
     src: PackagePromoteSource
+
+
+class PackageConstructParams(PackagePushParams):
+    scratch_buckets: T.Dict[str, str]
 
 
 class PackageConstructEntry(pydantic.BaseModel):


### PR DESCRIPTION
Changes required for cross-region chunksums (passing the scratch bucket map to the lambdas):

- Add `scratch_buckets` required field to `S3HashLambdaParams`
- Introduce `PackageConstructParams`

## TODO

- [x] [Changelog](../tree/master/docs/CHANGELOG.md) entry (skip if change is not significant to end users, e.g. docs only)
