### PR TITLE
Pass codecov token in CI jobs

### DIFF
--- a/.github/workflows/js-ci.yml
+++ b/.github/workflows/js-ci.yml
@@ -26,6 +26,8 @@ jobs:
           BUNDLEWATCH_GITHUB_TOKEN: ${{ secrets.BUNDLEWATCH_GITHUB_TOKEN }}
         run: npm run bundlewatch
       - uses: codecov/codecov-action@v3
+        env:
+          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
         with:
           flags: catalog
           name: ${{ github.job }}

--- a/.github/workflows/py-ci.yml
+++ b/.github/workflows/py-ci.yml
@@ -100,6 +100,7 @@ jobs:
           pytest --cov=api/python api/python
       - uses: codecov/codecov-action@v3
         env:
+          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
           OS: ${{ matrix.os }}
           PYTHON_VERSION: ${{ matrix.python-version }}
         with:
@@ -204,6 +205,7 @@ jobs:
           pytest --cov=lambdas lambdas/${{ matrix.path }}
       - uses: codecov/codecov-action@v3
         env:
+          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
           LAMBDA: ${{ matrix.path }}
         with:
           flags: lambda


### PR DESCRIPTION
# Description

This seems to fix coverage upload failing here:
https://github.com/quiltdata/quilt/actions/runs/8850160906/job/24303785228#step:6:44