### PR TITLE
Fix "NaN packages"; Fallback to "? packages" when the number is unknown

### DIFF
--- a/catalog/CHANGELOG.md
+++ b/catalog/CHANGELOG.md
@@ -18,7 +18,7 @@ where verb is one of
 
 ## Changes
 
-- [Added] Search: Table view for package search results (including matching entries) ([#4413](https://github.com/quiltdata/quilt/pull/4413))
+- [Added] Search: Table view for package search results (including matching entries) ([#4413](https://github.com/quiltdata/quilt/pull/4413), [#4451](https://github.com/quiltdata/quilt/pull/4451))
 - [Changed] Packages tab: Use search view to navigate packages ([#4413](https://github.com/quiltdata/quilt/pull/4413))
 - [Fixed] Freeform search: pass 'size' set to 0 to backend, properly handle 'from' ([#4432](https://github.com/quiltdata/quilt/pull/4432))
 - [Changed] Increase font size in tooltips and make them uniform ([#4425](https://github.com/quiltdata/quilt/pull/4425))

--- a/catalog/app/containers/Bucket/Overview/Header.tsx
+++ b/catalog/app/containers/Bucket/Overview/Header.tsx
@@ -314,7 +314,7 @@ function useStats(bucket: string, overviewUrl?: string | null) {
             case 'InvalidInput':
               return '?'
             case 'PackagesSearchResultSet':
-              return formatQuantity(r.total)
+              return r.total >= 0 ? formatQuantity(r.total) : '?'
             default:
               assertNever(r)
           }

--- a/catalog/app/utils/string.js
+++ b/catalog/app/utils/string.js
@@ -18,7 +18,7 @@ const splitNumber = (n, suffixes) => {
 const numberFormat = new Intl.NumberFormat('en-US')
 
 /**
- * @param {number} n Must be >= 0
+ * @param {number} q Must be >= 0
  */
 export function formatQuantity(
   q,

--- a/catalog/app/utils/string.js
+++ b/catalog/app/utils/string.js
@@ -17,6 +17,9 @@ const splitNumber = (n, suffixes) => {
 
 const numberFormat = new Intl.NumberFormat('en-US')
 
+/**
+ * @param {number} n Must be >= 0
+ */
 export function formatQuantity(
   q,
   {


### PR DESCRIPTION
- [x] [Changelog](../tree/master/docs/CHANGELOG.md) entry (skip if change is not significant to end users, e.g. docs only)
