### PR TITLE
Catalog: Tabulator: support `continue_on_error` config option

### DIFF
--- a/catalog/CHANGELOG.md
+++ b/catalog/CHANGELOG.md
@@ -18,6 +18,7 @@ where verb is one of
 
 ## Changes
 
+- [Changed] Tabulator: Support `continue_on_error` config option ([#4328](https://github.com/quiltdata/quilt/pull/4328))
 - [Added] Search: A switch to search only the latest revisions ([#4316](https://github.com/quiltdata/quilt/pull/4316))
 - [Changed] Tabulator: Allow uppercase letters in column names ([#4314](https://github.com/quiltdata/quilt/pull/4314))
 - [Fixed] Add Markdown preview when creating the Markdown file ([#4293](https://github.com/quiltdata/quilt/pull/4293))

--- a/shared/schemas/tabulatorTable.yml.json
+++ b/shared/schemas/tabulatorTable.yml.json
@@ -25,6 +25,10 @@
           "$ref": "#/definitions/ParquetParser"
         }
       ]
+    },
+    "continue_on_error": {
+      "title": "Continue On Error",
+      "type": "boolean"
     }
   },
   "required": [


### PR DESCRIPTION
- [x] [Changelog](../tree/master/docs/CHANGELOG.md) entry (skip if change is not significant to end users, e.g. docs only)
