### PR TITLE
Show `database` and `catalogName`

### DIFF
--- a/catalog/CHANGELOG.md
+++ b/catalog/CHANGELOG.md
@@ -22,3 +22,6 @@ and "Packages" respectively
 ([#4111](https://github.com/quiltdata/quilt/pull/4111))
 - [Added] Bootstrap the change log
 ([#4112](https://github.com/quiltdata/quilt/pull/4112))
+- [Changed] Make catalog name always visible and simplify setting execution
+context for Athena
+([#4123](https://github.com/quiltdata/quilt/pull/4123))

--- a/catalog/CHANGELOG.md
+++ b/catalog/CHANGELOG.md
@@ -16,11 +16,11 @@ where verb is one of
 
 ## Changes
 
+- [Changed] Athena: always show catalog name, simplify setting execution context
+([#4123](https://github.com/quiltdata/quilt/pull/4123))
 - [Added] Support `ui.actions.downloadObject` and `ui.actions.downloadPackage`
 options for configuring visibility of download buttons under "Bucket"
 and "Packages" respectively
 ([#4111](https://github.com/quiltdata/quilt/pull/4111))
 - [Added] Bootstrap the change log
 ([#4112](https://github.com/quiltdata/quilt/pull/4112))
-- [Changed] Athena: always show catalog name, simplify setting execution context
-([#4123](https://github.com/quiltdata/quilt/pull/4123))

--- a/catalog/app/containers/Bucket/Queries/Athena/Database.tsx
+++ b/catalog/app/containers/Bucket/Queries/Athena/Database.tsx
@@ -37,10 +37,6 @@ function SelectError({ className, error }: SelectErrorProps) {
   )
 }
 
-function SelectSkeleton() {
-  return <Skeleton height={32} animate />
-}
-
 const LOAD_MORE = '__load-more__'
 
 interface Response {
@@ -123,7 +119,7 @@ function SelectCatalogName({ className, value, onChange }: SelectCatalogNameProp
       />
     ),
     Err: (error) => <SelectError className={className} error={error} />,
-    _: () => <SelectSkeleton />,
+    _: () => <Skeleton className={className} height={32} animate />,
   })
 }
 
@@ -148,7 +144,7 @@ function SelectDatabase({ catalogName, onChange, ...rest }: SelectDatabaseProps)
       />
     ),
     Err: (error) => <SelectError className={rest.className} error={error} />,
-    _: () => <SelectSkeleton />,
+    _: () => <Skeleton className={rest.className} height={32} animate />,
   })
 }
 

--- a/catalog/app/containers/Bucket/Queries/Athena/Database.tsx
+++ b/catalog/app/containers/Bucket/Queries/Athena/Database.tsx
@@ -190,8 +190,15 @@ const useChangeButtonStyles = M.makeStyles((t) => ({
     display: 'flex',
   },
   field: {
+    cursor: 'pointer',
     flexGrow: 1,
     marginRight: t.spacing(2),
+    '& input': {
+      cursor: 'pointer',
+    },
+    '& > *': {
+      cursor: 'pointer',
+    },
   },
   button: {
     marginLeft: t.spacing(1),

--- a/catalog/app/containers/Bucket/Queries/Athena/Database.tsx
+++ b/catalog/app/containers/Bucket/Queries/Athena/Database.tsx
@@ -189,6 +189,10 @@ const useChangeButtonStyles = M.makeStyles((t) => ({
     alignItems: 'center',
     display: 'flex',
   },
+  field: {
+    flexGrow: 1,
+    marginRight: t.spacing(2),
+  },
   button: {
     marginLeft: t.spacing(1),
   },
@@ -196,25 +200,50 @@ const useChangeButtonStyles = M.makeStyles((t) => ({
 
 interface ChangeButtonProps {
   className?: string
-  database?: requests.athena.Database
+  executionContext: requests.athena.ExecutionContext | null
   onClick: () => void
 }
 
-function ChangeButton({ className, database, onClick }: ChangeButtonProps) {
+function ChangeButton({ className, executionContext, onClick }: ChangeButtonProps) {
   const classes = useChangeButtonStyles()
+  const handleClick = React.useCallback(
+    (event) => {
+      event.target.blur()
+      onClick()
+    },
+    [onClick],
+  )
   return (
-    <M.Typography className={cx(classes.root, className)} variant="body2">
-      Use {database ? <strong>{database}</strong> : 'default'} database or
-      <M.Button
-        className={classes.button}
-        color="primary"
-        onClick={onClick}
-        size="small"
-        variant="outlined"
-      >
-        {database ? 'change' : 'set'} database
-      </M.Button>
-    </M.Typography>
+    <div className={cx(classes.root, className)}>
+      {executionContext ? (
+        <>
+          <M.TextField
+            className={classes.field}
+            defaultValue={executionContext.catalogName}
+            label="Data catalog"
+            onClick={handleClick}
+            size="small"
+          />
+          <M.TextField
+            className={classes.field}
+            defaultValue={executionContext.database}
+            label="Database"
+            onClick={handleClick}
+            size="small"
+          />
+        </>
+      ) : (
+        <M.Button
+          className={classes.button}
+          color="primary"
+          onClick={onClick}
+          size="small"
+          variant="outlined"
+        >
+          Set database and data catalog
+        </M.Button>
+      )}
+    </div>
   )
 }
 
@@ -236,7 +265,7 @@ export default function Database({ className, value, onChange }: DatabaseProps) 
       />
       <ChangeButton
         className={className}
-        database={value?.database}
+        executionContext={value}
         onClick={() => setOpen(true)}
       />
     </>

--- a/catalog/app/containers/Bucket/Queries/Athena/QueryEditor.tsx
+++ b/catalog/app/containers/Bucket/Queries/Athena/QueryEditor.tsx
@@ -178,10 +178,23 @@ export { FormSkeleton as Skeleton }
 
 const useFormStyles = M.makeStyles((t) => ({
   actions: {
-    alignItems: 'center',
-    justifyContent: 'space-between',
     display: 'flex',
+    justifyContent: 'space-between',
     margin: t.spacing(2, 0),
+    [t.breakpoints.up('sm')]: {
+      alignItems: 'center',
+    },
+    [t.breakpoints.down('sm')]: {
+      flexDirection: 'column',
+    },
+  },
+  database: {
+    [t.breakpoints.up('sm')]: {
+      width: '50%',
+    },
+    [t.breakpoints.down('sm')]: {
+      marginBottom: t.spacing(2),
+    },
   },
   error: {
     margin: t.spacing(1, 0, 0),
@@ -230,6 +243,7 @@ export function Form({ bucket, className, onChange, value, workgroup }: FormProp
 
       <div className={classes.actions}>
         <Database
+          className={classes.database}
           onChange={({ catalogName, database }) =>
             onChange({ ...value, catalog: catalogName, db: database })
           }

--- a/catalog/app/containers/Bucket/Queries/Athena/QueryEditor.tsx
+++ b/catalog/app/containers/Bucket/Queries/Athena/QueryEditor.tsx
@@ -212,6 +212,7 @@ interface FormProps {
 export function Form({ bucket, className, onChange, value, workgroup }: FormProps) {
   const classes = useFormStyles()
 
+  // TODO: Confirm if no catalogName or database
   const executionContext = React.useMemo<requests.athena.ExecutionContext | null>(
     () =>
       value?.catalog && value?.db
@@ -227,6 +228,17 @@ export function Form({ bucket, className, onChange, value, workgroup }: FormProp
     if (!value?.query) return
     onSubmit(value?.query, executionContext)
   }, [executionContext, onSubmit, value])
+  const handleExecutionContext = React.useCallback(
+    (exeContext) => {
+      if (!exeContext) {
+        onChange({ ...value, catalog: undefined, db: undefined })
+        return
+      }
+      const { catalogName, database } = exeContext
+      onChange({ ...value, catalog: catalogName, db: database })
+    },
+    [onChange, value],
+  )
 
   return (
     <div className={className}>
@@ -244,9 +256,7 @@ export function Form({ bucket, className, onChange, value, workgroup }: FormProp
       <div className={classes.actions}>
         <Database
           className={classes.database}
-          onChange={({ catalogName, database }) =>
-            onChange({ ...value, catalog: catalogName, db: database })
-          }
+          onChange={handleExecutionContext}
           value={executionContext}
         />
         <M.Button


### PR DESCRIPTION
* Simplified `catalogName`/`database` selector
* `catalogName` is always visible alongside `database`

Before:
![image](https://github.com/user-attachments/assets/33962989-5b94-492f-84aa-80edd522d8fe)

After:
![image](https://github.com/user-attachments/assets/1ba46ca5-af49-4054-843c-c4135af4c846)

- [ ] [Changelog](../tree/master/docs/CHANGELOG.md) entry (skip if change is not significant to end users, e.g. docs only)
