### PR TITLE
Drop parsed.netloc check for files

### DIFF
--- a/api/python/quilt3/util.py
+++ b/api/python/quilt3/util.py
@@ -161,8 +161,6 @@ class PhysicalKey:
                 raise URLParseError(f"Unexpected S3 query string: {parsed.query!r}")
             return cls(bucket, path, version_id)
         elif parsed.scheme == 'file':
-            if parsed.netloc not in ('', 'localhost'):
-                raise URLParseError("Unexpected hostname")
             if not parsed.path:
                 raise URLParseError("Missing path")
             if not parsed.path.startswith('/'):


### PR DESCRIPTION
Network drives have a netloc of the drive IP. There's no reason to fail from_url just because of that.