### PR TITLE
Hotfix: `test_brackets` test

### DIFF
--- a/api/python/quilt3/util.py
+++ b/api/python/quilt3/util.py
@@ -248,7 +248,7 @@ def fix_url(url):
     # `resolve()` _tries_ to make the URI absolute - but doesn't guarantee anything.
     # In particular, on Windows, non-existent files won't be resolved.
     # `absolute()` makes the URI absolute, though it can still contain '..'
-    fixed_url = pathlib.Path(url).expanduser().resolve().absolute().as_uri()
+    fixed_url = pathlib.Path(url).expanduser().resolve().absolute().as_uri().replace('////', '//')
 
     # pathlib likes to remove trailing slashes, so add it back if needed.
     if url[-1:] in (os.sep, os.altsep) and not fixed_url.endswith('/'):

--- a/api/python/tests/integration/test_packages.py
+++ b/api/python/tests/integration/test_packages.py
@@ -844,7 +844,7 @@ class PackageTest(QuiltTestCase):
         pkg2 = pkg['asdf']
         assert set(pkg2.keys()) == {'jkl', 'qwer'}
 
-        assert pkg['asdf']['qwer'].get() == LOCAL_MANIFEST.as_uri()
+        assert pkg['asdf']['qwer'].get() == LOCAL_MANIFEST.as_uri().replace('////', '//')
 
         assert pkg['asdf']['qwer'] == pkg['asdf/qwer'] == pkg[('asdf', 'qwer')]
         assert pkg[[]] == pkg

--- a/api/python/tests/integration/test_packages.py
+++ b/api/python/tests/integration/test_packages.py
@@ -844,7 +844,7 @@ class PackageTest(QuiltTestCase):
         pkg2 = pkg['asdf']
         assert set(pkg2.keys()) == {'jkl', 'qwer'}
 
-        assert pkg['asdf']['qwer'].get() == LOCAL_MANIFEST.as_uri().replace('////', '//')
+        assert pkg['asdf']['qwer'].get() == LOCAL_MANIFEST.as_uri()
 
         assert pkg['asdf']['qwer'] == pkg['asdf/qwer'] == pkg[('asdf', 'qwer')]
         assert pkg[[]] == pkg


### PR DESCRIPTION
Python got a patch update. And, now `test_brackets` is failing. I guess, it is related to https://github.com/python/cpython/issues/67693