### PR TITLE
Double the expiration time of URL signing

### DIFF
--- a/catalog/app/utils/AWS/Signer.js
+++ b/catalog/app/utils/AWS/Signer.js
@@ -10,7 +10,7 @@ import { handleToHttpsUri } from 'utils/s3paths'
 import * as Credentials from './Credentials'
 import * as S3 from './S3'
 
-const DEFAULT_URL_EXPIRATION = 5 * 60 // in seconds
+const DEFAULT_URL_EXPIRATION = 10 * 60 // in seconds
 const POLL_INTERVAL = 10 // in seconds
 const LAG = POLL_INTERVAL * 3
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -14,6 +14,14 @@ Entries inside each section should be ordered by type:
 
 ## Catalog, Lambdas
 !-->
+# unreleased - YYYY-MM-DD
+## Python API
+
+## CLI
+
+## Catalog, Lambdas
+* [Changed] Double the expiration time of URL signing ([#3978](https://github.com/quiltdata/quilt/pull/3978))
+
 # 6.0.0a3 - 2024-04-25
 ## Python API
 * [Added] `quilt3.search()` and `quilt3.Bucket.search()` now accepts custom Elasticsearch queries ([#3448](https://github.com/quiltdata/quilt/pull/3448))


### PR DESCRIPTION
5 minutes is too small amount of time for downloading some IGV tracks assets.

- [x] [Changelog](../tree/master/docs/CHANGELOG.md) entry (skip if change is not significant to end users, e.g. docs only)
