### PR TITLE
quilt3: add credential process

### DIFF
--- a/api/python/quilt3/main.py
+++ b/api/python/quilt3/main.py
@@ -224,6 +224,20 @@ def cmd_push(name, dir, registry, dest, message, meta, workflow, force, dedupe, 
     )
 
 
+def cmd_get_credentials():
+    # TODO: check that the user is logged in
+    # TODO: do not refresh credentials if they are still valid?
+    session._refresh_credentials()
+    creds = session._load_credentials()
+    print(json.dumps({
+        "Version": 1,
+        "AccessKeyId": creds["access_key"],
+        "SecretAccessKey": creds["secret_key"],
+        "SessionToken": creds["token"],
+        "Expiration": creds["expiry_time"],
+    }))
+
+
 def create_parser():
     parser = argparse.ArgumentParser(allow_abbrev=False)
     parser.add_argument(
@@ -480,6 +494,11 @@ def create_parser():
         help="Do not copy data. Package manifest entries will reference the data at the original location.",
     )
     push_p.set_defaults(func=cmd_push)
+
+    # get-credentials
+    shorthelp = "Get temporary AWS credentials for the current user"  # TODO
+    get_credentials_p = subparsers.add_parser("get-credentials", description=shorthelp, help=shorthelp, allow_abbrev=False)
+    get_credentials_p.set_defaults(func=cmd_get_credentials)
 
     return parser
 


### PR DESCRIPTION
# Description

This allows using stack credentials with AWS CLI.

Add this to `~/.aws/config`:
```
[profile quilt-stack]
credential_process = quilt3 get-credentials
```

Now you can use stack credentials with AWS CLI:

```
AWS_PROFILE=quilt-stack aws s3 ls s3://your-stack-bucket
```

# TODO

<!-- Remove items that are irrelevant to this PR -->

- [ ] Unit tests
- [ ] Automated tests (e.g. Preflight)
- [ ] Confirm that this change meets security best practices and does not violate the security model
- [ ] Documentation
    - [ ] [Python: Run `build.py`](../tree/master/gendocs/build.py) for new docstrings
    - [ ] JavaScript: basic explanation and screenshot of new features
    - [ ] Markdown somewhere in docs/**/*.md that explains the feature to end users (said .md files should be linked from SUMMARY.md so they appear on https://docs.quiltdata.com)
    - [ ] Markdown docs for developers
- [ ] [Changelog](../tree/master/docs/CHANGELOG.md) entry (skip if change is not significant to end users, e.g. docs only)
