### PR TITLE
Search UI QoL improvements

### DIFF
--- a/catalog/app/components/SearchResults/SearchResults.tsx
+++ b/catalog/app/components/SearchResults/SearchResults.tsx
@@ -24,7 +24,7 @@ import usePrevious from 'utils/usePrevious'
 import * as requests from 'containers/Bucket/requests'
 
 const PER_PAGE = 10
-const ES_V = '6.8'
+const ES_V = '6.7'
 const ES_REF = `https://www.elastic.co/guide/en/elasticsearch/reference/${ES_V}`
 export const ES_REF_SYNTAX = `${ES_REF}/query-dsl-query-string-query.html#query-string-syntax`
 const ES_REF_WILDCARDS = `${ES_REF}/query-dsl-query-string-query.html#_wildcards`

--- a/catalog/app/containers/NavBar/Provider.tsx
+++ b/catalog/app/containers/NavBar/Provider.tsx
@@ -36,6 +36,7 @@ interface InputState extends M.InputBaseProps {
 interface SearchState {
   input: InputState
   onClickAway: () => void
+  focus: () => void
   reset: () => void
   suggestions: ReturnType<typeof Suggestions.use>
 }
@@ -131,13 +132,17 @@ function useSearchState(bucket?: string): SearchState {
     if (expanded || helpOpen) handleCollapse()
   }, [expanded, helpOpen, handleCollapse])
 
-  const reset = React.useCallback(() => {
-    change('')
+  const focus = React.useCallback(() => {
     // NOTE: wait for location change (making help closed),
     //       then focus
     // FIXME: find out better solution
     nextTick(() => setFocusTrigger((n) => n + 1))
-  }, [])
+  }, [setFocusTrigger])
+
+  const reset = React.useCallback(() => {
+    change('')
+    focus()
+  }, [focus])
 
   const isExpanded = expanded || !!searchUIModel
   const focusTriggeredCount = isExpanded ? focusTrigger : 0
@@ -151,6 +156,7 @@ function useSearchState(bucket?: string): SearchState {
       onKeyDown,
       value: value === null ? query : value,
     },
+    focus,
     reset,
     onClickAway,
     suggestions,

--- a/catalog/app/containers/NavBar/Suggestions/Suggestions.tsx
+++ b/catalog/app/containers/NavBar/Suggestions/Suggestions.tsx
@@ -20,6 +20,10 @@ const displaySuggestion = (s: Suggestion) => (
 const useSuggestionsStyles = M.makeStyles((t) => ({
   item: {
     paddingLeft: t.spacing(5.5),
+
+    '& b': {
+      fontWeight: t.typography.fontWeightMedium,
+    },
   },
   help: {
     ...t.typography.caption,

--- a/catalog/app/containers/NavBar/Suggestions/model.tsx
+++ b/catalog/app/containers/NavBar/Suggestions/model.tsx
@@ -30,7 +30,7 @@ function what(searchString: string, resultType: SearchUIModel.ResultType) {
     resultType === SearchUIModel.ResultType.QuiltPackage ? 'packages' : 'objects'
   return searchString ? (
     <>
-      <b>"{searchString}"</b> in <b>{typeDisplay}</b>
+      &laquo;<b>{searchString}</b>&raquo; in <b>{typeDisplay}</b>
     </>
   ) : (
     <b>all {typeDisplay}</b>

--- a/catalog/app/containers/Search/ResultType.tsx
+++ b/catalog/app/containers/Search/ResultType.tsx
@@ -6,8 +6,8 @@ import * as SearchUIModel from './model'
 const VALUES = [SearchUIModel.ResultType.QuiltPackage, SearchUIModel.ResultType.S3Object]
 
 const LABELS = {
-  [SearchUIModel.ResultType.QuiltPackage]: 'Quilt Packages',
-  [SearchUIModel.ResultType.S3Object]: 'S3 Objects',
+  [SearchUIModel.ResultType.QuiltPackage]: 'Packages',
+  [SearchUIModel.ResultType.S3Object]: 'Objects',
 }
 
 const getLabel = (value: SearchUIModel.ResultType) => LABELS[value]

--- a/catalog/app/containers/Search/Results.tsx
+++ b/catalog/app/containers/Search/Results.tsx
@@ -150,7 +150,7 @@ export function EmptyResults({ className }: EmptyResultsProps) {
         )}
         {numFilters > 0 && (
           <li>
-            Reset <StyledLink onClick={clearFilters}>search filters</StyledLink>
+            Reset the <StyledLink onClick={clearFilters}>search filters</StyledLink>
           </li>
         )}
         <li>

--- a/catalog/app/utils/GraphQL/Provider.tsx
+++ b/catalog/app/utils/GraphQL/Provider.tsx
@@ -110,6 +110,7 @@ export default function GraphQLProvider({ children }: React.PropsWithChildren<{}
           Status: () => null,
           StatusReport: (r) => (typeof r.timestamp === 'string' ? r.timestamp : null),
           StatusReportList: () => null,
+          SubscriptionState: () => null,
           TestStats: () => null,
           TestStatsTimeSeries: () => null,
           DatetimeExtents: () => null,

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -24,6 +24,7 @@ Entries inside each section should be ordered by type:
 * [Added] Sign URL in undocumented `compressedIndexURL` IGV property ([#3947](https://github.com/quiltdata/quilt/pull/3947))
 * [Changed] Pre-select first catalog and database for Athena ([#3949](https://github.com/quiltdata/quilt/pull/3949))
 * [Changed] Move pagination to the bottom ([#3950](https://github.com/quiltdata/quilt/pull/3950))
+* [Changed] Search UI QoL improvements ([#3960](https://github.com/quiltdata/quilt/pull/3960))
 
 # 6.0.0a2 - 2024-04-15
 ## Python API


### PR DESCRIPTION
## Description

(1) More concise result type labels (~~Quilt~~ Packages, ~~S3~~ Objects)

<img width="346" alt="Screenshot 2024-04-22 at 13 47 08" src="https://github.com/quiltdata/quilt/assets/122294/86549880-e9a7-43e3-8959-2bb0b5d57679">
<hr>

(2) Change quotes in search suggestions to avoid confusing them with user input. Also, make bold a bit less bold.

<img width="511" alt="Screenshot 2024-04-22 at 13 46 15" src="https://github.com/quiltdata/quilt/assets/122294/214905bc-7c24-44fc-b3f5-270058c0e781">
<hr>

(3) Make "no results" UI less empty and more actionable by providing more context and displaying helpful suggestions.

<img width="939" alt="Screenshot 2024-04-22 at 13 49 39" src="https://github.com/quiltdata/quilt/assets/122294/a58c1bd7-d743-4292-a4e2-b9c685ef3bf3">
<hr>

(4) Make error UI more concise and consistent with the "no results" UI.

<img width="933" alt="Screenshot 2024-04-22 at 13 47 25" src="https://github.com/quiltdata/quilt/assets/122294/434e9703-07b1-45cd-9ee8-4e74714f3eaf">
<img width="901" alt="Screenshot 2024-04-22 at 13 48 13" src="https://github.com/quiltdata/quilt/assets/122294/0c8dc0a5-013d-4ed3-8a0c-265bd1c24168">
<hr>

(5) Link to ES 6.7 docs everywhere (some links were pointing to 6.8 instead)



## TODO

- [x] [Changelog](../tree/master/docs/CHANGELOG.md) entry (skip if change is not significant to end users, e.g. docs only)
