### PR TITLE
shared: make version optional in CopyResult for unversioned dst buckets

### DIFF
--- a/py-shared/CHANGELOG.md
+++ b/py-shared/CHANGELOG.md
@@ -17,7 +17,7 @@ where verb is one of
 
 ## Changes
 
-- [Changed]: Make version optional in CopyResult for unversioned dst buckets ([#4299](https://github.com/quiltdata/quilt/pull/4299))
+- [Changed]: Make version optional in `CopyResult` for unversioned dst buckets ([#4299](https://github.com/quiltdata/quilt/pull/4299))
 - [Changed] **BREAKING**: Make `AWSCredentials` frozen ([#4197](https://github.com/quiltdata/quilt/pull/4197))
 - [Changed] **BREAKING**: Add `scratch_buckets` required field to `S3HashLambdaParams` ([#3922](https://github.com/quiltdata/quilt/pull/3922))
 - [Added] Introduce `PackageConstructParams` ([#3922](https://github.com/quiltdata/quilt/pull/3922))

--- a/py-shared/CHANGELOG.md
+++ b/py-shared/CHANGELOG.md
@@ -17,7 +17,7 @@ where verb is one of
 
 ## Changes
 
-- [Changed]: Make version optional in `CopyResult` for unversioned dst buckets ([#4299](https://github.com/quiltdata/quilt/pull/4299))
+- [Changed] Make version optional in `CopyResult` for unversioned dst buckets ([#4299](https://github.com/quiltdata/quilt/pull/4299))
 - [Changed] **BREAKING**: Make `AWSCredentials` frozen ([#4197](https://github.com/quiltdata/quilt/pull/4197))
 - [Changed] **BREAKING**: Add `scratch_buckets` required field to `S3HashLambdaParams` ([#3922](https://github.com/quiltdata/quilt/pull/3922))
 - [Added] Introduce `PackageConstructParams` ([#3922](https://github.com/quiltdata/quilt/pull/3922))

--- a/py-shared/CHANGELOG.md
+++ b/py-shared/CHANGELOG.md
@@ -17,6 +17,7 @@ where verb is one of
 
 ## Changes
 
+- [Changed]: Make version optional in CopyResult for unversioned dst buckets ([#4299](https://github.com/quiltdata/quilt/pull/4299))
 - [Changed] **BREAKING**: Make `AWSCredentials` frozen ([#4197](https://github.com/quiltdata/quilt/pull/4197))
 - [Changed] **BREAKING**: Add `scratch_buckets` required field to `S3HashLambdaParams` ([#3922](https://github.com/quiltdata/quilt/pull/3922))
 - [Added] Introduce `PackageConstructParams` ([#3922](https://github.com/quiltdata/quilt/pull/3922))

--- a/py-shared/src/quilt_shared/pkgpush.py
+++ b/py-shared/src/quilt_shared/pkgpush.py
@@ -108,7 +108,7 @@ class ChecksumResult(pydantic.BaseModel):
 
 
 class CopyResult(pydantic.BaseModel):
-    version: str
+    version: T.Optional[str]
 
 
 class PackagePushParams(pydantic.BaseModel):


### PR DESCRIPTION
# Description

needed for https://github.com/quiltdata/quilt/pull/4300

# TODO

- [x] [Changelog](../tree/master/docs/CHANGELOG.md) entry (skip if change is not significant to end users, e.g. docs only)
