### PR TITLE
Fix release CI job

### DIFF
--- a/.github/workflows/py-ci.yml
+++ b/.github/workflows/py-ci.yml
@@ -138,10 +138,10 @@ jobs:
         run: |
           python -m pip install --upgrade pip setuptools
           python -m pip install build==1.2.2.post1 twine==5.1.1
-      - name: verify git tag vs. version
-        env:
-          CIRCLE_TAG: ${{ github.ref_name }}
-        run: python setup.py verify
+      # - name: verify git tag vs. version
+      #   env:
+      #     CIRCLE_TAG: ${{ github.ref_name }}
+      #   run: python setup.py verify
       - name: build
         run: python -m build
       # - name: upload to PyPI

--- a/.github/workflows/py-ci.yml
+++ b/.github/workflows/py-ci.yml
@@ -134,14 +134,14 @@ jobs:
       - uses: actions/setup-python@v5
         with:
           python-version: '3.12'
-      - name: verify git tag vs. version
-        env:
-          CIRCLE_TAG: ${{ github.ref_name }}
-        run: python setup.py verify
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip setuptools
           python -m pip install build==1.2.2.post1 twine==5.1.1
+      - name: verify git tag vs. version
+        env:
+          CIRCLE_TAG: ${{ github.ref_name }}
+        run: python setup.py verify
       - name: build
         run: python -m build
       # - name: upload to PyPI

--- a/.github/workflows/py-ci.yml
+++ b/.github/workflows/py-ci.yml
@@ -123,8 +123,8 @@ jobs:
           fi
 
   pypi-release:
-    needs: pypi-release-tag-check
-    if: github.ref_type == 'tag' && needs.pypi-release-tag-check.outputs.check == 'true'
+    # needs: pypi-release-tag-check
+    # if: github.ref_type == 'tag' && needs.pypi-release-tag-check.outputs.check == 'true'
     runs-on: ubuntu-latest
     defaults:
       run:
@@ -133,7 +133,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
         with:
-          python-version: '3.7'
+          python-version: '3.12'
       - name: verify git tag vs. version
         env:
           CIRCLE_TAG: ${{ github.ref_name }}
@@ -141,14 +141,14 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip setuptools
-          python -m pip install build==0.8.0 twine==4.0.0
+          python -m pip install build==1.2.2.post1 twine==5.1.1
       - name: build
         run: python -m build
-      - name: upload to PyPI
-        env:
-          TWINE_USERNAME: ${{ secrets.PYPI_USERNAME }}
-          TWINE_PASSWORD: ${{ secrets.PYPI_PASSWORD }}
-        run: twine upload dist/*
+      # - name: upload to PyPI
+      #   env:
+      #     TWINE_USERNAME: ${{ secrets.PYPI_USERNAME }}
+      #     TWINE_PASSWORD: ${{ secrets.PYPI_PASSWORD }}
+      #   run: twine upload dist/*
 
   test-lambda:
     strategy:

--- a/.github/workflows/py-ci.yml
+++ b/.github/workflows/py-ci.yml
@@ -123,8 +123,8 @@ jobs:
           fi
 
   pypi-release:
-    # needs: pypi-release-tag-check
-    # if: github.ref_type == 'tag' && needs.pypi-release-tag-check.outputs.check == 'true'
+    needs: pypi-release-tag-check
+    if: github.ref_type == 'tag' && needs.pypi-release-tag-check.outputs.check == 'true'
     runs-on: ubuntu-latest
     defaults:
       run:
@@ -138,17 +138,17 @@ jobs:
         run: |
           python -m pip install --upgrade pip setuptools
           python -m pip install build==1.2.2.post1 twine==5.1.1
-      # - name: verify git tag vs. version
-      #   env:
-      #     CIRCLE_TAG: ${{ github.ref_name }}
-      #   run: python setup.py verify
+      - name: verify git tag vs. version
+        env:
+          CIRCLE_TAG: ${{ github.ref_name }}
+        run: python setup.py verify
       - name: build
         run: python -m build
-      # - name: upload to PyPI
-      #   env:
-      #     TWINE_USERNAME: ${{ secrets.PYPI_USERNAME }}
-      #     TWINE_PASSWORD: ${{ secrets.PYPI_PASSWORD }}
-      #   run: twine upload dist/*
+      - name: upload to PyPI
+        env:
+          TWINE_USERNAME: ${{ secrets.PYPI_USERNAME }}
+          TWINE_PASSWORD: ${{ secrets.PYPI_PASSWORD }}
+        run: twine upload dist/*
 
   test-lambda:
     strategy:


### PR DESCRIPTION
This job stopped to work because GH actions upgrades runner version and it doesn't have Python 3.7 anymore.
The plan is just to force push 6.1.0 tag after merging this.