### PR TITLE
Use allow_nan=False for JSON serialization of manifests

### DIFF
--- a/api/python/quilt3/packages.py
+++ b/api/python/quilt3/packages.py
@@ -1105,7 +1105,7 @@ class Package:
         return self._dump(writable_file)
 
     def _dump(self, writable_file):
-        json_encode = json.JSONEncoder(ensure_ascii=False).encode
+        json_encode = json.JSONEncoder(ensure_ascii=False, allow_nan=False).encode
 
         def dumps(obj):
             data = json_encode(obj)

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -13,6 +13,12 @@ Entries inside each section should be ordered by type:
 ## CLI
 !-->
 
+# unreleased - YYYY-MM-DD
+
+## Python API
+
+* [Changed] **BREAKING:** Forbid using non-finite `float`s in package metadata. Previously that was allowed and resulted in a package manifests that are not compliant to RFC 8259 ([#4340](https://github.com/quiltdata/quilt/pull/4340))
+
 # 6.3.0 - 2025-01-24
 
 ## Python API

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -17,7 +17,7 @@ Entries inside each section should be ordered by type:
 
 ## Python API
 
-* [Changed] **BREAKING:** Forbid using non-finite `float`s in package metadata. Previously that was allowed and resulted in a package manifests that are not compliant to RFC 8259 ([#4340](https://github.com/quiltdata/quilt/pull/4340))
+* [Changed] **BREAKING:** Forbid using non-finite `float`s in package metadata. Previously that was allowed and resulted in package manifests that are not compliant to RFC 8259 ([#4340](https://github.com/quiltdata/quilt/pull/4340))
 
 # 6.3.0 - 2025-01-24
 


### PR DESCRIPTION
# Description


# TODO

<!-- Remove items that are irrelevant to this PR -->

- [x] Unit tests
- [x] [Changelog](../tree/master/docs/CHANGELOG.md) entry (skip if change is not significant to end users, e.g. docs only)
