### PR TITLE
Use promises for URLs in IGV to have fresh signing each time they used

### DIFF
--- a/catalog/app/components/Preview/loaders/Igv.ts
+++ b/catalog/app/components/Preview/loaders/Igv.ts
@@ -73,6 +73,13 @@ export const Loader = function IgvLoader({ gated, handle, children }: IgvLoaderP
       const tail = data.tail.join('\n')
       try {
         const options = JSON.parse([head, tail].join('\n'))
+        if (!options.reference?.indexFile && options.reference?.fastaURL) {
+          // This is a copy of the IGV behaviour, that is a copy IGV desktop behaviour.
+          // But with a fix of a bug when after signing URLs `fastaURL` contains async thunk.
+          // `indexFile` will be discarded if reference has `indexURL`
+          // XXX: remove that after https://github.com/igvteam/igv.js/pull/1821 merged
+          options.reference.indexFile = `${options.reference.fastaURL}.fai`
+        }
         const auxOptions = await signUrls(options)
         return PreviewData.Igv({
           options: auxOptions,

--- a/catalog/app/components/Preview/loaders/Igv.ts
+++ b/catalog/app/components/Preview/loaders/Igv.ts
@@ -59,7 +59,7 @@ interface PreviewResult {
 }
 
 export const Loader = function IgvLoader({ gated, handle, children }: IgvLoaderProps) {
-  const signUrls = useSignObjectUrls(handle, traverseUrls)
+  const signUrls = useSignObjectUrls(handle, traverseUrls, { asyncReady: true })
 
   const { result, fetch } = utils.usePreview({
     type: 'txt',

--- a/catalog/app/components/Preview/loaders/useSignObjectUrls.spec.ts
+++ b/catalog/app/components/Preview/loaders/useSignObjectUrls.spec.ts
@@ -1,0 +1,115 @@
+import * as R from 'ramda'
+
+import type * as Model from 'model'
+import type { JsonRecord } from 'utils/types'
+
+import {
+  createObjectUrlsSigner,
+  createPathResolver,
+  createUrlProcessor,
+} from './useSignObjectUrls'
+
+describe('components/Preview/loaders/useSignObjectUrls', () => {
+  describe('createObjectUrlsSigner', () => {
+    const traverseUrls = (fn: (v: string) => string, obj: JsonRecord) =>
+      R.evolve(
+        {
+          foo: {
+            bar: fn,
+            foo: {
+              baz: fn,
+            },
+          },
+        },
+        obj,
+      )
+    const processUrl = async (path: string) => path.split('').reverse().join('')
+    let object = {
+      check: true,
+      foo: {
+        bar: 'FEDCBA',
+        foo: {
+          baz: '987654321',
+        },
+      },
+    }
+    it('should return strings', async () => {
+      let processor = createObjectUrlsSigner(traverseUrls, processUrl, false)
+      await expect(processor(object)).resolves.toEqual({
+        check: true,
+        foo: {
+          bar: 'ABCDEF',
+          foo: {
+            baz: '123456789',
+          },
+        },
+      })
+    })
+
+    it('should return async functions', async () => {
+      let processor = createObjectUrlsSigner(traverseUrls, processUrl, true)
+      const result = await processor(object)
+      let bar = (result.foo as any).bar
+      let baz = (result.foo as any).foo.baz
+      await expect(bar()).resolves.toBe('ABCDEF')
+      await expect(baz()).resolves.toBe('123456789')
+    })
+  })
+
+  describe('createUrlProcessor', () => {
+    let sign = ({ bucket, key, version }: Model.S3.S3ObjectLocation) =>
+      `https://${bucket}+${key}+${version}`
+    let resolvePath = async (path: string) => ({
+      bucket: 'resolved-bucket',
+      key: path,
+    })
+    let processUrl = createUrlProcessor(sign, resolvePath)
+    it('should return unsinged web', () => {
+      expect(processUrl('http://bucket/path')).resolves.toBe('http://bucket/path')
+    })
+    it('should return signed S3 URL', () => {
+      expect(processUrl('s3://bucket/path')).resolves.toBe(
+        'https://bucket+path+undefined',
+      )
+    })
+    it('should return signed S3 relative URL', () => {
+      expect(processUrl('s3://./relative/path')).resolves.toBe(
+        'https://resolved-bucket+./relative/path+undefined',
+      )
+    })
+    it('should return signed path', () => {
+      expect(processUrl('./relative/path')).resolves.toBe(
+        'https://resolved-bucket+./relative/path+undefined',
+      )
+    })
+  })
+
+  describe('createPathResolver', () => {
+    test('Join keys if no logical key', () => {
+      const resolveKey = (key: string) => ({
+        bucket: 'foo/bar',
+        key: `CCC/${key}`,
+      })
+      let resolve = createPathResolver(resolveKey, { bucket: 'foo/bar', key: 'AAA/' })
+      expect(resolve('BBB')).resolves.toEqual({
+        bucket: 'foo/bar',
+        key: 'AAA/BBB',
+      })
+    })
+    test('Resovle logical key', () => {
+      const resolveLogicalKey = (key: string) => ({
+        bucket: 'foo/bar',
+        key: `CCC/${key}`,
+      })
+      let resolve = createPathResolver(resolveLogicalKey, {
+        bucket: 'foo/bar',
+        key: 'AAA/',
+        logicalKey: 'AAA/',
+      })
+      expect(resolve('BBB')).resolves.toEqual({
+        bucket: 'foo/bar',
+        key: 'CCC/AAA/BBB',
+      })
+    })
+  })
+})

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -14,6 +14,14 @@ Entries inside each section should be ordered by type:
 
 ## Catalog, Lambdas
 !-->
+# unreleased - YYYY-MM-DD
+## Python API
+
+## CLI
+
+## Catalog, Lambdas
+* [Changed] Use promises for URLs in IGV to have fresh signing each time they used ([#3979](https://github.com/quiltdata/quilt/pull/3979))
+
 # 6.0.0a3 - 2024-04-25
 ## Python API
 * [Added] `quilt3.search()` and `quilt3.Bucket.search()` now accepts custom Elasticsearch queries ([#3448](https://github.com/quiltdata/quilt/pull/3448))


### PR DESCRIPTION
- [x] [Changelog](../tree/master/docs/CHANGELOG.md) entry (skip if change is not significant to end users, e.g. docs only)
