### PR TITLE
Catalog: Search UX adjustments

### DIFF
--- a/catalog/CHANGELOG.md
+++ b/catalog/CHANGELOG.md
@@ -18,6 +18,8 @@ where verb is one of
 
 ## Changes
 
+- [Changed] Search Results: Don't show package hash in the header ([#4319](https://github.com/quiltdata/quilt/pull/4319))
+- [Changed] Default package search to latest revisions only ([#4319](https://github.com/quiltdata/quilt/pull/4319))
 - [Changed] Tabulator: Support `continue_on_error` config option ([#4328](https://github.com/quiltdata/quilt/pull/4328))
 - [Added] Search: A switch to search only the latest revisions ([#4316](https://github.com/quiltdata/quilt/pull/4316))
 - [Changed] Tabulator: Allow uppercase letters in column names ([#4314](https://github.com/quiltdata/quilt/pull/4314))

--- a/catalog/app/components/Assistant/Model/GlobalContext/navigation.spec.ts
+++ b/catalog/app/components/Assistant/Model/GlobalContext/navigation.spec.ts
@@ -29,7 +29,7 @@ describe('components/Assistant/Model/GlobalTools/navigation', () => {
             params: {
               resultType: 'p',
               filter: [],
-              latestOnly: false,
+              latestOnly: true,
               userMetaFilters: [
                 {
                   path: '/author',

--- a/catalog/app/components/SearchResults/SearchResults.tsx
+++ b/catalog/app/components/SearchResults/SearchResults.tsx
@@ -117,10 +117,6 @@ function PackageHeader({ bucket, handle, hash, showBucket }: $TSFixMe) {
         )}
         <CrumbLink to={urls.bucketPackageTree(bucket, handle, hash)}>
           {handle}
-          <M.Box component="span" color="text.hint">
-            @
-          </M.Box>
-          {R.take(10, hash)}
         </CrumbLink>
       </span>
       <M.Box flexGrow={1} />

--- a/catalog/app/components/SearchResults/SearchResults.tsx
+++ b/catalog/app/components/SearchResults/SearchResults.tsx
@@ -115,9 +115,7 @@ function PackageHeader({ bucket, handle, hash, showBucket }: $TSFixMe) {
             &nbsp;/{' '}
           </>
         )}
-        <CrumbLink to={urls.bucketPackageTree(bucket, handle, hash)}>
-          {handle}
-        </CrumbLink>
+        <CrumbLink to={urls.bucketPackageTree(bucket, handle, hash)}>{handle}</CrumbLink>
       </span>
       <M.Box flexGrow={1} />
     </Heading>

--- a/catalog/app/containers/Search/Route.ts
+++ b/catalog/app/containers/Search/Route.ts
@@ -38,13 +38,13 @@ const PackageSearchParamsFromSearchParams = S.transform(
       resultType: SearchModel.ResultType.QuiltPackage as const,
       filter: S.decodeSync(Filter.PackageFilter.fromSearchParams)(params),
       userMetaFilters: S.decodeSync(UserMetaFilters.fromSearchParams)(params),
-      latestOnly: params.rev?.[0] === 'latest',
+      latestOnly: params.rev?.[0] !== 'all',
     }),
     // json api to qs
     encode: (toI) => ({
       ...S.encodeSync(Filter.PackageFilter.fromSearchParams)(toI.filter || []),
       ...S.encodeSync(UserMetaFilters.fromSearchParams)(toI.userMetaFilters || []),
-      ...(toI.latestOnly ? { rev: ['latest'] } : {}),
+      ...((toI.latestOnly ?? true) ? {} : { rev: ['all'] }),
     }),
   },
 )

--- a/catalog/app/containers/Search/Search.tsx
+++ b/catalog/app/containers/Search/Search.tsx
@@ -694,6 +694,14 @@ const usePackagesRevisionFilterStyles = M.makeStyles((t) => ({
   root: {
     marginBottom: t.spacing(2),
   },
+  hintIcon: {
+    color: t.palette.divider,
+    marginLeft: '4px',
+    verticalAlign: '-4px',
+    '&:hover': {
+      color: t.palette.text.secondary,
+    },
+  },
 }))
 
 function PackagesRevisionFilter() {
@@ -705,7 +713,7 @@ function PackagesRevisionFilter() {
 
   const handleChange = React.useCallback(
     (_event: unknown, checked: boolean) => {
-      setPackagesLatestOnly(checked)
+      setPackagesLatestOnly(!checked)
     },
     [setPackagesLatestOnly],
   )
@@ -713,8 +721,20 @@ function PackagesRevisionFilter() {
   return (
     <M.FormControlLabel
       className={classes.root}
-      control={<M.Switch checked={model.state.latestOnly} onChange={handleChange} />}
-      label="Search only latest revisions"
+      control={<M.Switch checked={!model.state.latestOnly} onChange={handleChange} />}
+      label={
+        <>
+          Include historical versions
+          <M.Tooltip
+            arrow
+            title="Enable to show matches from prior versions, versus only in the latest revision"
+          >
+            <M.Icon className={classes.hintIcon} fontSize="small">
+              help_outline
+            </M.Icon>
+          </M.Tooltip>
+        </>
+      }
     />
   )
 }
@@ -1230,7 +1250,10 @@ function ResultsCount() {
 
 const useResultsStyles = M.makeStyles((t) => ({
   root: {
+    // make space for box shadows
+    margin: '-4px',
     overflow: 'hidden',
+    padding: '4px',
   },
   button: {
     '& + &': {

--- a/catalog/app/containers/Search/gql/BaseSearch.generated.ts
+++ b/catalog/app/containers/Search/gql/BaseSearch.generated.ts
@@ -152,6 +152,11 @@ export const containers_Search_gql_BaseSearchDocument = {
                   name: { kind: 'Name', value: 'searchString' },
                 },
               },
+              {
+                kind: 'Argument',
+                name: { kind: 'Name', value: 'latestOnly' },
+                value: { kind: 'BooleanValue', value: true },
+              },
             ],
             selectionSet: {
               kind: 'SelectionSet',

--- a/catalog/app/containers/Search/gql/BaseSearch.graphql
+++ b/catalog/app/containers/Search/gql/BaseSearch.graphql
@@ -1,5 +1,5 @@
 query ($buckets: [String!], $searchString: String) {
-  searchPackages(buckets: $buckets, searchString: $searchString) {
+  searchPackages(buckets: $buckets, searchString: $searchString, latestOnly: true) {
     __typename
     ... on PackagesSearchResultSet {
       stats {

--- a/catalog/app/containers/Search/model.ts
+++ b/catalog/app/containers/Search/model.ts
@@ -555,7 +555,7 @@ export function parseSearchParams(qs: string): SearchUrlState {
         resultType,
         filter: PackagesSearchFilterIO.fromURLSearchParams(params),
         userMetaFilters: UserMetaFilters.fromURLSearchParams(params, META_PREFIX),
-        latestOnly: params.get('rev') === 'latest',
+        latestOnly: params.get('rev') !== 'all',
       }
     default:
       assertNever(resultType)
@@ -586,7 +586,7 @@ function serializeSearchUrlState(state: SearchUrlState): URLSearchParams {
     case ResultType.QuiltPackage:
       appendParams(PackagesSearchFilterIO.toURLSearchParams(state.filter))
       appendParams(state.userMetaFilters.toURLSearchParams(META_PREFIX))
-      if (state.latestOnly) params.set('rev', 'latest')
+      if (!state.latestOnly) params.set('rev', 'all')
       break
     default:
       assertNever(state)
@@ -652,7 +652,7 @@ function useFirstPagePackagesQuery(state: SearchUrlState) {
         state.resultType === ResultType.QuiltPackage
           ? state.userMetaFilters.toGQL()
           : null,
-      latestOnly: state.resultType === ResultType.QuiltPackage ? state.latestOnly : false,
+      latestOnly: state.resultType === ResultType.QuiltPackage ? state.latestOnly : true,
     },
     {
       pause: state.resultType !== ResultType.QuiltPackage,
@@ -1257,7 +1257,7 @@ function useSearchUIModel() {
               resultType,
               filter: PackagesSearchFilterIO.initialState,
               userMetaFilters: new UserMetaFilters(),
-              latestOnly: false,
+              latestOnly: true,
             }
           case ResultType.S3Object:
             return {
@@ -1420,7 +1420,7 @@ function useSearchUIModel() {
             resultType,
             filter: PackagesSearchFilterIO.initialState,
             userMetaFilters: new UserMetaFilters(),
-            latestOnly: false,
+            latestOnly: true,
           }
         case ResultType.S3Object:
           return {


### PR DESCRIPTION
# Description

- Search Results: Don't show package hash in the header
- Default package search to latest revisions only

<img width="429" alt="Screenshot 2025-02-17 at 12 59 30" src="https://github.com/user-attachments/assets/70c0caed-60ec-44de-9e5e-a09a457a3959" />


# TODO

- [x] Unit tests
- [x] Confirm that this change meets security best practices and does not violate the security model
- [x] [Changelog](../tree/master/docs/CHANGELOG.md) entry (skip if change is not significant to end users, e.g. docs only)
