### PR TITLE
Make `PhysicalKey` a facade above `s3://`, `file://` and (TODO) `sharepoint://` 

### DIFF
--- a/api/python/quilt3/packages.py
+++ b/api/python/quilt3/packages.py
@@ -286,7 +286,7 @@ class PackageEntry:
         if use_cache_if_available:
             cached_path = self.get_cached_path()
             if cached_path is not None:
-                return get_bytes(PhysicalKey(None, cached_path, None))
+                return get_bytes(PhysicalKey.from_local(cached_path))
 
         data = get_bytes(self.physical_key)
         return data
@@ -924,7 +924,7 @@ class Package:
                     if obj['Size'] != 0:
                         warnings.warn(f'Logical keys cannot end in "/", skipping: {obj["Key"]}')
                     continue
-                obj_pk = PhysicalKey(src.bucket, obj['Key'], obj.get('VersionId'))
+                obj_pk = PhysicalKey.from_s3(src.bucket, obj['Key'], obj.get('VersionId'))
                 logical_key = obj['Key'][len(src_path):]
                 # check update policy
                 if update_policy == 'existing' and logical_key in root:

--- a/api/python/quilt3/util.py
+++ b/api/python/quilt3/util.py
@@ -120,7 +120,7 @@ class URLParseError(ValueError):
     pass
 
 class LocalLocation:
-    __slots__ = ('path')
+    __slots__ = ('path',)
     def __init__(self, path):
         assert path is not None, "Local keys must have a path"
         if os.name == 'nt':
@@ -270,7 +270,7 @@ class S3ObjectLocation:
 
 
 class PhysicalKey:
-    __slots__ = ('location')
+    __slots__ = ('location',)
 
     def __init__(self, location):
         """

--- a/api/python/quilt3/util.py
+++ b/api/python/quilt3/util.py
@@ -119,8 +119,10 @@ class RemovedInQuilt4Warning(FutureWarning):
 class URLParseError(ValueError):
     pass
 
+
 class LocalLocation:
     __slots__ = ('path',)
+
     def __init__(self, path):
         assert path is not None, "Local keys must have a path"
         if os.name == 'nt':
@@ -302,7 +304,6 @@ class PhysicalKey:
     @classmethod
     def from_s3(cls, bucket, path, version_id):
         return PhysicalKey(S3ObjectLocation(bucket, path, version_id))
-
 
     def is_local(self):
         if isinstance(self.location, LocalLocation):

--- a/api/python/tests/integration/test_packages.py
+++ b/api/python/tests/integration/test_packages.py
@@ -774,7 +774,7 @@ class PackageTest(QuiltTestCase):
             with self.subTest(flag_value=flag_value, version_id=version_id):
                 pkg = Package()
                 pkg.set("bar", "s3://bucket/bar", unversioned=flag_value)
-                assert pkg["bar"].physical_key == PhysicalKey("bucket", "bar", version_id)
+                assert pkg["bar"].physical_key == PhysicalKey.from_s3("bucket", "bar", version_id)
 
     def test_tophash_changes(self):
         test_file = Path('test.txt')
@@ -1896,7 +1896,7 @@ class PackageTest(QuiltTestCase):
         push_manifest_mock.assert_called_once_with(pkg_name, mock.sentinel.top_hash, ANY)
         assert Package.load(
             BytesIO(push_manifest_mock.call_args[0][2])
-        )[lk].physical_key == PhysicalKey(dest_bucket, dest_key, version)
+        )[lk].physical_key == PhysicalKey.from_s3(dest_bucket, dest_key, version)
 
     @patch('quilt3.workflows.validate', mock.MagicMock(return_value=None))
     @patch('quilt3.Package._calculate_top_hash', mock.MagicMock(return_value=mock.sentinel.top_hash))
@@ -1918,11 +1918,11 @@ class PackageTest(QuiltTestCase):
             pkg.push(pkg_name, registry=f's3://{dst_bucket}', selector_fn=selector_fn, force=True)
 
         selector_fn.assert_called_once_with(lk, pkg[lk])
-        calculate_checksum_mock.assert_called_once_with([PhysicalKey(src_bucket, src_key, src_version)], [0])
+        calculate_checksum_mock.assert_called_once_with([PhysicalKey.from_s3(src_bucket, src_key, src_version)], [0])
         push_manifest_mock.assert_called_once_with(pkg_name, mock.sentinel.top_hash, ANY)
         assert Package.load(
             BytesIO(push_manifest_mock.call_args[0][2])
-        )[lk].physical_key == PhysicalKey(src_bucket, src_key, src_version)
+        )[lk].physical_key == PhysicalKey.from_s3(src_bucket, src_key, src_version)
 
     @patch('quilt3.workflows.validate', mock.MagicMock(return_value=None))
     @patch('quilt3.Package._calculate_top_hash', mock.MagicMock(return_value=mock.sentinel.top_hash))
@@ -1969,7 +1969,7 @@ class PackageTest(QuiltTestCase):
         push_manifest_mock.assert_called_once_with(pkg_name, mock.sentinel.top_hash, ANY)
         assert Package.load(
             BytesIO(push_manifest_mock.call_args[0][2])
-        )[lk].physical_key == PhysicalKey(dst_bucket, dst_key, dst_version)
+        )[lk].physical_key == PhysicalKey.from_s3(dst_bucket, dst_key, dst_version)
 
     def test_package_dump_file_mode(self):
         """

--- a/lambdas/pkgpush/src/t4_lambda_pkgpush/__init__.py
+++ b/lambdas/pkgpush/src/t4_lambda_pkgpush/__init__.py
@@ -188,7 +188,7 @@ def copy_pkg_entry_data(
     idx: int,
 ) -> T.Tuple[int, PhysicalKey]:
     version_id = invoke_copy_lambda(credentials, src, dst)
-    return idx, PhysicalKey(bucket=dst.bucket, path=dst.path, version_id=version_id)
+    return idx, PhysicalKey.from_s3(bucket=dst.bucket, path=dst.path, version_id=version_id)
 
 
 def copy_file_list(

--- a/lambdas/pkgpush/tests/test_hash_calc.py
+++ b/lambdas/pkgpush/tests/test_hash_calc.py
@@ -102,7 +102,7 @@ def test_calculate_pkg_entry_hash(
 
 def test_invoke_hash_lambda(lambda_stub: Stubber):
     checksum = {"type": "sha2-256-chunked", "value": "base64hash"}
-    pk = PhysicalKey(bucket="bucket", path="path", version_id="version-id")
+    pk = PhysicalKey.from_s3(bucket="bucket", path="path", version_id="version-id")
 
     lambda_stub.add_response(
         "invoke",
@@ -138,7 +138,7 @@ def test_invoke_hash_lambda(lambda_stub: Stubber):
 
 
 def test_invoke_hash_lambda_error(lambda_stub: Stubber):
-    pk = PhysicalKey(bucket="bucket", path="path", version_id="version-id")
+    pk = PhysicalKey.from_s3(bucket="bucket", path="path", version_id="version-id")
 
     lambda_stub.add_response(
         "invoke",

--- a/lambdas/pkgpush/tests/test_index.py
+++ b/lambdas/pkgpush/tests/test_index.py
@@ -501,7 +501,7 @@ class PackageCreateTestCaseBase(PackagePromoteTestBase):
     handler = staticmethod(t4_lambda_pkgpush.create_package)
     path = 'data/sample.csv'
     version_id = '1234'
-    physical_key = PhysicalKey(
+    physical_key = PhysicalKey.from_s3(
         bucket=PackagePromoteTestBase.parent_bucket,
         path=path,
         version_id=version_id,


### PR DESCRIPTION
# Description

# TODO:

* [x] Pass `location` to `PhysicalKey` instead of `bucket`, `path`, `version_id`
* [x] `location` is a `S3ObjectLocation` (`s3://`) or `LocalLocation` (`file://`)
* [x] Tests succeed 
* [ ] `location` can be `SharePointLocation` (`sharepoint://`)
* [ ] Tests succeed

---
<!-- Remove items that are irrelevant to this PR -->

- [ ] Unit tests
- [ ] Automated tests (e.g. Preflight)
- [ ] Confirm that this change meets security best practices and does not violate the security model
- [ ] Documentation
    - [ ] [Python: Run `build.py`](../tree/master/gendocs/build.py) for new docstrings
    - [ ] JavaScript: basic explanation and screenshot of new features
    - [ ] Markdown somewhere in docs/**/*.md that explains the feature to end users (said .md files should be linked from SUMMARY.md so they appear on https://docs.quiltdata.com)
    - [ ] Markdown docs for developers
- [ ] [Changelog](../tree/master/docs/CHANGELOG.md) entry (skip if change is not significant to end users, e.g. docs only)
