### PR TITLE
Fix thumbnail lambda build error caused by numpy@2 release

### DIFF
--- a/.github/workflows/py-ci.yml
+++ b/.github/workflows/py-ci.yml
@@ -181,22 +181,21 @@ jobs:
           python-version-file: lambdas/${{ matrix.path }}/.python-version
       - name: Install dependencies
         run: |
-          # Due to behavior change in pip>=23.1 installing tifffile==0.15.1
-          # from thumbnail lambda fails whithout installed wheel.
-          # See https://github.com/pypa/pip/issues/8559.
-          python -m pip install wheel
-
-          if [ ${{ matrix.path }} == "shared" ]
-            python -m pip install -e lambdas/shared[tests]
-          then
-            python -m pip install -e lambdas/shared
-            python -m pip install -e lambdas/${{ matrix.path }}
-          fi
-
           if [ ${{ matrix.path }} == "thumbnail" ]
           then
+            # Due to behavior change in pip>=23.1 installing tifffile==0.15.1
+            # from thumbnail lambda fails whithout installed wheel.
+            # See https://github.com/pypa/pip/issues/8559.
             # HACK: Pre-install numpy v1 as a build dependency for tifffile to prevent it from using v2 and failing to build
-            python -m pip install 'numpy<2'
+            python -m pip install wheel 'numpy<2'
+          fi
+
+          if [ ${{ matrix.path }} == "shared" ]
+          then
+            python -m pip install -e lambdas/shared[tests]
+          else
+            python -m pip install -e lambdas/shared
+            python -m pip install -e lambdas/${{ matrix.path }}
           fi
 
           python -m pip install -r lambdas/${{ matrix.path }}/test-requirements.txt

--- a/.github/workflows/py-ci.yml
+++ b/.github/workflows/py-ci.yml
@@ -185,14 +185,20 @@ jobs:
           # from thumbnail lambda fails whithout installed wheel.
           # See https://github.com/pypa/pip/issues/8559.
           python -m pip install wheel
-          # HACK: Pre-install numpy v1 as a build dependency for tifffile to prevent it from using v2 and failing to build
-          python -m pip install 'numpy<2'
+
           if [ ${{ matrix.path }} == "shared" ]
             python -m pip install -e lambdas/shared[tests]
           then
             python -m pip install -e lambdas/shared
             python -m pip install -e lambdas/${{ matrix.path }}
           fi
+
+          if [ ${{ matrix.path }} == "thumbnail" ]
+          then
+            # HACK: Pre-install numpy v1 as a build dependency for tifffile to prevent it from using v2 and failing to build
+            python -m pip install 'numpy<2'
+          fi
+
           python -m pip install -r lambdas/${{ matrix.path }}/test-requirements.txt
 
           # Try to simulate the lambda .zip file:

--- a/.github/workflows/py-ci.yml
+++ b/.github/workflows/py-ci.yml
@@ -190,10 +190,10 @@ jobs:
             python -m pip install wheel 'numpy<2'
           fi
 
+          # XXX: something fishy is going on with this "if [ ] X then Y" syntax
           if [ ${{ matrix.path }} == "shared" ]
-          then
             python -m pip install -e lambdas/shared[tests]
-          else
+          then
             python -m pip install -e lambdas/shared
             python -m pip install -e lambdas/${{ matrix.path }}
           fi

--- a/.github/workflows/py-ci.yml
+++ b/.github/workflows/py-ci.yml
@@ -185,6 +185,8 @@ jobs:
           # from thumbnail lambda fails whithout installed wheel.
           # See https://github.com/pypa/pip/issues/8559.
           python -m pip install wheel
+          # HACK: Pre-install numpy v1 as a build dependency for tifffile to prevent it from using v2 and failing to build
+          python -m pip install 'numpy<2'
           if [ ${{ matrix.path }} == "shared" ]
             python -m pip install -e lambdas/shared[tests]
           then

--- a/lambdas/thumbnail/Dockerfile
+++ b/lambdas/thumbnail/Dockerfile
@@ -17,9 +17,8 @@ RUN apt-get update && \
         python3-pip
 
 COPY thumbnail/requirements.txt /requirements/thumbnail.txt
-RUN pip install -U pip setuptools
 # HACK: Pre-install numpy v1 as a build dependency for tifffile to prevent it from using v2 and failing to build
-RUN pip install 'numpy<2'
+RUN pip install -U pip setuptools 'numpy<2'
 RUN pip install --target /deps -r /requirements/thumbnail.txt
 RUN curl --output /deps/unoconv \
     https://raw.githubusercontent.com/unoconv/unoconv/be5301a757552f4ecac5d73187ce4d8e18341306/unoconv

--- a/lambdas/thumbnail/Dockerfile
+++ b/lambdas/thumbnail/Dockerfile
@@ -18,6 +18,8 @@ RUN apt-get update && \
 
 COPY thumbnail/requirements.txt /requirements/thumbnail.txt
 RUN pip install -U pip setuptools
+# HACK: Pre-install numpy v1 as a build dependency for tifffile to prevent it from using v2 and failing to build
+RUN pip install 'numpy<2'
 RUN pip install --target /deps -r /requirements/thumbnail.txt
 RUN curl --output /deps/unoconv \
     https://raw.githubusercontent.com/unoconv/unoconv/be5301a757552f4ecac5d73187ce4d8e18341306/unoconv


### PR DESCRIPTION
Thumbnail lambda has a transitive dependency (via `aicsimageio`) on `tifffile @ 0.15.1`,
which states `numpy >= 1.x` as a build dependency.
`pip` resolves this to a recently released `numpy @ 2` (even tho the top-level requirements file has `numpy < 2`),
and that breaks the build (which is only compatible with v1).
Workaround is quite simple -- install `numpy @ 1` before trying to install / build `tifffile`,
satisfying the build requirement and avoiding installation of `numpy @ 2`.
