### PR TITLE
ignore some markdownlint rules in main changelog to fix CI job

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,4 +1,4 @@
-<!-- markdownlint-disable line-length -->
+<!-- markdownlint-disable line-length single-h1 descriptive-link-text -->
 <!--
 Entries inside each section should be ordered by type:
 1. Removed


### PR DESCRIPTION
# Description


# TODO

<!-- Remove items that are irrelevant to this PR -->

- [ ] Unit tests
- [ ] Automated tests (e.g. Preflight)
- [ ] Confirm that this change meets security best practices and does not violate the security model
- [ ] Documentation
    - [ ] run `optipng` on any new PNGs
    - [ ] [Python: Run `build.py`](../tree/master/gendocs/build.py) for new docstrings
    - [ ] JavaScript: basic explanation and screenshot of new features
    - [ ] Markdown somewhere in docs/**/*.md that explains the feature to end users (said .md files should be linked from SUMMARY.md so they appear on https://docs.quilt.bio)
    - [ ] Markdown docs for developers
- [ ] [Changelog](../tree/master/docs/CHANGELOG.md) entry (skip if change is not significant to end users, e.g. docs only)
