### PR TITLE
Catalog: Tabulator: Allow uppercase letters in column names

### DIFF
--- a/catalog/CHANGELOG.md
+++ b/catalog/CHANGELOG.md
@@ -18,6 +18,7 @@ where verb is one of
 
 ## Changes
 
+- [Changed] Tabulator: Allow uppercase letters in column names ([#4314](https://github.com/quiltdata/quilt/pull/4314))
 - [Fixed] Add Markdown preview when creating the Markdown file ([#4293](https://github.com/quiltdata/quilt/pull/4293))
 - [Added] Visual editor for the Bucket UI config (`.quilt/catalog/config.yaml`) ([#4261](https://github.com/quiltdata/quilt/pull/4261))
 - [Added] Button to add a `quilt_summarize.json` to a package ([#4273](https://github.com/quiltdata/quilt/pull/4273))

--- a/shared/schemas/tabulatorTable.yml.json
+++ b/shared/schemas/tabulatorTable.yml.json
@@ -42,7 +42,7 @@
           "title": "Name",
           "maxLength": 255,
           "minLength": 1,
-          "pattern": "^[a-z][a-z0-9_-]*$",
+          "pattern": "^[A-Za-z][A-Za-z0-9_-]*$",
           "type": "string"
         },
         "type": {


### PR DESCRIPTION
- [x] [Changelog](../tree/master/docs/CHANGELOG.md) entry (skip if change is not significant to end users, e.g. docs only)
