### PR TITLE
`AwsDataCatalog` is always visible and selectable

### DIFF
--- a/catalog/CHANGELOG.md
+++ b/catalog/CHANGELOG.md
@@ -18,6 +18,7 @@ where verb is one of
 
 ## Changes
 
+- [Fixed] Athena: always show `AwsDataCatalog` in Data catalog selection ([#4335](https://github.com/quiltdata/quilt/pull/4335))
 - [Changed] Search Results: Don't show package hash in the header ([#4319](https://github.com/quiltdata/quilt/pull/4319))
 - [Changed] Default package search to latest revisions only ([#4319](https://github.com/quiltdata/quilt/pull/4319))
 - [Changed] Tabulator: Support `continue_on_error` config option ([#4328](https://github.com/quiltdata/quilt/pull/4328))

--- a/catalog/app/containers/Bucket/Queries/Athena/model/requests.ts
+++ b/catalog/app/containers/Bucket/Queries/Athena/model/requests.ts
@@ -550,7 +550,6 @@ async function fetchCatalogName(
     )
   } catch (error) {
     if (isAwsErrorAccessDenied(error)) {
-      if (catalogName === 'AwsDataCatalog') return catalogName
       Log.info(`Fetching "${catalogName}" catalog name failed: ${error.code}`)
     } else {
       Log.error(`Fetching "${catalogName}" catalog name failed:`, error)
@@ -573,7 +572,11 @@ async function fetchCatalogNames(
       .filter(Boolean)
       .sort()
     const available = (
-      await Promise.all(parsed.map((name) => fetchCatalogName(athena, workgroup, name)))
+      await Promise.all(
+        parsed.map((name) =>
+          name === 'AwsDataCatalog' ? name : fetchCatalogName(athena, workgroup, name),
+        ),
+      )
     ).filter(Boolean)
     const list = (prev?.list || []).concat(available as Workgroup[])
     return {

--- a/catalog/app/containers/Bucket/Queries/Athena/model/requests.ts
+++ b/catalog/app/containers/Bucket/Queries/Athena/model/requests.ts
@@ -543,6 +543,10 @@ async function fetchCatalogName(
   workgroup: Workgroup,
   catalogName: CatalogName,
 ): Promise<CatalogName | null> {
+  // This is default place where we create tables for quilt packages
+  // We show it regardless of permissions
+  if (catalogName === 'AwsDataCatalog') return catalogName
+
   try {
     return (
       (await athena.getDataCatalog({ Name: catalogName, WorkGroup: workgroup }).promise())
@@ -572,13 +576,9 @@ async function fetchCatalogNames(
       .filter(Boolean)
       .sort()
     const available = (
-      await Promise.all(
-        parsed.map((name) =>
-          name === 'AwsDataCatalog' ? name : fetchCatalogName(athena, workgroup, name),
-        ),
-      )
+      await Promise.all(parsed.map((name) => fetchCatalogName(athena, workgroup, name)))
     ).filter(Boolean)
-    const list = (prev?.list || []).concat(available as Workgroup[])
+    const list = (prev?.list || []).concat(available as CatalogName[])
     return {
       list,
       next: catalogsOutput.NextToken,

--- a/catalog/app/containers/Bucket/Queries/Athena/model/requests.ts
+++ b/catalog/app/containers/Bucket/Queries/Athena/model/requests.ts
@@ -550,6 +550,7 @@ async function fetchCatalogName(
     )
   } catch (error) {
     if (isAwsErrorAccessDenied(error)) {
+      if (catalogName === 'AwsDataCatalog') return catalogName
       Log.info(`Fetching "${catalogName}" catalog name failed: ${error.code}`)
     } else {
       Log.error(`Fetching "${catalogName}" catalog name failed:`, error)


### PR DESCRIPTION
- [x] [Changelog](../tree/master/docs/CHANGELOG.md) entry (skip if change is not significant to end users, e.g. docs only)
