### PR TITLE
Auto-format `SetTabulatorOpenQuery.graphql`

### DIFF
--- a/catalog/app/containers/Admin/Settings/gql/SetTabulatorOpenQuery.graphql
+++ b/catalog/app/containers/Admin/Settings/gql/SetTabulatorOpenQuery.graphql
@@ -1,4 +1,4 @@
-mutation($enabled: Boolean!) {
+mutation ($enabled: Boolean!) {
   admin {
     setTabulatorOpenQuery(enabled: $enabled) {
       tabulatorOpenQuery


### PR DESCRIPTION
`prettier`'d ".graphql" file, so `npm run lint` is passed.