### PR TITLE
 Handle invalid dates in `DatesRange`

### DIFF
--- a/catalog/CHANGELOG.md
+++ b/catalog/CHANGELOG.md
@@ -18,6 +18,7 @@ where verb is one of
 
 ## Changes
 
+- [Fixed] Search: handle invalid dates ([#4466](https://github.com/quiltdata/quilt/pull/4466))
 - [Added] A page for redirecting Quilt+ URIs to QuiltSync ([#4446](https://github.com/quiltdata/quilt/pull/4446))
 - [Added] Search: Table view for package search results (including matching entries) ([#4413](https://github.com/quiltdata/quilt/pull/4413), [#4451](https://github.com/quiltdata/quilt/pull/4451), [#4452](https://github.com/quiltdata/quilt/pull/4452), [#4460](https://github.com/quiltdata/quilt/pull/4460), [#4461](https://github.com/quiltdata/quilt/pull/4461), [#4462](https://github.com/quiltdata/quilt/pull/4462))
 - [Changed] Packages tab: Use search view to navigate packages ([#4413](https://github.com/quiltdata/quilt/pull/4413))

--- a/catalog/app/components/Filters/DateField.spec.tsx
+++ b/catalog/app/components/Filters/DateField.spec.tsx
@@ -1,0 +1,137 @@
+import * as React from 'react'
+import { act, create } from 'react-test-renderer'
+
+import DateField from './DateField'
+
+jest.mock(
+  '@material-ui/core',
+  jest.fn(() => ({
+    ...jest.requireActual('@material-ui/core'),
+    TextField: jest.fn(
+      ({
+        value,
+        inputProps: { min, max } = {},
+        helperText,
+      }: {
+        value: string
+        inputProps?: { min?: string; max?: string }
+        helperText?: string
+      }) => <input value={value} min={min} max={max} data-error={helperText} />,
+    ),
+  })),
+)
+
+jest.mock('utils/Logging', () => ({
+  __esModule: true,
+  default: { error: jest.fn() },
+}))
+
+const onChange = jest.fn()
+
+const findInput = (tree: any) => tree.root.findByType('input')
+
+describe('DateField', () => {
+  it('renders with a valid date prop', () => {
+    const renderer = create(
+      <DateField date={new Date(2025, 0, 13)} extents={{}} onChange={onChange} />,
+    )
+    const input = findInput(renderer)
+    expect(input.props.value).toBe('2025-01-13')
+  })
+
+  it('updates value when prop "date" changes', () => {
+    const renderer = create(
+      <DateField date={new Date(2025, 0, 13)} extents={{}} onChange={onChange} />,
+    )
+
+    const inputInitial = findInput(renderer)
+    expect(inputInitial.props.value).toBe('2025-01-13')
+
+    act(() => {
+      renderer.update(
+        <DateField date={new Date(2025, 6, 15)} extents={{}} onChange={onChange} />,
+      )
+    })
+
+    const inputChanged = findInput(renderer)
+    expect(inputChanged.props.value).toBe('2025-07-15')
+  })
+
+  it('sets min/max from extents', () => {
+    const min = new Date(2020, 0, 1)
+    const max = new Date(2030, 11, 31)
+
+    const renderer = create(
+      <DateField
+        date={new Date(2025, 0, 13)}
+        extents={{ min, max }}
+        onChange={onChange}
+      />,
+    )
+
+    const input = findInput(renderer)
+    expect(input.props.min).toBe('2020-01-01')
+    expect(input.props.max).toBe('2030-12-31')
+  })
+
+  it('handles null/undefined extents gracefully', () => {
+    const renderer = create(
+      <DateField date={new Date(2025, 0, 13)} extents={{}} onChange={onChange} />,
+    )
+
+    const input = findInput(renderer)
+    expect(input.props.min).toBeUndefined()
+    expect(input.props.max).toBeUndefined()
+  })
+
+  it('shows empty value when date is null', () => {
+    const renderer = create(<DateField date={null} extents={{}} onChange={onChange} />)
+    const input = findInput(renderer)
+    expect(input.props.value).toBe('')
+  })
+
+  it('shows empty value and error when date is invalid', () => {
+    const renderer = create(
+      <DateField date={new Date('I XIII MMXXV')} extents={{}} onChange={onChange} />,
+    )
+    const input = findInput(renderer)
+    expect(input.props.value).toBe('')
+    expect(input.props['data-error']).toBe('Invalid time value')
+  })
+
+  it('shows error when clear the date', () => {
+    const renderer = create(
+      <DateField date={new Date(2025, 0, 13)} extents={{}} onChange={onChange} />,
+    )
+
+    const inputInitial = findInput(renderer)
+    expect(inputInitial.props.value).toBe('2025-01-13')
+
+    act(() => {
+      renderer.update(<DateField date={null} extents={{}} onChange={onChange} />)
+    })
+
+    const inputChanged = findInput(renderer)
+    expect(inputChanged.props.value).toBe('')
+    expect(inputChanged.props['data-error']).toBe('Empty date')
+  })
+
+  it('resets error when date is fine', () => {
+    const renderer = create(
+      <DateField date={new Date('I XIII MMXXV')} extents={{}} onChange={onChange} />,
+    )
+    const inputInitial = findInput(renderer)
+    expect(inputInitial.props.value).toBe('')
+    expect(inputInitial.props['data-error']).toBe('Invalid time value')
+
+    act(() => {
+      renderer.update(
+        <DateField date={new Date(2025, 0, 13)} extents={{}} onChange={onChange} />,
+      )
+    })
+
+    const inputChanged = findInput(renderer)
+    expect(inputChanged.props.value).toBe('2025-01-13')
+    expect(inputChanged.props['data-error']).toBeFalsy()
+  })
+})

--- a/catalog/app/components/Filters/DateField.tsx
+++ b/catalog/app/components/Filters/DateField.tsx
@@ -29,10 +29,8 @@ function Err<V>(value: V, error: unknown): InputStateError<V> {
 const InputLabelProps = { shrink: true }
 
 function fromYmd(ymd: string): InputState<string, Date> {
-  const date = new Date(ymd)
-  return Number.isNaN(date.valueOf())
-    ? Err(ymd, new Error(date.toString()))
-    : Ok(ymd, date)
+  const date = dateFns.parseISO(ymd)
+  return dateFns.isValid(date) ? Ok(ymd, date) : Err(ymd, new Error(date.toString()))
 }
 
 function fromDate(date?: Date | null): InputState<string, Date> {

--- a/catalog/app/components/Filters/DateField.tsx
+++ b/catalog/app/components/Filters/DateField.tsx
@@ -28,16 +28,14 @@ function Err<V>(value: V, error: unknown): InputStateError<V> {
 
 const InputLabelProps = { shrink: true }
 
-const fromYmd = (ymd: string): InputState<string, Date> => {
+function fromYmd(ymd: string): InputState<string, Date> {
   const date = new Date(ymd)
-  if (Number.isNaN(date.valueOf())) {
-    const error = new Error(date.toString())
-    return Err(ymd, error)
-  }
-  return Ok(ymd, date)
+  return Number.isNaN(date.valueOf())
+    ? Err(ymd, new Error(date.toString()))
+    : Ok(ymd, date)
 }
 
-const fromDate = (date?: Date | null): InputState<string, Date> => {
+function fromDate(date?: Date | null): InputState<string, Date> {
   if (!date) return Err('', new Error('Empty date'))
   try {
     return Ok(dateFns.format(date, 'yyyy-MM-dd'), date)

--- a/catalog/app/components/Filters/DateField.tsx
+++ b/catalog/app/components/Filters/DateField.tsx
@@ -67,12 +67,14 @@ export default function DateField({
 }: Omit<M.TextFieldProps, 'value' | 'onChange'> & DateFieldProps) {
   const classes = useDateFieldStyles()
 
-  const [state, setState] = React.useState<InputState<string, Date | null>>(Ok('', date))
+  const [state, setState] = React.useState<InputState<string, Date | null>>(
+    fromDate(date),
+  )
 
   React.useEffect(() => setState(fromDate(date)), [date])
 
   const handleChange = React.useCallback(
-    (event) => {
+    (event: React.ChangeEvent<HTMLInputElement>) => {
       const newState = fromYmd(event.target.value)
       setState(newState)
       if (newState._tag === 'ok') {
@@ -83,7 +85,10 @@ export default function DateField({
   )
 
   const inputProps = React.useMemo(
-    () => ({ min: fromDate(extents.min).value, max: fromDate(extents.max).value }),
+    () => ({
+      min: fromDate(extents.min).value || undefined,
+      max: fromDate(extents.max).value || undefined,
+    }),
     [extents],
   )
 

--- a/catalog/app/components/Filters/DateField.tsx
+++ b/catalog/app/components/Filters/DateField.tsx
@@ -4,13 +4,13 @@ import * as M from '@material-ui/core'
 
 import Log from 'utils/Logging'
 
-type ValueOk<V, P> = { _tag: 'ok'; value: V; parsed: P }
+type InputStateOk<V, P> = { _tag: 'ok'; value: V; parsed: P }
 
-type ValueErr<V> = { _tag: 'error'; value: V; error: Error }
+type InputStateError<V> = { _tag: 'error'; value: V; error: Error }
 
-type Value<V, P> = ValueOk<V, P> | ValueErr<V>
+type InputState<V, P> = InputStateOk<V, P> | InputStateError<V>
 
-function Ok<V, P>(value: V, parsed: P): ValueOk<V, P> {
+function Ok<V, P>(value: V, parsed: P): InputStateOk<V, P> {
   return {
     _tag: 'ok',
     value,
@@ -18,7 +18,7 @@ function Ok<V, P>(value: V, parsed: P): ValueOk<V, P> {
   }
 }
 
-function Err<V>(value: V, error: unknown): ValueErr<V> {
+function Err<V>(value: V, error: unknown): InputStateError<V> {
   return {
     _tag: 'error',
     value,
@@ -28,7 +28,7 @@ function Err<V>(value: V, error: unknown): ValueErr<V> {
 
 const InputLabelProps = { shrink: true }
 
-const fromYmd = (ymd: string): Value<string, Date> => {
+const fromYmd = (ymd: string): InputState<string, Date> => {
   const date = new Date(ymd)
   if (Number.isNaN(date.valueOf())) {
     const error = new Error(date.toString())
@@ -37,7 +37,7 @@ const fromYmd = (ymd: string): Value<string, Date> => {
   return Ok(ymd, date)
 }
 
-const fromDate = (date?: Date | null): Value<string, Date> => {
+const fromDate = (date?: Date | null): InputState<string, Date> => {
   if (!date) return Err('', new Error('Empty date'))
   try {
     return Ok(dateFns.format(date, 'yyyy-MM-dd'), date)
@@ -69,7 +69,7 @@ export default function DateField({
 }: Omit<M.TextFieldProps, 'value' | 'onChange'> & DateFieldProps) {
   const classes = useDateFieldStyles()
 
-  const [state, setState] = React.useState<Value<string, Date | null>>(Ok('', date))
+  const [state, setState] = React.useState<InputState<string, Date | null>>(Ok('', date))
 
   React.useEffect(() => setState(fromDate(date)), [date])
 

--- a/catalog/app/components/Filters/DateField.tsx
+++ b/catalog/app/components/Filters/DateField.tsx
@@ -43,6 +43,15 @@ function fromDate(date?: Date | null): InputState<string, Date> {
   }
 }
 
+function areEqual(
+  a: InputState<string, Date | null>,
+  b: InputState<string, Date | null>,
+): boolean {
+  if (a._tag === 'ok' && b._tag === 'ok') return a.parsed === b.parsed
+  if (a._tag === 'error' && b._tag === 'error') return a.error.message === b.error.message
+  return false
+}
+
 const useDateFieldStyles = M.makeStyles((t) => ({
   input: {
     background: t.palette.background.paper,
@@ -69,7 +78,14 @@ export default function DateField({
     fromDate(date),
   )
 
-  React.useEffect(() => setState(fromDate(date)), [date])
+  React.useEffect(
+    () =>
+      setState((prev) => {
+        const newDate = fromDate(date)
+        return areEqual(prev, newDate) ? prev : newDate
+      }),
+    [date],
+  )
 
   const handleChange = React.useCallback(
     (event: React.ChangeEvent<HTMLInputElement>) => {

--- a/catalog/app/components/Filters/DateField.tsx
+++ b/catalog/app/components/Filters/DateField.tsx
@@ -4,9 +4,73 @@ import * as M from '@material-ui/core'
 
 import Log from 'utils/Logging'
 
+const InputLabelProps = { shrink: true }
+
+// TODO: return Value?
 const ymdToDate = (ymd: string): Date => new Date(ymd)
 
+// TODO: return Value?
 const dateToYmd = (date: Date): string => dateFns.format(date, 'yyyy-MM-dd')
+
+const dateToYmdSafe = (date?: Date): string | undefined => {
+  if (!date) return undefined
+  try {
+    return dateToYmd(date)
+  } catch (e) {
+    Log.error(e)
+    return undefined
+  }
+}
+
+type ValueOk = { _tag: 'ok'; value: string }
+
+type ValueErr = { _tag: 'error'; value: string; error: Error }
+
+type Value = ValueOk | ValueErr
+
+const Ok = (value: string): ValueOk => ({
+  _tag: 'ok',
+  value,
+})
+
+const Err = (value: string, error: unknown): ValueErr => ({
+  _tag: 'error',
+  value,
+  error: error instanceof Error ? error : new Error('Invalid date'),
+})
+
+function useDateInput(date: Date | null): {
+  state: Value
+  setValue: (v: string) => Error | Date
+} {
+  const [state, setState] = React.useState<ValueOk | ValueErr>(Ok(''))
+
+  React.useEffect(() => {
+    if (!date) {
+      setState(Err('', new Error('Empty date')))
+      return
+    }
+    try {
+      setState(Ok(dateToYmd(date)))
+    } catch (e) {
+      setState(Err('', e))
+    }
+  }, [date])
+
+  const setValue = React.useCallback((value: string) => {
+    const d = ymdToDate(value)
+    if (!Number.isNaN(d.valueOf())) {
+      setState(Ok(value))
+      return d
+    }
+
+    const invalid = new Error(d.toString())
+    setState(Err(value, invalid))
+    return invalid
+  }, [])
+
+  return { state, setValue }
+}
 
 const useDateFieldStyles = M.makeStyles((t) => ({
   input: {
@@ -30,71 +94,35 @@ export default function DateField({
 }: Omit<M.TextFieldProps, 'value' | 'onChange'> & DateFieldProps) {
   const classes = useDateFieldStyles()
 
-  const [value, setValue] = React.useState('')
-  const [error, setError] = React.useState<Error | null>(null)
-
-  React.useEffect(() => {
-    if (!date) {
-      setError(new Error('Empty date'))
-      setValue('')
-      return
-    }
-    try {
-      const ymd = dateToYmd(date)
-      setError(null)
-      setValue(ymd)
-    } catch (e) {
-      setError(e instanceof Error ? e : new Error('Failed to format'))
-      setValue('')
-    }
-  }, [date])
-
+  const { state, setValue } = useDateInput(date)
   const handleChange = React.useCallback(
     (event) => {
-      setValue(event.target.value)
-
-      const d = ymdToDate(event.target.value)
-      if (Number.isNaN(d.valueOf())) {
-        setError(new Error(d.toString()))
-      } else {
-        onChange(d)
-      }
+      const dateOrError = setValue(event.target.value)
+      if (dateOrError instanceof Error) return
+      onChange(dateOrError)
     },
-    [onChange],
+    [onChange, setValue],
   )
 
-  const min = React.useMemo(() => {
-    if (!extents.min) return undefined
-    try {
-      return dateToYmd(extents.min)
-    } catch (e) {
-      Log.error(e)
-      return undefined
-    }
-  }, [extents])
+  const inputProps = React.useMemo(
+    () => ({ min: dateToYmdSafe(extents.min), max: dateToYmdSafe(extents.max) }),
+    [extents],
+  )
 
-  const max = React.useMemo(() => {
-    if (!extents.max) return undefined
-    try {
-      return dateToYmd(extents.max)
-    } catch (e) {
-      Log.error(e)
-      return undefined
-    }
-  }, [extents])
+  const InputProps = React.useMemo(() => ({ classes }), [classes])
 
   return (
     <M.TextField
-      InputLabelProps={{ shrink: true }}
-      InputProps={{ classes }}
-      inputProps={{ min, max }}
+      InputLabelProps={InputLabelProps}
+      InputProps={InputProps}
       className={className}
-      error={!!error}
-      helperText={error?.message}
+      error={state._tag === 'error'}
+      helperText={state._tag === 'error' && state.error.message}
+      inputProps={inputProps}
       onChange={handleChange}
       size="small"
       type="date"
-      value={value}
+      value={state.value}
       variant="outlined"
       {...props}
     />

--- a/catalog/app/components/Filters/DateField.tsx
+++ b/catalog/app/components/Filters/DateField.tsx
@@ -1,0 +1,102 @@
+import * as dateFns from 'date-fns'
+import * as React from 'react'
+import * as M from '@material-ui/core'
+
+import Log from 'utils/Logging'
+
+const ymdToDate = (ymd: string): Date => new Date(ymd)
+
+const dateToYmd = (date: Date): string => dateFns.format(date, 'yyyy-MM-dd')
+
+const useDateFieldStyles = M.makeStyles((t) => ({
+  input: {
+    background: t.palette.background.paper,
+  },
+}))
+
+interface DateFieldProps {
+  className?: string
+  date: Date | null
+  onChange: (v: Date) => void
+  extents: { min?: Date; max?: Date }
+}
+
+export default function DateField({
+  className,
+  date,
+  extents,
+  onChange,
+  ...props
+}: Omit<M.TextFieldProps, 'value' | 'onChange'> & DateFieldProps) {
+  const classes = useDateFieldStyles()
+
+  const [value, setValue] = React.useState('')
+  const [error, setError] = React.useState<Error | null>(null)
+
+  React.useEffect(() => {
+    if (!date) {
+      setError(new Error('Empty date'))
+      setValue('')
+      return
+    }
+    try {
+      const ymd = dateToYmd(date)
+      setError(null)
+      setValue(ymd)
+    } catch (e) {
+      setError(e instanceof Error ? e : new Error('Failed to format'))
+      setValue('')
+    }
+  }, [date])
+
+  const handleChange = React.useCallback(
+    (event) => {
+      setValue(event.target.value)
+
+      const d = ymdToDate(event.target.value)
+      if (Number.isNaN(d.valueOf())) {
+        setError(new Error(d.toString()))
+      } else {
+        onChange(d)
+      }
+    },
+    [onChange],
+  )
+
+  const min = React.useMemo(() => {
+    if (!extents.min) return undefined
+    try {
+      return dateToYmd(extents.min)
+    } catch (e) {
+      Log.error(e)
+      return undefined
+    }
+  }, [extents])
+
+  const max = React.useMemo(() => {
+    if (!extents.max) return undefined
+    try {
+      return dateToYmd(extents.max)
+    } catch (e) {
+      Log.error(e)
+      return undefined
+    }
+  }, [extents])
+
+  return (
+    <M.TextField
+      InputLabelProps={{ shrink: true }}
+      InputProps={{ classes }}
+      inputProps={{ min, max }}
+      className={className}
+      error={!!error}
+      helperText={error?.message}
+      onChange={handleChange}
+      size="small"
+      type="date"
+      value={value}
+      variant="outlined"
+      {...props}
+    />
+  )
+}

--- a/catalog/app/components/Filters/DatesRange.tsx
+++ b/catalog/app/components/Filters/DatesRange.tsx
@@ -1,10 +1,7 @@
-import * as dateFns from 'date-fns'
 import * as React from 'react'
 import * as M from '@material-ui/core'
 
-const ymdToDate = (ymd: string): Date => new Date(ymd)
-
-const dateToYmd = (date: Date): string => dateFns.format(date, 'yyyy-MM-dd')
+import DateField from './DateField'
 
 const useStyles = M.makeStyles((t) => {
   const gap = t.spacing(1)
@@ -14,50 +11,31 @@ const useStyles = M.makeStyles((t) => {
       gridTemplateColumns: `calc(50% - ${gap / 2}px) calc(50% - ${gap / 2}px)`,
       columnGap: gap,
     },
-    input: {
-      background: t.palette.background.paper,
-    },
   }
 })
 
 interface DateRangeProps {
-  extents: { min: Date; max: Date }
+  extents: { min?: Date; max?: Date }
   onChange: (v: { min: Date | null; max: Date | null }) => void
   value: { min: Date | null; max: Date | null }
 }
 
 export default function DatesRange({ extents, value, onChange }: DateRangeProps) {
   const classes = useStyles()
-  const min = value.min || extents.min
-  const max = value.max || extents.max
-  const handleFrom = React.useCallback(
-    (event) => onChange({ min: ymdToDate(event.target.value), max }),
-    [onChange, max],
+  const gte = value.min || extents.min || null
+  const lte = value.max || extents.max || null
+  const handleGte = React.useCallback(
+    (min) => onChange({ min, max: lte }),
+    [lte, onChange],
   )
-  const handleTo = React.useCallback(
-    (event) => onChange({ min, max: ymdToDate(event.target.value) }),
-    [onChange, min],
+  const handleLte = React.useCallback(
+    (max) => onChange({ min: gte, max }),
+    [gte, onChange],
   )
   return (
     <div className={classes.root}>
-      <M.TextField
-        className={classes.input}
-        label="From"
-        onChange={handleFrom}
-        size="small"
-        type="date"
-        value={dateToYmd(min)}
-        variant="outlined"
-      />
-      <M.TextField
-        className={classes.input}
-        label="To"
-        onChange={handleTo}
-        size="small"
-        type="date"
-        value={dateToYmd(max)}
-        variant="outlined"
-      />
+      <DateField date={gte} extents={extents} onChange={handleGte} label="From" />
+      <DateField date={lte} extents={extents} onChange={handleLte} label="To" />
     </div>
   )
 }

--- a/catalog/app/containers/Search/FilterWidget.tsx
+++ b/catalog/app/containers/Search/FilterWidget.tsx
@@ -149,19 +149,13 @@ function NumberFilterWidget({
   )
 }
 
+const NO_RANGE_EXTENTS = { min: undefined, max: undefined }
+
 function DatetimeFilterWidget({
   state,
   extents,
   onChange,
 }: FilterWidgetProps<SearchUIModel.Predicates['Datetime']>) {
-  const fixedExtents = React.useMemo(
-    () => ({
-      min: extents?.min ?? new Date(),
-      max: extents?.max ?? new Date(),
-    }),
-    [extents?.min, extents?.max],
-  )
-
   const fixedValue = React.useMemo(
     () => ({ min: state.gte, max: state.lte }),
     [state.gte, state.lte],
@@ -176,7 +170,7 @@ function DatetimeFilterWidget({
 
   return (
     <FiltersUI.DatesRange
-      extents={fixedExtents}
+      extents={extents || NO_RANGE_EXTENTS}
       onChange={handleChange}
       value={fixedValue}
     />

--- a/catalog/app/containers/Search/Layout/PackageFilters.tsx
+++ b/catalog/app/containers/Search/Layout/PackageFilters.tsx
@@ -329,7 +329,7 @@ function PackagesFilter({ className, field }: PackagesFilterProps) {
   const predicateState = model.state.filter.predicates[field]
   invariant(predicateState, 'Filter not active')
 
-  const extents = SearchUIModel.usePackageSystemMetaFacetExtents(field)
+  const { fetching, extents } = SearchUIModel.usePackageSystemMetaFacetExtents(field)
 
   const { deactivatePackagesFilter, setPackagesFilter } = model.actions
 
@@ -351,7 +351,9 @@ function PackagesFilter({ className, field }: PackagesFilterProps) {
       onDeactivate={deactivate}
       title={PACKAGE_FILTER_LABELS[field]}
     >
-      <FilterWidget state={predicateState} extents={extents} onChange={change} />
+      {!fetching && (
+        <FilterWidget state={predicateState} extents={extents} onChange={change} />
+      )}
     </FiltersUI.Container>
   )
 }

--- a/catalog/app/containers/Search/Table/Table.tsx
+++ b/catalog/app/containers/Search/Table/Table.tsx
@@ -581,7 +581,7 @@ function Filter({ filter, onChange, value }: FilterProps) {
   const model = SearchUIModel.use(SearchUIModel.ResultType.QuiltPackage)
   const initialValue = model.state.filter.predicates[filter]
   invariant(initialValue, 'Filter not active')
-  const extents = SearchUIModel.usePackageSystemMetaFacetExtents(filter)
+  const { extents } = SearchUIModel.usePackageSystemMetaFacetExtents(filter)
 
   return (
     <FilterWidget state={value || initialValue} extents={extents} onChange={onChange} />

--- a/catalog/app/containers/Search/model.ts
+++ b/catalog/app/containers/Search/model.ts
@@ -1270,26 +1270,29 @@ function oneOf<T extends string, L extends T[]>(
   return comparisonList.some((compare) => compare === subject)
 }
 
-export function usePackageSystemMetaFacetExtents(
-  field: keyof PackagesSearchFilter,
-): Extents | undefined {
+export function usePackageSystemMetaFacetExtents(field: keyof PackagesSearchFilter): {
+  fetching: boolean
+  extents: Extents | undefined
+} {
   const model = useSearchUIModelContext(ResultType.QuiltPackage)
   return GQL.fold(model.baseSearchQuery, {
     data: ({ searchPackages: r }) => {
       switch (r.__typename) {
         case 'EmptySearchResultSet':
-          return undefined
+          return { fetching: false, extents: undefined }
         case 'InvalidInput':
-          return undefined
+          return { fetching: false, extents: undefined }
         case 'PackagesSearchResultSet':
-          if (!oneOf(['workflow', 'modified', 'size', 'entries'], field)) return undefined
-          return r.stats[field]
+          if (oneOf(['workflow', 'modified', 'size', 'entries'], field)) {
+            return { fetching: false, extents: r.stats[field] }
+          }
+          return { fetching: false, extents: undefined }
         default:
           assertNever(r)
       }
     },
-    fetching: () => undefined,
-    error: () => undefined,
+    fetching: () => ({ fetching: true, extents: undefined }),
+    error: () => ({ fetching: false, extents: undefined }),
   })
 }
 


### PR DESCRIPTION
Handle invalid dates, for example, https://nightly.quilttest.com/search?modified={%22gte%22%3A%222019-13-31%22%2C%22lte%22%3A%222025-08-08%22} (13-th month in the URL).

<img width="346" height="131" alt="image" src="https://github.com/user-attachments/assets/98a94bad-e424-42cc-9a4c-c0fbccca1e34" />

* Add `DateField` component, that keeps string representation of the Date internally
* Show error if date is invalid (for both cases if Date is invalid, or if failed to create date from string)

Also, fix "fetching" state when extents for system meta are loading.

- [x] Unit tests
- [x] [Changelog](../tree/master/docs/CHANGELOG.md) entry (skip if change is not significant to end users, e.g. docs only)


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1208780583886775