### PR TITLE
Fix PhysicalKey to URI conversion in Python 3.12 on Windows

### DIFF
--- a/api/python/quilt3/util.py
+++ b/api/python/quilt3/util.py
@@ -13,7 +13,7 @@ from urllib.parse import (
     urlparse,
     urlunparse,
 )
-from urllib.request import pathname2url, url2pathname
+from urllib.request import url2pathname
 
 import requests
 # Third-Party
@@ -222,7 +222,7 @@ class PhysicalKey:
 
     def __str__(self):
         if self.bucket is None:
-            return urlunparse(('file', '', pathname2url(self.path.replace('/', os.path.sep)), None, None, None))
+            return pathlib.PurePath(self.path).as_uri()
         else:
             if self.version_id is None:
                 params = {}


### PR DESCRIPTION
On Windows, `pathname2url` returns three leading slashes for some reason. `urlunparse` has been ignoring them - until Python 3.12, where they result in a URL like `file://///C:/...`.

We can instead use `pathlib.PurePath.as_uri` for this. It is certainly cleaner than using `pathname2url` (whose documentation basically says "don't use it") - however, we are still stuck with using the `url2pathname` for the opposite conversion, since there's no `pathlib` solution for that.