### PR TITLE
Minor Athena page UI simplifications

### DIFF
--- a/catalog/CHANGELOG.md
+++ b/catalog/CHANGELOG.md
@@ -17,6 +17,7 @@ where verb is one of
 
 ## Changes
 
+- [Fixed] Athena: fix minor UI bugs ([#4232](https://github.com/quiltdata/quilt/pull/4232))
 - [Fixed] Show Athena query editor when no named queries ([#4230](https://github.com/quiltdata/quilt/pull/4230))
 - [Fixed] Fix some doc URLs in catalog ([#4205](https://github.com/quiltdata/quilt/pull/4205))
 - [Changed] S3 Select -> GQL API calls for getting access counts ([#4218](https://github.com/quiltdata/quilt/pull/4218))

--- a/catalog/app/containers/Bucket/Queries/Athena/Database.tsx
+++ b/catalog/app/containers/Bucket/Queries/Athena/Database.tsx
@@ -205,15 +205,8 @@ const useStyles = M.makeStyles((t) => ({
     display: 'flex',
   },
   field: {
-    cursor: 'pointer',
     flexBasis: '50%',
     marginRight: t.spacing(2),
-    '& input': {
-      cursor: 'pointer',
-    },
-    '& > *': {
-      cursor: 'pointer',
-    },
   },
   button: {
     marginLeft: t.spacing(1),

--- a/catalog/app/containers/Bucket/Queries/Athena/History.tsx
+++ b/catalog/app/containers/Bucket/Queries/Athena/History.tsx
@@ -277,6 +277,13 @@ export default function History({ bucket, executions, onLoadMore }: HistoryProps
   const { workgroup } = Model.use()
   if (!Model.hasValue(workgroup)) return null
 
+  if (!executions.length)
+    return (
+      <M.Paper>
+        <Empty />
+      </M.Paper>
+    )
+
   return (
     <>
       <M.Paper>
@@ -304,7 +311,6 @@ export default function History({ bucket, executions, onLoadMore }: HistoryProps
             />
           ),
         )}
-        {!executions.length && <Empty />}
         {(hasPagination || !!onLoadMore) && (
           <div className={classes.footer}>
             {hasPagination && (


### PR DESCRIPTION
* Remove table header from empty athena executions list
* Remove workaround for cursor pointer, it works out-of-the box already

- [x] [Changelog](../tree/master/docs/CHANGELOG.md) entry (skip if change is not significant to end users, e.g. docs only)
