### PR TITLE
View and edit SSO config

### DIFF
--- a/catalog/app/components/Lock/Lock.tsx
+++ b/catalog/app/components/Lock/Lock.tsx
@@ -5,21 +5,27 @@ import { fade } from '@material-ui/core/styles'
 
 const useStyles = M.makeStyles((t) => ({
   root: {
+    alignItems: 'center',
     background: fade(t.palette.background.paper, 0.5),
     bottom: 0,
+    cursor: 'not-allowed',
+    display: 'flex',
+    flexDirection: 'column',
+    justifyContent: 'center',
     left: 0,
     position: 'absolute',
     right: 0,
     top: 0,
-    zIndex: 1,
+    zIndex: 3, // above Select, Checkbox and sticky table header
   },
 }))
 
 interface LockProps {
   className?: string
+  children?: React.ReactNode
 }
 
-export default function Lock({ className }: LockProps) {
+export default function Lock({ children, className }: LockProps) {
   const classes = useStyles()
-  return <div className={cx(classes.root, className)} />
+  return <div className={cx(classes.root, className)}>{children}</div>
 }

--- a/catalog/app/containers/Admin/Table/Table.tsx
+++ b/catalog/app/containers/Admin/Table/Table.tsx
@@ -133,6 +133,7 @@ const useToolbarStyles = M.makeStyles((t) => ({
   },
   actions: {
     color: t.palette.text.secondary,
+    display: 'flex',
   },
   title: {
     flex: '0 0 auto',

--- a/catalog/app/containers/Admin/UsersAndRoles/Roles.tsx
+++ b/catalog/app/containers/Admin/UsersAndRoles/Roles.tsx
@@ -18,8 +18,10 @@ import * as Form from '../Form'
 import * as Table from '../Table'
 
 import AttachedPolicies from './AttachedPolicies'
+import SsoConfig from './SsoConfig'
 import { MAX_POLICIES_PER_ROLE, getArnLink } from './shared'
 
+import HAS_SSO_CONFIG_QUERY from './gql/HasSsoConfig.generated'
 import ROLES_QUERY from './gql/Roles.generated'
 import ROLE_CREATE_MANAGED_MUTATION from './gql/RoleCreateManaged.generated'
 import ROLE_CREATE_UNMANAGED_MUTATION from './gql/RoleCreateUnmanaged.generated'
@@ -703,6 +705,9 @@ export default function Roles() {
   const defaultRoleId = data.defaultRole?.id
   const isDefaultRoleSettingDisabled = !!data.admin?.isDefaultRoleSettingDisabled
 
+  const ssoConfigData = GQL.useQueryS(HAS_SSO_CONFIG_QUERY)
+  const hasSsoConfig = !!ssoConfigData.admin?.ssoConfig
+
   const filtering = Table.useFiltering({
     rows,
     filterBy: ({ name }) => name,
@@ -713,15 +718,21 @@ export default function Roles() {
   })
   const dialogs = Dialogs.use()
 
-  const toolbarActions = [
-    {
-      title: 'Create',
-      icon: <M.Icon>add</M.Icon>,
-      fn: React.useCallback(() => {
-        dialogs.open(({ close }) => <Create {...{ close }} />)
-      }, [dialogs.open]), // eslint-disable-line react-hooks/exhaustive-deps
-    },
-  ]
+  const createAction = {
+    title: 'Create',
+    icon: <M.Icon>add</M.Icon>,
+    fn: React.useCallback(() => {
+      dialogs.open(({ close }) => <Create {...{ close }} />)
+    }, [dialogs.open]), // eslint-disable-line react-hooks/exhaustive-deps
+  }
+  const ssoConfigAction = {
+    title: 'SSO Config',
+    icon: <M.Icon>assignment_ind</M.Icon>,
+    fn: React.useCallback(() => {
+      dialogs.open(({ close }) => <SsoConfig {...{ close }} />)
+    }, [dialogs.open]), // eslint-disable-line react-hooks/exhaustive-deps
+  }
+  const toolbarActions = hasSsoConfig ? [ssoConfigAction, createAction] : [createAction]
 
   const inlineActions = (role: Role) => [
     role.arn

--- a/catalog/app/containers/Admin/UsersAndRoles/SsoConfig.tsx
+++ b/catalog/app/containers/Admin/UsersAndRoles/SsoConfig.tsx
@@ -17,8 +17,6 @@ import SSO_CONFIG_QUERY from './gql/SsoConfig.generated'
 
 const TextEditor = React.lazy(() => import('components/FileEditor/TextEditor'))
 
-// TODO: validate yaml
-
 type TextFieldProps = RF.FieldRenderProps<string> & M.TextFieldProps
 
 const TEXT_EDITOR_TYPE = { brace: 'yaml' as const }
@@ -28,6 +26,7 @@ const ERRORS = {
 }
 
 function TextField({ input, meta }: TextFieldProps) {
+  // TODO: lint yaml
   return (
     <TextEditor
       error={null}

--- a/catalog/app/containers/Admin/UsersAndRoles/SsoConfig.tsx
+++ b/catalog/app/containers/Admin/UsersAndRoles/SsoConfig.tsx
@@ -19,7 +19,7 @@ const TextEditor = React.lazy(() => import('components/FileEditor/TextEditor'))
 
 // TODO: wait for mutation result
 // TODO: show error in dialog
-// TODO: move  <SsoConfigForm /> to Suspended
+// TODO: move  onSubmit to Suspended
 // TODO: validate yaml
 
 type TextFieldProps = RF.FieldRenderProps<string> & M.TextFieldProps
@@ -47,13 +47,7 @@ interface FormProps
   ssoConfig: Pick<Model.GQLTypes.SsoConfig, 'text'> | null
 }
 
-function SsoConfigForm({
-  close,
-  handleSubmit,
-  pristine,
-  ssoConfig,
-  submitting,
-}: FormProps) {
+function Form({ close, handleSubmit, pristine, ssoConfig, submitting }: FormProps) {
   const classes = useStyles()
   return (
     <form onSubmit={handleSubmit}>
@@ -91,10 +85,11 @@ function SsoConfigForm({
 }
 
 interface SsoConfigProps {
+  children: (props: $TSFixMe) => React.ReactNode
   close: Dialogs.Close<string | void>
 }
 
-function Data({ close }: SsoConfigProps) {
+function Data({ children, close }: SsoConfigProps) {
   const { push } = Notifications.use()
 
   const data = GQL.useQueryS(SSO_CONFIG_QUERY)
@@ -138,9 +133,7 @@ function Data({ close }: SsoConfigProps) {
 
   return (
     <RF.Form onSubmit={onSubmit}>
-      {(props) => (
-        <SsoConfigForm {...props} close={close} ssoConfig={data.admin?.ssoConfig} />
-      )}
+      {(props) => children({ ...props, close, ssoConfig: data.admin?.ssoConfig })}
     </RF.Form>
   )
 }
@@ -152,7 +145,7 @@ interface SuspendedProps {
 export default function Suspended({ close }: SuspendedProps) {
   return (
     <React.Suspense fallback={<M.CircularProgress size={80} />}>
-      <Data close={close} />
+      <Data close={close}>{(props) => <Form {...props} />}</Data>
     </React.Suspense>
   )
 }

--- a/catalog/app/containers/Admin/UsersAndRoles/SsoConfig.tsx
+++ b/catalog/app/containers/Admin/UsersAndRoles/SsoConfig.tsx
@@ -1,0 +1,158 @@
+import * as FF from 'final-form'
+import * as React from 'react'
+import * as RF from 'react-final-form'
+import * as M from '@material-ui/core'
+
+import Lock from 'components/Lock'
+import TextEditor from 'components/FileEditor/TextEditor'
+import { loadMode } from 'components/FileEditor/loader'
+import * as Notifications from 'containers/Notifications'
+import type * as Model from 'model'
+import type * as Dialogs from 'utils/GlobalDialogs'
+import * as GQL from 'utils/GraphQL'
+import assertNever from 'utils/assertNever'
+import * as validators from 'utils/validators'
+
+import SET_SSO_CONFIG_MUTATION from './gql/SetSsoConfig.generated'
+import SSO_CONFIG_QUERY from './gql/SsoConfig.generated'
+
+// TODO: wait for mutation result
+// TODO: show error in dialog
+// TODO: move  <SsoConfigForm /> to Suspended
+// TODO: validate yaml
+// TODO: lazy-load TextEditor
+
+type TextFieldProps = RF.FieldRenderProps<string> & M.TextFieldProps
+
+const TEXT_EDITOR_TYPE = { brace: 'yaml' as const }
+
+const ERRORS = {
+  required: 'Enter an SSO config',
+}
+
+function TextField({ input }: TextFieldProps) {
+  return <TextEditor {...input} error={null} type={TEXT_EDITOR_TYPE} />
+}
+
+const useStyles = M.makeStyles({
+  lock: {
+    bottom: 52,
+    top: 64,
+  },
+})
+
+interface FormProps
+  extends Pick<RF.FormRenderProps, 'handleSubmit' | 'pristine' | 'submitting'> {
+  close: Dialogs.Close<string | void>
+  ssoConfig: Pick<Model.GQLTypes.SsoConfig, 'text'> | null
+}
+
+function SsoConfigForm({
+  close,
+  handleSubmit,
+  pristine,
+  ssoConfig,
+  submitting,
+}: FormProps) {
+  const classes = useStyles()
+  return (
+    <form onSubmit={handleSubmit}>
+      <M.DialogTitle disableTypography>
+        <M.Typography variant="h5">SSO config</M.Typography>
+      </M.DialogTitle>
+      <M.DialogContent>
+        <RF.Field
+          component={TextField}
+          name="config"
+          validate={validators.required as FF.FieldValidator<any>}
+          placeholder="Enter SSO config"
+          label="SSO config"
+          fullWidth
+          margin="normal"
+          errors={ERRORS}
+          initialValue={ssoConfig?.text}
+        />
+      </M.DialogContent>
+      <M.DialogActions>
+        <M.Button onClick={() => close('cancel')} color="primary" disabled={submitting}>
+          Cancel
+        </M.Button>
+        <M.Button color="primary" disabled={pristine || submitting} type="submit">
+          Save
+        </M.Button>
+      </M.DialogActions>
+      {submitting && (
+        <Lock className={classes.lock}>
+          <M.CircularProgress size={80} />
+        </Lock>
+      )}
+    </form>
+  )
+}
+
+interface SsoConfigProps {
+  close: Dialogs.Close<string | void>
+}
+
+function Data({ close }: SsoConfigProps) {
+  const { push } = Notifications.use()
+
+  const data = GQL.useQueryS(SSO_CONFIG_QUERY)
+  loadMode('yaml')
+  const setSsoConfig = GQL.useMutation(SET_SSO_CONFIG_MUTATION)
+
+  const submit = React.useCallback(
+    async (config: string) => {
+      try {
+        const {
+          admin: { setSsoConfig: r },
+        } = await setSsoConfig({ config })
+        switch (r.__typename) {
+          case 'Ok':
+            return
+          case 'InvalidInput':
+            // shouldnt happen
+            push('Unable to update SSO config')
+            return
+          case 'OperationError':
+            push(`Unable to update SSO config: ${r.message}`)
+            return
+          default:
+            assertNever(r)
+        }
+      } catch (e) {
+        push('Error updating SSO config')
+        // eslint-disable-next-line no-console
+        console.error('Error deleting policy')
+        // eslint-disable-next-line no-console
+        console.error(e)
+      }
+    },
+    [push, setSsoConfig],
+  )
+
+  const onSubmit = React.useCallback(
+    ({ config }) => close(submit(config)),
+    [close, submit],
+  )
+
+  return (
+    <RF.Form onSubmit={onSubmit}>
+      {(props) => (
+        <SsoConfigForm {...props} close={close} ssoConfig={data.admin?.ssoConfig} />
+      )}
+    </RF.Form>
+  )
+}
+
+interface SuspendedProps {
+  close: Dialogs.Close<string | void>
+}
+
+export default function Suspended({ close }: SuspendedProps) {
+  return (
+    <React.Suspense fallback={<M.CircularProgress size={80} />}>
+      <Data close={close} />
+    </React.Suspense>
+  )
+}

--- a/catalog/app/containers/Admin/UsersAndRoles/SsoConfig.tsx
+++ b/catalog/app/containers/Admin/UsersAndRoles/SsoConfig.tsx
@@ -4,7 +4,6 @@ import * as RF from 'react-final-form'
 import * as M from '@material-ui/core'
 
 import Lock from 'components/Lock'
-import TextEditor from 'components/FileEditor/TextEditor'
 import { loadMode } from 'components/FileEditor/loader'
 import * as Notifications from 'containers/Notifications'
 import type * as Model from 'model'
@@ -16,11 +15,12 @@ import * as validators from 'utils/validators'
 import SET_SSO_CONFIG_MUTATION from './gql/SetSsoConfig.generated'
 import SSO_CONFIG_QUERY from './gql/SsoConfig.generated'
 
+const TextEditor = React.lazy(() => import('components/FileEditor/TextEditor'))
+
 // TODO: wait for mutation result
 // TODO: show error in dialog
 // TODO: move  <SsoConfigForm /> to Suspended
 // TODO: validate yaml
-// TODO: lazy-load TextEditor
 
 type TextFieldProps = RF.FieldRenderProps<string> & M.TextFieldProps
 

--- a/catalog/app/containers/Admin/UsersAndRoles/SsoConfig.tsx
+++ b/catalog/app/containers/Admin/UsersAndRoles/SsoConfig.tsx
@@ -64,7 +64,7 @@ function Form({
 }: FormProps) {
   const classes = useStyles()
   return (
-    <form onSubmit={handleSubmit}>
+    <>
       <M.DialogTitle disableTypography>
         <M.Typography variant="h5">SSO config</M.Typography>
       </M.DialogTitle>
@@ -90,7 +90,11 @@ function Form({
         <M.Button onClick={() => close('cancel')} color="primary" disabled={submitting}>
           Cancel
         </M.Button>
-        <M.Button color="primary" disabled={pristine || submitting} type="submit">
+        <M.Button
+          color="primary"
+          disabled={pristine || submitting}
+          onClick={handleSubmit}
+        >
           Save
         </M.Button>
       </M.DialogActions>
@@ -99,7 +103,7 @@ function Form({
           <M.CircularProgress size={80} />
         </Lock>
       )}
-    </form>
+    </>
   )
 }
 

--- a/catalog/app/containers/Admin/UsersAndRoles/gql/HasSsoConfig.generated.ts
+++ b/catalog/app/containers/Admin/UsersAndRoles/gql/HasSsoConfig.generated.ts
@@ -1,0 +1,57 @@
+/* eslint-disable @typescript-eslint/naming-convention */
+import type { TypedDocumentNode as DocumentNode } from '@graphql-typed-document-node/core'
+import * as Types from '../../../../model/graphql/types.generated'
+
+export type containers_Admin_UsersAndRoles_gql_HasSsoConfigQueryVariables = Types.Exact<{
+  [key: string]: never
+}>
+
+export type containers_Admin_UsersAndRoles_gql_HasSsoConfigQuery = {
+  readonly __typename: 'Query'
+} & {
+  readonly admin: { readonly __typename: 'AdminQueries' } & {
+    readonly ssoConfig: Types.Maybe<
+      { readonly __typename: 'SsoConfig' } & Pick<Types.SsoConfig, 'timestamp'>
+    >
+  }
+}
+
+export const containers_Admin_UsersAndRoles_gql_HasSsoConfigDocument = {
+  kind: 'Document',
+  definitions: [
+    {
+      kind: 'OperationDefinition',
+      operation: 'query',
+      name: { kind: 'Name', value: 'containers_Admin_UsersAndRoles_gql_HasSsoConfig' },
+      selectionSet: {
+        kind: 'SelectionSet',
+        selections: [
+          {
+            kind: 'Field',
+            name: { kind: 'Name', value: 'admin' },
+            selectionSet: {
+              kind: 'SelectionSet',
+              selections: [
+                {
+                  kind: 'Field',
+                  name: { kind: 'Name', value: 'ssoConfig' },
+                  selectionSet: {
+                    kind: 'SelectionSet',
+                    selections: [
+                      { kind: 'Field', name: { kind: 'Name', value: 'timestamp' } },
+                    ],
+                  },
+                },
+              ],
+            },
+          },
+        ],
+      },
+    },
+  ],
+} as unknown as DocumentNode<
+  containers_Admin_UsersAndRoles_gql_HasSsoConfigQuery,
+  containers_Admin_UsersAndRoles_gql_HasSsoConfigQueryVariables
+>
+
+export { containers_Admin_UsersAndRoles_gql_HasSsoConfigDocument as default }

--- a/catalog/app/containers/Admin/UsersAndRoles/gql/HasSsoConfig.graphql
+++ b/catalog/app/containers/Admin/UsersAndRoles/gql/HasSsoConfig.graphql
@@ -1,0 +1,7 @@
+query {
+  admin {
+    ssoConfig {
+      timestamp
+    }
+  }
+}

--- a/catalog/app/containers/Admin/UsersAndRoles/gql/SetSsoConfig.generated.ts
+++ b/catalog/app/containers/Admin/UsersAndRoles/gql/SetSsoConfig.generated.ts
@@ -1,0 +1,131 @@
+/* eslint-disable @typescript-eslint/naming-convention */
+import type { TypedDocumentNode as DocumentNode } from '@graphql-typed-document-node/core'
+import * as Types from '../../../../model/graphql/types.generated'
+
+export type containers_Admin_UsersAndRoles_gql_SetSsoConfigMutationVariables =
+  Types.Exact<{
+    config: Types.Scalars['String']
+  }>
+
+export type containers_Admin_UsersAndRoles_gql_SetSsoConfigMutation = {
+  readonly __typename: 'Mutation'
+} & {
+  readonly admin: { readonly __typename: 'AdminMutations' } & {
+    readonly setSsoConfig:
+      | { readonly __typename: 'Ok' }
+      | ({ readonly __typename: 'InvalidInput' } & {
+          readonly errors: ReadonlyArray<
+            { readonly __typename: 'InputError' } & Pick<
+              Types.InputError,
+              'path' | 'message'
+            >
+          >
+        })
+      | ({ readonly __typename: 'OperationError' } & Pick<
+          Types.OperationError,
+          'message'
+        >)
+  }
+}
+
+export const containers_Admin_UsersAndRoles_gql_SetSsoConfigDocument = {
+  kind: 'Document',
+  definitions: [
+    {
+      kind: 'OperationDefinition',
+      operation: 'mutation',
+      name: { kind: 'Name', value: 'containers_Admin_UsersAndRoles_gql_SetSsoConfig' },
+      variableDefinitions: [
+        {
+          kind: 'VariableDefinition',
+          variable: { kind: 'Variable', name: { kind: 'Name', value: 'config' } },
+          type: {
+            kind: 'NonNullType',
+            type: { kind: 'NamedType', name: { kind: 'Name', value: 'String' } },
+          },
+        },
+      ],
+      selectionSet: {
+        kind: 'SelectionSet',
+        selections: [
+          {
+            kind: 'Field',
+            name: { kind: 'Name', value: 'admin' },
+            selectionSet: {
+              kind: 'SelectionSet',
+              selections: [
+                {
+                  kind: 'Field',
+                  name: { kind: 'Name', value: 'setSsoConfig' },
+                  arguments: [
+                    {
+                      kind: 'Argument',
+                      name: { kind: 'Name', value: 'config' },
+                      value: {
+                        kind: 'Variable',
+                        name: { kind: 'Name', value: 'config' },
+                      },
+                    },
+                  ],
+                  selectionSet: {
+                    kind: 'SelectionSet',
+                    selections: [
+                      { kind: 'Field', name: { kind: 'Name', value: '__typename' } },
+                      {
+                        kind: 'InlineFragment',
+                        typeCondition: {
+                          kind: 'NamedType',
+                          name: { kind: 'Name', value: 'InvalidInput' },
+                        },
+                        selectionSet: {
+                          kind: 'SelectionSet',
+                          selections: [
+                            {
+                              kind: 'Field',
+                              name: { kind: 'Name', value: 'errors' },
+                              selectionSet: {
+                                kind: 'SelectionSet',
+                                selections: [
+                                  {
+                                    kind: 'Field',
+                                    name: { kind: 'Name', value: 'path' },
+                                  },
+                                  {
+                                    kind: 'Field',
+                                    name: { kind: 'Name', value: 'message' },
+                                  },
+                                ],
+                              },
+                            },
+                          ],
+                        },
+                      },
+                      {
+                        kind: 'InlineFragment',
+                        typeCondition: {
+                          kind: 'NamedType',
+                          name: { kind: 'Name', value: 'OperationError' },
+                        },
+                        selectionSet: {
+                          kind: 'SelectionSet',
+                          selections: [
+                            { kind: 'Field', name: { kind: 'Name', value: 'message' } },
+                          ],
+                        },
+                      },
+                    ],
+                  },
+                },
+              ],
+            },
+          },
+        ],
+      },
+    },
+  ],
+} as unknown as DocumentNode<
+  containers_Admin_UsersAndRoles_gql_SetSsoConfigMutation,
+  containers_Admin_UsersAndRoles_gql_SetSsoConfigMutationVariables
+>
+
+export { containers_Admin_UsersAndRoles_gql_SetSsoConfigDocument as default }

--- a/catalog/app/containers/Admin/UsersAndRoles/gql/SetSsoConfig.graphql
+++ b/catalog/app/containers/Admin/UsersAndRoles/gql/SetSsoConfig.graphql
@@ -1,0 +1,16 @@
+mutation ($config: String!) {
+  admin {
+    setSsoConfig(config: $config) {
+      __typename
+      ... on InvalidInput {
+        errors {
+          path
+          message
+        }
+      }
+      ... on OperationError {
+        message
+      }
+    }
+  }
+}

--- a/catalog/app/containers/Admin/UsersAndRoles/gql/SsoConfig.generated.ts
+++ b/catalog/app/containers/Admin/UsersAndRoles/gql/SsoConfig.generated.ts
@@ -1,0 +1,58 @@
+/* eslint-disable @typescript-eslint/naming-convention */
+import type { TypedDocumentNode as DocumentNode } from '@graphql-typed-document-node/core'
+import * as Types from '../../../../model/graphql/types.generated'
+
+export type containers_Admin_UsersAndRoles_gql_SsoConfigQueryVariables = Types.Exact<{
+  [key: string]: never
+}>
+
+export type containers_Admin_UsersAndRoles_gql_SsoConfigQuery = {
+  readonly __typename: 'Query'
+} & {
+  readonly admin: { readonly __typename: 'AdminQueries' } & {
+    readonly ssoConfig: Types.Maybe<
+      { readonly __typename: 'SsoConfig' } & Pick<Types.SsoConfig, 'text' | 'timestamp'>
+    >
+  }
+}
+
+export const containers_Admin_UsersAndRoles_gql_SsoConfigDocument = {
+  kind: 'Document',
+  definitions: [
+    {
+      kind: 'OperationDefinition',
+      operation: 'query',
+      name: { kind: 'Name', value: 'containers_Admin_UsersAndRoles_gql_SsoConfig' },
+      selectionSet: {
+        kind: 'SelectionSet',
+        selections: [
+          {
+            kind: 'Field',
+            name: { kind: 'Name', value: 'admin' },
+            selectionSet: {
+              kind: 'SelectionSet',
+              selections: [
+                {
+                  kind: 'Field',
+                  name: { kind: 'Name', value: 'ssoConfig' },
+                  selectionSet: {
+                    kind: 'SelectionSet',
+                    selections: [
+                      { kind: 'Field', name: { kind: 'Name', value: 'text' } },
+                      { kind: 'Field', name: { kind: 'Name', value: 'timestamp' } },
+                    ],
+                  },
+                },
+              ],
+            },
+          },
+        ],
+      },
+    },
+  ],
+} as unknown as DocumentNode<
+  containers_Admin_UsersAndRoles_gql_SsoConfigQuery,
+  containers_Admin_UsersAndRoles_gql_SsoConfigQueryVariables
+>
+
+export { containers_Admin_UsersAndRoles_gql_SsoConfigDocument as default }

--- a/catalog/app/containers/Admin/UsersAndRoles/gql/SsoConfig.graphql
+++ b/catalog/app/containers/Admin/UsersAndRoles/gql/SsoConfig.graphql
@@ -1,0 +1,8 @@
+query {
+  admin {
+    ssoConfig {
+      text
+      timestamp
+    }
+  }
+}

--- a/catalog/app/utils/GraphQL/Provider.tsx
+++ b/catalog/app/utils/GraphQL/Provider.tsx
@@ -304,10 +304,6 @@ export default function GraphQLProvider({ children }: React.PropsWithChildren<{}
                 defaultRole: { __typename: role.__typename, id: role.id },
               }))
             },
-            setSsoConfig: (result, _vars, cache) => {
-              if ((result.setSsoConfig as any)?.__typename !== 'Ok') return
-              cache.invalidate({ __typename: 'SsoConfig' })
-            },
             packageRevisionDelete: (result, { bucket, name, hash }, cache) => {
               const del = result.packageRevisionDelete as any
               if (del.__typename !== 'PackageRevisionDeleteSuccess') return
@@ -339,6 +335,10 @@ export default function GraphQLProvider({ children }: React.PropsWithChildren<{}
                   { query: USERS_QUERY },
                   R.evolve({ admin: { user: { list: rmUser } } }),
                 )
+              }
+              if (result.admin?.setSsoConfig?.__typename === 'Ok') {
+                cache.invalidate({ __typename: 'Query' }, 'admin')
+                cache.invalidate({ __typename: 'Query' }, 'roles')
               }
             },
           },

--- a/catalog/app/utils/GraphQL/Provider.tsx
+++ b/catalog/app/utils/GraphQL/Provider.tsx
@@ -108,6 +108,7 @@ export default function GraphQLProvider({ children }: React.PropsWithChildren<{}
             p.bucket?.name && p.policy?.id ? `${p.bucket.name}/${p.policy.id}` : null,
           RoleBucketPermission: (p: any) =>
             p.bucket?.name && p.role?.id ? `${p.bucket.name}/${p.role.id}` : null,
+          SsoConfig: (c) => c.timestamp as string,
           Status: () => null,
           StatusReport: (r) => (typeof r.timestamp === 'string' ? r.timestamp : null),
           StatusReportList: () => null,
@@ -302,6 +303,10 @@ export default function GraphQLProvider({ children }: React.PropsWithChildren<{}
               cache.updateQuery({ query: DEFAULT_ROLE_QUERY }, () => ({
                 defaultRole: { __typename: role.__typename, id: role.id },
               }))
+            },
+            setSsoConfig: (result, _vars, cache) => {
+              if ((result.setSsoConfig as any)?.__typename !== 'Ok') return
+              cache.invalidate({ __typename: 'SsoConfig' })
             },
             packageRevisionDelete: (result, { bucket, name, hash }, cache) => {
               const del = result.packageRevisionDelete as any

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -23,7 +23,7 @@ Entries inside each section should be ordered by type:
 ## Catalog, Lambdas
 * [Fixed] **SECURITY**: Remove `polyfill.io` references ([#4038](https://github.com/quiltdata/quilt/pull/4038))
 * [Changed] Renamed "Admin settings" to "Admin" ([#4045](https://github.com/quiltdata/quilt/pull/4045))
-* [Added] Disable role assignment for SSO-mapped users ([#4070](https://github.com/quiltdata/quilt/pull/4070))
+* [Added] Disable role assignment for SSO-mapped users and add SSO config editor ([#4070](https://github.com/quiltdata/quilt/pull/4070), [#4072](https://github.com/quiltdata/quilt/pull/4072))
 
 # 6.0.0a5 - 2024-06-25
 ## Python API


### PR DESCRIPTION
* Check if there is SSO config (without fetching it) and show "individual assignment" icon button
* Show YAML editor in popup dialog. Editor is heavy, but it is lazy loaded

![Screenshot from 2024-08-09 14-15-03](https://github.com/user-attachments/assets/681e7a1c-3724-4f0a-8b2c-ba1945e3e89e)
![Screenshot from 2024-08-09 14-15-39](https://github.com/user-attachments/assets/5af1dc0e-44a9-47b5-bd9a-9a7d9631be42)

- [x] [Changelog](../tree/master/docs/CHANGELOG.md) entry (skip if change is not significant to end users, e.g. docs only)
