### PR TITLE
Handle invalid bucket in S3Filepicker and don't load listing when closed

### DIFF
--- a/catalog/app/containers/Bucket/PackageDialog/S3FilePicker.tsx
+++ b/catalog/app/containers/Bucket/PackageDialog/S3FilePicker.tsx
@@ -210,7 +210,19 @@ export function Dialog({ bucket, buckets, selectBucket, open, onClose }: DialogP
     [selectBucket],
   )
 
-  const data = useData(bucketListing, { bucket, path, prefix, prev, drain: true })
+  const data = useData(
+    bucketListing,
+    {
+      bucket,
+      path,
+      prefix,
+      prev,
+      drain: true,
+    },
+    {
+      noAutoFetch: !open,
+    },
+  )
 
   const loadMore = React.useCallback(() => {
     AsyncResult.case(

--- a/catalog/app/containers/Bucket/PackageDialog/S3FilePicker.tsx
+++ b/catalog/app/containers/Bucket/PackageDialog/S3FilePicker.tsx
@@ -1,3 +1,4 @@
+import type { AWSError } from 'aws-sdk'
 import invariant from 'invariant'
 import cx from 'classnames'
 import * as R from 'ramda'
@@ -287,7 +288,16 @@ export function Dialog({ bucket, buckets, selectBucket, open, onClose }: DialogP
       </div>
       {data.case({
         // TODO: customized error display?
-        Err: displayError(),
+        Err: displayError([
+          [
+            (e: unknown) => (e as AWSError)?.code === 'InvalidBucketName',
+            (e: AWSError) => (
+              <M.Box m={2}>
+                <M.Typography>{e.message}</M.Typography>
+              </M.Box>
+            ),
+          ],
+        ]),
         Init: () => null,
         _: (x: $TSFixMe) => {
           const res: requests.BucketListingResult | null = AsyncResult.getPrevResult(x)


### PR DESCRIPTION
- [ ] [Changelog](../tree/master/docs/CHANGELOG.md) entry (skip if change is not significant to end users, e.g. docs only)
