### PR TITLE
Athena: Pre-select first catalog and database

### DIFF
--- a/catalog/app/containers/Bucket/Queries/requests/athena.ts
+++ b/catalog/app/containers/Bucket/Queries/requests/athena.ts
@@ -464,7 +464,7 @@ export interface DatabasesResponse {
 interface DatabasesArgs {
   athena: Athena
   catalogName: CatalogName
-  prev: DatabasesResponse
+  prev?: DatabasesResponse
 }
 
 async function fetchDatabases({
@@ -493,6 +493,33 @@ export function useDatabases(
     { athena, catalogName, prev },
     { noAutoFetch: !catalogName },
   )
+}
+
+interface DefaultDatabaseArgs {
+  athena: Athena
+}
+
+async function fetchDefaultQueryExecution({
+  athena,
+}: DefaultDatabaseArgs): Promise<QueryExecution | null> {
+  const catalogNames = await fetchCatalogNames({ athena })
+  if (!catalogNames.list.length) {
+    return null
+  }
+  const catalogName = catalogNames.list[0]
+  const databases = await fetchDatabases({ athena, catalogName })
+  if (!databases.list.length) {
+    return null
+  }
+  return {
+    catalog: catalogName,
+    db: databases.list[0],
+  }
+}
+
+export function useDefaultQueryExecution(): AsyncData<QueryExecution> {
+  const athena = AWS.Athena.use()
+  return useData(fetchDefaultQueryExecution, { athena })
 }
 
 export interface ExecutionContext {

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -21,6 +21,7 @@ Entries inside each section should be ordered by type:
 
 ## Catalog, Lambdas
 * [Added] Sign URL in undocumented `compressedIndexURL` IGV property ([#3947](https://github.com/quiltdata/quilt/pull/3947))
+* [Changed] Pre-select first catalog and database for Athena ([#3949](https://github.com/quiltdata/quilt/pull/3949))
 
 # 6.0.0a2 - 2024-04-15
 ## Python API


### PR DESCRIPTION
* Pre-select first catalog and database if nothing was chosen
* Fix showing current catalog and database as selected in catalog/database form

- [x] [Changelog](../tree/master/docs/CHANGELOG.md) entry (skip if change is not significant to end users, e.g. docs only)
