### PR TITLE
Catalog: Respect `cfg.packageRoot`: prefix physical keys when creating, and set `destPrefix` when promoting a package

### DIFF
--- a/.github/workflows/deploy-catalog.yaml
+++ b/.github/workflows/deploy-catalog.yaml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - master
+      - frontend-package-root-create-and-promote
     paths:
       - '.github/workflows/deploy-catalog.yaml'
       - 'catalog/**'

--- a/.github/workflows/deploy-catalog.yaml
+++ b/.github/workflows/deploy-catalog.yaml
@@ -4,7 +4,6 @@ on:
   push:
     branches:
       - master
-      - frontend-package-root-create-and-promote
     paths:
       - '.github/workflows/deploy-catalog.yaml'
       - 'catalog/**'

--- a/catalog/CHANGELOG.md
+++ b/catalog/CHANGELOG.md
@@ -18,6 +18,7 @@ where verb is one of
 
 ## Changes
 
+- [Added] Support setting the location where files are uploaded while creating or promoting packages (using `packageRoot` config property) ([#4384](https://github.com/quiltdata/quilt/pull/4384))
 - [Changed] Search: Only show package comment and hash when including historical versions, adjust stylings ([#4371](https://github.com/quiltdata/quilt/pull/4371))
 - [Changed] Allow forms and popups in iframes when **Permissive HTML Rendering** enabled ([#4366](https://github.com/quiltdata/quilt/pull/4366))
 - [Changed] Search: Loose matching, debounce, hide empty previews ([#4367](https://github.com/quiltdata/quilt/pull/4367))

--- a/catalog/app/containers/Bucket/PackageCopyDialog.tsx
+++ b/catalog/app/containers/Bucket/PackageCopyDialog.tsx
@@ -147,7 +147,7 @@ function DialogForm({
           name: initialName,
           hash,
         },
-        destPrefix: successor.copyData ? cfg.packageRoot : undefined,
+        destPrefix: successor.copyData && cfg.packageRoot ? cfg.packageRoot : null,
       })
       switch (r.__typename) {
         case 'PackagePushSuccess':

--- a/catalog/app/containers/Bucket/PackageCopyDialog.tsx
+++ b/catalog/app/containers/Bucket/PackageCopyDialog.tsx
@@ -6,6 +6,7 @@ import useResizeObserver from 'use-resize-observer'
 import * as M from '@material-ui/core'
 
 import * as Intercom from 'components/Intercom'
+import cfg from 'constants/config'
 import * as AWS from 'utils/AWS'
 import * as Data from 'utils/Data'
 import { useMutation } from 'utils/GraphQL'
@@ -146,6 +147,7 @@ function DialogForm({
           name: initialName,
           hash,
         },
+        destPrefix: successor.copyData ? cfg.packageRoot : undefined,
       })
       switch (r.__typename) {
         case 'PackagePushSuccess':

--- a/catalog/app/containers/Bucket/PackageDialog/PackageCreationForm.tsx
+++ b/catalog/app/containers/Bucket/PackageDialog/PackageCreationForm.tsx
@@ -332,12 +332,17 @@ function PackageCreationForm({
       }
     }
 
+    const prefix = s3paths.withoutPrefix(
+      '/',
+      `${s3paths.ensureNoSlash(cfg.packageRoot || '')}/${name}`,
+    )
+
     let uploadedEntries
     try {
       uploadedEntries = await uploads.upload({
         files: toUpload,
         bucket: successor.slug,
-        prefix: name,
+        prefix,
         getMeta: (path) => files.existing[path]?.meta || files.added[path]?.meta,
       })
     } catch (e) {

--- a/catalog/app/containers/Bucket/PackageDialog/gql/PackagePromote.generated.ts
+++ b/catalog/app/containers/Bucket/PackageDialog/gql/PackagePromote.generated.ts
@@ -88,7 +88,7 @@ export const containers_Bucket_PackageDialog_gql_PackagePromoteDocument = {
               },
               {
                 kind: 'Argument',
-                name: { kind: 'Name', value: 'dest_prefix' },
+                name: { kind: 'Name', value: 'destPrefix' },
                 value: { kind: 'Variable', name: { kind: 'Name', value: 'destPrefix' } },
               },
             ],

--- a/catalog/app/containers/Bucket/PackageDialog/gql/PackagePromote.generated.ts
+++ b/catalog/app/containers/Bucket/PackageDialog/gql/PackagePromote.generated.ts
@@ -19,6 +19,7 @@ export type containers_Bucket_PackageDialog_gql_PackagePromoteMutationVariables 
   Types.Exact<{
     params: Types.PackagePushParams
     src: Types.PackagePromoteSource
+    destPrefix: Types.Maybe<Types.Scalars['String']>
   }>
 
 export type containers_Bucket_PackageDialog_gql_PackagePromoteMutation = {
@@ -62,6 +63,11 @@ export const containers_Bucket_PackageDialog_gql_PackagePromoteDocument = {
             },
           },
         },
+        {
+          kind: 'VariableDefinition',
+          variable: { kind: 'Variable', name: { kind: 'Name', value: 'destPrefix' } },
+          type: { kind: 'NamedType', name: { kind: 'Name', value: 'String' } },
+        },
       ],
       selectionSet: {
         kind: 'SelectionSet',
@@ -79,6 +85,11 @@ export const containers_Bucket_PackageDialog_gql_PackagePromoteDocument = {
                 kind: 'Argument',
                 name: { kind: 'Name', value: 'src' },
                 value: { kind: 'Variable', name: { kind: 'Name', value: 'src' } },
+              },
+              {
+                kind: 'Argument',
+                name: { kind: 'Name', value: 'dest_prefix' },
+                value: { kind: 'Variable', name: { kind: 'Name', value: 'destPrefix' } },
               },
             ],
             selectionSet: {

--- a/catalog/app/containers/Bucket/PackageDialog/gql/PackagePromote.graphql
+++ b/catalog/app/containers/Bucket/PackageDialog/gql/PackagePromote.graphql
@@ -3,7 +3,7 @@
 # import OperationErrorSelection from "./OperationErrorSelection.graphql"
 
 mutation ($params: PackagePushParams!, $src: PackagePromoteSource!, $destPrefix: String) {
-  packagePromote(params: $params, src: $src, dest_prefix: $destPrefix) {
+  packagePromote(params: $params, src: $src, destPrefix: $destPrefix) {
     __typename
     ...PackagePushSuccessSelection
     ...InvalidInputSelection

--- a/catalog/app/containers/Bucket/PackageDialog/gql/PackagePromote.graphql
+++ b/catalog/app/containers/Bucket/PackageDialog/gql/PackagePromote.graphql
@@ -2,8 +2,8 @@
 # import InvalidInputSelection from "./InvalidInputSelection.graphql"
 # import OperationErrorSelection from "./OperationErrorSelection.graphql"
 
-mutation ($params: PackagePushParams!, $src: PackagePromoteSource!) {
-  packagePromote(params: $params, src: $src) {
+mutation ($params: PackagePushParams!, $src: PackagePromoteSource!, $destPrefix: String) {
+  packagePromote(params: $params, src: $src, dest_prefix: $destPrefix) {
     __typename
     ...PackagePushSuccessSelection
     ...InvalidInputSelection

--- a/catalog/app/model/graphql/schema.generated.ts
+++ b/catalog/app/model/graphql/schema.generated.ts
@@ -2036,7 +2036,7 @@ export default {
                 },
               },
               {
-                name: 'dest_prefix',
+                name: 'destPrefix',
                 type: {
                   kind: 'SCALAR',
                   name: 'String',

--- a/catalog/app/model/graphql/schema.generated.ts
+++ b/catalog/app/model/graphql/schema.generated.ts
@@ -2035,6 +2035,14 @@ export default {
                   },
                 },
               },
+              {
+                name: 'dest_prefix',
+                type: {
+                  kind: 'SCALAR',
+                  name: 'String',
+                  ofType: null,
+                },
+              },
             ],
           },
           {

--- a/catalog/app/model/graphql/types.generated.ts
+++ b/catalog/app/model/graphql/types.generated.ts
@@ -453,6 +453,7 @@ export interface MutationpackageConstructArgs {
 export interface MutationpackagePromoteArgs {
   params: PackagePushParams
   src: PackagePromoteSource
+  dest_prefix: Maybe<Scalars['String']>
 }
 
 export interface MutationpackageRevisionDeleteArgs {

--- a/catalog/app/model/graphql/types.generated.ts
+++ b/catalog/app/model/graphql/types.generated.ts
@@ -453,7 +453,7 @@ export interface MutationpackageConstructArgs {
 export interface MutationpackagePromoteArgs {
   params: PackagePushParams
   src: PackagePromoteSource
-  dest_prefix: Maybe<Scalars['String']>
+  destPrefix: Maybe<Scalars['String']>
 }
 
 export interface MutationpackageRevisionDeleteArgs {

--- a/catalog/app/utils/Config.ts
+++ b/catalog/app/utils/Config.ts
@@ -49,6 +49,7 @@ export interface ConfigJson {
 
   build_version?: string // not sure where this comes from
   stackVersion: string
+  packageRoot?: string
 }
 
 const ajv = new Ajv({ allErrors: true, removeAdditional: true })

--- a/catalog/config-schema.json
+++ b/catalog/config-schema.json
@@ -100,6 +100,10 @@
     "stackVersion": {
       "type": "string",
       "description": "Stack release version"
+    },
+    "packageRoot": {
+      "type": "string",
+      "description": "Package prefix where package files will be uploaded"
     }
   },
   "required": [

--- a/catalog/config-schema.json
+++ b/catalog/config-schema.json
@@ -103,7 +103,7 @@
     },
     "packageRoot": {
       "type": "string",
-      "description": "Package prefix where package files will be uploaded"
+      "description": "Prefix where package files will be uploaded"
     }
   },
   "required": [

--- a/catalog/config.json.tmpl
+++ b/catalog/config.json.tmpl
@@ -16,5 +16,6 @@
     "mode": "${CATALOG_MODE}",
     "chunkedChecksums": ${CHUNKED_CHECKSUMS},
     "qurator": ${QURATOR},
-    "stackVersion": "${STACK_VERSION}"
+    "stackVersion": "${STACK_VERSION}",
+    "packageRoot": "${PACKAGE_ROOT}"
 }

--- a/shared/graphql/schema.graphql
+++ b/shared/graphql/schema.graphql
@@ -946,6 +946,7 @@ type Mutation {
   packagePromote(
     params: PackagePushParams!
     src: PackagePromoteSource!
+    dest_prefix: String
   ): PackagePromoteResult!
   packageRevisionDelete(
     bucket: String!

--- a/shared/graphql/schema.graphql
+++ b/shared/graphql/schema.graphql
@@ -946,7 +946,7 @@ type Mutation {
   packagePromote(
     params: PackagePushParams!
     src: PackagePromoteSource!
-    dest_prefix: String
+    destPrefix: String
   ): PackagePromoteResult!
   packageRevisionDelete(
     bucket: String!


### PR DESCRIPTION

- [x] [Changelog](../tree/master/docs/CHANGELOG.md) entry (skip if change is not significant to end users, e.g. docs only)
