### PR TITLE
Bucket toolbar: Get functionality (download & code samples)

### DIFF
--- a/catalog/app/containers/Bucket/Dir/Toolbar/Get/Options.tsx
+++ b/catalog/app/containers/Bucket/Dir/Toolbar/Get/Options.tsx
@@ -1,0 +1,78 @@
+import { basename } from 'path'
+
+import * as React from 'react'
+import * as M from '@material-ui/core'
+
+import * as CodeSamples from 'containers/Bucket/CodeSamples'
+import * as Buttons from 'containers/Bucket/Download/Buttons'
+import GetOptions from 'containers/Bucket/Toolbar/GetOptions'
+import type * as Toolbar from 'containers/Bucket/Toolbar'
+
+const useCodeSamplesStyles = M.makeStyles((t) => ({
+  code: {
+    marginBottom: t.spacing(2),
+  },
+}))
+
+interface DirCodeSamplesProps {
+  className?: string
+  bucket: string
+  path: string
+}
+
+function DirCodeSamples({ className, bucket, path }: DirCodeSamplesProps) {
+  const classes = useCodeSamplesStyles()
+  const dest = path ? basename(path) : bucket
+  const props = { className: classes.code, bucket, path }
+  return (
+    <div className={className}>
+      <CodeSamples.Quilt3List {...props} />
+      <CodeSamples.Quilt3Fetch {...props} dest={dest} />
+      <CodeSamples.CliList {...props} />
+      <CodeSamples.CliFetch {...props} dest={dest} />
+    </div>
+  )
+}
+
+interface DownloadDirProps {
+  dirHandle: Toolbar.DirHandle
+}
+
+function DownloadDir({ dirHandle }: DownloadDirProps) {
+  // TODO: pass selection to Buttons.DownloadDir
+  const [downloading, setDownloading] = React.useState(false)
+  React.useEffect(() => {
+    if (!downloading) return
+    setTimeout(() => setDownloading(false), 1000)
+  }, [downloading])
+  return (
+    <Buttons.DownloadDir
+      suffix={`dir/${dirHandle.bucket}/${dirHandle.path}`}
+      onClick={(event) => {
+        event.stopPropagation()
+        setDownloading(true)
+      }}
+      {...(downloading
+        ? {
+            startIcon: <M.CircularProgress size={20} />,
+          }
+        : {})}
+    >
+      Download ZIP (directory)
+    </Buttons.DownloadDir>
+  )
+}
+
+interface OptionsProps {
+  handle: Toolbar.DirHandle
+  hideCode?: boolean
+}
+
+export default function Options({ handle, hideCode }: OptionsProps) {
+  const download = <DownloadDir dirHandle={handle} />
+  const code = hideCode ? undefined : (
+    <DirCodeSamples bucket={handle.bucket} path={handle.path} />
+  )
+
+  return <GetOptions download={download} code={code} />
+}

--- a/catalog/app/containers/Bucket/Download/Buttons.tsx
+++ b/catalog/app/containers/Bucket/Download/Buttons.tsx
@@ -1,0 +1,71 @@
+import * as React from 'react'
+import * as M from '@material-ui/core'
+import {
+  ArrowDownwardOutlined as IconArrowDownwardOutlined,
+  ArchiveOutlined as IconArchiveOutlined,
+} from '@material-ui/icons'
+
+import type * as Model from 'model'
+import * as AWS from 'utils/AWS'
+
+import { ZipDownloadForm } from '../FileView'
+
+const useDownloadButtonStyles = M.makeStyles({
+  root: {
+    justifyContent: 'flex-start',
+    lineHeight: '1.25rem',
+    width: '100%',
+  },
+})
+
+interface DownloadFileProps {
+  fileHandle: Model.S3.S3ObjectLocation
+}
+
+export function DownloadFile({ fileHandle }: DownloadFileProps) {
+  const url = AWS.Signer.useDownloadUrl(fileHandle)
+  const classes = useDownloadButtonStyles()
+  return (
+    <M.Button
+      className={classes.root}
+      download
+      href={url}
+      startIcon={<IconArrowDownwardOutlined />}
+    >
+      Download file
+    </M.Button>
+  )
+}
+
+interface DownloadDirProps {
+  className?: string
+  suffix: string
+  fileHandles?: Model.S3.S3ObjectLocation[]
+  children: React.ReactNode
+}
+
+export function DownloadDir({
+  children,
+  fileHandles,
+  className,
+  suffix,
+  ...props
+}: DownloadDirProps & M.ButtonProps) {
+  const classes = useDownloadButtonStyles()
+  const files = React.useMemo(
+    () => fileHandles && fileHandles.map(({ key }) => key),
+    [fileHandles],
+  )
+  return (
+    <ZipDownloadForm className={className} files={files} suffix={suffix}>
+      <M.Button
+        className={classes.root}
+        startIcon={<IconArchiveOutlined />}
+        type="submit"
+        {...props}
+      >
+        <span>{children}</span>
+      </M.Button>
+    </ZipDownloadForm>
+  )
+}

--- a/catalog/app/containers/Bucket/Download/Code.tsx
+++ b/catalog/app/containers/Bucket/Download/Code.tsx
@@ -1,6 +1,10 @@
 import hljs from 'highlight.js'
 import * as React from 'react'
 import * as M from '@material-ui/core'
+import {
+  HelpOutline as IconHelpOutline,
+  FileCopy as IconFileCopy,
+} from '@material-ui/icons'
 
 import * as Notifications from 'containers/Notifications'
 import copyToClipboard from 'utils/clipboard'
@@ -92,14 +96,14 @@ export default function Code({ className, help, hl, label, lines }: CodeProps) {
         {label}
         <a href={help} target="_blank" rel="noopener noreferrer" className={classes.help}>
           <M.IconButton size="small">
-            <M.Icon fontSize="inherit">help</M.Icon>
+            <IconHelpOutline fontSize="inherit" />
           </M.IconButton>
         </a>
       </M.Typography>
       <div className={classes.container}>
         <div className={classes.copy}>
           <M.IconButton onClick={handleCopy} title="Copy to clipboard" size="small">
-            <M.Icon fontSize="inherit">file_copy</M.Icon>
+            <IconFileCopy fontSize="inherit" />
           </M.IconButton>
         </div>
         {lines.map((line, index) => (

--- a/catalog/app/containers/Bucket/Download/PackageOptions.tsx
+++ b/catalog/app/containers/Bucket/Download/PackageOptions.tsx
@@ -1,33 +1,22 @@
+// TODO: move to Bucket/Toolbar/Get/
+
 import * as React from 'react'
 import * as M from '@material-ui/core'
+import { GetApp as IconGetApp, FileCopy as IconFileCopy } from '@material-ui/icons'
 
 import * as urls from 'constants/urls'
 import * as Notifications from 'containers/Notifications'
+import GetOptions from 'containers/Bucket/Toolbar/GetOptions'
 import type * as Model from 'model'
-import * as AWS from 'utils/AWS'
 import * as BucketPreferences from 'utils/BucketPreferences'
 import * as PackageUri from 'utils/PackageUri'
 import StyledLink from 'utils/StyledLink'
 import copyToClipboard from 'utils/clipboard'
 
-import * as FileView from '../FileView'
 import * as Selection from '../Selection'
 
-import { Tabs, TabPanel } from './OptionsTabs'
+import * as Buttons from './Buttons'
 import PackageCodeSamples from './PackageCodeSamples'
-
-interface DownloadFileProps {
-  fileHandle: Model.S3.S3ObjectLocation
-}
-
-function DownloadFile({ fileHandle }: DownloadFileProps) {
-  const url = AWS.Signer.useDownloadUrl(fileHandle)
-  return (
-    <M.Button startIcon={<M.Icon>arrow_downward</M.Icon>} href={url} download>
-      Download file
-    </M.Button>
-  )
-}
 
 interface DownloadDirProps {
   selection?: Selection.ListingSelection
@@ -45,23 +34,26 @@ function DownloadDir({ selection, uri }: DownloadDirProps) {
     uri.path && isSelectionEmpty
       ? `package/${uri.bucket}/${uri.name}/${uri.hash}/${uri.path}`
       : `package/${uri.bucket}/${uri.name}/${uri.hash}`
+  const fileHandles = React.useMemo(
+    () => selection && Selection.toHandlesList(selection),
+    [selection],
+  )
   return (
-    <FileView.ZipDownloadForm
-      files={selection && Selection.toHandlesList(selection).map(({ key }) => key)}
-      suffix={downloadPath}
-    >
-      <M.Button startIcon={<M.Icon>archive</M.Icon>} type="submit">
-        {downloadLabel}
-      </M.Button>
-    </FileView.ZipDownloadForm>
+    <Buttons.DownloadDir suffix={downloadPath} fileHandles={fileHandles}>
+      {downloadLabel}
+    </Buttons.DownloadDir>
   )
 }
 
 const useQuiltSyncStyles = M.makeStyles((t) => ({
   link: {
-    marginBottom: t.spacing(0.5),
+    marginBottom: t.spacing(1),
+  },
+  open: {
+    justifyContent: 'flex-start',
   },
   copy: {
+    fontSize: t.typography.body1.fontSize,
     width: 'auto',
   },
 }))
@@ -84,14 +76,14 @@ function QuiltSync({ className, uri }: QuiltSyncProps) {
   return (
     <div className={className}>
       <M.ButtonGroup variant="outlined" fullWidth className={classes.link}>
-        <M.Button startIcon={<M.Icon>download</M.Icon>} href={uriString}>
+        <M.Button startIcon={<IconGetApp />} href={uriString} className={classes.open}>
           Open in QuiltSync
         </M.Button>
         <M.Button className={classes.copy} onClick={handleCopy}>
-          <M.Icon fontSize="inherit">file_copy_outlined</M.Icon>
+          <IconFileCopy fontSize="inherit" />
         </M.Button>
       </M.ButtonGroup>
-      <M.Typography variant="caption">
+      <M.Typography variant="caption" component="p">
         Don't have QuiltSync?{' '}
         <StyledLink href={urls.quiltSync} target="_blank">
           Download it here
@@ -119,7 +111,7 @@ function DownloadPanel({ fileHandle, selection, uri }: DownloadPanelProps) {
   const classes = useDownloadPanelStyles()
   const { prefs } = BucketPreferences.use()
   return (
-    <TabPanel>
+    <>
       {BucketPreferences.Result.match(
         {
           Ok: ({ ui: { actions } }) =>
@@ -131,11 +123,11 @@ function DownloadPanel({ fileHandle, selection, uri }: DownloadPanelProps) {
         prefs,
       )}
       {fileHandle ? (
-        <DownloadFile fileHandle={fileHandle} />
+        <Buttons.DownloadFile fileHandle={fileHandle} />
       ) : (
         <DownloadDir selection={selection} uri={uri} />
       )}
-    </TabPanel>
+    </>
   )
 }
 
@@ -145,11 +137,7 @@ interface CodePanelProps {
 }
 
 function CodePanel({ hashOrTag, uri }: CodePanelProps) {
-  return (
-    <TabPanel>
-      <PackageCodeSamples hashOrTag={hashOrTag} {...uri} />
-    </TabPanel>
-  )
+  return <PackageCodeSamples hashOrTag={hashOrTag} {...uri} />
 }
 
 interface OptionsProps {
@@ -170,9 +158,7 @@ export default function Options({
   const download = (
     <DownloadPanel fileHandle={fileHandle} selection={selection} uri={uri} />
   )
+  const code = hideCode ? undefined : <CodePanel hashOrTag={hashOrTag} uri={uri} />
 
-  if (hideCode) return download
-
-  const code = <CodePanel hashOrTag={hashOrTag} uri={uri} />
-  return <Tabs {...{ download, code }} />
+  return <GetOptions download={download} code={code} />
 }

--- a/catalog/app/containers/Bucket/Download/index.tsx
+++ b/catalog/app/containers/Bucket/Download/index.tsx
@@ -1,0 +1,18 @@
+// TODO: move to Bucket/Toolbar/Get/index.tsx
+
+import * as React from 'react'
+import { GetAppOutlined as IconGetAppOutlined } from '@material-ui/icons'
+
+import * as Buttons from 'components/Buttons'
+
+export { default as PackageOptions } from './PackageOptions'
+
+interface ButtonProps {
+  children: NonNullable<React.ReactNode>
+  className?: string
+  label?: string
+}
+
+export const Button = ({ label = 'Get files', ...props }: ButtonProps) => (
+  <Buttons.WithPopover icon={IconGetAppOutlined} label={label} {...props} />
+)


### PR DESCRIPTION
## Summary
- Implements Get button functionality with tabbed interface for download options and code samples
- Adds GetOptions component with Material-UI tabs for Download and Code panels
- Provides directory-specific and file-specific Get implementations
- Includes comprehensive CodeSamples with Quilt3 Python API and AWS CLI examples
- Adds Download module with buttons and comprehensive download functionality

## Dependencies
- Depends on PR #4498 (base structure)
- Uses existing Buttons.WithPopover and Selection components

## Test plan
- [ ] Get button renders correctly in Dir and File contexts
- [ ] Popover opens with Download and Code tabs
- [ ] Download buttons work for files and directories
- [ ] Code samples show correct bucket/path parameters
- [ ] Quilt3 and CLI code examples are accurate

🤖 Generated with [Claude Code](https://claude.ai/code)