### PR TITLE
Fix showing default Intercom launcher after closing Package Dialog

### DIFF
--- a/catalog/CHANGELOG.md
+++ b/catalog/CHANGELOG.md
@@ -17,6 +17,7 @@ where verb is one of
 
 ## Changes
 
+- [Fixed] Remain default Intercom launcher closed when closing Package Dialog ([#4244](https://github.com/quiltdata/quilt/pull/4244))
 - [Added] Preview Markdown while editing ([#4153](https://github.com/quiltdata/quilt/pull/4153))
 - [Changed] Athena: hide data catalogs user doesn't have access to ([#4239](https://github.com/quiltdata/quilt/pull/4239))
 - [Added] Enable MixPanel tracking in Embed mode ([#4237](https://github.com/quiltdata/quilt/pull/4237))

--- a/catalog/app/components/Intercom/Intercom.js
+++ b/catalog/app/components/Intercom/Intercom.js
@@ -103,6 +103,7 @@ export function useIntercom() {
 
 export { IntercomProvider as Provider, useIntercom as use }
 
+// Hides or shows __default__ Intercom launcher when the `condition` changes
 export function usePauseVisibilityWhen(condition) {
   const intercom = useIntercom()
   const [isVisible, setVisible] = React.useState(true)
@@ -117,7 +118,8 @@ export function usePauseVisibilityWhen(condition) {
     [intercom, isVisible, setVisible],
   )
   React.useEffect(() => {
+    if (intercom.isCustom) return
     if (condition) showIntercom(false)
     return () => showIntercom(true)
-  }, [condition, showIntercom])
+  }, [condition, intercom.isCustom, showIntercom])
 }


### PR DESCRIPTION
Don't toggle Intercom launcher visibility when it is custom

- [x] [Changelog](../tree/master/docs/CHANGELOG.md) entry (skip if change is not significant to end users, e.g. docs only)
