### PR TITLE
gql for "me" and role switching

### DIFF
--- a/catalog/app/containers/NavBar/gql/Me.generated.ts
+++ b/catalog/app/containers/NavBar/gql/Me.generated.ts
@@ -1,0 +1,70 @@
+/* eslint-disable @typescript-eslint/naming-convention */
+import type { TypedDocumentNode as DocumentNode } from '@graphql-typed-document-node/core'
+import * as Types from '../../../model/graphql/types.generated'
+
+export type containers_NavBar_gql_MeQueryVariables = Types.Exact<{ [key: string]: never }>
+
+export type containers_NavBar_gql_MeQuery = { readonly __typename: 'Query' } & {
+  readonly me: { readonly __typename: 'Me' } & Pick<
+    Types.Me,
+    'name' | 'email' | 'isAdmin'
+  > & {
+      readonly role: { readonly __typename: 'MyRole' } & Pick<Types.MyRole, 'name'>
+      readonly roles: ReadonlyArray<
+        { readonly __typename: 'MyRole' } & Pick<Types.MyRole, 'name'>
+      >
+    }
+}
+
+export const containers_NavBar_gql_MeDocument = {
+  kind: 'Document',
+  definitions: [
+    {
+      kind: 'OperationDefinition',
+      operation: 'query',
+      name: { kind: 'Name', value: 'containers_NavBar_gql_Me' },
+      selectionSet: {
+        kind: 'SelectionSet',
+        selections: [
+          {
+            kind: 'Field',
+            name: { kind: 'Name', value: 'me' },
+            selectionSet: {
+              kind: 'SelectionSet',
+              selections: [
+                { kind: 'Field', name: { kind: 'Name', value: 'name' } },
+                { kind: 'Field', name: { kind: 'Name', value: 'email' } },
+                { kind: 'Field', name: { kind: 'Name', value: 'isAdmin' } },
+                {
+                  kind: 'Field',
+                  name: { kind: 'Name', value: 'role' },
+                  selectionSet: {
+                    kind: 'SelectionSet',
+                    selections: [
+                      { kind: 'Field', name: { kind: 'Name', value: 'name' } },
+                    ],
+                  },
+                },
+                {
+                  kind: 'Field',
+                  name: { kind: 'Name', value: 'roles' },
+                  selectionSet: {
+                    kind: 'SelectionSet',
+                    selections: [
+                      { kind: 'Field', name: { kind: 'Name', value: 'name' } },
+                    ],
+                  },
+                },
+              ],
+            },
+          },
+        ],
+      },
+    },
+  ],
+} as unknown as DocumentNode<
+  containers_NavBar_gql_MeQuery,
+  containers_NavBar_gql_MeQueryVariables
+>
+
+export { containers_NavBar_gql_MeDocument as default }

--- a/catalog/app/containers/NavBar/gql/Me.graphql
+++ b/catalog/app/containers/NavBar/gql/Me.graphql
@@ -1,0 +1,9 @@
+query {
+  me {
+    name
+    email
+    isAdmin
+    role { name }
+    roles { name }
+  }
+}

--- a/catalog/app/containers/NavBar/gql/SwitchRole.generated.ts
+++ b/catalog/app/containers/NavBar/gql/SwitchRole.generated.ts
@@ -1,0 +1,120 @@
+/* eslint-disable @typescript-eslint/naming-convention */
+import type { TypedDocumentNode as DocumentNode } from '@graphql-typed-document-node/core'
+import * as Types from '../../../model/graphql/types.generated'
+
+export type containers_NavBar_gql_SwitchRoleMutationVariables = Types.Exact<{
+  roleName: Types.Scalars['String']
+}>
+
+export type containers_NavBar_gql_SwitchRoleMutation = {
+  readonly __typename: 'Mutation'
+} & {
+  readonly switchRole:
+    | ({ readonly __typename: 'Me' } & Pick<Types.Me, 'name' | 'email' | 'isAdmin'> & {
+          readonly role: { readonly __typename: 'MyRole' } & Pick<Types.MyRole, 'name'>
+          readonly roles: ReadonlyArray<
+            { readonly __typename: 'MyRole' } & Pick<Types.MyRole, 'name'>
+          >
+        })
+    | ({ readonly __typename: 'OperationError' } & Pick<
+        Types.OperationError,
+        'message' | 'name'
+      >)
+}
+
+export const containers_NavBar_gql_SwitchRoleDocument = {
+  kind: 'Document',
+  definitions: [
+    {
+      kind: 'OperationDefinition',
+      operation: 'mutation',
+      name: { kind: 'Name', value: 'containers_NavBar_gql_SwitchRole' },
+      variableDefinitions: [
+        {
+          kind: 'VariableDefinition',
+          variable: { kind: 'Variable', name: { kind: 'Name', value: 'roleName' } },
+          type: {
+            kind: 'NonNullType',
+            type: { kind: 'NamedType', name: { kind: 'Name', value: 'String' } },
+          },
+        },
+      ],
+      selectionSet: {
+        kind: 'SelectionSet',
+        selections: [
+          {
+            kind: 'Field',
+            name: { kind: 'Name', value: 'switchRole' },
+            arguments: [
+              {
+                kind: 'Argument',
+                name: { kind: 'Name', value: 'roleName' },
+                value: { kind: 'Variable', name: { kind: 'Name', value: 'roleName' } },
+              },
+            ],
+            selectionSet: {
+              kind: 'SelectionSet',
+              selections: [
+                { kind: 'Field', name: { kind: 'Name', value: '__typename' } },
+                {
+                  kind: 'InlineFragment',
+                  typeCondition: {
+                    kind: 'NamedType',
+                    name: { kind: 'Name', value: 'Me' },
+                  },
+                  selectionSet: {
+                    kind: 'SelectionSet',
+                    selections: [
+                      { kind: 'Field', name: { kind: 'Name', value: 'name' } },
+                      { kind: 'Field', name: { kind: 'Name', value: 'email' } },
+                      { kind: 'Field', name: { kind: 'Name', value: 'isAdmin' } },
+                      {
+                        kind: 'Field',
+                        name: { kind: 'Name', value: 'role' },
+                        selectionSet: {
+                          kind: 'SelectionSet',
+                          selections: [
+                            { kind: 'Field', name: { kind: 'Name', value: 'name' } },
+                          ],
+                        },
+                      },
+                      {
+                        kind: 'Field',
+                        name: { kind: 'Name', value: 'roles' },
+                        selectionSet: {
+                          kind: 'SelectionSet',
+                          selections: [
+                            { kind: 'Field', name: { kind: 'Name', value: 'name' } },
+                          ],
+                        },
+                      },
+                    ],
+                  },
+                },
+                {
+                  kind: 'InlineFragment',
+                  typeCondition: {
+                    kind: 'NamedType',
+                    name: { kind: 'Name', value: 'OperationError' },
+                  },
+                  selectionSet: {
+                    kind: 'SelectionSet',
+                    selections: [
+                      { kind: 'Field', name: { kind: 'Name', value: 'message' } },
+                      { kind: 'Field', name: { kind: 'Name', value: 'name' } },
+                    ],
+                  },
+                },
+              ],
+            },
+          },
+        ],
+      },
+    },
+  ],
+} as unknown as DocumentNode<
+  containers_NavBar_gql_SwitchRoleMutation,
+  containers_NavBar_gql_SwitchRoleMutationVariables
+>
+
+export { containers_NavBar_gql_SwitchRoleDocument as default }

--- a/catalog/app/containers/NavBar/gql/SwitchRole.graphql
+++ b/catalog/app/containers/NavBar/gql/SwitchRole.graphql
@@ -1,0 +1,16 @@
+mutation ($roleName: String!) {
+  switchRole(roleName: $roleName) {
+    __typename
+    ... on Me {
+      name
+      email
+      isAdmin
+      role { name }
+      roles { name }
+    }
+    ... on OperationError {
+      message
+      name
+    }
+  }
+}

--- a/catalog/app/model/graphql/schema.generated.ts
+++ b/catalog/app/model/graphql/schema.generated.ts
@@ -1351,6 +1351,79 @@ export default {
       },
       {
         kind: 'OBJECT',
+        name: 'Me',
+        fields: [
+          {
+            name: 'name',
+            type: {
+              kind: 'NON_NULL',
+              ofType: {
+                kind: 'SCALAR',
+                name: 'String',
+                ofType: null,
+              },
+            },
+            args: [],
+          },
+          {
+            name: 'email',
+            type: {
+              kind: 'NON_NULL',
+              ofType: {
+                kind: 'SCALAR',
+                name: 'String',
+                ofType: null,
+              },
+            },
+            args: [],
+          },
+          {
+            name: 'isAdmin',
+            type: {
+              kind: 'NON_NULL',
+              ofType: {
+                kind: 'SCALAR',
+                name: 'Boolean',
+                ofType: null,
+              },
+            },
+            args: [],
+          },
+          {
+            name: 'role',
+            type: {
+              kind: 'NON_NULL',
+              ofType: {
+                kind: 'OBJECT',
+                name: 'MyRole',
+                ofType: null,
+              },
+            },
+            args: [],
+          },
+          {
+            name: 'roles',
+            type: {
+              kind: 'NON_NULL',
+              ofType: {
+                kind: 'LIST',
+                ofType: {
+                  kind: 'NON_NULL',
+                  ofType: {
+                    kind: 'OBJECT',
+                    name: 'MyRole',
+                    ofType: null,
+                  },
+                },
+              },
+            },
+            args: [],
+          },
+        ],
+        interfaces: [],
+      },
+      {
+        kind: 'OBJECT',
         name: 'MutateUserAdminMutations',
         fields: [
           {
@@ -1477,6 +1550,30 @@ export default {
         kind: 'OBJECT',
         name: 'Mutation',
         fields: [
+          {
+            name: 'switchRole',
+            type: {
+              kind: 'NON_NULL',
+              ofType: {
+                kind: 'UNION',
+                name: 'SwitchRoleResult',
+                ofType: null,
+              },
+            },
+            args: [
+              {
+                name: 'roleName',
+                type: {
+                  kind: 'NON_NULL',
+                  ofType: {
+                    kind: 'SCALAR',
+                    name: 'String',
+                    ofType: null,
+                  },
+                },
+              },
+            ],
+          },
           {
             name: 'packageConstruct',
             type: {
@@ -2075,6 +2172,25 @@ export default {
                 },
               },
             ],
+          },
+        ],
+        interfaces: [],
+      },
+      {
+        kind: 'OBJECT',
+        name: 'MyRole',
+        fields: [
+          {
+            name: 'name',
+            type: {
+              kind: 'NON_NULL',
+              ofType: {
+                kind: 'SCALAR',
+                name: 'String',
+                ofType: null,
+              },
+            },
+            args: [],
           },
         ],
         interfaces: [],
@@ -3501,6 +3617,18 @@ export default {
         name: 'Query',
         fields: [
           {
+            name: 'me',
+            type: {
+              kind: 'NON_NULL',
+              ofType: {
+                kind: 'OBJECT',
+                name: 'Me',
+                ofType: null,
+              },
+            },
+            args: [],
+          },
+          {
             name: 'config',
             type: {
               kind: 'NON_NULL',
@@ -4767,6 +4895,20 @@ export default {
           },
         ],
         interfaces: [],
+      },
+      {
+        kind: 'UNION',
+        name: 'SwitchRoleResult',
+        possibleTypes: [
+          {
+            kind: 'OBJECT',
+            name: 'Me',
+          },
+          {
+            kind: 'OBJECT',
+            name: 'OperationError',
+          },
+        ],
       },
       {
         kind: 'OBJECT',

--- a/catalog/app/model/graphql/types.generated.ts
+++ b/catalog/app/model/graphql/types.generated.ts
@@ -319,6 +319,15 @@ export interface ManagedRoleInput {
   readonly policies: ReadonlyArray<Scalars['ID']>
 }
 
+export interface Me {
+  readonly __typename: 'Me'
+  readonly name: Scalars['String']
+  readonly email: Scalars['String']
+  readonly isAdmin: Scalars['Boolean']
+  readonly role: MyRole
+  readonly roles: ReadonlyArray<MyRole>
+}
+
 export interface MutateUserAdminMutations {
   readonly __typename: 'MutateUserAdminMutations'
   readonly delete: OperationResult
@@ -347,6 +356,7 @@ export interface MutateUserAdminMutationssetActiveArgs {
 
 export interface Mutation {
   readonly __typename: 'Mutation'
+  readonly switchRole: SwitchRoleResult
   readonly packageConstruct: PackageConstructResult
   readonly packagePromote: PackagePromoteResult
   readonly packageRevisionDelete: PackageRevisionDeleteResult
@@ -368,6 +378,10 @@ export interface Mutation {
   readonly browsingSessionCreate: BrowsingSessionCreateResult
   readonly browsingSessionRefresh: BrowsingSessionRefreshResult
   readonly browsingSessionDispose: BrowsingSessionDisposeResult
+}
+
+export interface MutationswitchRoleArgs {
+  roleName: Scalars['String']
 }
 
 export interface MutationpackageConstructArgs {
@@ -459,6 +473,11 @@ export interface MutationbrowsingSessionRefreshArgs {
 
 export interface MutationbrowsingSessionDisposeArgs {
   id: Scalars['ID']
+}
+
+export interface MyRole {
+  readonly __typename: 'MyRole'
+  readonly name: Scalars['String']
 }
 
 export interface NotificationConfigurationError {
@@ -796,6 +815,7 @@ export type PolicyResult = Policy | InvalidInput | OperationError
 
 export interface Query {
   readonly __typename: 'Query'
+  readonly me: Me
   readonly config: Config
   readonly bucketConfigs: ReadonlyArray<BucketConfig>
   readonly bucketConfig: Maybe<BucketConfig>
@@ -1053,6 +1073,8 @@ export interface SubscriptionState {
   readonly active: Scalars['Boolean']
   readonly timestamp: Scalars['Datetime']
 }
+
+export type SwitchRoleResult = Me | OperationError
 
 export interface TestStats {
   readonly __typename: 'TestStats'

--- a/catalog/app/utils/GraphQL/Provider.tsx
+++ b/catalog/app/utils/GraphQL/Provider.tsx
@@ -132,6 +132,8 @@ export default function GraphQLProvider({ children }: React.PropsWithChildren<{}
           PackagesSearchResultSet: () => null,
           InvalidInput: () => null,
           InputError: () => null,
+          Me: (me) => me.name as string,
+          MyRole: (r) => r.name as string,
           User: (u) => (u.name as string) ?? null,
           AdminQueries: () => null,
           UserAdminQueries: () => null,

--- a/shared/graphql/schema.graphql
+++ b/shared/graphql/schema.graphql
@@ -500,7 +500,23 @@ type AdminQueries {
   user: UserAdminQueries!
 }
 
+type MyRole {
+  name: String!
+}
+
+type Me {
+  name: String!
+  email: String!
+  isAdmin: Boolean!
+  role: MyRole!
+  roles: [MyRole!]!
+}
+
+union SwitchRoleResult = Me | OperationError
+
 type Query {
+  me: Me!
+
   config: Config!
   bucketConfigs: [BucketConfig!]!
   bucketConfig(name: String!): BucketConfig
@@ -845,6 +861,8 @@ type AdminMutations {
 }
 
 type Mutation {
+  switchRole(roleName: String!): SwitchRoleResult!
+
   packageConstruct(
     params: PackagePushParams!
     src: PackageConstructSource!


### PR DESCRIPTION
# Description


# TODO

<!-- Remove items that are irrelevant to this PR -->

- [ ] Unit tests
- [ ] Automated tests (e.g. Preflight)
- [ ] Confirm that this change meets security best practices and does not violate the security model
- [ ] Documentation
    - [ ] [Python: Run `build.py`](../tree/master/gendocs/build.py) for new docstrings
    - [ ] JavaScript: basic explanation and screenshot of new features
    - [ ] Markdown somewhere in docs/**/*.md that explains the feature to end users (said .md files should be linked from SUMMARY.md so they appear on https://docs.quiltdata.com)
    - [ ] Markdown docs for developers
- [ ] [Changelog](../tree/master/docs/CHANGELOG.md) entry (skip if change is not significant to end users, e.g. docs only)
