### PR TITLE
Optimize search results toolbar for mobile

### DIFF
--- a/catalog/CHANGELOG.md
+++ b/catalog/CHANGELOG.md
@@ -18,7 +18,7 @@ where verb is one of
 
 ## Changes
 
-- [Added] Search: Table view for package search results (including matching entries) ([#4413](https://github.com/quiltdata/quilt/pull/4413), [#4451](https://github.com/quiltdata/quilt/pull/4451), [#4452](https://github.com/quiltdata/quilt/pull/4452), [#4460](https://github.com/quiltdata/quilt/pull/4460))
+- [Added] Search: Table view for package search results (including matching entries) ([#4413](https://github.com/quiltdata/quilt/pull/4413), [#4451](https://github.com/quiltdata/quilt/pull/4451), [#4452](https://github.com/quiltdata/quilt/pull/4452), [#4460](https://github.com/quiltdata/quilt/pull/4460), [#4461](https://github.com/quiltdata/quilt/pull/4461))
 - [Changed] Packages tab: Use search view to navigate packages ([#4413](https://github.com/quiltdata/quilt/pull/4413))
 - [Fixed] Freeform search: pass 'size' set to 0 to backend, properly handle 'from' ([#4432](https://github.com/quiltdata/quilt/pull/4432))
 - [Changed] Increase font size in tooltips and make them uniform ([#4425](https://github.com/quiltdata/quilt/pull/4425))

--- a/catalog/app/components/SelectDropdown/SelectDropdown.tsx
+++ b/catalog/app/components/SelectDropdown/SelectDropdown.tsx
@@ -32,17 +32,9 @@ export interface ValueBase {
   valueOf: () => string | number | boolean | null
 }
 
-type Breakpoint = M.Theme['breakpoints']['keys'][number]
-
-function useBreakpoint(breakpoint?: Breakpoint) {
-  const t = M.useTheme()
-  const triggered = M.useMediaQuery(t.breakpoints.up(breakpoint || 'xl'))
-  return breakpoint ? triggered : null
-}
-
 interface SelectDropdownProps<Value extends ValueBase> {
   ButtonProps?: M.ButtonProps
-  breakpoint?: Breakpoint
+  shrink?: boolean
   children?: React.ReactNode
   disabled?: boolean
   emptySlot?: React.ReactNode
@@ -61,7 +53,7 @@ interface SelectDropdownProps<Value extends ValueBase> {
 
 export default function SelectDropdown<Value extends ValueBase>({
   ButtonProps,
-  breakpoint,
+  shrink = false,
   children,
   className,
   classes: classesProp,
@@ -100,7 +92,6 @@ export default function SelectDropdown<Value extends ValueBase>({
     [onChange],
   )
 
-  const showLabel = useBreakpoint(breakpoint)
   const { className: buttonClassName, ...buttonProps } = ButtonProps || {}
 
   return (
@@ -118,7 +109,7 @@ export default function SelectDropdown<Value extends ValueBase>({
         {...buttonProps}
       >
         {children}
-        {showLabel && (
+        {!shrink && (
           <>
             <span className={cx(classes.value, classesProp?.value)}>
               {value.toString()}

--- a/catalog/app/components/SelectDropdown/SelectDropdown.tsx
+++ b/catalog/app/components/SelectDropdown/SelectDropdown.tsx
@@ -5,10 +5,6 @@ import * as M from '@material-ui/core'
 const useStyles = M.makeStyles((t) => ({
   root: {
     display: 'inline-flex',
-    [t.breakpoints.down('sm')]: {
-      borderRadius: 0,
-      boxShadow: 'none',
-    },
   },
   button: {
     ...t.typography.body1,
@@ -36,9 +32,12 @@ export interface ValueBase {
   valueOf: () => string | number | boolean | null
 }
 
+type Breakpoint = M.Theme['breakpoints']['keys'][number]
+
 interface SelectDropdownProps<Value extends ValueBase> {
   ButtonProps?: M.ButtonProps
   adaptive?: boolean
+  breakpoint?: Breakpoint
   children?: React.ReactNode
   disabled?: boolean
   emptySlot?: React.ReactNode
@@ -58,6 +57,7 @@ interface SelectDropdownProps<Value extends ValueBase> {
 export default function SelectDropdown<Value extends ValueBase>({
   ButtonProps,
   adaptive = true,
+  breakpoint = 'sm',
   children,
   className,
   classes: classesProp,
@@ -97,7 +97,7 @@ export default function SelectDropdown<Value extends ValueBase>({
   )
 
   const t = M.useTheme()
-  const aboveSm = M.useMediaQuery(t.breakpoints.up('sm'))
+  const aboveSm = M.useMediaQuery(t.breakpoints.up(breakpoint))
   const { className: buttonClassName, ...buttonProps } = ButtonProps || {}
 
   return (

--- a/catalog/app/components/SelectDropdown/SelectDropdown.tsx
+++ b/catalog/app/components/SelectDropdown/SelectDropdown.tsx
@@ -34,9 +34,14 @@ export interface ValueBase {
 
 type Breakpoint = M.Theme['breakpoints']['keys'][number]
 
+function useBreakpoint(breakpoint?: Breakpoint) {
+  const t = M.useTheme()
+  const triggered = M.useMediaQuery(t.breakpoints.up(breakpoint || 'xl'))
+  return breakpoint ? triggered : null
+}
+
 interface SelectDropdownProps<Value extends ValueBase> {
   ButtonProps?: M.ButtonProps
-  adaptive?: boolean
   breakpoint?: Breakpoint
   children?: React.ReactNode
   disabled?: boolean
@@ -56,8 +61,7 @@ interface SelectDropdownProps<Value extends ValueBase> {
 
 export default function SelectDropdown<Value extends ValueBase>({
   ButtonProps,
-  adaptive = true,
-  breakpoint = 'sm',
+  breakpoint,
   children,
   className,
   classes: classesProp,
@@ -96,8 +100,7 @@ export default function SelectDropdown<Value extends ValueBase>({
     [onChange],
   )
 
-  const t = M.useTheme()
-  const aboveSm = M.useMediaQuery(t.breakpoints.up(breakpoint))
+  const showLabel = useBreakpoint(breakpoint)
   const { className: buttonClassName, ...buttonProps } = ButtonProps || {}
 
   return (
@@ -115,7 +118,7 @@ export default function SelectDropdown<Value extends ValueBase>({
         {...buttonProps}
       >
         {children}
-        {(aboveSm || !adaptive) && (
+        {showLabel && (
           <>
             <span className={cx(classes.value, classesProp?.value)}>
               {value.toString()}

--- a/catalog/app/containers/Admin/Settings/SearchSettings.tsx
+++ b/catalog/app/containers/Admin/Settings/SearchSettings.tsx
@@ -87,7 +87,6 @@ export default function SearchSettings() {
     <div className={classes.root}>
       <div className={classes.actions}>
         <SelectDropdown
-          adaptive={false}
           value={value}
           options={searchModes}
           ButtonProps={{ className: classes.selectBtn }}

--- a/catalog/app/containers/Bucket/FileView.js
+++ b/catalog/app/containers/Bucket/FileView.js
@@ -42,7 +42,7 @@ export function ViewModeSelector({ className, ...props }) {
   const t = M.useTheme()
   const sm = M.useMediaQuery(t.breakpoints.down('sm'))
   return (
-    <SelectDropdown className={cx(classes.root, className)} breakpoint="sm" {...props}>
+    <SelectDropdown className={cx(classes.root, className)} shrink={sm} {...props}>
       {sm ? <M.Icon>visibility</M.Icon> : <span className={classes.label}>View as:</span>}
     </SelectDropdown>
   )

--- a/catalog/app/containers/Bucket/FileView.js
+++ b/catalog/app/containers/Bucket/FileView.js
@@ -42,7 +42,7 @@ export function ViewModeSelector({ className, ...props }) {
   const t = M.useTheme()
   const sm = M.useMediaQuery(t.breakpoints.down('sm'))
   return (
-    <SelectDropdown className={cx(classes.root, className)} {...props}>
+    <SelectDropdown className={cx(classes.root, className)} breakpoint="sm" {...props}>
       {sm ? <M.Icon>visibility</M.Icon> : <span className={classes.label}>View as:</span>}
     </SelectDropdown>
   )

--- a/catalog/app/containers/Bucket/Successors.tsx
+++ b/catalog/app/containers/Bucket/Successors.tsx
@@ -209,7 +209,6 @@ export function Dropdown({
   return (
     <SelectDropdown
       ButtonProps={ButtonProps}
-      adaptive={false}
       className={className}
       disabled={!onChange || (Array.isArray(successors) && !successors?.length)}
       emptySlot={emptySlot}

--- a/catalog/app/containers/Search/Sort.tsx
+++ b/catalog/app/containers/Search/Sort.tsx
@@ -100,7 +100,7 @@ export default function Sort({ className }: SortProps) {
       value={value}
       onChange={handleChange}
       ButtonProps={{ classes: buttonClasses, size: 'medium' }}
-      breakpoint="md"
+      shrink={sm}
     >
       {sm ? <M.Icon>sort</M.Icon> : 'Sort by:'}
     </SelectDropdown>

--- a/catalog/app/containers/Search/Sort.tsx
+++ b/catalog/app/containers/Search/Sort.tsx
@@ -100,6 +100,7 @@ export default function Sort({ className }: SortProps) {
       value={value}
       onChange={handleChange}
       ButtonProps={{ classes: buttonClasses, size: 'medium' }}
+      breakpoint="md"
     >
       {sm ? <M.Icon>sort</M.Icon> : 'Sort by:'}
     </SelectDropdown>

--- a/catalog/app/containers/Search/Table/Table.tsx
+++ b/catalog/app/containers/Search/Table/Table.tsx
@@ -182,9 +182,13 @@ function AvailableUserMetaColumn({ column, ...props }: AvailableUserMetaColumnPr
     showColumn()
     open(column)
   }, [column, open, showColumn])
+
   return (
     <M.MenuItem onClick={handleClick}>
-      <M.ListItemText {...props} />
+      <M.ListItemText
+        secondary={column?.state?.filtered && 'Filters applied'}
+        {...props}
+      />
       <M.ListItemSecondaryAction>
         <M.Checkbox edge="end" onChange={handleChange} checked={column.state.visible} />
       </M.ListItemSecondaryAction>


### PR DESCRIPTION
Also, changes in `SelectDropdown` (to customize Sort selector):

* make non-shrinkable by default
* pass `shrink` flag instead of containing Media Query breakpoint inside


[simplescreenrecorder-2025-07-29_13.30.59.webm](https://github.com/user-attachments/assets/c528c72d-4173-4d96-80b0-acaa32e9eae7)

[simplescreenrecorder-2025-07-29_13.33.03.webm](https://github.com/user-attachments/assets/487059a5-2ccd-4e2b-b2e2-39ab89ac7675)

- [x] [Changelog](../tree/master/docs/CHANGELOG.md) entry (skip if change is not significant to end users, e.g. docs only)
