### PR TITLE
WIP: fix sub-package level meta

### DIFF
--- a/api/python/quilt3/packages.py
+++ b/api/python/quilt3/packages.py
@@ -1540,6 +1540,9 @@ class Package:
                 new_entry.hash = dict(type=SHA256_CHUNKED_HASH_NAME, value=checksum)
             pkg._set(logical_key, new_entry)
 
+        for lk, meta in self._walk_dir_meta():
+            pkg._ensure_subpackage(self._split_key(lk[:-1])).set_meta(meta)
+
         # Some entries may miss hash values (e.g because of selector_fn), so we need
         # to fix them before calculating the top hash.
         pkg._calculate_missing_hashes()


### PR DESCRIPTION
# Description


# TODO

<!-- Remove items that are irrelevant to this PR -->

- [ ] user_meta vs meta?
- [ ] use sub-package level meta for top hash
- [ ] Unit tests
- [ ] Automated tests (e.g. Preflight)
- [ ] Confirm that this change meets security best practices and does not violate the security model
- [ ] Documentation
    - [ ] [Python: Run `build.py`](../tree/master/gendocs/build.py) for new docstrings
    - [ ] JavaScript: basic explanation and screenshot of new features
    - [ ] Markdown somewhere in docs/**/*.md that explains the feature to end users (said .md files should be linked from SUMMARY.md so they appear on https://docs.quiltdata.com)
    - [ ] Markdown docs for developers
- [ ] [Changelog](../tree/master/docs/CHANGELOG.md) entry (skip if change is not significant to end users, e.g. docs only)
