### PR TITLE
Search: Only show package comment and hash when including historical versions

### DIFF
--- a/.github/workflows/deploy-catalog.yaml
+++ b/.github/workflows/deploy-catalog.yaml
@@ -4,7 +4,6 @@ on:
   push:
     branches:
       - master
-      - hide-revision-when-latest
     paths:
       - '.github/workflows/deploy-catalog.yaml'
       - 'catalog/**'
@@ -65,5 +64,5 @@ jobs:
             -t $ECR_REGISTRY_MP/$ECR_REPOSITORY_MP:$IMAGE_TAG \
             .
           docker push $ECR_REGISTRY_PROD/$ECR_REPOSITORY:$IMAGE_TAG
-          # docker push $ECR_REGISTRY_GOVCLOUD/$ECR_REPOSITORY:$IMAGE_TAG
-          # docker push $ECR_REGISTRY_MP/$ECR_REPOSITORY_MP:$IMAGE_TAG
+          docker push $ECR_REGISTRY_GOVCLOUD/$ECR_REPOSITORY:$IMAGE_TAG
+          docker push $ECR_REGISTRY_MP/$ECR_REPOSITORY_MP:$IMAGE_TAG

--- a/.github/workflows/deploy-catalog.yaml
+++ b/.github/workflows/deploy-catalog.yaml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - master
+      - hide-revision-when-latest
     paths:
       - '.github/workflows/deploy-catalog.yaml'
       - 'catalog/**'
@@ -64,5 +65,5 @@ jobs:
             -t $ECR_REGISTRY_MP/$ECR_REPOSITORY_MP:$IMAGE_TAG \
             .
           docker push $ECR_REGISTRY_PROD/$ECR_REPOSITORY:$IMAGE_TAG
-          docker push $ECR_REGISTRY_GOVCLOUD/$ECR_REPOSITORY:$IMAGE_TAG
-          docker push $ECR_REGISTRY_MP/$ECR_REPOSITORY_MP:$IMAGE_TAG
+          # docker push $ECR_REGISTRY_GOVCLOUD/$ECR_REPOSITORY:$IMAGE_TAG
+          # docker push $ECR_REGISTRY_MP/$ECR_REPOSITORY_MP:$IMAGE_TAG

--- a/catalog/CHANGELOG.md
+++ b/catalog/CHANGELOG.md
@@ -18,6 +18,7 @@ where verb is one of
 
 ## Changes
 
+- [Changed] Search: Only show package comment and hash when including historical versions, adjust stylings ([#4371](https://github.com/quiltdata/quilt/pull/4371))
 - [Changed] Allow forms and popups in iframes when **Permissive HTML Rendering** enabled ([#4366](https://github.com/quiltdata/quilt/pull/4366))
 - [Changed] Search: Loose matching, debounce, hide empty previews ([#4367](https://github.com/quiltdata/quilt/pull/4367))
 - [Changed] Streamline search results display ([#4362](https://github.com/quiltdata/quilt/pull/4362))

--- a/catalog/app/containers/Search/Hit.tsx
+++ b/catalog/app/containers/Search/Hit.tsx
@@ -251,13 +251,13 @@ export function Object({ hit, showBucket = false, ...props }: ObjectProps) {
           {hit.deleted ? 'Delete Marker' : readableBytes(hit.size)}
           <Divider />
           {hit.deleted ? 'Deleted' : 'Updated'}{' '}
-          <M.Tooltip title={hit.modified.toLocaleString()}>
+          <M.Tooltip arrow title={hit.modified.toLocaleString()}>
             <span style={{ position: 'relative' }}>
               <Format.Relative value={hit.modified} />
             </span>
           </M.Tooltip>
           <Divider />
-          <M.Tooltip title={`VersionID: ${hit.version}`}>
+          <M.Tooltip arrow title={`VersionID: ${hit.version}`}>
             <span style={{ position: 'relative' }}>v.{hit.version.slice(0, 4)}</span>
           </M.Tooltip>
         </Secondary>

--- a/catalog/app/containers/Search/Hit.tsx
+++ b/catalog/app/containers/Search/Hit.tsx
@@ -84,11 +84,11 @@ function Section({
 const useHeadingStyles = M.makeStyles((t) => ({
   heading: {
     ...t.typography.body1,
-    fontWeight: t.typography.fontWeightRegular,
+    fontWeight: t.typography.fontWeightMedium,
     lineHeight: '20px',
   },
   secondary: {
-    fontWeight: t.typography.fontWeightLight,
+    fontWeight: t.typography.fontWeightRegular,
     color: t.palette.text.secondary,
   },
 }))

--- a/catalog/app/containers/Search/Hit.tsx
+++ b/catalog/app/containers/Search/Hit.tsx
@@ -163,9 +163,15 @@ function Divider() {
 interface PackageProps {
   hit: SearchUIModel.SearchHitPackage
   showBucket?: boolean
+  showRevision?: boolean
 }
 
-export function Package({ hit, showBucket = false, ...props }: PackageProps) {
+export function Package({
+  hit,
+  showBucket = false,
+  showRevision = false,
+  ...props
+}: PackageProps) {
   const { urls } = NamedRoutes.use()
 
   // this is actually a string, so we need to parse it
@@ -178,6 +184,8 @@ export function Package({ hit, showBucket = false, ...props }: PackageProps) {
     }
   }, [hit.meta])
 
+  const comment = hit.comment === 'None' ? null : hit.comment
+
   return (
     <Card {...props}>
       <Section grow>
@@ -188,21 +196,32 @@ export function Package({ hit, showBucket = false, ...props }: PackageProps) {
         <Secondary>
           {readableBytes(hit.size)}
           <Divider />
-          Updated <Format.Relative value={hit.modified} />
+          <M.Tooltip arrow title={hit.modified.toLocaleString()}>
+            <span style={{ position: 'relative' }}>
+              Updated <Format.Relative value={hit.modified} />
+            </span>
+          </M.Tooltip>
           {!!hit.workflow?.id && (
             <>
-              <Divider /> <span style={{ fontWeight: 500 }}>{hit.workflow.id}</span>
+              <Divider />{' '}
+              <M.Chip size="small" variant="outlined" label={hit.workflow.id} />
+            </>
+          )}
+          {showRevision && (
+            <>
+              <Divider />{' '}
+              <M.Tooltip arrow title={hit.hash}>
+                <span style={{ position: 'relative' }}>{hit.hash.slice(0, 8)}</span>
+              </M.Tooltip>
             </>
           )}
         </Secondary>
+        {showRevision && !!comment && (
+          <Secondary>
+            <span style={{ position: 'relative', fontWeight: 300 }}>{comment}</span>
+          </Secondary>
+        )}
       </Section>
-
-      {!!hit.comment && (
-        // XXX: render this in a Secondary instead of a seprarate Section?
-        <Section divider>
-          <M.Typography variant="body2">{hit.comment}</M.Typography>
-        </Section>
-      )}
 
       {!!metaJson && (
         <Section divider>


### PR DESCRIPTION
## hide

<img width="1254" alt="Screenshot 2025-04-08 at 16 23 30" src="https://github.com/user-attachments/assets/2658fa24-3e6b-4169-b386-26d646d6fd3f" />

## show

<img width="1252" alt="Screenshot 2025-04-08 at 16 24 18" src="https://github.com/user-attachments/assets/2c47e513-d29c-47bf-a8bc-11cef780799b" />

## Checklist

- [x] [Changelog](../tree/master/docs/CHANGELOG.md) entry (skip if change is not significant to end users, e.g. docs only)
