### PR TITLE
Catalog: More search UI tweaks

### DIFF
--- a/catalog/app/containers/Search/ResultType.tsx
+++ b/catalog/app/containers/Search/ResultType.tsx
@@ -1,6 +1,7 @@
 import * as React from 'react'
 import * as M from '@material-ui/core'
 
+import * as GQL from 'utils/GraphQL'
 import * as SearchUIModel from './model'
 
 const VALUES = [SearchUIModel.ResultType.QuiltPackage, SearchUIModel.ResultType.S3Object]
@@ -45,6 +46,10 @@ const useResultTypeStyles = M.makeStyles((t) => ({
   icon: {
     minWidth: t.spacing(3.5),
   },
+  chip: {
+    backgroundColor: t.palette.text.hint,
+    color: t.palette.getContrastText(t.palette.text.hint),
+  },
   item: {
     paddingLeft: t.spacing(1.5),
     paddingRight: t.spacing(1),
@@ -60,10 +65,47 @@ const useResultTypeStyles = M.makeStyles((t) => ({
 export default function ResultType() {
   const classes = useResultTypeStyles()
   const model = SearchUIModel.use()
+
+  const getTotalSelectedResults = () => {
+    if (model.firstPageQuery._tag !== 'data') return null
+    const d = model.firstPageQuery.data
+    switch (d.__typename) {
+      case 'ObjectsSearchResultSet':
+      case 'PackagesSearchResultSet':
+        return d.stats.total
+      case 'EmptySearchResultSet':
+        return 0
+      default:
+        return null
+    }
+  }
+
+  const getTotalOtherResults = (resultType: SearchUIModel.ResultType) =>
+    GQL.fold(model.baseSearchQuery, {
+      data: (data) => {
+        const r =
+          resultType === SearchUIModel.ResultType.QuiltPackage
+            ? data.searchPackages
+            : data.searchObjects
+        switch (r.__typename) {
+          case 'EmptySearchResultSet':
+            return 0
+          case 'ObjectsSearchResultSet':
+          case 'PackagesSearchResultSet':
+            return r.stats.total
+          default:
+            return null
+        }
+      },
+      fetching: () => null,
+      error: () => null,
+    })
+
   return (
     <M.List dense disablePadding className={classes.root}>
       {VALUES.map((v) => {
         const selected = model.state.resultType === v
+        const total = selected ? getTotalSelectedResults() : getTotalOtherResults(v)
         return (
           <M.ListItem
             button
@@ -77,6 +119,11 @@ export default function ResultType() {
               <Icon resultType={v} />
             </M.ListItemIcon>
             <M.ListItemText primary={getLabel(v)} />
+            {total != null && (
+              <M.ListItemSecondaryAction>
+                <M.Chip className={classes.chip} size="small" label={total} />
+              </M.ListItemSecondaryAction>
+            )}
           </M.ListItem>
         )
       })}

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -18,6 +18,7 @@ Entries inside each section should be ordered by type:
 ## Python API
 * [Added] `quilt3.search()` and `quilt3.Bucket.search()` now accept custom Elasticsearch queries ([#3448](https://github.com/quiltdata/quilt/pull/3448))
 * [Fixed] `quilt3.search()` and `quilt3.Bucket.search()` now work with 2022+ Quilt stacks ([#3448](https://github.com/quiltdata/quilt/pull/3448))
+* [Changed] Search UI QoL improvements ([#3967](https://github.com/quiltdata/quilt/pull/3967))
 
 ## Catalog, Lambdas
 * [Added] Added "text" as a file type for quilt_summarize.json ([#3946](https://github.com/quiltdata/quilt/pull/3946))


### PR DESCRIPTION
## Description


- Show number of results in result type selector
- Make switching to the other result type the default (first) suggestion, show result count

<img width="1264" alt="Screenshot 2024-04-26 at 10 00 49" src="https://github.com/quiltdata/quilt/assets/122294/2e5f753c-55fc-4895-b7fa-91712f742994">

## TODO

<!-- Remove items that are irrelevant to this PR -->

- [x] [Changelog](../tree/master/docs/CHANGELOG.md) entry (skip if change is not significant to end users, e.g. docs only)
