### PR TITLE
Fix `fetching` state for next page results

### DIFF
--- a/catalog/app/containers/Search/model.ts
+++ b/catalog/app/containers/Search/model.ts
@@ -790,7 +790,8 @@ function useFirstPageQuery(state: SearchUrlState) {
 export function useNextPageObjectsQuery(after: string, pause?: boolean) {
   const result = GQL.useQuery(NEXT_PAGE_OBJECTS_QUERY, { after }, { pause })
   const folded = GQL.fold(result, {
-    data: ({ searchMoreObjects: data }) => addTag('data', { data }),
+    data: ({ searchMoreObjects: data }, { fetching }) =>
+      fetching ? addTag('fetching', {}) : addTag('data', { data }),
     fetching: () => addTag('fetching', {}),
     error: (error) => addTag('error', { error }),
   })
@@ -800,7 +801,8 @@ export function useNextPageObjectsQuery(after: string, pause?: boolean) {
 export function useNextPagePackagesQuery(after: string, pause?: boolean) {
   const result = GQL.useQuery(NEXT_PAGE_PACKAGES_QUERY, { after }, { pause })
   const folded = GQL.fold(result, {
-    data: ({ searchMorePackages: data }) => addTag('data', { data }),
+    data: ({ searchMorePackages: data }, { fetching }) =>
+      fetching ? addTag('fetching', {}) : addTag('data', { data }),
     fetching: () => addTag('fetching', {}),
     error: (error) => addTag('error', { error }),
   })

--- a/catalog/app/utils/GraphQL/wrappers.ts
+++ b/catalog/app/utils/GraphQL/wrappers.ts
@@ -78,7 +78,12 @@ interface FoldConfig<Data, OnData, OnFecthing, OnError>
  * ```ts
  * const result = useQuery(...)
  * const value = fold(result, {
- *   data: (data) => data,
+ *   data: (data, { fetching }) => {
+ *     if (fetching) {
+ *       return 'fetching new data, but returning the previous data'
+ *     }
+ *     return data
+ *   },
  *   fetching: () => 'fetching',
  * })
  * ```


### PR DESCRIPTION
- [x] Documentation
    - [x] Markdown docs for developers
- [ ] ~~[Changelog](../tree/master/docs/CHANGELOG.md) entry (skip if change is not significant to end users, e.g. docs only)~~
