### PR TITLE
Quilt3 search doc

### DIFF
--- a/api/python/quilt3/api.py
+++ b/api/python/quilt3/api.py
@@ -175,7 +175,8 @@ def search(query: T.Union[str, dict], limit: int = 10) -> T.List[dict]:
         limit: maximum number of results to return. Defaults to 10
 
     Query Syntax:
-        [Query String Query](https://www.elastic.co/guide/en/elasticsearch/reference/6.8/query-dsl-query-string-query.html)
+        [Query String Query](
+            https://www.elastic.co/guide/en/elasticsearch/reference/6.8/query-dsl-query-string-query.html)
         [Query DSL](https://www.elastic.co/guide/en/elasticsearch/reference/6.8/query-dsl.html)
 
     Index schemas and search examples can be found in the

--- a/api/python/quilt3/api.py
+++ b/api/python/quilt3/api.py
@@ -175,9 +175,11 @@ def search(query: T.Union[str, dict], limit: int = 10) -> T.List[dict]:
         limit: maximum number of results to return. Defaults to 10
 
     Query Syntax:
-        [Query String Query](
-            https://www.elastic.co/guide/en/elasticsearch/reference/6.8/query-dsl-query-string-query.html)
+        [Query String Query](https://www.elastic.co/guide/en/elasticsearch/reference/6.8/query-dsl-query-string-query.html)
         [Query DSL](https://www.elastic.co/guide/en/elasticsearch/reference/6.8/query-dsl.html)
+
+    Index schemas and search examples can be found in the
+    [Quilt Search documentation](https://docs.quilt.bio/quilt-platform-catalog-user/search).
 
     Returns:
         search results

--- a/api/python/quilt3/bucket.py
+++ b/api/python/quilt3/bucket.py
@@ -46,9 +46,11 @@ class Bucket:
             limit: maximum number of results to return. Defaults to 10
 
         Query Syntax:
-            [Query String Query](
-                https://www.elastic.co/guide/en/elasticsearch/reference/6.8/query-dsl-query-string-query.html)
+            [Query String Query](https://www.elastic.co/guide/en/elasticsearch/reference/6.8/query-dsl-query-string-query.html)
             [Query DSL](https://www.elastic.co/guide/en/elasticsearch/reference/6.8/query-dsl.html)
+
+        Index schemas and search examples can be found in the
+        [Quilt Search documentation](https://docs.quilt.bio/quilt-platform-catalog-user/search).
 
         Returns:
             search results

--- a/api/python/quilt3/bucket.py
+++ b/api/python/quilt3/bucket.py
@@ -46,7 +46,8 @@ class Bucket:
             limit: maximum number of results to return. Defaults to 10
 
         Query Syntax:
-            [Query String Query](https://www.elastic.co/guide/en/elasticsearch/reference/6.8/query-dsl-query-string-query.html)
+            [Query String Query](
+                https://www.elastic.co/guide/en/elasticsearch/reference/6.8/query-dsl-query-string-query.html)
             [Query DSL](https://www.elastic.co/guide/en/elasticsearch/reference/6.8/query-dsl.html)
 
         Index schemas and search examples can be found in the

--- a/docs/api-reference/Bucket.md
+++ b/docs/api-reference/Bucket.md
@@ -24,9 +24,11 @@ __Arguments__
 * __limit__:  maximum number of results to return. Defaults to 10
 
 Query Syntax:
-    [Query String Query](
-        https://www.elastic.co/guide/en/elasticsearch/reference/6.8/query-dsl-query-string-query.html)
+    [Query String Query](https://www.elastic.co/guide/en/elasticsearch/reference/6.8/query-dsl-query-string-query.html)
     [Query DSL](https://www.elastic.co/guide/en/elasticsearch/reference/6.8/query-dsl.html)
+
+Index schemas and search examples can be found in the
+[Quilt Search documentation](https://docs.quilt.bio/quilt-platform-catalog-user/search).
 
 __Returns__
 

--- a/docs/api-reference/Bucket.md
+++ b/docs/api-reference/Bucket.md
@@ -24,7 +24,8 @@ __Arguments__
 * __limit__:  maximum number of results to return. Defaults to 10
 
 Query Syntax:
-    [Query String Query](https://www.elastic.co/guide/en/elasticsearch/reference/6.8/query-dsl-query-string-query.html)
+    [Query String Query](
+        https://www.elastic.co/guide/en/elasticsearch/reference/6.8/query-dsl-query-string-query.html)
     [Query DSL](https://www.elastic.co/guide/en/elasticsearch/reference/6.8/query-dsl.html)
 
 Index schemas and search examples can be found in the

--- a/docs/api-reference/api.md
+++ b/docs/api-reference/api.md
@@ -113,7 +113,8 @@ __Arguments__
 * __limit__:  maximum number of results to return. Defaults to 10
 
 Query Syntax:
-    [Query String Query](https://www.elastic.co/guide/en/elasticsearch/reference/6.8/query-dsl-query-string-query.html)
+    [Query String Query](
+        https://www.elastic.co/guide/en/elasticsearch/reference/6.8/query-dsl-query-string-query.html)
     [Query DSL](https://www.elastic.co/guide/en/elasticsearch/reference/6.8/query-dsl.html)
 
 Index schemas and search examples can be found in the

--- a/docs/api-reference/api.md
+++ b/docs/api-reference/api.md
@@ -113,9 +113,11 @@ __Arguments__
 * __limit__:  maximum number of results to return. Defaults to 10
 
 Query Syntax:
-    [Query String Query](
-        https://www.elastic.co/guide/en/elasticsearch/reference/6.8/query-dsl-query-string-query.html)
+    [Query String Query](https://www.elastic.co/guide/en/elasticsearch/reference/6.8/query-dsl-query-string-query.html)
     [Query DSL](https://www.elastic.co/guide/en/elasticsearch/reference/6.8/query-dsl.html)
+
+Index schemas and search examples can be found in the
+[Quilt Search documentation](https://docs.quilt.bio/quilt-platform-catalog-user/search).
 
 __Returns__
 


### PR DESCRIPTION
This pull request improves the documentation for the `search` method in both the Python API and the user documentation. It adds direct links to the Quilt Search documentation, making it easier for users to find information about index schemas and search examples.

Documentation improvements:

* Added a reference and link to the Quilt Search documentation for index schemas and search examples in the docstrings of the `search` method in `api/python/quilt3/api.py`  and `api/python/quilt3/bucket.py`.
* Updated the API reference documentation in `docs/api-reference/Bucket.md` and `docs/api-reference/api.md` to include a link to the Quilt Search documentation for further guidance on search queries.