### PR TITLE
Bucket toolbar: Organize functionality (move, delete, bookmarks)

### DIFF
--- a/catalog/app/containers/Bucket/Dir/Toolbar/Organize/Context.tsx
+++ b/catalog/app/containers/Bucket/Dir/Toolbar/Organize/Context.tsx
@@ -1,0 +1,131 @@
+import invariant from 'invariant'
+import * as React from 'react'
+
+import * as Bookmarks from 'containers/Bookmarks'
+import * as Selection from 'containers/Bucket/Selection'
+import DeleteDialog, { type DeleteResult } from 'containers/Bucket/Toolbar/DeleteDialog'
+import * as Dialogs from 'utils/Dialogs'
+
+interface OrganizeState {
+  addToBookmarks: () => void
+  removeFromBookmarks: () => void
+  toggleBookmarks: () => void
+  bookmarkStatus: 'none' | 'partial' | 'all'
+
+  openSelectionPopup: () => void
+  clearSelection: () => void
+
+  confirmDeleteSelected: () => void
+
+  selectionCount: number
+}
+
+const Context = React.createContext<OrganizeState | null>(null)
+
+function useContext(): OrganizeState {
+  const context = React.useContext(Context)
+  invariant(context, 'useContext must be used within OrganizeDirProvider')
+  return context
+}
+
+export const use = useContext
+
+interface OrganizeProviderProps {
+  children: React.ReactNode
+  onReload: () => void
+}
+
+export function OrganizeProvider({ children, onReload }: OrganizeProviderProps) {
+  const bookmarks = Bookmarks.use()
+  const dialogs = Dialogs.use()
+  const slt = Selection.use()
+
+  const handles = React.useMemo(
+    () => Selection.toHandlesList(slt.selection),
+    [slt.selection],
+  )
+
+  const bookmarkStatus = React.useMemo(() => {
+    if (!bookmarks || slt.isEmpty) return 'none'
+    const bookmarkedCount = handles.filter((handle) =>
+      bookmarks.isBookmarked('main', handle),
+    ).length
+    if (bookmarkedCount === 0) return 'none'
+    if (bookmarkedCount === handles.length) return 'all'
+    return 'partial'
+  }, [bookmarks, slt.isEmpty, handles])
+
+  const addToBookmarks = React.useCallback(() => {
+    if (!bookmarks || slt.isEmpty) return
+    bookmarks.append('main', handles)
+  }, [bookmarks, slt.isEmpty, handles])
+
+  const removeFromBookmarks = React.useCallback(() => {
+    if (!bookmarks || slt.isEmpty) return
+    bookmarks.remove('main', handles)
+  }, [bookmarks, slt.isEmpty, handles])
+
+  const toggleBookmarks = React.useCallback(() => {
+    if (bookmarkStatus === 'all') {
+      removeFromBookmarks()
+    } else {
+      addToBookmarks()
+    }
+  }, [bookmarkStatus, addToBookmarks, removeFromBookmarks])
+
+  const openSelectionPopup = React.useCallback(() => {
+    dialogs.open(({ close }) => <Selection.Popup close={close} />)
+  }, [dialogs])
+
+  const clearSelection = React.useCallback(() => {
+    slt.clear()
+  }, [slt])
+
+  const confirmDeleteSelected = React.useCallback(async () => {
+    if (slt.isEmpty) return
+
+    const result = await dialogs.open<DeleteResult>(({ close }) => (
+      <DeleteDialog close={close} handles={handles} />
+    ))
+
+    if (result.deleted) {
+      onReload()
+      slt.clear()
+    }
+  }, [dialogs, onReload, slt, handles])
+
+  const selectionCount = slt.totalCount
+
+  const actions = React.useMemo(
+    (): OrganizeState => ({
+      addToBookmarks,
+      removeFromBookmarks,
+      toggleBookmarks,
+      bookmarkStatus,
+      openSelectionPopup,
+      clearSelection,
+      confirmDeleteSelected,
+      selectionCount,
+    }),
+    [
+      addToBookmarks,
+      removeFromBookmarks,
+      toggleBookmarks,
+      bookmarkStatus,
+      openSelectionPopup,
+      clearSelection,
+      confirmDeleteSelected,
+      selectionCount,
+    ],
+  )
+
+  return (
+    <Context.Provider value={actions}>
+      {children}
+
+      {dialogs.render({ fullWidth: true, maxWidth: 'sm' })}
+    </Context.Provider>
+  )
+}
+
+export { OrganizeProvider as Provider }

--- a/catalog/app/containers/Bucket/Dir/Toolbar/Organize/Options.tsx
+++ b/catalog/app/containers/Bucket/Dir/Toolbar/Organize/Options.tsx
@@ -1,0 +1,124 @@
+import * as React from 'react'
+import * as M from '@material-ui/core'
+import {
+  TurnedInNotOutlined as IconTurnedInNotOutlined,
+  TurnedInOutlined as IconTurnedInOutlined,
+  BookmarksOutlined as IconBookmarksOutlined,
+  DeleteOutlined as IconDeleteOutlined,
+  EditOutlined as IconEditOutlined,
+  ClearOutlined as IconClearOutlined,
+} from '@material-ui/icons'
+
+import * as Format from 'utils/format'
+import assertNever from 'utils/assertNever'
+
+import * as Context from './Context'
+
+const LIST_ITEM_TYPOGRAPHY_PROPS = { noWrap: true }
+
+interface MenuItemProps {
+  className?: string
+  icon: React.ReactElement
+  primary: string
+  onClick: () => void
+}
+
+function MenuItem({ className, icon, primary, onClick }: MenuItemProps) {
+  return (
+    <M.ListItem button onClick={onClick} className={className}>
+      <M.ListItemIcon>{icon}</M.ListItemIcon>
+      <M.ListItemText
+        primary={primary}
+        primaryTypographyProps={LIST_ITEM_TYPOGRAPHY_PROPS}
+      />
+    </M.ListItem>
+  )
+}
+
+const useStyles = M.makeStyles((t) => ({
+  error: {
+    color: t.palette.error.main,
+  },
+}))
+
+export default function OrganizeOptions() {
+  const classes = useStyles()
+  const {
+    toggleBookmarks,
+    bookmarkStatus,
+    openSelectionPopup,
+    clearSelection,
+    confirmDeleteSelected,
+    selectionCount,
+  } = Context.use()
+
+  const bookmarkIcon = React.useMemo(() => {
+    switch (bookmarkStatus) {
+      case 'all':
+        return <IconTurnedInOutlined />
+      case 'partial':
+        return <IconBookmarksOutlined />
+      case 'none':
+        return <IconTurnedInNotOutlined />
+      default:
+        return assertNever(bookmarkStatus)
+    }
+  }, [bookmarkStatus])
+
+  const bookmarkText = React.useMemo(() => {
+    switch (bookmarkStatus) {
+      case 'all':
+        return 'Remove from bookmarks'
+      case 'partial':
+        return 'Add all to bookmarks'
+      case 'none':
+        return 'Add to bookmarks'
+      default:
+        return assertNever(bookmarkStatus)
+    }
+  }, [bookmarkStatus])
+
+  return (
+    <>
+      <M.ListSubheader inset component="div" disableSticky>
+        <Format.Plural
+          value={selectionCount}
+          one="One selected item"
+          other={(n) => `${n} selected items`}
+        />
+      </M.ListSubheader>
+
+      <M.Divider />
+
+      <M.List dense>
+        <MenuItem icon={bookmarkIcon} onClick={toggleBookmarks} primary={bookmarkText} />
+      </M.List>
+
+      <M.Divider />
+
+      <M.List dense>
+        <MenuItem
+          icon={<IconEditOutlined />}
+          onClick={openSelectionPopup}
+          primary="Manage selection"
+        />
+        <MenuItem
+          icon={<IconClearOutlined />}
+          onClick={clearSelection}
+          primary="Clear selection"
+        />
+      </M.List>
+
+      <M.Divider />
+
+      <M.List dense>
+        <MenuItem
+          className={classes.error}
+          icon={<IconDeleteOutlined color="error" />}
+          onClick={confirmDeleteSelected}
+          primary="Delete selected items"
+        />
+      </M.List>
+    </>
+  )
+}

--- a/catalog/app/containers/Bucket/Dir/Toolbar/Organize/index.ts
+++ b/catalog/app/containers/Bucket/Dir/Toolbar/Organize/index.ts
@@ -1,0 +1,2 @@
+export * as Context from './Context'
+export { default as Options } from './Options'

--- a/catalog/app/containers/Bucket/File/Toolbar/Organize/Context.tsx
+++ b/catalog/app/containers/Bucket/File/Toolbar/Organize/Context.tsx
@@ -1,0 +1,97 @@
+import invariant from 'invariant'
+import * as React from 'react'
+
+import * as Bookmarks from 'containers/Bookmarks'
+import type * as Toolbar from 'containers/Bucket/Toolbar'
+import DeleteDialog, { type DeleteResult } from 'containers/Bucket/Toolbar/DeleteDialog'
+import * as FileEditor from 'components/FileEditor'
+import * as Dialogs from 'utils/Dialogs'
+
+interface OrganizeState {
+  toggleBookmark: () => void
+  isBookmarked: boolean
+
+  editFile: (type: FileEditor.EditorInputType) => void
+  editTypes: FileEditor.EditorInputType[]
+
+  confirmDelete: () => void
+
+  handle: Toolbar.FileHandle
+}
+
+const Context = React.createContext<OrganizeState | null>(null)
+
+function useContext(): OrganizeState {
+  const context = React.useContext(Context)
+  invariant(context, 'useOrganizeFileActions must be used within OrganizeFileProvider')
+  return context
+}
+
+export const use = useContext
+
+interface OrganizeProviderProps {
+  children: React.ReactNode
+  editorState: FileEditor.EditorState
+  handle: Toolbar.FileHandle
+  onReload: () => void
+}
+
+function OrganizeProvider({
+  children,
+  editorState,
+  handle,
+  onReload,
+}: OrganizeProviderProps) {
+  const bookmarks = Bookmarks.use()
+  const dialogs = Dialogs.use()
+
+  invariant(editorState, '`editorState` should be provided')
+
+  const isBookmarked = React.useMemo(
+    () => (bookmarks ? bookmarks.isBookmarked('main', handle) : false),
+    [bookmarks, handle],
+  )
+
+  const toggleBookmark = React.useCallback(() => {
+    if (!bookmarks) return
+    bookmarks.toggle('main', handle)
+  }, [bookmarks, handle])
+
+  const editFile = React.useCallback(
+    (type: FileEditor.EditorInputType) => {
+      editorState.onEdit(type)
+    },
+    [editorState],
+  )
+
+  const confirmDelete = React.useCallback(async () => {
+    const result = await dialogs.open<DeleteResult>(({ close }) => (
+      <DeleteDialog handles={[handle]} close={close} />
+    ))
+
+    if (result.deleted) {
+      onReload()
+    }
+  }, [dialogs, handle, onReload])
+
+  const actions = React.useMemo(
+    (): OrganizeState => ({
+      toggleBookmark,
+      isBookmarked,
+      editFile,
+      editTypes: editorState.types,
+      confirmDelete,
+      handle,
+    }),
+    [editorState.types, toggleBookmark, isBookmarked, editFile, confirmDelete, handle],
+  )
+
+  return (
+    <Context.Provider value={actions}>
+      {children}
+      {dialogs.render({ fullWidth: true, maxWidth: 'sm' })}
+    </Context.Provider>
+  )
+}
+
+export { OrganizeProvider as Provider }

--- a/catalog/app/containers/Bucket/File/Toolbar/Organize/Options.tsx
+++ b/catalog/app/containers/Bucket/File/Toolbar/Organize/Options.tsx
@@ -1,0 +1,148 @@
+import * as React from 'react'
+import * as RRDom from 'react-router-dom'
+import * as M from '@material-ui/core'
+import {
+  TurnedInNotOutlined as IconTurnedInNotOutlined,
+  TurnedInOutlined as IconTurnedInOutlined,
+  DeleteOutlined as IconDeleteOutlined,
+  CheckOutlined as IconCheckOutlined,
+  AssignmentOutlined as IconAssignmentOutlined,
+  SubjectOutlined as IconSubjectOutlined,
+} from '@material-ui/icons'
+
+import { viewModeToSelectOption } from 'containers/Bucket/viewModes'
+import type { ViewModes } from 'containers/Bucket/viewModes'
+import * as NamedRoutes from 'utils/NamedRoutes'
+
+import * as Context from './Context'
+
+const LIST_ITEM_TYPOGRAPHY_PROPS = { noWrap: true } as const
+
+// NOTE: 'div' is a workaround for hardcoded MUI types
+interface MenuItemProps extends Omit<M.ListItemProps<'div'>, 'button'> {
+  icon?: React.ReactElement
+  children: React.ReactNode
+}
+
+function MenuItem({ icon, children, ...props }: MenuItemProps) {
+  return (
+    <M.ListItem {...props} button>
+      {icon && <M.ListItemIcon>{icon}</M.ListItemIcon>}
+      <M.ListItemText
+        inset={!icon}
+        primary={children}
+        primaryTypographyProps={LIST_ITEM_TYPOGRAPHY_PROPS}
+      />
+    </M.ListItem>
+  )
+}
+
+interface LinkItemProps extends Omit<M.ListItemProps<typeof RRDom.Link>, 'button'> {
+  icon?: React.ReactElement
+  children: React.ReactNode
+}
+
+function LinkItem({ icon, children, ...props }: LinkItemProps) {
+  return (
+    <M.ListItem {...props} button component={RRDom.Link}>
+      <M.ListItemIcon>{icon}</M.ListItemIcon>
+      <M.ListItemText
+        primary={children}
+        primaryTypographyProps={LIST_ITEM_TYPOGRAPHY_PROPS}
+      />
+    </M.ListItem>
+  )
+}
+
+const useStyles = M.makeStyles((t) => ({
+  danger: {
+    color: t.palette.error.main,
+  },
+  subList: {
+    '& + &': {
+      borderTop: `1px solid ${t.palette.divider}`,
+    },
+  },
+}))
+
+interface OrganizeOptionsProps {
+  viewModes?: ViewModes
+}
+
+export default function OrganizeOptions({ viewModes }: OrganizeOptionsProps) {
+  const classes = useStyles()
+  const {
+    confirmDelete,
+    editFile,
+    editTypes,
+    handle: { bucket, key, version },
+    isBookmarked,
+    toggleBookmark,
+  } = Context.use()
+  const { urls } = NamedRoutes.use()
+
+  const viewModesOptions = React.useMemo(
+    () => viewModes?.modes.map((m) => viewModeToSelectOption(m)) || [],
+    [viewModes],
+  )
+
+  return (
+    <>
+      <M.List dense className={classes.subList}>
+        <MenuItem
+          icon={isBookmarked ? <IconTurnedInOutlined /> : <IconTurnedInNotOutlined />}
+          onClick={toggleBookmark}
+        >
+          {isBookmarked ? 'Remove from bookmarks' : 'Add to bookmarks'}
+        </MenuItem>
+      </M.List>
+
+      {editTypes.length && (
+        <M.List dense className={classes.subList}>
+          {editTypes.map((t) => (
+            <MenuItem
+              key={t.brace}
+              icon={t.title ? <IconAssignmentOutlined /> : <IconSubjectOutlined />}
+              onClick={() => editFile(t)}
+            >
+              {t.title || 'Edit text content'}
+            </MenuItem>
+          ))}
+        </M.List>
+      )}
+
+      {viewModesOptions.length > 0 && (
+        <M.List
+          className={classes.subList}
+          dense
+          subheader={<M.ListSubheader inset>View as</M.ListSubheader>}
+        >
+          {viewModesOptions.map(({ toString, valueOf }) =>
+            valueOf() === viewModes?.mode ? (
+              <MenuItem key={toString()} icon={<IconCheckOutlined />} disabled>
+                {toString()}
+              </MenuItem>
+            ) : (
+              <LinkItem
+                key={toString()}
+                to={urls.bucketFile(bucket, key, { version, mode: valueOf() })}
+              >
+                {toString()}
+              </LinkItem>
+            ),
+          )}
+        </M.List>
+      )}
+
+      <M.List dense className={classes.subList}>
+        <MenuItem
+          className={classes.danger}
+          icon={<IconDeleteOutlined color="error" />}
+          onClick={confirmDelete}
+        >
+          Delete
+        </MenuItem>
+      </M.List>
+    </>
+  )
+}

--- a/catalog/app/containers/Bucket/File/Toolbar/Organize/index.ts
+++ b/catalog/app/containers/Bucket/File/Toolbar/Organize/index.ts
@@ -1,0 +1,2 @@
+export * as Context from './Context'
+export { default as Options } from './Options'

--- a/catalog/app/containers/Bucket/Toolbar/DeleteDialog.tsx
+++ b/catalog/app/containers/Bucket/Toolbar/DeleteDialog.tsx
@@ -1,0 +1,157 @@
+import cx from 'classnames'
+import * as React from 'react'
+import * as M from '@material-ui/core'
+import { Error as IconError } from '@material-ui/icons'
+
+import Code from 'components/Code'
+import { deleteObject, useFilesListing } from 'containers/Bucket/requests'
+import * as Model from 'model'
+import * as AWS from 'utils/AWS'
+import Log from 'utils/Logging'
+
+const useDeleteDialogStyles = M.makeStyles({
+  deleted: {
+    textDecoration: 'line-through',
+  },
+})
+
+type FileStatus = 'pending' | 'success' | 'error'
+
+interface ResolvedObject {
+  handle: Model.S3.S3ObjectLocation
+  status: FileStatus
+  error?: any
+}
+
+export type DeleteResult = {
+  deleted: boolean
+}
+
+export interface DeleteDialogProps {
+  close: (result: DeleteResult) => void
+  handles: Model.S3.S3ObjectLocation[]
+}
+
+export default function DeleteDialog({ close, handles }: DeleteDialogProps) {
+  const classes = useDeleteDialogStyles()
+  const [submitting, setSubmitting] = React.useState(false)
+  const [resolvedObjects, setResolvedObjects] = React.useState<ResolvedObject[] | null>(
+    null,
+  )
+
+  const hasErrors = React.useMemo(
+    () => resolvedObjects?.some((obj) => obj.status === 'error') ?? false,
+    [resolvedObjects],
+  )
+
+  const isComplete = React.useMemo(
+    () => resolvedObjects?.every((obj) => obj.status !== 'pending') ?? false,
+    [resolvedObjects],
+  )
+
+  const hasSuccessfulDeletions = React.useMemo(
+    () => resolvedObjects?.some((obj) => obj.status === 'success') ?? false,
+    [resolvedObjects],
+  )
+
+  const s3 = AWS.S3.use()
+  const getFiles = useFilesListing()
+
+  React.useEffect(() => {
+    async function resolveHandles() {
+      const filesMap = await getFiles(handles)
+      const resolved = Object.values(filesMap)
+      setResolvedObjects(
+        resolved.map((handle) => ({ handle, status: 'pending' as FileStatus })),
+      )
+    }
+    resolveHandles()
+  }, [getFiles, handles])
+
+  const onSubmit = React.useCallback(async () => {
+    setSubmitting(true)
+
+    if (resolvedObjects) {
+      const results = await Promise.all(
+        resolvedObjects.map(async ({ handle }) => {
+          try {
+            await deleteObject({ s3, handle })
+            return { status: 'success' as FileStatus, error: undefined }
+          } catch (error) {
+            Log.error('Failed to delete object:', error)
+            return { status: 'error' as FileStatus, error }
+          }
+        }),
+      )
+
+      setResolvedObjects((prev) =>
+        prev!.map((item, index) => ({
+          ...item,
+          status: results[index].status,
+          error: results[index].error,
+        })),
+      )
+    }
+
+    setSubmitting(false)
+  }, [s3, resolvedObjects])
+
+  const title = React.useMemo(() => {
+    if (!isComplete) return 'Delete objects?'
+    return hasErrors ? 'Some files could not be deleted' : 'Files deleted successfully'
+  }, [isComplete, hasErrors])
+
+  return (
+    <>
+      <M.DialogTitle>{title}</M.DialogTitle>
+      <M.DialogContent>
+        {resolvedObjects ? (
+          <M.List dense disablePadding>
+            {resolvedObjects.map(
+              ({ handle: { bucket, key, version }, status, error }) => (
+                <M.ListItem key={`${bucket}${key}${version}`} disableGutters>
+                  {status === 'error' && (
+                    <M.Tooltip title={error.message}>
+                      <M.ListItemIcon>
+                        <IconError color="error" />
+                      </M.ListItemIcon>
+                    </M.Tooltip>
+                  )}
+                  <M.ListItemText
+                    primary={
+                      <Code className={cx(status === 'success' && classes.deleted)}>
+                        s3://{bucket}/{key}
+                      </Code>
+                    }
+                    secondary={version}
+                  />
+                </M.ListItem>
+              ),
+            )}
+          </M.List>
+        ) : (
+          <M.CircularProgress size={64} />
+        )}
+      </M.DialogContent>
+      <M.DialogActions>
+        <M.Button
+          onClick={() => close({ deleted: hasSuccessfulDeletions })}
+          color="primary"
+          variant="outlined"
+        >
+          {isComplete ? 'Close' : 'Cancel'}
+        </M.Button>
+        {!isComplete && (
+          <M.Button
+            color="primary"
+            disabled={submitting}
+            variant="contained"
+            onClick={onSubmit}
+          >
+            Submit
+          </M.Button>
+        )}
+      </M.DialogActions>
+    </>
+  )
+}


### PR DESCRIPTION
## Summary
- Implements comprehensive Organize button functionality with selection-based operations
- Adds Dir and File specific organize contexts and options
- Provides bookmark management (add/remove/toggle for individual files and selections)
- Implements batch file deletion with progress dialog and error handling
- Adds file editing capabilities and view mode switching for individual files
- Includes Material-UI styled organize menu with icons and proper categorization

## Dependencies  
- Depends on PR #4498 (base structure)
- Uses existing Selection, Bookmarks, and Dialogs providers

## Test plan
- [ ] Organize button shows selection count badge correctly
- [ ] Bookmark operations work for single files and selections
- [ ] File deletion dialog handles errors and shows progress
- [ ] Selection management (clear, manage popup) works correctly
- [ ] File editing and view mode switching works for individual files
- [ ] Organize menu renders correctly with proper icons and categories

🤖 Generated with [Claude Code](https://claude.ai/code)