### PR TITLE
Fix images display for GitBook in URI.md

### DIFF
--- a/docs/Catalog/URI.md
+++ b/docs/Catalog/URI.md
@@ -3,12 +3,19 @@ Every package and object in the Bucket and Packages views has a "CODE" pane,
 which contains code snippets that can be used to download and upload a package
 or object via either:
 
-- Python (API) ![Python](../imgs/uri-python.png)
-- CLI (shell commands) ![CLI](../imgs/uri-cli.png)
+- Python (API)
+
+    ![Python](../imgs/uri-python.png)
+
+- CLI (shell commands)
+
+    ![CLI](../imgs/uri-cli.png)
 
 In addition, Packages have a third tab that returns a Quilt+ URI:
 
-- URI (identifier) ![URI](../imgs/uri-uri.png)
+- URI (identifier)
+
+    ![URI](../imgs/uri-uri.png)
 
 They all have a `copy` button that copies the code to the clipboard.
 


### PR DESCRIPTION
currently it looks like this

![image](https://github.com/user-attachments/assets/2d9a9474-0cd7-44df-b9bb-83cb8d1be41b)
