### PR TITLE
Fix tabulator config schema

### DIFF
--- a/shared/schemas/tabulatorTable.yml.json
+++ b/shared/schemas/tabulatorTable.yml.json
@@ -17,13 +17,6 @@
     },
     "parser": {
       "title": "Parser",
-      "discriminator": {
-        "propertyName": "format",
-        "mapping": {
-          "csv": "#/definitions/CsvParser",
-          "parquet": "#/definitions/ParquetParser"
-        }
-      },
       "oneOf": [
         {
           "$ref": "#/definitions/CsvParser"


### PR DESCRIPTION
# Description

Fixes `strict mode: unknown keyword: "discriminator"` error


# TODO

- [ ] [Changelog](../tree/master/docs/CHANGELOG.md) entry (skip if change is not significant to end users, e.g. docs only)
