### PR TITLE
Admin bucket page cards

### DIFF
--- a/catalog/app/containers/Admin/Buckets/Buckets.tsx
+++ b/catalog/app/containers/Admin/Buckets/Buckets.tsx
@@ -916,6 +916,11 @@ function IndexingAndNotifications({
         icon="find_in_page"
         title="Indexing and notifications"
       >
+        {!!reindex && (
+          <M.Button variant="outlined" onClick={reindex} size="small">
+            Re-index and repair
+          </M.Button>
+        )}
         {enableDeepIndexing ? (
           <>
             {bucket.fileExtensionsToIndex ? (

--- a/catalog/app/containers/Admin/Buckets/Buckets.tsx
+++ b/catalog/app/containers/Admin/Buckets/Buckets.tsx
@@ -908,7 +908,7 @@ function IndexingAndNotifications({
   const settings = data.config.contentIndexingSettings
 
   if (!editing && bucket) {
-    const { enableDeepIndexing } = bucketToFormValues(bucket)
+    const { enableDeepIndexing, snsNotificationArn } = bucketToFormValues(bucket)
     return (
       <Card
         className={className}
@@ -950,9 +950,9 @@ function IndexingAndNotifications({
           </M.Typography>
         )}
         {bucket.skipMetaDataIndexing && (
-          <M.Typography variant="body2">Metadata indexing skiped</M.Typography>
+          <M.Typography variant="body2">Metadata indexing is disabled</M.Typography>
         )}
-        {bucket.snsNotificationArn && (
+        {typeof snsNotificationArn === 'string' && (
           <M.Typography variant="body2">
             SNS Topic ARN:{' '}
             <StyledLink

--- a/catalog/app/containers/Admin/Buckets/Buckets.tsx
+++ b/catalog/app/containers/Admin/Buckets/Buckets.tsx
@@ -69,15 +69,19 @@ const bucketToFormValues = (bucket: BucketConfig) => ({
 })
 
 interface CardAvatarProps {
+  className?: string
   src: string
 }
 
-function CardAvatar({ src }: CardAvatarProps) {
-  if (src.startsWith('http')) return <M.Avatar src={src} />
-  return <M.Icon>{src}</M.Icon>
+function CardAvatar({ className, src }: CardAvatarProps) {
+  if (src.startsWith('http')) return <M.Avatar className={className} src={src} />
+  return <M.Icon className={className}>{src}</M.Icon>
 }
 
 const useCardStyles = M.makeStyles((t) => ({
+  avatar: {
+    display: 'block',
+  },
   header: {
     paddingBottom: t.spacing(1),
   },
@@ -117,7 +121,7 @@ function Card({
             <M.Icon>edit</M.Icon>
           </M.IconButton>
         }
-        avatar={icon && <CardAvatar src={icon} />}
+        avatar={icon && <CardAvatar className={classes.avatar} src={icon} />}
         className={classes.header}
         subheader={subTitle}
         title={title}

--- a/catalog/app/containers/Admin/Buckets/Buckets.tsx
+++ b/catalog/app/containers/Admin/Buckets/Buckets.tsx
@@ -92,19 +92,28 @@ const useCardStyles = M.makeStyles((t) => ({
 interface CardProps {
   children?: React.ReactNode
   className?: string
+  disabled?: boolean
   icon?: string | null
   onEdit: () => void
   subTitle?: string
   title: string
 }
 
-function Card({ children, className, icon, onEdit, subTitle, title }: CardProps) {
+function Card({
+  children,
+  className,
+  disabled,
+  icon,
+  onEdit,
+  subTitle,
+  title,
+}: CardProps) {
   const classes = useCardStyles()
   return (
     <M.Card className={className}>
       <M.CardHeader
         action={
-          <M.IconButton onClick={onEdit}>
+          <M.IconButton onClick={onEdit} disabled={disabled}>
             <M.Icon>edit</M.Icon>
           </M.IconButton>
         }
@@ -681,6 +690,7 @@ function PrimaryOptions({
     return (
       <Card
         className={className}
+        disabled={form.getState().submitting}
         icon={bucket.iconUrl || undefined}
         onEdit={() => setEditing(true)}
         subTitle={`s3://${bucket.name}`}
@@ -781,6 +791,7 @@ function MetadataOptions({
     return (
       <Card
         className={className}
+        disabled={form.getState().submitting}
         icon="toc"
         onEdit={() => setEditing(true)}
         title="Metadata"
@@ -912,12 +923,18 @@ function IndexingAndNotifications({
     return (
       <Card
         className={className}
+        disabled={form.getState().submitting}
         onEdit={() => setEditing(true)}
         icon="find_in_page"
         title="Indexing and notifications"
       >
         {!!reindex && (
-          <M.Button variant="outlined" onClick={reindex} size="small">
+          <M.Button
+            variant="outlined"
+            onClick={reindex}
+            size="small"
+            disabled={form.getState().submitting}
+          >
             Re-index and repair
           </M.Button>
         )}
@@ -1160,6 +1177,7 @@ function PreviewOptions({
     return (
       <Card
         className={className}
+        disabled={form.getState().submitting}
         onEdit={() => setEditing(true)}
         icon="code"
         title={`Permissive HTML rendering is ${

--- a/catalog/app/containers/Admin/Buckets/Buckets.tsx
+++ b/catalog/app/containers/Admin/Buckets/Buckets.tsx
@@ -773,6 +773,19 @@ function PrimaryOptions({
   )
 }
 
+const useMetadataOptionsStyles = M.makeStyles((t) => ({
+  tagsList: {
+    marginBottoM: t.spacing(-1),
+  },
+  tag: {
+    marginBottom: t.spacing(1),
+    verticalAlign: 'baseline',
+    '& + &': {
+      marginLeft: t.spacing(0.5),
+    },
+  },
+}))
+
 interface MetadataOptionsProps {
   bucket?: BucketConfig
   className: string
@@ -786,6 +799,7 @@ function MetadataOptions({
   form,
   initialEditing,
 }: MetadataOptionsProps) {
+  const classes = useMetadataOptionsStyles()
   const [editing, setEditing] = React.useState(initialEditing)
   if (!editing && bucket) {
     return (
@@ -803,10 +817,16 @@ function MetadataOptions({
           Relevance score: {bucket.relevanceScore.toString()}
         </M.Typography>
         {bucket.tags && (
-          <M.Typography variant="body2">
+          <M.Typography variant="body2" className={classes.tagsList}>
             Tags:{' '}
             {bucket.tags.map((tag) => (
-              <M.Chip label={tag} key={tag} component="span" />
+              <M.Chip
+                className={classes.tag}
+                label={tag}
+                key={tag}
+                component="span"
+                size="small"
+              />
             ))}
           </M.Typography>
         )}

--- a/catalog/app/containers/Admin/Buckets/Buckets.tsx
+++ b/catalog/app/containers/Admin/Buckets/Buckets.tsx
@@ -1,5 +1,4 @@
 import cx from 'classnames'
-import * as dateFns from 'date-fns'
 import * as FF from 'final-form'
 import * as FP from 'fp-ts'
 import * as IO from 'io-ts'
@@ -12,17 +11,14 @@ import useResizeObserver from 'use-resize-observer'
 import * as M from '@material-ui/core'
 import * as Lab from '@material-ui/lab'
 
-import BucketIcon from 'components/BucketIcon'
 import * as Buttons from 'components/Buttons'
 import * as Dialog from 'components/Dialog'
 import JsonDisplay from 'components/JsonDisplay'
-import * as Pagination from 'components/Pagination'
 import Skeleton from 'components/Skeleton'
 import * as Notifications from 'containers/Notifications'
 import type * as Model from 'model'
 import * as APIConnector from 'utils/APIConnector'
 import Delay from 'utils/Delay'
-import * as Dialogs from 'utils/Dialogs'
 import type FormSpec from 'utils/FormSpec'
 import * as GQL from 'utils/GraphQL'
 import MetaTitle from 'utils/MetaTitle'
@@ -30,19 +26,18 @@ import * as NamedRoutes from 'utils/NamedRoutes'
 import StyledLink from 'utils/StyledLink'
 import StyledTooltip from 'utils/StyledTooltip'
 import assertNever from 'utils/assertNever'
-import parseSearch from 'utils/parseSearch'
 import { formatQuantity } from 'utils/string'
 import { useTracker } from 'utils/tracking'
 import * as Types from 'utils/types'
 import * as validators from 'utils/validators'
 
 import * as Form from '../Form'
-import * as Table from '../Table'
+
+import List, { ListSkeleton } from './List'
 
 import BUCKET_CONFIGS_QUERY from './gql/BucketConfigs.generated'
 import ADD_MUTATION from './gql/BucketsAdd.generated'
 import UPDATE_MUTATION from './gql/BucketsUpdate.generated'
-import REMOVE_MUTATION from './gql/BucketsRemove.generated'
 import { BucketConfigSelectionFragment as BucketConfig } from './gql/BucketConfigSelection.generated'
 import CONTENT_INDEXING_SETTINGS_QUERY from './gql/ContentIndexingSettings.generated'
 
@@ -1782,255 +1777,6 @@ function EditPageSkeleton({ back }: EditPageSkeletonProps) {
   )
 }
 
-interface DeleteProps {
-  bucket: BucketConfig
-  close: (reason?: string) => void
-}
-
-function Delete({ bucket, close }: DeleteProps) {
-  const { push } = Notifications.use()
-  const { track } = useTracker()
-  const rm = GQL.useMutation(REMOVE_MUTATION)
-  const doDelete = React.useCallback(async () => {
-    close()
-    try {
-      const { bucketRemove: r } = await rm({ name: bucket.name })
-      switch (r.__typename) {
-        case 'BucketRemoveSuccess':
-          track('WEB', { type: 'admin', action: 'bucket delete', bucket: bucket.name })
-          return
-        case 'IndexingInProgress':
-          push(`Can't delete bucket "${bucket.name}" while it's being indexed`)
-          return
-        case 'BucketNotFound':
-          push(`Can't delete bucket "${bucket.name}": not found`)
-          return
-        default:
-          assertNever(r)
-      }
-    } catch (e) {
-      push(`Error deleting bucket "${bucket.name}"`)
-      // eslint-disable-next-line no-console
-      console.error('Error deleting bucket')
-      // eslint-disable-next-line no-console
-      console.error(e)
-    }
-  }, [bucket, close, rm, push, track])
-
-  return (
-    <>
-      <M.DialogTitle>Delete a bucket</M.DialogTitle>
-      <M.DialogContent>
-        You are about to disconnect &quot;{bucket.name}&quot; from Quilt. The search index
-        will be deleted. Bucket contents will remain unchanged.
-      </M.DialogContent>
-      <M.DialogActions>
-        <M.Button onClick={() => close('cancel')} color="primary">
-          Cancel
-        </M.Button>
-        <M.Button onClick={doDelete} color="primary">
-          Delete
-        </M.Button>
-      </M.DialogActions>
-    </>
-  )
-}
-
-function useLegacyBucketNameParam() {
-  const location = RRDom.useLocation()
-  const params = parseSearch(location.search)
-  return Array.isArray(params.bucket) ? params.bucket[0] : params.bucket
-}
-
-const useCustomBucketIconStyles = M.makeStyles({
-  stub: {
-    opacity: 0.7,
-  },
-})
-
-interface CustomBucketIconProps {
-  src: string
-}
-
-function CustomBucketIcon({ src }: CustomBucketIconProps) {
-  const classes = useCustomBucketIconStyles()
-
-  return <BucketIcon alt="" classes={classes} src={src} title="Default icon" />
-}
-
-const columns: Table.Column<BucketConfig>[] = [
-  {
-    id: 'name',
-    label: 'Name (relevance)',
-    getValue: R.prop('name'),
-    getDisplay: (v: string, b: BucketConfig) => (
-      <span>
-        <M.Box fontFamily="monospace.fontFamily" component="span">
-          {v}
-        </M.Box>{' '}
-        <M.Box color="text.secondary" component="span">
-          ({b.relevanceScore})
-        </M.Box>
-      </span>
-    ),
-  },
-  {
-    id: 'icon',
-    label: 'Icon',
-    sortable: false,
-    align: 'center',
-    getValue: R.prop('iconUrl'),
-    getDisplay: (v: string) => <CustomBucketIcon src={v} />,
-  },
-  {
-    id: 'title',
-    label: 'Title',
-    getValue: R.prop('title'),
-    getDisplay: (v: string) => (
-      <M.Box
-        component="span"
-        maxWidth={240}
-        textOverflow="ellipsis"
-        overflow="hidden"
-        whiteSpace="nowrap"
-        display="inline-block"
-      >
-        {v}
-      </M.Box>
-    ),
-  },
-  {
-    id: 'description',
-    label: 'Description',
-    getValue: R.prop('description'),
-    getDisplay: (v: string | undefined) =>
-      v ? (
-        <M.Box
-          component="span"
-          maxWidth={240}
-          textOverflow="ellipsis"
-          overflow="hidden"
-          whiteSpace="nowrap"
-          display="inline-block"
-        >
-          {v}
-        </M.Box>
-      ) : (
-        <M.Box color="text.secondary" component="span">
-          {'<Empty>'}
-        </M.Box>
-      ),
-  },
-  {
-    id: 'lastIndexed',
-    label: 'Last indexed',
-    getValue: R.prop('lastIndexed'),
-    getDisplay: (v: Date | undefined) =>
-      v ? (
-        <span title={v.toLocaleString()}>
-          {dateFns.formatDistanceToNow(v, { addSuffix: true })}
-        </span>
-      ) : (
-        <M.Box color="text.secondary" component="span">
-          {'<N/A>'}
-        </M.Box>
-      ),
-  },
-]
-
-function List() {
-  const { bucketConfigs: rows } = GQL.useQueryS(BUCKET_CONFIGS_QUERY)
-  const filtering = Table.useFiltering({
-    rows,
-    filterBy: ({ name, title }) => name + title,
-  })
-  const ordering = Table.useOrdering({
-    rows: filtering.filtered,
-    column: columns[0],
-  })
-  const pagination = Pagination.use(ordering.ordered, {
-    // @ts-expect-error
-    getItemId: R.prop('name'),
-  })
-  const { open: openDialog, render: renderDialogs } = Dialogs.use()
-
-  const { urls } = NamedRoutes.use()
-  const history = RRDom.useHistory()
-
-  const toolbarActions = [
-    {
-      title: 'Add bucket',
-      icon: <M.Icon>add</M.Icon>,
-      fn: React.useCallback(() => {
-        history.push(urls.adminBucketAdd())
-      }, [history, urls]),
-    },
-  ]
-
-  const bucketName = useLegacyBucketNameParam()
-  if (bucketName) {
-    return <RRDom.Redirect to={urls.adminBucketEdit(bucketName)} />
-  }
-
-  const edit = (bucket: BucketConfig) => () => {
-    history.push(urls.adminBucketEdit(bucket.name))
-  }
-
-  const inlineActions = (bucket: BucketConfig) => [
-    {
-      title: 'Delete',
-      icon: <M.Icon>delete</M.Icon>,
-      fn: () => {
-        openDialog(({ close }) => <Delete {...{ bucket, close }} />)
-      },
-    },
-    {
-      title: 'Edit',
-      icon: <M.Icon>edit</M.Icon>,
-      fn: edit(bucket),
-    },
-  ]
-
-  return (
-    <M.Paper>
-      {renderDialogs({ maxWidth: 'xs', fullWidth: true })}
-
-      <Table.Toolbar heading="Buckets" actions={toolbarActions}>
-        <Table.Filter {...filtering} />
-      </Table.Toolbar>
-      <Table.Wrapper>
-        <M.Table size="small">
-          <Table.Head columns={columns} ordering={ordering} withInlineActions />
-          <M.TableBody>
-            {pagination.paginated.map((bucket: BucketConfig) => (
-              <M.TableRow
-                hover
-                key={bucket.name}
-                onClick={edit(bucket)}
-                style={{ cursor: 'pointer' }}
-              >
-                {columns.map((col) => (
-                  <M.TableCell key={col.id} align={col.align} {...col.props}>
-                    {(col.getDisplay || R.identity)(col.getValue(bucket), bucket)}
-                  </M.TableCell>
-                ))}
-                <M.TableCell
-                  align="right"
-                  padding="none"
-                  onClick={(e) => e.stopPropagation()}
-                >
-                  <Table.InlineActions actions={inlineActions(bucket)} />
-                </M.TableCell>
-              </M.TableRow>
-            ))}
-          </M.TableBody>
-        </M.Table>
-      </Table.Wrapper>
-      <Table.Pagination pagination={pagination} />
-    </M.Paper>
-  )
-}
-
 interface EditRouteParams {
   bucketName: string
 }
@@ -2070,14 +1816,7 @@ export default function Buckets() {
           </React.Suspense>
         </RRDom.Route>
         <RRDom.Route>
-          <React.Suspense
-            fallback={
-              <M.Paper>
-                <Table.Toolbar heading="Buckets" />
-                <Table.Progress />
-              </M.Paper>
-            }
-          >
+          <React.Suspense fallback={<ListSkeleton />}>
             <List />
           </React.Suspense>
         </RRDom.Route>

--- a/catalog/app/containers/Admin/Buckets/List.tsx
+++ b/catalog/app/containers/Admin/Buckets/List.tsx
@@ -1,0 +1,279 @@
+import * as dateFns from 'date-fns'
+import * as R from 'ramda'
+import * as React from 'react'
+import * as RRDom from 'react-router-dom'
+import * as M from '@material-ui/core'
+
+import BucketIcon from 'components/BucketIcon'
+import * as Pagination from 'components/Pagination'
+import * as Notifications from 'containers/Notifications'
+import * as Dialogs from 'utils/Dialogs'
+import * as GQL from 'utils/GraphQL'
+import * as NamedRoutes from 'utils/NamedRoutes'
+import assertNever from 'utils/assertNever'
+import parseSearch from 'utils/parseSearch'
+import { useTracker } from 'utils/tracking'
+
+import * as Table from '../Table'
+
+import { BucketConfigSelectionFragment as BucketConfig } from './gql/BucketConfigSelection.generated'
+import BUCKET_CONFIGS_QUERY from './gql/BucketConfigs.generated'
+import REMOVE_MUTATION from './gql/BucketsRemove.generated'
+
+export function ListSkeleton() {
+  return (
+    <M.Paper>
+      <Table.Toolbar heading="Buckets" />
+      <Table.Progress />
+    </M.Paper>
+  )
+}
+
+interface DeleteProps {
+  bucket: BucketConfig
+  close: (reason?: string) => void
+}
+
+function Delete({ bucket, close }: DeleteProps) {
+  const { push } = Notifications.use()
+  const { track } = useTracker()
+  const rm = GQL.useMutation(REMOVE_MUTATION)
+  const doDelete = React.useCallback(async () => {
+    close()
+    try {
+      const { bucketRemove: r } = await rm({ name: bucket.name })
+      switch (r.__typename) {
+        case 'BucketRemoveSuccess':
+          track('WEB', { type: 'admin', action: 'bucket delete', bucket: bucket.name })
+          return
+        case 'IndexingInProgress':
+          push(`Can't delete bucket "${bucket.name}" while it's being indexed`)
+          return
+        case 'BucketNotFound':
+          push(`Can't delete bucket "${bucket.name}": not found`)
+          return
+        default:
+          assertNever(r)
+      }
+    } catch (e) {
+      push(`Error deleting bucket "${bucket.name}"`)
+      // eslint-disable-next-line no-console
+      console.error('Error deleting bucket')
+      // eslint-disable-next-line no-console
+      console.error(e)
+    }
+  }, [bucket, close, rm, push, track])
+
+  return (
+    <>
+      <M.DialogTitle>Delete a bucket</M.DialogTitle>
+      <M.DialogContent>
+        You are about to disconnect &quot;{bucket.name}&quot; from Quilt. The search index
+        will be deleted. Bucket contents will remain unchanged.
+      </M.DialogContent>
+      <M.DialogActions>
+        <M.Button onClick={() => close('cancel')} color="primary">
+          Cancel
+        </M.Button>
+        <M.Button onClick={doDelete} color="primary">
+          Delete
+        </M.Button>
+      </M.DialogActions>
+    </>
+  )
+}
+
+function useLegacyBucketNameParam() {
+  const location = RRDom.useLocation()
+  const params = parseSearch(location.search)
+  return Array.isArray(params.bucket) ? params.bucket[0] : params.bucket
+}
+
+const useCustomBucketIconStyles = M.makeStyles({
+  stub: {
+    opacity: 0.7,
+  },
+})
+
+interface CustomBucketIconProps {
+  src: string
+}
+
+function CustomBucketIcon({ src }: CustomBucketIconProps) {
+  const classes = useCustomBucketIconStyles()
+
+  return <BucketIcon alt="" classes={classes} src={src} title="Default icon" />
+}
+
+const columns: Table.Column<BucketConfig>[] = [
+  {
+    id: 'name',
+    label: 'Name (relevance)',
+    getValue: R.prop('name'),
+    getDisplay: (v: string, b: BucketConfig) => (
+      <span>
+        <M.Box fontFamily="monospace.fontFamily" component="span">
+          {v}
+        </M.Box>{' '}
+        <M.Box color="text.secondary" component="span">
+          ({b.relevanceScore})
+        </M.Box>
+      </span>
+    ),
+  },
+  {
+    id: 'icon',
+    label: 'Icon',
+    sortable: false,
+    align: 'center',
+    getValue: R.prop('iconUrl'),
+    getDisplay: (v: string) => <CustomBucketIcon src={v} />,
+  },
+  {
+    id: 'title',
+    label: 'Title',
+    getValue: R.prop('title'),
+    getDisplay: (v: string) => (
+      <M.Box
+        component="span"
+        maxWidth={240}
+        textOverflow="ellipsis"
+        overflow="hidden"
+        whiteSpace="nowrap"
+        display="inline-block"
+      >
+        {v}
+      </M.Box>
+    ),
+  },
+  {
+    id: 'description',
+    label: 'Description',
+    getValue: R.prop('description'),
+    getDisplay: (v: string | undefined) =>
+      v ? (
+        <M.Box
+          component="span"
+          maxWidth={240}
+          textOverflow="ellipsis"
+          overflow="hidden"
+          whiteSpace="nowrap"
+          display="inline-block"
+        >
+          {v}
+        </M.Box>
+      ) : (
+        <M.Box color="text.secondary" component="span">
+          {'<Empty>'}
+        </M.Box>
+      ),
+  },
+  {
+    id: 'lastIndexed',
+    label: 'Last indexed',
+    getValue: R.prop('lastIndexed'),
+    getDisplay: (v: Date | undefined) =>
+      v ? (
+        <span title={v.toLocaleString()}>
+          {dateFns.formatDistanceToNow(v, { addSuffix: true })}
+        </span>
+      ) : (
+        <M.Box color="text.secondary" component="span">
+          {'<N/A>'}
+        </M.Box>
+      ),
+  },
+]
+
+export default function List() {
+  const { bucketConfigs: rows } = GQL.useQueryS(BUCKET_CONFIGS_QUERY)
+  const filtering = Table.useFiltering({
+    rows,
+    filterBy: ({ name, title }) => name + title,
+  })
+  const ordering = Table.useOrdering({
+    rows: filtering.filtered,
+    column: columns[0],
+  })
+  const pagination = Pagination.use(ordering.ordered, {
+    // @ts-expect-error
+    getItemId: R.prop('name'),
+  })
+  const { open: openDialog, render: renderDialogs } = Dialogs.use()
+
+  const { urls } = NamedRoutes.use()
+  const history = RRDom.useHistory()
+
+  const toolbarActions = [
+    {
+      title: 'Add bucket',
+      icon: <M.Icon>add</M.Icon>,
+      fn: React.useCallback(() => {
+        history.push(urls.adminBucketAdd())
+      }, [history, urls]),
+    },
+  ]
+
+  const bucketName = useLegacyBucketNameParam()
+  if (bucketName) {
+    return <RRDom.Redirect to={urls.adminBucketEdit(bucketName)} />
+  }
+
+  const edit = (bucket: BucketConfig) => () => {
+    history.push(urls.adminBucketEdit(bucket.name))
+  }
+
+  const inlineActions = (bucket: BucketConfig) => [
+    {
+      title: 'Delete',
+      icon: <M.Icon>delete</M.Icon>,
+      fn: () => {
+        openDialog(({ close }) => <Delete {...{ bucket, close }} />)
+      },
+    },
+    {
+      title: 'Edit',
+      icon: <M.Icon>edit</M.Icon>,
+      fn: edit(bucket),
+    },
+  ]
+
+  return (
+    <M.Paper>
+      {renderDialogs({ maxWidth: 'xs', fullWidth: true })}
+
+      <Table.Toolbar heading="Buckets" actions={toolbarActions}>
+        <Table.Filter {...filtering} />
+      </Table.Toolbar>
+      <Table.Wrapper>
+        <M.Table size="small">
+          <Table.Head columns={columns} ordering={ordering} withInlineActions />
+          <M.TableBody>
+            {pagination.paginated.map((bucket: BucketConfig) => (
+              <M.TableRow
+                hover
+                key={bucket.name}
+                onClick={edit(bucket)}
+                style={{ cursor: 'pointer' }}
+              >
+                {columns.map((col) => (
+                  <M.TableCell key={col.id} align={col.align} {...col.props}>
+                    {(col.getDisplay || R.identity)(col.getValue(bucket), bucket)}
+                  </M.TableCell>
+                ))}
+                <M.TableCell
+                  align="right"
+                  padding="none"
+                  onClick={(e) => e.stopPropagation()}
+                >
+                  <Table.InlineActions actions={inlineActions(bucket)} />
+                </M.TableCell>
+              </M.TableRow>
+            ))}
+          </M.TableBody>
+        </M.Table>
+      </Table.Wrapper>
+      <Table.Pagination pagination={pagination} />
+    </M.Paper>
+  )
+}


### PR DESCRIPTION
"Add bucket" page. No preview cards, single form.
![Screenshot from 2024-09-03 14-47-01](https://github.com/user-attachments/assets/1a9152e1-e3eb-43ca-a15e-67b97746b700)

---

Bucket page. Bucket has avatar
![Screenshot from 2024-09-03 14-48-20](https://github.com/user-attachments/assets/c2612bcb-848e-4109-a57f-39b9549f0a23)

---

Bucket page. No avatar, many tags.
![Screenshot from 2024-09-03 15-11-19](https://github.com/user-attachments/assets/c147bd8e-f293-47b5-90c9-cb6ed14880c3)

---

Edit metadata on bucket page. All other cards are in preview mode.
![Screenshot from 2024-09-03 15-11-29](https://github.com/user-attachments/assets/dfb17e6c-6dbb-4377-80b9-cdc63603ed2a)