### PR TITLE
lambdas: cross-region chunksums support (use per-region scratch buckets)

### DIFF
--- a/.github/workflows/deploy-lambdas.yaml
+++ b/.github/workflows/deploy-lambdas.yaml
@@ -4,7 +4,6 @@ on:
   push:
     branches:
       - master
-      - lambdas-scratch-buckets
     paths:
       - '.github/workflows/deploy-lambdas.yaml'
       - 'lambdas/**'
@@ -14,17 +13,17 @@ jobs:
     strategy:
       matrix:
         path:
-          # - access_counts
-          # - indexer
-          # - pkgevents
+          - access_counts
+          - indexer
+          - pkgevents
           - pkgpush
-          # - pkgselect
-          # - preview
+          - pkgselect
+          - preview
           - s3hash
-          # - s3select
-          # - status_reports
-          # - tabular_preview
-          # - transcode
+          - s3select
+          - status_reports
+          - tabular_preview
+          - transcode
     runs-on: ubuntu-latest
     # These permissions are needed to interact with GitHub's OIDC Token endpoint.
     permissions:
@@ -54,43 +53,43 @@ jobs:
         run: |
           s3_key="${{ matrix.path }}/${{ github.sha }}.zip"
           ./lambdas/scripts/upload_zip.sh ./out.zip "$AWS_REGION" "$s3_key"
-      # - name: Configure AWS credentials from GovCloud account
-      #   uses: aws-actions/configure-aws-credentials@v4
-      #   with:
-      #     role-to-assume: arn:aws-us-gov:iam::313325871032:role/github/GitHub-Quilt
-      #     aws-region: us-gov-east-1
-      # - name: Upload zips to GovCloud S3
-      #   run: |
-      #     s3_key="${{ matrix.path }}/${{ github.sha }}.zip"
-      #     ./lambdas/scripts/upload_zip.sh ./out.zip "$AWS_REGION" "$s3_key"
+      - name: Configure AWS credentials from GovCloud account
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: arn:aws-us-gov:iam::313325871032:role/github/GitHub-Quilt
+          aws-region: us-gov-east-1
+      - name: Upload zips to GovCloud S3
+        run: |
+          s3_key="${{ matrix.path }}/${{ github.sha }}.zip"
+          ./lambdas/scripts/upload_zip.sh ./out.zip "$AWS_REGION" "$s3_key"
 
-  # deploy-lambda-ecr:
-  #   strategy:
-  #     matrix:
-  #       path:
-  #         - molecule
-  #         - thumbnail
-  #   runs-on: ubuntu-latest
-  #   # These permissions are needed to interact with GitHub's OIDC Token endpoint.
-  #   permissions:
-  #     id-token: write
-  #     contents: read
-  #   steps:
-  #     - uses: actions/checkout@v4
-  #     - name: Build Docker image
-  #       working-directory: ./lambdas/${{ matrix.path }}
-  #       run: docker buildx build -t "quiltdata/lambdas/${{ matrix.path }}:${{ github.sha }}" -f Dockerfile ..
-  #     - name: Configure AWS credentials from Prod account
-  #       uses: aws-actions/configure-aws-credentials@v4
-  #       with:
-  #         role-to-assume: arn:aws:iam::730278974607:role/github/GitHub-Quilt
-  #         aws-region: us-east-1
-  #     - name: Push Docker image to Prod ECR
-  #       run: ./lambdas/scripts/upload_ecr.sh 730278974607 "quiltdata/lambdas/${{ matrix.path }}:${{ github.sha }}"
-  #     - name: Configure AWS credentials from GovCloud account
-  #       uses: aws-actions/configure-aws-credentials@v4
-  #       with:
-  #         role-to-assume: arn:aws-us-gov:iam::313325871032:role/github/GitHub-Quilt
-  #         aws-region: us-gov-east-1
-  #     - name: Push Docker image to GovCloud ECR
-  #       run: ./lambdas/scripts/upload_ecr.sh 313325871032 "quiltdata/lambdas/${{ matrix.path }}:${{ github.sha }}"
+  deploy-lambda-ecr:
+    strategy:
+      matrix:
+        path:
+          - molecule
+          - thumbnail
+    runs-on: ubuntu-latest
+    # These permissions are needed to interact with GitHub's OIDC Token endpoint.
+    permissions:
+      id-token: write
+      contents: read
+    steps:
+      - uses: actions/checkout@v4
+      - name: Build Docker image
+        working-directory: ./lambdas/${{ matrix.path }}
+        run: docker buildx build -t "quiltdata/lambdas/${{ matrix.path }}:${{ github.sha }}" -f Dockerfile ..
+      - name: Configure AWS credentials from Prod account
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: arn:aws:iam::730278974607:role/github/GitHub-Quilt
+          aws-region: us-east-1
+      - name: Push Docker image to Prod ECR
+        run: ./lambdas/scripts/upload_ecr.sh 730278974607 "quiltdata/lambdas/${{ matrix.path }}:${{ github.sha }}"
+      - name: Configure AWS credentials from GovCloud account
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: arn:aws-us-gov:iam::313325871032:role/github/GitHub-Quilt
+          aws-region: us-gov-east-1
+      - name: Push Docker image to GovCloud ECR
+        run: ./lambdas/scripts/upload_ecr.sh 313325871032 "quiltdata/lambdas/${{ matrix.path }}:${{ github.sha }}"

--- a/.github/workflows/deploy-lambdas.yaml
+++ b/.github/workflows/deploy-lambdas.yaml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - master
+      - lambdas-scratch-buckets
     paths:
       - '.github/workflows/deploy-lambdas.yaml'
       - 'lambdas/**'
@@ -13,17 +14,17 @@ jobs:
     strategy:
       matrix:
         path:
-          - access_counts
-          - indexer
-          - pkgevents
+          # - access_counts
+          # - indexer
+          # - pkgevents
           - pkgpush
-          - pkgselect
-          - preview
+          # - pkgselect
+          # - preview
           - s3hash
-          - s3select
-          - status_reports
-          - tabular_preview
-          - transcode
+          # - s3select
+          # - status_reports
+          # - tabular_preview
+          # - transcode
     runs-on: ubuntu-latest
     # These permissions are needed to interact with GitHub's OIDC Token endpoint.
     permissions:
@@ -53,43 +54,43 @@ jobs:
         run: |
           s3_key="${{ matrix.path }}/${{ github.sha }}.zip"
           ./lambdas/scripts/upload_zip.sh ./out.zip "$AWS_REGION" "$s3_key"
-      - name: Configure AWS credentials from GovCloud account
-        uses: aws-actions/configure-aws-credentials@v4
-        with:
-          role-to-assume: arn:aws-us-gov:iam::313325871032:role/github/GitHub-Quilt
-          aws-region: us-gov-east-1
-      - name: Upload zips to GovCloud S3
-        run: |
-          s3_key="${{ matrix.path }}/${{ github.sha }}.zip"
-          ./lambdas/scripts/upload_zip.sh ./out.zip "$AWS_REGION" "$s3_key"
+      # - name: Configure AWS credentials from GovCloud account
+      #   uses: aws-actions/configure-aws-credentials@v4
+      #   with:
+      #     role-to-assume: arn:aws-us-gov:iam::313325871032:role/github/GitHub-Quilt
+      #     aws-region: us-gov-east-1
+      # - name: Upload zips to GovCloud S3
+      #   run: |
+      #     s3_key="${{ matrix.path }}/${{ github.sha }}.zip"
+      #     ./lambdas/scripts/upload_zip.sh ./out.zip "$AWS_REGION" "$s3_key"
 
-  deploy-lambda-ecr:
-    strategy:
-      matrix:
-        path:
-          - molecule
-          - thumbnail
-    runs-on: ubuntu-latest
-    # These permissions are needed to interact with GitHub's OIDC Token endpoint.
-    permissions:
-      id-token: write
-      contents: read
-    steps:
-      - uses: actions/checkout@v4
-      - name: Build Docker image
-        working-directory: ./lambdas/${{ matrix.path }}
-        run: docker buildx build -t "quiltdata/lambdas/${{ matrix.path }}:${{ github.sha }}" -f Dockerfile ..
-      - name: Configure AWS credentials from Prod account
-        uses: aws-actions/configure-aws-credentials@v4
-        with:
-          role-to-assume: arn:aws:iam::730278974607:role/github/GitHub-Quilt
-          aws-region: us-east-1
-      - name: Push Docker image to Prod ECR
-        run: ./lambdas/scripts/upload_ecr.sh 730278974607 "quiltdata/lambdas/${{ matrix.path }}:${{ github.sha }}"
-      - name: Configure AWS credentials from GovCloud account
-        uses: aws-actions/configure-aws-credentials@v4
-        with:
-          role-to-assume: arn:aws-us-gov:iam::313325871032:role/github/GitHub-Quilt
-          aws-region: us-gov-east-1
-      - name: Push Docker image to GovCloud ECR
-        run: ./lambdas/scripts/upload_ecr.sh 313325871032 "quiltdata/lambdas/${{ matrix.path }}:${{ github.sha }}"
+  # deploy-lambda-ecr:
+  #   strategy:
+  #     matrix:
+  #       path:
+  #         - molecule
+  #         - thumbnail
+  #   runs-on: ubuntu-latest
+  #   # These permissions are needed to interact with GitHub's OIDC Token endpoint.
+  #   permissions:
+  #     id-token: write
+  #     contents: read
+  #   steps:
+  #     - uses: actions/checkout@v4
+  #     - name: Build Docker image
+  #       working-directory: ./lambdas/${{ matrix.path }}
+  #       run: docker buildx build -t "quiltdata/lambdas/${{ matrix.path }}:${{ github.sha }}" -f Dockerfile ..
+  #     - name: Configure AWS credentials from Prod account
+  #       uses: aws-actions/configure-aws-credentials@v4
+  #       with:
+  #         role-to-assume: arn:aws:iam::730278974607:role/github/GitHub-Quilt
+  #         aws-region: us-east-1
+  #     - name: Push Docker image to Prod ECR
+  #       run: ./lambdas/scripts/upload_ecr.sh 730278974607 "quiltdata/lambdas/${{ matrix.path }}:${{ github.sha }}"
+  #     - name: Configure AWS credentials from GovCloud account
+  #       uses: aws-actions/configure-aws-credentials@v4
+  #       with:
+  #         role-to-assume: arn:aws-us-gov:iam::313325871032:role/github/GitHub-Quilt
+  #         aws-region: us-gov-east-1
+  #     - name: Push Docker image to GovCloud ECR
+  #       run: ./lambdas/scripts/upload_ecr.sh 313325871032 "quiltdata/lambdas/${{ matrix.path }}:${{ github.sha }}"

--- a/.gitignore
+++ b/.gitignore
@@ -49,3 +49,4 @@ testdocs/scripts
 .env
 
 .venv
+.aider*

--- a/lambdas/pkgpush/CHANGELOG.md
+++ b/lambdas/pkgpush/CHANGELOG.md
@@ -16,6 +16,7 @@ where verb is one of
 
 ## Changes
 
+- [Changed] Use per-region scratch buckets ([#3923](https://github.com/quiltdata/quilt/pull/3923))
 - [Changed] Speed-up copying of large files during promotion ([#3884](https://github.com/quiltdata/quilt/pull/3884))
 - [Changed] Bump quilt3 to set max_pool_connections, this improves performance ([#3870](https://github.com/quiltdata/quilt/pull/3870))
 - [Changed] Compute multipart checksums ([#3402](https://github.com/quiltdata/quilt/pull/3402))

--- a/lambdas/pkgpush/requirements.txt
+++ b/lambdas/pkgpush/requirements.txt
@@ -61,7 +61,7 @@ python-dateutil==2.8.2
     # via botocore
 pyyaml==6.0.1
     # via quilt3
-quilt-shared[boto,pydantic,quilt] @ git+https://github.com/quiltdata/quilt@e833b19fde894b640d9b657bb04a5f761cd4d567#subdirectory=py-shared
+quilt-shared[boto,pydantic,quilt] @ git+https://github.com/quiltdata/quilt@7c6edd14fbe8a26613bc26b1bbdc0b956132ef8c#subdirectory=py-shared
     # via t4_lambda_pkgpush (setup.py)
 quilt3 @ git+https://github.com/quiltdata/quilt@5c2b79128fe4d5d1e6093ff6a7d11d09d3315843#subdirectory=api/python
     # via

--- a/lambdas/pkgpush/requirements.txt
+++ b/lambdas/pkgpush/requirements.txt
@@ -61,7 +61,7 @@ python-dateutil==2.8.2
     # via botocore
 pyyaml==6.0.1
     # via quilt3
-quilt-shared[boto,pydantic,quilt] @ git+https://github.com/quiltdata/quilt@47055f7c5c0a93ddddfa5030a73b22a5d42b9c10#subdirectory=py-shared
+quilt-shared[boto,pydantic,quilt] @ git+https://github.com/quiltdata/quilt@e833b19fde894b640d9b657bb04a5f761cd4d567#subdirectory=py-shared
     # via t4_lambda_pkgpush (setup.py)
 quilt3 @ git+https://github.com/quiltdata/quilt@5c2b79128fe4d5d1e6093ff6a7d11d09d3315843#subdirectory=api/python
     # via

--- a/lambdas/pkgpush/setup.py
+++ b/lambdas/pkgpush/setup.py
@@ -15,7 +15,7 @@ setup(
         ),
         (
             "quilt_shared[pydantic,boto,quilt] @ git+https://github.com/quiltdata/quilt@"
-            "47055f7c5c0a93ddddfa5030a73b22a5d42b9c10"
+            "e833b19fde894b640d9b657bb04a5f761cd4d567"
             "#subdirectory=py-shared"
         ),
     ],

--- a/lambdas/pkgpush/setup.py
+++ b/lambdas/pkgpush/setup.py
@@ -15,7 +15,7 @@ setup(
         ),
         (
             "quilt_shared[pydantic,boto,quilt] @ git+https://github.com/quiltdata/quilt@"
-            "e833b19fde894b640d9b657bb04a5f761cd4d567"
+            "7c6edd14fbe8a26613bc26b1bbdc0b956132ef8c"
             "#subdirectory=py-shared"
         ),
     ],

--- a/lambdas/pkgpush/test-requirements.in
+++ b/lambdas/pkgpush/test-requirements.in
@@ -1,3 +1,4 @@
 -c requirements.txt
 pytest ~= 8.0
+pytest-mock ~= 3.14
 pytest-subtests ~= 0.11

--- a/lambdas/pkgpush/test-requirements.txt
+++ b/lambdas/pkgpush/test-requirements.txt
@@ -19,7 +19,10 @@ pluggy==1.4.0
 pytest==8.0.0
     # via
     #   -r test-requirements.in
+    #   pytest-mock
     #   pytest-subtests
+pytest-mock==3.14.0
+    # via -r test-requirements.in
 pytest-subtests==0.11.0
     # via -r test-requirements.in
 tomli==2.0.1

--- a/lambdas/pkgpush/tests/conftest.py
+++ b/lambdas/pkgpush/tests/conftest.py
@@ -1,25 +1,41 @@
 import os
 
+import pytest
+from botocore.stub import Stubber
+
 
 def pytest_configure(config):
     os.environ.update(
-        AWS_ACCESS_KEY_ID='foo',
-        AWS_SECRET_ACCESS_KEY='bar',
-        AWS_DEFAULT_REGION='us-east-1',
-        SERVICE_BUCKET='service-bucket',
+        AWS_ACCESS_KEY_ID="foo",
+        AWS_SECRET_ACCESS_KEY="bar",
+        AWS_DEFAULT_REGION="us-east-1",
+        SERVICE_BUCKET="service-bucket",
         **dict.fromkeys(
             (
-                'PROMOTE_PKG_MAX_MANIFEST_SIZE',
-                'PROMOTE_PKG_MAX_PKG_SIZE',
-                'PROMOTE_PKG_MAX_FILES',
-                'MAX_BYTES_TO_HASH',
-                'MAX_FILES_TO_HASH',
-                'S3_HASH_LAMBDA_MAX_FILE_SIZE_BYTES',
+                "PROMOTE_PKG_MAX_MANIFEST_SIZE",
+                "PROMOTE_PKG_MAX_PKG_SIZE",
+                "PROMOTE_PKG_MAX_FILES",
+                "MAX_BYTES_TO_HASH",
+                "MAX_FILES_TO_HASH",
+                "S3_HASH_LAMBDA_MAX_FILE_SIZE_BYTES",
             ),
-            str(2 ** 64),  # Value big enough to serve as 'unlimited'.
+            str(2**64),  # Value big enough to serve as 'unlimited'.
         ),
-        S3_HASH_LAMBDA='s3-hash-lambda-name',
-        S3_COPY_LAMBDA='s3-copy-lambda-name',
-        S3_HASH_LAMBDA_CONCURRENCY='40',
-        S3_COPY_LAMBDA_CONCURRENCY='40',
+        S3_HASH_LAMBDA="s3-hash-lambda-name",
+        S3_COPY_LAMBDA="s3-copy-lambda-name",
+        S3_HASH_LAMBDA_CONCURRENCY="40",
+        S3_COPY_LAMBDA_CONCURRENCY="40",
     )
+
+
+@pytest.fixture
+def lambda_stub():
+    import t4_lambda_pkgpush
+
+    stub = Stubber(t4_lambda_pkgpush.lambda_)
+    stub.activate()
+    try:
+        yield stub
+        stub.assert_no_pending_responses()
+    finally:
+        stub.deactivate()

--- a/lambdas/pkgpush/tests/test_copy.py
+++ b/lambdas/pkgpush/tests/test_copy.py
@@ -7,7 +7,6 @@ from quilt3.util import PhysicalKey
 from quilt_shared.aws import AWSCredentials
 from quilt_shared.types import NonEmptyStr
 
-
 CREDENTIALS = AWSCredentials(
     key=NonEmptyStr("test_aws_access_key_id"),
     secret=NonEmptyStr("test_aws_secret_access_key"),

--- a/lambdas/pkgpush/tests/test_copy.py
+++ b/lambdas/pkgpush/tests/test_copy.py
@@ -1,0 +1,42 @@
+import io
+
+from botocore.stub import Stubber
+
+import t4_lambda_pkgpush
+from quilt3.util import PhysicalKey
+from quilt_shared.aws import AWSCredentials
+from quilt_shared.types import NonEmptyStr
+
+
+CREDENTIALS = AWSCredentials(
+    key=NonEmptyStr("test_aws_access_key_id"),
+    secret=NonEmptyStr("test_aws_secret_access_key"),
+    token=NonEmptyStr("test_aws_session_token"),
+)
+
+
+def test_invoke_copy_lambda(lambda_stub: Stubber):
+    SRC_BUCKET = "src-bucket"
+    SRC_KEY = "src-key"
+    SRC_VERSION_ID = "src-version-id"
+    DST_BUCKET = "dst-bucket"
+    DST_KEY = "dst-key"
+    DST_VERSION_ID = "dst-version-id"
+
+    lambda_stub.add_response(
+        "invoke",
+        {
+            "Payload": io.BytesIO(
+                b'{"result": {"version": "%s"}}' % DST_VERSION_ID.encode()
+            )
+        },
+    )
+
+    assert (
+        t4_lambda_pkgpush.invoke_copy_lambda(
+            CREDENTIALS,
+            PhysicalKey(SRC_BUCKET, SRC_KEY, SRC_VERSION_ID),
+            PhysicalKey(DST_BUCKET, DST_KEY, None),
+        )
+        == DST_VERSION_ID
+    )

--- a/lambdas/pkgpush/tests/test_hash_calc.py
+++ b/lambdas/pkgpush/tests/test_hash_calc.py
@@ -1,0 +1,162 @@
+import io
+import json
+import unittest
+from unittest import mock
+
+import boto3
+import pytest
+from botocore.stub import Stubber
+
+import quilt_shared.aws
+import t4_lambda_pkgpush
+from quilt3.packages import Package, PackageEntry
+from quilt3.util import PhysicalKey
+from quilt_shared.pkgpush import Checksum, ChecksumType
+from quilt_shared.types import NonEmptyStr
+
+
+CREDENTIALS = quilt_shared.aws.AWSCredentials(
+    key=NonEmptyStr("test_aws_access_key_id"),
+    secret=NonEmptyStr("test_aws_secret_access_key"),
+    token=NonEmptyStr("test_aws_session_token"),
+)
+
+SCRATCH_BUCKETS = {"us-east-1": "test-scratch-bucket"}
+
+
+class HashCalculationTest(unittest.TestCase):
+    def setUp(self):
+        self.pkg = Package()
+        self.entry_with_hash = PackageEntry(
+            PhysicalKey("test-bucket", "with-hash", "with-hash"),
+            42,
+            {"type": "SHA256", "value": "0" * 64},
+            {},
+        )
+        self.entry_without_hash = PackageEntry(
+            PhysicalKey("test-bucket", "without-hash", "without-hash"),
+            42,
+            None,
+            {},
+        )
+        self.pkg.set("with-hash", self.entry_with_hash)
+        self.pkg.set("without-hash", self.entry_without_hash)
+
+    def test_calculate_pkg_hashes(self):
+        with mock.patch.object(
+            t4_lambda_pkgpush, "calculate_pkg_entry_hash"
+        ) as calculate_pkg_entry_hash_mock:
+            session_mock = boto3.Session(**CREDENTIALS.boto_args)
+            with t4_lambda_pkgpush.setup_user_boto_session(session_mock):
+                t4_lambda_pkgpush.calculate_pkg_hashes(self.pkg, SCRATCH_BUCKETS)
+
+        calculate_pkg_entry_hash_mock.assert_called_once_with(
+            self.entry_without_hash,
+            CREDENTIALS,
+            SCRATCH_BUCKETS,
+        )
+
+    @mock.patch.object(t4_lambda_pkgpush, "S3_HASH_LAMBDA_MAX_FILE_SIZE_BYTES", 1)
+    def test_calculate_pkg_hashes_too_large_file_error(self):
+        with pytest.raises(t4_lambda_pkgpush.PkgpushException) as excinfo:
+            t4_lambda_pkgpush.calculate_pkg_hashes(self.pkg, SCRATCH_BUCKETS)
+        assert excinfo.value.name == "FileTooLargeForHashing"
+
+    def test_calculate_pkg_entry_hash(self):
+        with mock.patch(
+            "t4_lambda_pkgpush.invoke_hash_lambda",
+            return_value=Checksum(type=ChecksumType.SHA256_CHUNKED, value="base64hash"),
+        ) as invoke_hash_lambda_mock:
+            t4_lambda_pkgpush.calculate_pkg_entry_hash(
+                self.entry_without_hash, CREDENTIALS, SCRATCH_BUCKETS
+            )
+
+        invoke_hash_lambda_mock.assert_called_once_with(
+            self.entry_without_hash.physical_key,
+            CREDENTIALS,
+            SCRATCH_BUCKETS,
+        )
+
+        assert (
+            self.entry_without_hash.hash == invoke_hash_lambda_mock.return_value.dict()
+        )
+
+    def test_invoke_hash_lambda(self):
+        lambda_client_stubber = Stubber(t4_lambda_pkgpush.lambda_)
+        lambda_client_stubber.activate()
+        self.addCleanup(lambda_client_stubber.deactivate)
+        checksum = {"type": "sha2-256-chunked", "value": "base64hash"}
+        pk = PhysicalKey(bucket="bucket", path="path", version_id="version-id")
+
+        lambda_client_stubber.add_response(
+            "invoke",
+            service_response={
+                "Payload": io.BytesIO(
+                    b'{"result": {"checksum": %s}}' % json.dumps(checksum).encode()
+                ),
+            },
+            expected_params={
+                "FunctionName": t4_lambda_pkgpush.S3_HASH_LAMBDA,
+                "Payload": json.dumps(
+                    {
+                        "credentials": {
+                            "key": CREDENTIALS.key,
+                            "secret": CREDENTIALS.secret,
+                            "token": CREDENTIALS.token,
+                        },
+                        "scratch_buckets": SCRATCH_BUCKETS,
+                        "location": {
+                            "bucket": pk.bucket,
+                            "key": pk.path,
+                            "version": pk.version_id,
+                        },
+                    }
+                ),
+            },
+        )
+
+        assert (
+            t4_lambda_pkgpush.invoke_hash_lambda(pk, CREDENTIALS, SCRATCH_BUCKETS)
+            == checksum
+        )
+        lambda_client_stubber.assert_no_pending_responses()
+
+    def test_invoke_hash_lambda_error(self):
+        lambda_client_stubber = Stubber(t4_lambda_pkgpush.lambda_)
+        lambda_client_stubber.activate()
+        self.addCleanup(lambda_client_stubber.deactivate)
+        pk = PhysicalKey(bucket="bucket", path="path", version_id="version-id")
+
+        lambda_client_stubber.add_response(
+            "invoke",
+            service_response={
+                "FunctionError": "Unhandled",
+                "Payload": io.BytesIO(
+                    b'{"errorMessage":"2024-02-02T14:33:39.754Z e0db9ea8-1329-44d5-a0dc-364ba2749b09'
+                    b' Task timed out after 1.00 seconds"}'
+                ),
+            },
+            expected_params={
+                "FunctionName": t4_lambda_pkgpush.S3_HASH_LAMBDA,
+                "Payload": json.dumps(
+                    {
+                        "credentials": {
+                            "key": CREDENTIALS.key,
+                            "secret": CREDENTIALS.secret,
+                            "token": CREDENTIALS.token,
+                        },
+                        "scratch_buckets": SCRATCH_BUCKETS,
+                        "location": {
+                            "bucket": pk.bucket,
+                            "key": pk.path,
+                            "version": pk.version_id,
+                        },
+                    }
+                ),
+            },
+        )
+
+        with pytest.raises(t4_lambda_pkgpush.PkgpushException) as excinfo:
+            t4_lambda_pkgpush.invoke_hash_lambda(pk, CREDENTIALS, SCRATCH_BUCKETS)
+        assert excinfo.value.name == "S3HashLambdaUnhandledError"
+        lambda_client_stubber.assert_no_pending_responses()

--- a/lambdas/pkgpush/tests/test_hash_calc.py
+++ b/lambdas/pkgpush/tests/test_hash_calc.py
@@ -13,7 +13,6 @@ from quilt_shared.aws import AWSCredentials
 from quilt_shared.pkgpush import Checksum, ChecksumType
 from quilt_shared.types import NonEmptyStr
 
-
 CREDENTIALS = AWSCredentials(
     key=NonEmptyStr("test_aws_access_key_id"),
     secret=NonEmptyStr("test_aws_secret_access_key"),

--- a/lambdas/pkgpush/tests/test_hash_calc.py
+++ b/lambdas/pkgpush/tests/test_hash_calc.py
@@ -6,15 +6,15 @@ import pytest
 from botocore.stub import Stubber
 from pytest_mock import MockerFixture
 
-import quilt_shared.aws
 import t4_lambda_pkgpush
 from quilt3.packages import Package, PackageEntry
 from quilt3.util import PhysicalKey
+from quilt_shared.aws import AWSCredentials
 from quilt_shared.pkgpush import Checksum, ChecksumType
 from quilt_shared.types import NonEmptyStr
 
 
-CREDENTIALS = quilt_shared.aws.AWSCredentials(
+CREDENTIALS = AWSCredentials(
     key=NonEmptyStr("test_aws_access_key_id"),
     secret=NonEmptyStr("test_aws_secret_access_key"),
     token=NonEmptyStr("test_aws_session_token"),
@@ -49,17 +49,6 @@ def pkg(entry_with_hash: PackageEntry, entry_without_hash: PackageEntry) -> Pack
     p.set("with-hash", entry_with_hash)
     p.set("without-hash", entry_without_hash)
     return p
-
-
-@pytest.fixture
-def lambda_stub():
-    stub = Stubber(t4_lambda_pkgpush.lambda_)
-    stub.activate()
-    try:
-        yield stub
-        stub.assert_no_pending_responses()
-    finally:
-        stub.deactivate()
 
 
 def test_calculate_pkg_hashes(

--- a/lambdas/pkgpush/tests/test_hash_calc.py
+++ b/lambdas/pkgpush/tests/test_hash_calc.py
@@ -1,11 +1,10 @@
 import io
 import json
-import unittest
-from unittest import mock
 
 import boto3
 import pytest
 from botocore.stub import Stubber
+from pytest_mock import MockerFixture
 
 import quilt_shared.aws
 import t4_lambda_pkgpush
@@ -24,139 +23,164 @@ CREDENTIALS = quilt_shared.aws.AWSCredentials(
 SCRATCH_BUCKETS = {"us-east-1": "test-scratch-bucket"}
 
 
-class HashCalculationTest(unittest.TestCase):
-    def setUp(self):
-        self.pkg = Package()
-        self.entry_with_hash = PackageEntry(
-            PhysicalKey("test-bucket", "with-hash", "with-hash"),
-            42,
-            {"type": "SHA256", "value": "0" * 64},
-            {},
-        )
-        self.entry_without_hash = PackageEntry(
-            PhysicalKey("test-bucket", "without-hash", "without-hash"),
-            42,
-            None,
-            {},
-        )
-        self.pkg.set("with-hash", self.entry_with_hash)
-        self.pkg.set("without-hash", self.entry_without_hash)
+@pytest.fixture
+def entry_with_hash() -> PackageEntry:
+    return PackageEntry(
+        PhysicalKey("test-bucket", "with-hash", "with-hash"),
+        42,
+        {"type": "SHA256", "value": "0" * 64},
+        {},
+    )
 
-    def test_calculate_pkg_hashes(self):
-        with mock.patch.object(
-            t4_lambda_pkgpush, "calculate_pkg_entry_hash"
-        ) as calculate_pkg_entry_hash_mock:
-            session_mock = boto3.Session(**CREDENTIALS.boto_args)
-            with t4_lambda_pkgpush.setup_user_boto_session(session_mock):
-                t4_lambda_pkgpush.calculate_pkg_hashes(self.pkg, SCRATCH_BUCKETS)
 
-        calculate_pkg_entry_hash_mock.assert_called_once_with(
-            self.entry_without_hash,
-            CREDENTIALS,
-            SCRATCH_BUCKETS,
-        )
+@pytest.fixture
+def entry_without_hash() -> PackageEntry:
+    return PackageEntry(
+        PhysicalKey("test-bucket", "without-hash", "without-hash"),
+        42,
+        None,
+        {},
+    )
 
-    @mock.patch.object(t4_lambda_pkgpush, "S3_HASH_LAMBDA_MAX_FILE_SIZE_BYTES", 1)
-    def test_calculate_pkg_hashes_too_large_file_error(self):
-        with pytest.raises(t4_lambda_pkgpush.PkgpushException) as excinfo:
-            t4_lambda_pkgpush.calculate_pkg_hashes(self.pkg, SCRATCH_BUCKETS)
-        assert excinfo.value.name == "FileTooLargeForHashing"
 
-    def test_calculate_pkg_entry_hash(self):
-        with mock.patch(
-            "t4_lambda_pkgpush.invoke_hash_lambda",
-            return_value=Checksum(type=ChecksumType.SHA256_CHUNKED, value="base64hash"),
-        ) as invoke_hash_lambda_mock:
-            t4_lambda_pkgpush.calculate_pkg_entry_hash(
-                self.entry_without_hash, CREDENTIALS, SCRATCH_BUCKETS
-            )
+@pytest.fixture
+def pkg(entry_with_hash: PackageEntry, entry_without_hash: PackageEntry) -> Package:
+    p = Package()
+    p.set("with-hash", entry_with_hash)
+    p.set("without-hash", entry_without_hash)
+    return p
 
-        invoke_hash_lambda_mock.assert_called_once_with(
-            self.entry_without_hash.physical_key,
-            CREDENTIALS,
-            SCRATCH_BUCKETS,
-        )
 
-        assert (
-            self.entry_without_hash.hash == invoke_hash_lambda_mock.return_value.dict()
-        )
+@pytest.fixture
+def lambda_stub():
+    stub = Stubber(t4_lambda_pkgpush.lambda_)
+    stub.activate()
+    try:
+        yield stub
+        stub.assert_no_pending_responses()
+    finally:
+        stub.deactivate()
 
-    def test_invoke_hash_lambda(self):
-        lambda_client_stubber = Stubber(t4_lambda_pkgpush.lambda_)
-        lambda_client_stubber.activate()
-        self.addCleanup(lambda_client_stubber.deactivate)
-        checksum = {"type": "sha2-256-chunked", "value": "base64hash"}
-        pk = PhysicalKey(bucket="bucket", path="path", version_id="version-id")
 
-        lambda_client_stubber.add_response(
-            "invoke",
-            service_response={
-                "Payload": io.BytesIO(
-                    b'{"result": {"checksum": %s}}' % json.dumps(checksum).encode()
-                ),
-            },
-            expected_params={
-                "FunctionName": t4_lambda_pkgpush.S3_HASH_LAMBDA,
-                "Payload": json.dumps(
-                    {
-                        "credentials": {
-                            "key": CREDENTIALS.key,
-                            "secret": CREDENTIALS.secret,
-                            "token": CREDENTIALS.token,
-                        },
-                        "scratch_buckets": SCRATCH_BUCKETS,
-                        "location": {
-                            "bucket": pk.bucket,
-                            "key": pk.path,
-                            "version": pk.version_id,
-                        },
-                    }
-                ),
-            },
-        )
+def test_calculate_pkg_hashes(
+    pkg: Package, entry_without_hash: PackageEntry, mocker: MockerFixture
+):
+    calculate_pkg_entry_hash_mock = mocker.patch.object(
+        t4_lambda_pkgpush, "calculate_pkg_entry_hash"
+    )
+    session_mock = boto3.Session(**CREDENTIALS.boto_args)
 
-        assert (
-            t4_lambda_pkgpush.invoke_hash_lambda(pk, CREDENTIALS, SCRATCH_BUCKETS)
-            == checksum
-        )
-        lambda_client_stubber.assert_no_pending_responses()
+    with t4_lambda_pkgpush.setup_user_boto_session(session_mock):
+        t4_lambda_pkgpush.calculate_pkg_hashes(pkg, SCRATCH_BUCKETS)
 
-    def test_invoke_hash_lambda_error(self):
-        lambda_client_stubber = Stubber(t4_lambda_pkgpush.lambda_)
-        lambda_client_stubber.activate()
-        self.addCleanup(lambda_client_stubber.deactivate)
-        pk = PhysicalKey(bucket="bucket", path="path", version_id="version-id")
+    calculate_pkg_entry_hash_mock.assert_called_once_with(
+        entry_without_hash,
+        CREDENTIALS,
+        SCRATCH_BUCKETS,
+    )
 
-        lambda_client_stubber.add_response(
-            "invoke",
-            service_response={
-                "FunctionError": "Unhandled",
-                "Payload": io.BytesIO(
-                    b'{"errorMessage":"2024-02-02T14:33:39.754Z e0db9ea8-1329-44d5-a0dc-364ba2749b09'
-                    b' Task timed out after 1.00 seconds"}'
-                ),
-            },
-            expected_params={
-                "FunctionName": t4_lambda_pkgpush.S3_HASH_LAMBDA,
-                "Payload": json.dumps(
-                    {
-                        "credentials": {
-                            "key": CREDENTIALS.key,
-                            "secret": CREDENTIALS.secret,
-                            "token": CREDENTIALS.token,
-                        },
-                        "scratch_buckets": SCRATCH_BUCKETS,
-                        "location": {
-                            "bucket": pk.bucket,
-                            "key": pk.path,
-                            "version": pk.version_id,
-                        },
-                    }
-                ),
-            },
-        )
 
-        with pytest.raises(t4_lambda_pkgpush.PkgpushException) as excinfo:
-            t4_lambda_pkgpush.invoke_hash_lambda(pk, CREDENTIALS, SCRATCH_BUCKETS)
-        assert excinfo.value.name == "S3HashLambdaUnhandledError"
-        lambda_client_stubber.assert_no_pending_responses()
+def test_calculate_pkg_hashes_too_large_file_error(pkg: Package, mocker: MockerFixture):
+    mocker.patch.object(t4_lambda_pkgpush, "S3_HASH_LAMBDA_MAX_FILE_SIZE_BYTES", 1)
+
+    with pytest.raises(t4_lambda_pkgpush.PkgpushException) as excinfo:
+        t4_lambda_pkgpush.calculate_pkg_hashes(pkg, SCRATCH_BUCKETS)
+    assert excinfo.value.name == "FileTooLargeForHashing"
+
+
+def test_calculate_pkg_entry_hash(
+    entry_without_hash: PackageEntry,
+    mocker: MockerFixture,
+):
+    invoke_hash_lambda_mock = mocker.patch(
+        "t4_lambda_pkgpush.invoke_hash_lambda",
+        return_value=Checksum(type=ChecksumType.SHA256_CHUNKED, value="base64hash"),
+    )
+
+    t4_lambda_pkgpush.calculate_pkg_entry_hash(
+        entry_without_hash,
+        CREDENTIALS,
+        SCRATCH_BUCKETS,
+    )
+
+    invoke_hash_lambda_mock.assert_called_once_with(
+        entry_without_hash.physical_key,
+        CREDENTIALS,
+        SCRATCH_BUCKETS,
+    )
+
+    assert entry_without_hash.hash == invoke_hash_lambda_mock.return_value.dict()
+
+
+def test_invoke_hash_lambda(lambda_stub: Stubber):
+    checksum = {"type": "sha2-256-chunked", "value": "base64hash"}
+    pk = PhysicalKey(bucket="bucket", path="path", version_id="version-id")
+
+    lambda_stub.add_response(
+        "invoke",
+        service_response={
+            "Payload": io.BytesIO(
+                b'{"result": {"checksum": %s}}' % json.dumps(checksum).encode()
+            ),
+        },
+        expected_params={
+            "FunctionName": t4_lambda_pkgpush.S3_HASH_LAMBDA,
+            "Payload": json.dumps(
+                {
+                    "credentials": {
+                        "key": CREDENTIALS.key,
+                        "secret": CREDENTIALS.secret,
+                        "token": CREDENTIALS.token,
+                    },
+                    "scratch_buckets": SCRATCH_BUCKETS,
+                    "location": {
+                        "bucket": pk.bucket,
+                        "key": pk.path,
+                        "version": pk.version_id,
+                    },
+                }
+            ),
+        },
+    )
+
+    assert (
+        t4_lambda_pkgpush.invoke_hash_lambda(pk, CREDENTIALS, SCRATCH_BUCKETS)
+        == checksum
+    )
+
+
+def test_invoke_hash_lambda_error(lambda_stub: Stubber):
+    pk = PhysicalKey(bucket="bucket", path="path", version_id="version-id")
+
+    lambda_stub.add_response(
+        "invoke",
+        service_response={
+            "FunctionError": "Unhandled",
+            "Payload": io.BytesIO(
+                b'{"errorMessage":"2024-02-02T14:33:39.754Z e0db9ea8-1329-44d5-a0dc-364ba2749b09'
+                b' Task timed out after 1.00 seconds"}'
+            ),
+        },
+        expected_params={
+            "FunctionName": t4_lambda_pkgpush.S3_HASH_LAMBDA,
+            "Payload": json.dumps(
+                {
+                    "credentials": {
+                        "key": CREDENTIALS.key,
+                        "secret": CREDENTIALS.secret,
+                        "token": CREDENTIALS.token,
+                    },
+                    "scratch_buckets": SCRATCH_BUCKETS,
+                    "location": {
+                        "bucket": pk.bucket,
+                        "key": pk.path,
+                        "version": pk.version_id,
+                    },
+                }
+            ),
+        },
+    )
+
+    with pytest.raises(t4_lambda_pkgpush.PkgpushException) as excinfo:
+        t4_lambda_pkgpush.invoke_hash_lambda(pk, CREDENTIALS, SCRATCH_BUCKETS)
+    assert excinfo.value.name == "S3HashLambdaUnhandledError"

--- a/lambdas/pkgpush/tests/test_index.py
+++ b/lambdas/pkgpush/tests/test_index.py
@@ -866,121 +866,6 @@ class PackageCreateWithHashingTestCase(PackageCreateTestCaseBase):
         assert "result" in pkg_response
 
 
-class HashCalculationTest(unittest.TestCase):
-    def setUp(self):
-        self.pkg = Package()
-        self.entry_with_hash = PackageEntry(
-            PhysicalKey('test-bucket', 'with-hash', 'with-hash'),
-            42,
-            {'type': 'SHA256', 'value': '0' * 64},
-            {},
-        )
-        self.entry_without_hash = PackageEntry(
-            PhysicalKey('test-bucket', 'without-hash', 'without-hash'),
-            42,
-            None,
-            {},
-        )
-        self.pkg.set('with-hash', self.entry_with_hash)
-        self.pkg.set('without-hash', self.entry_without_hash)
-
-    def test_calculate_pkg_hashes(self):
-        with mock.patch.object(t4_lambda_pkgpush, 'calculate_pkg_entry_hash') as calculate_pkg_entry_hash_mock:
-            session_mock = boto3.Session(**CREDENTIALS.boto_args)
-            with t4_lambda_pkgpush.setup_user_boto_session(session_mock):
-                t4_lambda_pkgpush.calculate_pkg_hashes(self.pkg)
-
-        calculate_pkg_entry_hash_mock.assert_called_once_with(self.entry_without_hash, CREDENTIALS)
-
-    @mock.patch.object(t4_lambda_pkgpush, 'S3_HASH_LAMBDA_MAX_FILE_SIZE_BYTES', 1)
-    def test_calculate_pkg_hashes_too_large_file_error(self):
-        with pytest.raises(t4_lambda_pkgpush.PkgpushException) as excinfo:
-            t4_lambda_pkgpush.calculate_pkg_hashes(self.pkg)
-        assert excinfo.value.name == "FileTooLargeForHashing"
-
-    def test_calculate_pkg_entry_hash(self):
-        with mock.patch(
-            "t4_lambda_pkgpush.invoke_hash_lambda",
-            return_value=Checksum(type=ChecksumType.SHA256_CHUNKED, value="base64hash"),
-        ) as invoke_hash_lambda_mock:
-            t4_lambda_pkgpush.calculate_pkg_entry_hash(self.entry_without_hash, CREDENTIALS)
-
-        invoke_hash_lambda_mock.assert_called_once_with(self.entry_without_hash.physical_key, CREDENTIALS)
-
-        assert self.entry_without_hash.hash == invoke_hash_lambda_mock.return_value.dict()
-
-    def test_invoke_hash_lambda(self):
-        lambda_client_stubber = Stubber(t4_lambda_pkgpush.lambda_)
-        lambda_client_stubber.activate()
-        self.addCleanup(lambda_client_stubber.deactivate)
-        checksum = {"type": "sha2-256-chunked", "value": "base64hash"}
-        pk = PhysicalKey(bucket="bucket", path="path", version_id="version-id")
-
-        lambda_client_stubber.add_response(
-            'invoke',
-            service_response={
-                'Payload': io.BytesIO(
-                    b'{"result": {"checksum": %s}}' % json.dumps(checksum).encode()
-                ),
-            },
-            expected_params={
-                'FunctionName': t4_lambda_pkgpush.S3_HASH_LAMBDA,
-                'Payload': json.dumps({
-                    "credentials": {
-                        "key": CREDENTIALS.key,
-                        "secret": CREDENTIALS.secret,
-                        "token": CREDENTIALS.token,
-                    },
-                    "location": {
-                        "bucket": pk.bucket,
-                        "key": pk.path,
-                        "version": pk.version_id,
-                    }
-                })
-            },
-        )
-
-        assert t4_lambda_pkgpush.invoke_hash_lambda(pk, CREDENTIALS) == checksum
-        lambda_client_stubber.assert_no_pending_responses()
-
-    def test_invoke_hash_lambda_error(self):
-        lambda_client_stubber = Stubber(t4_lambda_pkgpush.lambda_)
-        lambda_client_stubber.activate()
-        self.addCleanup(lambda_client_stubber.deactivate)
-        pk = PhysicalKey(bucket="bucket", path="path", version_id="version-id")
-
-        lambda_client_stubber.add_response(
-            'invoke',
-            service_response={
-                'FunctionError': 'Unhandled',
-                'Payload': io.BytesIO(
-                    b'{"errorMessage":"2024-02-02T14:33:39.754Z e0db9ea8-1329-44d5-a0dc-364ba2749b09'
-                    b' Task timed out after 1.00 seconds"}'
-                 ),
-            },
-            expected_params={
-                'FunctionName': t4_lambda_pkgpush.S3_HASH_LAMBDA,
-                'Payload': json.dumps({
-                    "credentials": {
-                        "key": CREDENTIALS.key,
-                        "secret": CREDENTIALS.secret,
-                        "token": CREDENTIALS.token,
-                    },
-                    "location": {
-                        "bucket": pk.bucket,
-                        "key": pk.path,
-                        "version": pk.version_id,
-                    }
-                })
-            },
-        )
-
-        with pytest.raises(t4_lambda_pkgpush.PkgpushException) as excinfo:
-            t4_lambda_pkgpush.invoke_hash_lambda(pk, CREDENTIALS)
-        assert excinfo.value.name == "S3HashLambdaUnhandledError"
-        lambda_client_stubber.assert_no_pending_responses()
-
-
 def test_invoke_copy_lambda():
     SRC_BUCKET = "src-bucket"
     SRC_KEY = "src-key"
@@ -993,16 +878,21 @@ def test_invoke_copy_lambda():
     stubber.add_response(
         "invoke",
         {
-            "Payload": io.BytesIO(b'{"result": {"version": "%s"}}' % DST_VERSION_ID.encode())
-        }
+            "Payload": io.BytesIO(
+                b'{"result": {"version": "%s"}}' % DST_VERSION_ID.encode()
+            )
+        },
     )
     stubber.activate()
     try:
-        assert t4_lambda_pkgpush.invoke_copy_lambda(
-            CREDENTIALS,
-            PhysicalKey(SRC_BUCKET, SRC_KEY, SRC_VERSION_ID),
-            PhysicalKey(DST_BUCKET, DST_KEY, None),
-        ) == DST_VERSION_ID
+        assert (
+            t4_lambda_pkgpush.invoke_copy_lambda(
+                CREDENTIALS,
+                PhysicalKey(SRC_BUCKET, SRC_KEY, SRC_VERSION_ID),
+                PhysicalKey(DST_BUCKET, DST_KEY, None),
+            )
+            == DST_VERSION_ID
+        )
         stubber.assert_no_pending_responses()
     finally:
         stubber.deactivate()

--- a/lambdas/pkgpush/tests/test_index.py
+++ b/lambdas/pkgpush/tests/test_index.py
@@ -15,7 +15,6 @@ import t4_lambda_pkgpush
 from quilt3.backends import get_package_registry
 from quilt3.packages import Package, PackageEntry
 from quilt3.util import PhysicalKey
-from quilt_shared.pkgpush import Checksum, ChecksumType
 
 
 def hash_data(data):
@@ -864,35 +863,3 @@ class PackageCreateWithHashingTestCase(PackageCreateTestCaseBase):
                 entry,
             ])
         assert "result" in pkg_response
-
-
-def test_invoke_copy_lambda():
-    SRC_BUCKET = "src-bucket"
-    SRC_KEY = "src-key"
-    SRC_VERSION_ID = "src-version-id"
-    DST_BUCKET = "dst-bucket"
-    DST_KEY = "dst-key"
-    DST_VERSION_ID = "dst-version-id"
-
-    stubber = Stubber(t4_lambda_pkgpush.lambda_)
-    stubber.add_response(
-        "invoke",
-        {
-            "Payload": io.BytesIO(
-                b'{"result": {"version": "%s"}}' % DST_VERSION_ID.encode()
-            )
-        },
-    )
-    stubber.activate()
-    try:
-        assert (
-            t4_lambda_pkgpush.invoke_copy_lambda(
-                CREDENTIALS,
-                PhysicalKey(SRC_BUCKET, SRC_KEY, SRC_VERSION_ID),
-                PhysicalKey(DST_BUCKET, DST_KEY, None),
-            )
-            == DST_VERSION_ID
-        )
-        stubber.assert_no_pending_responses()
-    finally:
-        stubber.deactivate()

--- a/lambdas/s3hash/CHANGELOG.md
+++ b/lambdas/s3hash/CHANGELOG.md
@@ -16,6 +16,7 @@ where verb is one of
 
 ## Changes
 
+- [Changed] Use per-region scratch buckets ([#3923](https://github.com/quiltdata/quilt/pull/3923))
 - [Changed] Always stream bytes in legacy mode ([#3903](https://github.com/quiltdata/quilt/pull/3903))
 - [Changed] Compute chunked checksums, adhere to the spec ([#3889](https://github.com/quiltdata/quilt/pull/3889))
 - [Added] Lambda handler for file copy ([#3884](https://github.com/quiltdata/quilt/pull/3884))

--- a/lambdas/s3hash/pytest.ini
+++ b/lambdas/s3hash/pytest.ini
@@ -3,4 +3,3 @@ asyncio_mode=auto
 env =
     MPU_CONCURRENCY=1000
     CHUNKED_CHECKSUMS=true
-    SERVICE_BUCKET=service-bucket

--- a/lambdas/s3hash/requirements.txt
+++ b/lambdas/s3hash/requirements.txt
@@ -83,7 +83,7 @@ python-dateutil==2.8.2
     # via botocore
 pyyaml==6.0.1
     # via quilt3
-quilt-shared[boto,pydantic,quilt] @ git+https://github.com/quiltdata/quilt@e833b19fde894b640d9b657bb04a5f761cd4d567#subdirectory=py-shared
+quilt-shared[boto,pydantic,quilt] @ git+https://github.com/quiltdata/quilt@7c6edd14fbe8a26613bc26b1bbdc0b956132ef8c#subdirectory=py-shared
     # via t4_lambda_s3hash (setup.py)
 quilt3==5.4.0
     # via quilt-shared

--- a/lambdas/s3hash/requirements.txt
+++ b/lambdas/s3hash/requirements.txt
@@ -83,7 +83,7 @@ python-dateutil==2.8.2
     # via botocore
 pyyaml==6.0.1
     # via quilt3
-quilt-shared[boto,pydantic,quilt] @ git+https://github.com/quiltdata/quilt@47055f7c5c0a93ddddfa5030a73b22a5d42b9c10#subdirectory=py-shared
+quilt-shared[boto,pydantic,quilt] @ git+https://github.com/quiltdata/quilt@e833b19fde894b640d9b657bb04a5f761cd4d567#subdirectory=py-shared
     # via t4_lambda_s3hash (setup.py)
 quilt3==5.4.0
     # via quilt-shared

--- a/lambdas/s3hash/setup.py
+++ b/lambdas/s3hash/setup.py
@@ -12,7 +12,7 @@ setup(
         "types-aiobotocore[s3] ~= 2.11",
         (
             "quilt_shared[pydantic,boto,quilt] @ git+https://github.com/quiltdata/quilt@"
-            "47055f7c5c0a93ddddfa5030a73b22a5d42b9c10"
+            "e833b19fde894b640d9b657bb04a5f761cd4d567"
             "#subdirectory=py-shared"
         ),
     ],

--- a/lambdas/s3hash/setup.py
+++ b/lambdas/s3hash/setup.py
@@ -12,7 +12,7 @@ setup(
         "types-aiobotocore[s3] ~= 2.11",
         (
             "quilt_shared[pydantic,boto,quilt] @ git+https://github.com/quiltdata/quilt@"
-            "e833b19fde894b640d9b657bb04a5f761cd4d567"
+            "7c6edd14fbe8a26613bc26b1bbdc0b956132ef8c"
             "#subdirectory=py-shared"
         ),
     ],

--- a/lambdas/s3hash/src/t4_lambda_s3hash/__init__.py
+++ b/lambdas/s3hash/src/t4_lambda_s3hash/__init__.py
@@ -116,9 +116,10 @@ async def get_bucket_region(bucket: str) -> str:
         resp = await S3.get().head_bucket(Bucket=bucket)
     except botocore.exceptions.ClientError as e:
         resp = e.response
-        if resp["Error"]["Code"] == "404":
+        if resp.get("Error", {}).get("Code") == "404":
             raise
 
+    assert "ResponseMetadata" in resp
     return resp["ResponseMetadata"]["HTTPHeaders"]["x-amz-bucket-region"]
 
 

--- a/lambdas/s3hash/src/t4_lambda_s3hash/__init__.py
+++ b/lambdas/s3hash/src/t4_lambda_s3hash/__init__.py
@@ -126,8 +126,10 @@ async def get_mpu_dst_for_location(location: S3ObjectSource, scratch_buckets: T.
     region = await get_bucket_region(location.bucket)
     scratch_bucket = scratch_buckets.get(region)
     if scratch_bucket is None:
-        # TODO: proper exception
-        raise Exception(f"Scratch bucket not found for {region}")
+        raise LambdaError(
+            "ScratchBucketNotFound",
+            {"region": region, "bucket": location.bucket, "scratch_buckets": scratch_buckets},
+        )
 
     return S3ObjectDestination(bucket=scratch_bucket, key=SCRATCH_KEY)
 

--- a/lambdas/s3hash/src/t4_lambda_s3hash/__init__.py
+++ b/lambdas/s3hash/src/t4_lambda_s3hash/__init__.py
@@ -467,6 +467,6 @@ async def lambda_handler_copy(
     credentials: AWSCredentials,
     location: S3ObjectSource,
     target: S3ObjectDestination,
-) -> str:
+) -> CopyResult:
     async with aio_context(credentials):
         return await copy(location, target)

--- a/lambdas/s3hash/tests/conftest.py
+++ b/lambdas/s3hash/tests/conftest.py
@@ -14,6 +14,7 @@ AWS_CREDENTIALS = s3hash.AWSCredentials.parse_obj(
     }
 )
 
+
 # pytest's async fixtures don't propagate contextvars, so we have to set them manually in a sync fixture
 @pytest.fixture
 def s3_stub():

--- a/lambdas/s3hash/tests/conftest.py
+++ b/lambdas/s3hash/tests/conftest.py
@@ -1,10 +1,9 @@
 import asyncio
 
-from botocore.stub import Stubber
 import pytest
+from botocore.stub import Stubber
 
 import t4_lambda_s3hash as s3hash
-
 
 AWS_CREDENTIALS = s3hash.AWSCredentials.parse_obj(
     {

--- a/lambdas/s3hash/tests/conftest.py
+++ b/lambdas/s3hash/tests/conftest.py
@@ -1,0 +1,32 @@
+import asyncio
+
+from botocore.stub import Stubber
+import pytest
+
+import t4_lambda_s3hash as s3hash
+
+
+AWS_CREDENTIALS = s3hash.AWSCredentials.parse_obj(
+    {
+        "key": "test-key",
+        "secret": "test-secret",
+        "token": "test-token",
+    }
+)
+
+# pytest's async fixtures don't propagate contextvars, so we have to set them manually in a sync fixture
+@pytest.fixture
+def s3_stub():
+    async def _get_s3():
+        async with s3hash.aio_context(AWS_CREDENTIALS):
+            return s3hash.S3.get()
+
+    s3 = asyncio.run(_get_s3())
+    stubber = Stubber(s3)
+    stubber.activate()
+    s3_token = s3hash.S3.set(s3)
+    try:
+        yield stubber
+        stubber.assert_no_pending_responses()
+    finally:
+        s3hash.S3.reset(s3_token)

--- a/lambdas/s3hash/tests/test_compute_checksum.py
+++ b/lambdas/s3hash/tests/test_compute_checksum.py
@@ -1,4 +1,3 @@
-import asyncio
 import base64
 import io
 
@@ -32,14 +31,6 @@ def make_body(contents: bytes) -> StreamingBody:
     )
 
 
-AWS_CREDENTIALS = s3hash.AWSCredentials.parse_obj(
-    {
-        "key": "test-key",
-        "secret": "test-secret",
-        "token": "test-token",
-    }
-)
-
 LOC = s3hash.S3ObjectSource(
     bucket="test-bucket",
     key="test-key",
@@ -56,24 +47,6 @@ EXPECTED_MPU_PARAMS = {
     **s3hash.MPU_DST.boto_args,
     "ChecksumAlgorithm": "SHA256",
 }
-
-
-# pytest's async fixtures don't propagate contextvars, so we have to set them manually in a sync fixture
-@pytest.fixture
-def s3_stub():
-    async def _get_s3():
-        async with s3hash.aio_context(AWS_CREDENTIALS):
-            return s3hash.S3.get()
-
-    s3 = asyncio.run(_get_s3())
-    stubber = Stubber(s3)
-    stubber.activate()
-    s3_token = s3hash.S3.set(s3)
-    try:
-        yield stubber
-        stubber.assert_no_pending_responses()
-    finally:
-        s3hash.S3.reset(s3_token)
 
 
 async def test_compliant(s3_stub: Stubber):

--- a/lambdas/s3hash/tests/test_mpu_dst.py
+++ b/lambdas/s3hash/tests/test_mpu_dst.py
@@ -1,5 +1,5 @@
-from botocore.stub import Stubber
 import pytest
+from botocore.stub import Stubber
 
 import t4_lambda_s3hash as s3hash
 

--- a/lambdas/s3hash/tests/test_mpu_dst.py
+++ b/lambdas/s3hash/tests/test_mpu_dst.py
@@ -82,6 +82,6 @@ async def test_get_mpu_dst_for_location_no_scratch_bucket(s3_stub: Stubber):
         },
     )
 
-    with pytest.raises(LambdaError) as exc_info:
+    with pytest.raises(s3hash.LambdaError) as exc_info:
         await s3hash.get_mpu_dst_for_location(src_loc, scratch_buckets)
     assert "ScratchBucketNotFound" in str(exc_info.value)

--- a/lambdas/s3hash/tests/test_mpu_dst.py
+++ b/lambdas/s3hash/tests/test_mpu_dst.py
@@ -82,6 +82,6 @@ async def test_get_mpu_dst_for_location_no_scratch_bucket(s3_stub: Stubber):
         },
     )
 
-    with pytest.raises(Exception) as exc_info:
+    with pytest.raises(LambdaError) as exc_info:
         await s3hash.get_mpu_dst_for_location(src_loc, scratch_buckets)
     assert "ScratchBucketNotFound" in str(exc_info.value)

--- a/lambdas/s3hash/tests/test_mpu_dst.py
+++ b/lambdas/s3hash/tests/test_mpu_dst.py
@@ -27,7 +27,7 @@ async def test_get_bucket_region_exist_error(s3_stub: Stubber):
         method="head_bucket",
         service_error_code="403",
         expected_params={"Bucket": bucket_name},
-        service_message="Not Found",
+        service_message="Not Found",  # we only care about the error code, not the message
         response_meta={
             "HTTPHeaders": {"x-amz-bucket-region": expected_region},
         },

--- a/lambdas/s3hash/tests/test_mpu_dst.py
+++ b/lambdas/s3hash/tests/test_mpu_dst.py
@@ -1,0 +1,52 @@
+from botocore.stub import Stubber
+import pytest
+
+import t4_lambda_s3hash as s3hash
+
+
+@pytest.mark.asyncio
+async def test_get_bucket_region_valid(s3_stub: Stubber):
+    expected_region = "us-west-2"
+    bucket_name = "test-bucket"
+    s3_stub.add_response(
+        method="head_bucket",
+        expected_params={"Bucket": bucket_name},
+        service_response={
+            "ResponseMetadata": {
+                "HTTPHeaders": {"x-amz-bucket-region": expected_region},
+            },
+        },
+    )
+    region = await s3hash.get_bucket_region(bucket_name)
+    assert region == expected_region
+
+
+@pytest.mark.asyncio
+async def test_get_bucket_region_exist_error(s3_stub: Stubber):
+    bucket_name = "existent-bucket"
+    expected_region = "us-west-2"
+    s3_stub.add_client_error(
+        method="head_bucket",
+        service_error_code="403",
+        expected_params={"Bucket": bucket_name},
+        service_message="Not Found",
+        response_meta={
+            "HTTPHeaders": {"x-amz-bucket-region": expected_region},
+        },
+    )
+    region = await s3hash.get_bucket_region(bucket_name)
+    assert region == expected_region
+
+
+@pytest.mark.asyncio
+async def test_get_bucket_region_nonexist_error(s3_stub: Stubber):
+    bucket_name = "non-existent-bucket"
+    s3_stub.add_client_error(
+        method="head_bucket",
+        service_error_code="404",
+        expected_params={"Bucket": bucket_name},
+        service_message="Not Found",
+    )
+    with pytest.raises(Exception) as exc_info:
+        await s3hash.get_bucket_region(bucket_name)
+    assert "Not Found" in str(exc_info.value)

--- a/lambdas/s3hash/tests/test_mpu_dst.py
+++ b/lambdas/s3hash/tests/test_mpu_dst.py
@@ -4,7 +4,6 @@ import pytest
 import t4_lambda_s3hash as s3hash
 
 
-@pytest.mark.asyncio
 async def test_get_bucket_region_valid(s3_stub: Stubber):
     expected_region = "us-west-2"
     bucket_name = "test-bucket"
@@ -21,7 +20,6 @@ async def test_get_bucket_region_valid(s3_stub: Stubber):
     assert region == expected_region
 
 
-@pytest.mark.asyncio
 async def test_get_bucket_region_exist_error(s3_stub: Stubber):
     bucket_name = "existent-bucket"
     expected_region = "us-west-2"
@@ -38,7 +36,6 @@ async def test_get_bucket_region_exist_error(s3_stub: Stubber):
     assert region == expected_region
 
 
-@pytest.mark.asyncio
 async def test_get_bucket_region_nonexist_error(s3_stub: Stubber):
     bucket_name = "non-existent-bucket"
     s3_stub.add_client_error(
@@ -50,3 +47,41 @@ async def test_get_bucket_region_nonexist_error(s3_stub: Stubber):
     with pytest.raises(Exception) as exc_info:
         await s3hash.get_bucket_region(bucket_name)
     assert "Not Found" in str(exc_info.value)
+
+
+async def test_get_mpu_dst_for_location_valid(s3_stub: Stubber):
+    src_loc = s3hash.S3ObjectSource(bucket="source-bucket", key="source-key", version="source-version")
+    scratch_buckets = {"us-west-2": "scratch-bucket-us-west-2"}
+    expected_dst = s3hash.S3ObjectDestination(bucket="scratch-bucket-us-west-2", key=s3hash.SCRATCH_KEY)
+
+    s3_stub.add_response(
+        method="head_bucket",
+        expected_params={"Bucket": src_loc.bucket},
+        service_response={
+            "ResponseMetadata": {
+                "HTTPHeaders": {"x-amz-bucket-region": "us-west-2"},
+            },
+        },
+    )
+
+    dst = await s3hash.get_mpu_dst_for_location(src_loc, scratch_buckets)
+    assert dst == expected_dst
+
+
+async def test_get_mpu_dst_for_location_no_scratch_bucket(s3_stub: Stubber):
+    src_loc = s3hash.S3ObjectSource(bucket="source-bucket", key="source-key", version="source-version")
+    scratch_buckets = {"us-east-1": "scratch-bucket-us-east-1"}
+
+    s3_stub.add_response(
+        method="head_bucket",
+        expected_params={"Bucket": src_loc.bucket},
+        service_response={
+            "ResponseMetadata": {
+                "HTTPHeaders": {"x-amz-bucket-region": "us-west-2"},
+            },
+        },
+    )
+
+    with pytest.raises(Exception) as exc_info:
+        await s3hash.get_mpu_dst_for_location(src_loc, scratch_buckets)
+    assert "ScratchBucketNotFound" in str(exc_info.value)

--- a/lambdas/s3hash/tests/test_wrapper.py
+++ b/lambdas/s3hash/tests/test_wrapper.py
@@ -55,7 +55,7 @@ def test_timeout(mocker: MockerFixture):
 
     # pylint: disable-next=missing-kwoa
     res = s3hash.lambda_handler(
-        {"credentials": AWS_CREDENTIALS, "location": S3_SRC},
+        {"credentials": AWS_CREDENTIALS, "location": S3_SRC, "scratch_buckets": {}},
         FakeContext(1001),
     )
 
@@ -82,7 +82,7 @@ def test_aws_wiring(mocker: MockerFixture):
 
     # pylint: disable-next=missing-kwoa
     res = s3hash.lambda_handler(
-        {"credentials": AWS_CREDENTIALS, "location": S3_SRC},
+        {"credentials": AWS_CREDENTIALS, "location": S3_SRC, "scratch_buckets": {"region": "bucket"}},
         FakeContext(2000),
     )
 
@@ -94,6 +94,7 @@ def test_aws_wiring(mocker: MockerFixture):
             key=S3_SRC["key"],
             version=S3_SRC["version"],
         ),
+        {"region": "bucket"},
     )
 
     aio_context_mock.assert_called_once_with(s3hash.AWSCredentials.parse_obj(AWS_CREDENTIALS))


### PR DESCRIPTION
## TODO

- [x] Unit tests
- [x] [Changelog](../tree/master/docs/CHANGELOG.md) entry (skip if change is not significant to end users, e.g. docs only)
