### PR TITLE
fix search#search-bar link

### DIFF
--- a/catalog/app/containers/NavBar/Suggestions/Suggestions.tsx
+++ b/catalog/app/containers/NavBar/Suggestions/Suggestions.tsx
@@ -62,7 +62,7 @@ function SuggestionsList({ items, selected }: SuggestionsProps) {
       <div className={classes.help}>
         Learn the{' '}
         <StyledLink
-          href={`${docs}/quilt-platform-catalog-user/searchquery#search-bar`}
+          href={`${docs}/quilt-platform-catalog-user/search#search-bar`}
           target="_blank"
         >
           advanced search syntax


### PR DESCRIPTION
# Description

replace invalid URL hard-coded in the search help

https://docs.quiltdata.com/quilt-platform-catalog-user/search#search-bar