### PR TITLE
thumbnail lambda: allow to override PIL.Image.MAX_IMAGE_PIXELS

### DIFF
--- a/lambdas/thumbnail/CHANGELOG.md
+++ b/lambdas/thumbnail/CHANGELOG.md
@@ -1,0 +1,19 @@
+# Changelog
+
+Changes are listed in reverse chronological order (newer entries at the top).
+The entry format is
+
+```markdown
+- [Verb] Change description ([#<PR-number>](https://github.com/quiltdata/quilt/pull/<PR-number>))
+```
+
+where verb is one of
+
+- Removed
+- Added
+- Fixed
+- Changed
+
+## Changes
+
+- [Added] Allow overriding PIL.Image.MAX_IMAGE_PIXELS using env var ([#4100](https://github.com/quiltdata/quilt/pull/4100))

--- a/lambdas/thumbnail/src/t4_lambda_thumbnail/__init__.py
+++ b/lambdas/thumbnail/src/t4_lambda_thumbnail/__init__.py
@@ -35,6 +35,11 @@ from PIL import Image
 from t4_lambda_shared.decorator import QUILT_INFO_HEADER, api, validate
 from t4_lambda_shared.utils import get_default_origins, make_json_response
 
+# See https://pillow.readthedocs.io/en/stable/reference/Image.html#PIL.Image.open.
+# Use 0 to disable the limit.
+if _MAX_IMAGE_PIXELS := os.environ.get("MAX_IMAGE_PIXELS"):
+    Image.MAX_IMAGE_PIXELS = int(_MAX_IMAGE_PIXELS) or None
+
 # Eventually we'll want to precompute/cache thumbnails, so we won't be able to support
 # arbitrary sizes. Might as well copy Dropbox' API:
 # https://www.dropbox.com/developers/documentation/http/documentation#files-get_thumbnail


### PR DESCRIPTION
# Description
This enables thumbnailing of large images.

# TODO

<!-- Remove items that are irrelevant to this PR -->

- [x] [Changelog](../tree/master/docs/CHANGELOG.md) entry (skip if change is not significant to end users, e.g. docs only)
