### PR TITLE
Ignore line-length lint rule for CHANGELOG

### DIFF
--- a/catalog/CHANGELOG.md
+++ b/catalog/CHANGELOG.md
@@ -1,3 +1,4 @@
+<!-- markdownlint-disable line-length -->
 # Changelog
 
 Changes are listed in reverse chronological order (newer entries at the top).
@@ -16,11 +17,6 @@ where verb is one of
 
 ## Changes
 
-- [Changed] Athena: always show catalog name, simplify setting execution context
-([#4123](https://github.com/quiltdata/quilt/pull/4123))
-- [Added] Support `ui.actions.downloadObject` and `ui.actions.downloadPackage`
-options for configuring visibility of download buttons under "Bucket"
-and "Packages" respectively
-([#4111](https://github.com/quiltdata/quilt/pull/4111))
-- [Added] Bootstrap the change log
-([#4112](https://github.com/quiltdata/quilt/pull/4112))
+- [Changed] Athena: always show catalog name, simplify setting execution context ([#4123](https://github.com/quiltdata/quilt/pull/4123))
+- [Added] Support `ui.actions.downloadObject` and `ui.actions.downloadPackage` options for configuring visibility of download buttons under "Bucket" and "Packages" respectively ([#4111](https://github.com/quiltdata/quilt/pull/4111))
+- [Added] Bootstrap the change log ([#4112](https://github.com/quiltdata/quilt/pull/4112))


### PR DESCRIPTION
Changelog is not a regular prose, and I think it is more readable and easier to add new entries without line-length restriction.