### PR TITLE
Match CI line length

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,0 +1,2 @@
+[flake8]
+max-line-length = 119


### PR DESCRIPTION
Configure flake8 to match line-length used in CI
Works with VS Code