### PR TITLE
s3-proxy: remove mentions of REGISTRY_HOST env var

### DIFF
--- a/s3-proxy/.env.example
+++ b/s3-proxy/.env.example
@@ -1,2 +1,1 @@
-REGISTRY_HOST=host.docker.internal:5000
 INTERNAL_REGISTRY_URL=http://host.docker.internal:5000

--- a/s3-proxy/docker-compose.yml
+++ b/s3-proxy/docker-compose.yml
@@ -2,7 +2,6 @@ services:
   s3proxy:
     build: .
     environment:
-      - REGISTRY_HOST
       - INTERNAL_REGISTRY_URL
     ports:
       - "5002:80"

--- a/s3-proxy/run-nginx.sh
+++ b/s3-proxy/run-nginx.sh
@@ -1,12 +1,6 @@
 #!/bin/bash
 set -exo pipefail
 
-if [ -z "$REGISTRY_HOST" ]
-then
-    echo "REGISTRY_HOST not set"
-    exit 1
-fi
-
 if [ -z "$INTERNAL_REGISTRY_URL" ]
 then
     echo "INTERNAL_REGISTRY_URL not set"


### PR DESCRIPTION
it seems unused since
2e31106e308fedac2e0d30f9127546067d56c269