### PR TITLE
Enable "html" in `quilt_summarize.json`

### DIFF
--- a/catalog/CHANGELOG.md
+++ b/catalog/CHANGELOG.md
@@ -17,6 +17,7 @@ where verb is one of
 
 ## Changes
 
+- [Added] Added "html" type for `quilt_summarize.json` ([#4252](https://github.com/quiltdata/quilt/pull/4252))
 - [Fixed] Resolve caching issues where changes in `.quilt/{workflows,catalog}` were not applied ([#4245](https://github.com/quiltdata/quilt/pull/4245))
 - [Added] A shortcut to enable adding files to a package from the current bucket ([#4245](https://github.com/quiltdata/quilt/pull/4245))
 - [Changed] Qurator: propagate error messages from Bedrock ([#4192](https://github.com/quiltdata/quilt/pull/4192))

--- a/catalog/CHANGELOG.md
+++ b/catalog/CHANGELOG.md
@@ -17,7 +17,7 @@ where verb is one of
 
 ## Changes
 
-- [Added] Added "html" type for `quilt_summarize.json` ([#4252](https://github.com/quiltdata/quilt/pull/4252))
+- [Added] Support "html" type in `quilt_summarize.json` ([#4252](https://github.com/quiltdata/quilt/pull/4252))
 - [Fixed] Resolve caching issues where changes in `.quilt/{workflows,catalog}` were not applied ([#4245](https://github.com/quiltdata/quilt/pull/4245))
 - [Added] A shortcut to enable adding files to a package from the current bucket ([#4245](https://github.com/quiltdata/quilt/pull/4245))
 - [Changed] Qurator: propagate error messages from Bedrock ([#4192](https://github.com/quiltdata/quilt/pull/4192))

--- a/catalog/app/components/Preview/loaders/summarize.ts
+++ b/catalog/app/components/Preview/loaders/summarize.ts
@@ -12,6 +12,7 @@ export type TypeShorthand =
   | typeof FileType.Vega
   | typeof FileType.Voila
   | typeof FileType.Text
+  | typeof FileType.Html
 
 export type FileShortcut = string
 

--- a/docs/Catalog/VisualizationDashboards.md
+++ b/docs/Catalog/VisualizationDashboards.md
@@ -76,6 +76,7 @@ or an object with one or more of the following properties:
     - `["perspective"]` to render tabular data (csv, xlsx etc.) with Perspective
     - `["igv"]` to render JSON with Integrative Genomics Viewer
     - `["voila"]` to render a Jupyter notebook as an interactive Voila dashboard
+    - `["html"]` to render HTML in iframes. See also [Advanced HTML rendering](./Preview.md#advanced-html-rendering-and-quilt-package-file-server)
     - `["text"]` to render anything as text with syntax highlighting
 
 If you need to control the height of an element (useful for Voila dashboards),

--- a/shared/schemas/quilt_summarize.json
+++ b/shared/schemas/quilt_summarize.json
@@ -44,7 +44,7 @@
 
     "typeShorthand": {
       "type": "string",
-      "enum": ["echarts", "igv", "json", "jupyter", "perspective", "text", "vega", "voila"]
+      "enum": ["echarts", "html", "igv", "json", "jupyter", "perspective", "text", "vega", "voila"]
     },
 
     "typeExtended": {


### PR DESCRIPTION
This is a quick fix. I've started to work on a more general solution, but this small piece, I think, self-sustainable.

More scalable solutions require more involvement, but I have several ideas already:
* enable everything we have Previews for
* make "name" optional, and treat it like fallback type
* improve `JsonEditor`, so users can create with config with some helper and make "name" a plain string but with select from supported types
* make custom editor for writing `quilt_summarize.json`
* or, change (make v2) Schema (but I'd go with custom editor first, so customers wouldn't care about Schema)

- [x] Documentation
- [x] [Changelog](../tree/master/docs/CHANGELOG.md) entry (skip if change is not significant to end users, e.g. docs only)