### PR TITLE
Use s3hash lambda in packager

### DIFF
--- a/lambdas/pkgpush/src/t4_lambda_pkgpush/__init__.py
+++ b/lambdas/pkgpush/src/t4_lambda_pkgpush/__init__.py
@@ -588,6 +588,10 @@ def setup_user_boto_session_once():
     user_boto_session = get_user_boto_session()
 
 
+def get_scratch_buckets() -> T.Dict[str, str]:
+    return json.load(s3.get_object(Bucket=SERVICE_BUCKET, Key="scratch_buckets.json")["Body"])
+
+
 def package_prefix_sqs(event, context):
     import pprint
 
@@ -626,6 +630,7 @@ def package_prefix(event, context):
         name=pkg_name,
         message=params.commit_message,
     )
+    calculate_pkg_hashes(pkg, get_scratch_buckets())
     pkg._build(
         name=pkg_name,
         registry=registry_url,

--- a/lambdas/pkgpush/src/t4_lambda_pkgpush/__init__.py
+++ b/lambdas/pkgpush/src/t4_lambda_pkgpush/__init__.py
@@ -589,7 +589,7 @@ def setup_user_boto_session_once():
 
 
 def get_scratch_buckets() -> T.Dict[str, str]:
-    return json.load(s3.get_object(Bucket=SERVICE_BUCKET, Key="scratch_buckets.json")["Body"])
+    return json.load(s3.get_object(Bucket=SERVICE_BUCKET, Key="scratch-buckets.json")["Body"])
 
 
 def package_prefix_sqs(event, context):


### PR DESCRIPTION
# Description


# TODO

<!-- Remove items that are irrelevant to this PR -->

- [ ] Unit tests
- [ ] Automated tests (e.g. Preflight)
- [ ] Confirm that this change meets security best practices and does not violate the security model
- [ ] Documentation
    - [ ] run `optipng` on any new PNGs
    - [ ] [Python: Run `build.py`](../tree/master/gendocs/build.py) for new docstrings
    - [ ] JavaScript: basic explanation and screenshot of new features
    - [ ] Markdown somewhere in docs/**/*.md that explains the feature to end users (said .md files should be linked from SUMMARY.md so they appear on https://docs.quiltdata.com)
    - [ ] Markdown docs for developers
- [ ] [Changelog](../tree/master/docs/CHANGELOG.md) entry (skip if change is not significant to end users, e.g. docs only)
