### PR TITLE
Qurator fixes: cross-region inference, UI jumps

### DIFF
--- a/catalog/CHANGELOG.md
+++ b/catalog/CHANGELOG.md
@@ -17,7 +17,7 @@ where verb is one of
 
 ## Changes
 
-- [Added] Qurator Omni: initial public release ([#4032](https://github.com/quiltdata/quilt/pull/4032))
+- [Added] Qurator Omni: initial public release ([#4032](https://github.com/quiltdata/quilt/pull/4032), [#4181](https://github.com/quiltdata/quilt/pull/4181))
 - [Added] Admin: UI for configuring longitudinal queries (Tabulator) ([#4135](https://github.com/quiltdata/quilt/pull/4135), [#4164](https://github.com/quiltdata/quilt/pull/4164), [#4165](https://github.com/quiltdata/quilt/pull/4165))
 - [Changed] Admin: Move bucket settings to a separate page ([#4122](https://github.com/quiltdata/quilt/pull/4122))
 - [Changed] Athena: always show catalog name, simplify setting execution context ([#4123](https://github.com/quiltdata/quilt/pull/4123))

--- a/catalog/app/components/Assistant/Model/Bedrock.ts
+++ b/catalog/app/components/Assistant/Model/Bedrock.ts
@@ -8,7 +8,7 @@ import * as LLM from './LLM'
 
 const MODULE = 'Bedrock'
 
-const MODEL_ID = 'anthropic.claude-3-5-sonnet-20240620-v1:0'
+const MODEL_ID = 'us.anthropic.claude-3-5-sonnet-20240620-v1:0'
 
 const mapContent = (contentBlocks: BedrockRuntime.ContentBlocks | undefined) =>
   Eff.pipe(

--- a/catalog/app/containers/Bucket/AssistButton.tsx
+++ b/catalog/app/containers/Bucket/AssistButton.tsx
@@ -1,0 +1,26 @@
+import * as React from 'react'
+import * as M from '@material-ui/core'
+
+import * as Assistant from 'components/Assistant'
+
+interface AssistButtonProps extends M.IconButtonProps {
+  title?: string
+  message?: string
+}
+
+export default function AssistButton({ message, title, ...props }: AssistButtonProps) {
+  const assist = Assistant.use()
+  if (!assist) return null
+  return (
+    <M.IconButton
+      color="primary"
+      onClick={() => assist(message || 'Summarize this document')}
+      style={{ marginTop: '-12px', marginBottom: '-12px' }}
+      {...props}
+    >
+      <M.Tooltip title={title || 'Summarize and chat with AI'}>
+        <M.Icon>assistant</M.Icon>
+      </M.Tooltip>
+    </M.IconButton>
+  )
+}

--- a/catalog/app/containers/Bucket/File.js
+++ b/catalog/app/containers/Bucket/File.js
@@ -6,7 +6,6 @@ import * as React from 'react'
 import { Link, useHistory, useLocation, useParams } from 'react-router-dom'
 import * as M from '@material-ui/core'
 
-import * as Assistant from 'components/Assistant'
 import * as BreadCrumbs from 'components/BreadCrumbs'
 import * as Buttons from 'components/Buttons'
 import * as FileEditor from 'components/FileEditor'
@@ -30,6 +29,7 @@ import parseSearch from 'utils/parseSearch'
 import { up, decode, handleToHttpsUri } from 'utils/s3paths'
 import { readableBytes, readableQuantity } from 'utils/string'
 
+import AssistButton from './AssistButton'
 import FileCodeSamples from './CodeSamples/File'
 import * as AssistantContext from './FileAssistantContext'
 import FileProperties from './FileProperties'
@@ -38,19 +38,6 @@ import Section from './Section'
 import renderPreview from './renderPreview'
 import * as requests from './requests'
 import { useViewModes, viewModeToSelectOption } from './viewModes'
-
-function SummarizeButton() {
-  const assist = Assistant.use()
-  if (!assist) return null
-  const msg = 'Summarize this document'
-  return (
-    <M.IconButton color="primary" onClick={() => assist(msg)} edge="end">
-      <M.Tooltip title="Summarize and chat with AI">
-        <M.Icon>assistant</M.Icon>
-      </M.Tooltip>
-    </M.IconButton>
-  )
-}
 
 const useVersionInfoStyles = M.makeStyles(({ typography }) => ({
   version: {
@@ -514,7 +501,7 @@ export default function File() {
           {BucketPreferences.Result.match(
             {
               // XXX: only show this when the object exists?
-              Ok: ({ ui: { blocks } }) => (blocks.qurator ? <SummarizeButton /> : null),
+              Ok: ({ ui }) => ui.blocks.qurator && <AssistButton edge="end" />,
               _: () => null,
             },
             prefs,

--- a/catalog/app/containers/Bucket/PackageTree/PackageTree.tsx
+++ b/catalog/app/containers/Bucket/PackageTree/PackageTree.tsx
@@ -32,6 +32,7 @@ import * as s3paths from 'utils/s3paths'
 import usePrevious from 'utils/usePrevious'
 import * as workflows from 'utils/workflows'
 
+import AssistButton from '../AssistButton'
 import PackageCodeSamples from '../CodeSamples/Package'
 import * as Download from '../Download'
 import { FileProperties } from '../FileProperties'
@@ -582,19 +583,6 @@ const FileContext = Assistant.Context.LazyContext(({ pkg, file }: FileContextPro
   }
 })
 
-function SummarizeButton() {
-  const assist = Assistant.use()
-  if (!assist) return null
-  const msg = 'Summarize this document'
-  return (
-    <M.IconButton color="primary" onClick={() => assist(msg)} edge="end">
-      <M.Tooltip title="Summarize and chat with AI">
-        <M.Icon>assistant</M.Icon>
-      </M.Tooltip>
-    </M.IconButton>
-  )
-}
-
 interface FileDisplayProps extends FileDisplayQueryProps {
   file: Model.GQLTypes.PackageFile
 }
@@ -716,18 +704,20 @@ function FileDisplay({
                 )}
                 {BucketPreferences.Result.match(
                   {
-                    Ok: ({ ui: { actions, blocks } }) => (
+                    Ok: ({ ui }) => (
                       <>
                         {!cfg.noDownload &&
                           !deleted &&
                           !archived &&
-                          actions.downloadPackage && (
+                          ui.actions.downloadPackage && (
                             <FileView.DownloadButton
                               className={classes.button}
                               handle={handle}
                             />
                           )}
-                        {blocks.qurator && !deleted && !archived && <SummarizeButton />}
+                        {ui.blocks.qurator && !deleted && !archived && (
+                          <AssistButton edge="end" />
+                        )}
                       </>
                     ),
                     Pending: () => (


### PR DESCRIPTION
# Description

- fix model invocation in regions other than us-east-1 by using an **inference profile** instead of a plain model id (for cross-region inference)
- remove margins on the assistant button so that it doesn't push the other ui elements

# TODO

- [x] [Changelog](../tree/master/docs/CHANGELOG.md) entry (skip if change is not significant to end users, e.g. docs only)
