### PR TITLE
Move Listing's pagination to the bottom

### DIFF
--- a/catalog/app/components/Preview/loaders/Igv.ts
+++ b/catalog/app/components/Preview/loaders/Igv.ts
@@ -20,6 +20,7 @@ const traverseUrls = (fn: (v: any) => any, json: JsonRecord) =>
       reference: R.evolve({
         fastaURL: fn,
         indexURL: fn,
+        compressedIndexURL: fn,
         cytobandURL: fn,
         aliasURL: fn,
       }),

--- a/catalog/app/containers/Bucket/Listing.tsx
+++ b/catalog/app/containers/Bucket/Listing.tsx
@@ -581,7 +581,7 @@ function Toolbar({
         </div>
       )}
       <div className={classes.summary}>
-        Showing {from}—{to} out of {items.length}
+        Showing {from}—{to} out of {truncated ? 'first' : ''} {items.length}
       </div>
       <FilterToolbarButton />
       {locked && <div className={classes.lock} />}

--- a/catalog/app/containers/Bucket/Listing.tsx
+++ b/catalog/app/containers/Bucket/Listing.tsx
@@ -753,7 +753,6 @@ interface FooterProps {
 
 function Footer({ truncated = false, locked = false, loadMore, items }: FooterProps) {
   const { state } = DG.useGridSlotComponentProps()
-  const t = M.useTheme()
   const classes = useFooterStyles()
 
   const apiRef = React.useContext(DG.GridApiContext)
@@ -762,14 +761,6 @@ function Footer({ truncated = false, locked = false, loadMore, items }: FooterPr
   const stats = React.useMemo(() => computeStats(items), [items])
 
   const paginationState = DG.useGridSelector(apiRef, DG.gridPaginationSelector)
-
-  const style = React.useMemo(() => {
-    const rowHeight = t.spacing(4.5)
-    const rowsToFillThisPage = (paginationState.page + 1) * paginationState.pageSize
-    const missingRows = rowsToFillThisPage - items.length
-    const marginTop = missingRows > 0 ? rowHeight * missingRows : 0
-    return { marginTop }
-  }, [items, t, paginationState])
 
   const filteredStats = React.useMemo(() => {
     if (!filterCount) return undefined
@@ -782,7 +773,7 @@ function Footer({ truncated = false, locked = false, loadMore, items }: FooterPr
   const modified = filteredStats ? filteredStats.modified : stats.modified
 
   return (
-    <div style={style}>
+    <>
       <div className={classes.section}>
         <div className={classes.cellFirst}>
           <M.Tooltip title="Directories" arrow enterDelay={TIP_DELAY}>
@@ -860,7 +851,7 @@ function Footer({ truncated = false, locked = false, loadMore, items }: FooterPr
           loadMore={loadMore}
         />
       </div>
-    </div>
+    </>
   )
 }
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -14,6 +14,13 @@ Entries inside each section should be ordered by type:
 
 ## Catalog, Lambdas
 !-->
+# unreleased - YYYY-MM-DD
+## Python API
+
+## CLI
+
+## Catalog, Lambdas
+* [Added] Sign URL in undocumented `compressedIndexURL` IGV property ([#3947](https://github.com/quiltdata/quilt/pull/3947))
 
 # 6.0.0a2 - 2024-04-15
 ## Python API

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -21,6 +21,7 @@ Entries inside each section should be ordered by type:
 
 ## Catalog, Lambdas
 * [Added] Sign URL in undocumented `compressedIndexURL` IGV property ([#3947](https://github.com/quiltdata/quilt/pull/3947))
+* [Changed] Move pagination to the bottom ([#3950](https://github.com/quiltdata/quilt/pull/3950))
 
 # 6.0.0a2 - 2024-04-15
 ## Python API


### PR DESCRIPTION
* Moved pagination to the bottom
* Added message how many rows are rendered
* Slightly increased pagination controls size
* Added rows fillers on the last page, so layout doesn't jump

[simplescreenrecorder-2024-04-17_18.18.01.webm](https://github.com/quiltdata/quilt/assets/533229/9b33058c-a7b2-4ee6-b453-8f62c02e790e)

- [x] [Changelog](../tree/master/docs/CHANGELOG.md) entry (skip if change is not significant to end users, e.g. docs only)
