### PR TITLE
Bucket toolbar: Add functionality (file upload & creation)

### DIFF
--- a/catalog/app/containers/Bucket/Dir/Toolbar/Add/Context.tsx
+++ b/catalog/app/containers/Bucket/Dir/Toolbar/Add/Context.tsx
@@ -1,0 +1,61 @@
+import invariant from 'invariant'
+import * as React from 'react'
+
+import * as FileEditor from 'components/FileEditor'
+import type * as Toolbar from 'containers/Bucket/Toolbar'
+import * as Dialogs from 'utils/Dialogs'
+
+import UploadDialog from './UploadDialog'
+
+interface AddState {
+  createFile: () => void
+  openUploadDialog: () => void
+}
+
+const Context = React.createContext<AddState | null>(null)
+
+function useContext(): AddState {
+  const context = React.useContext(Context)
+  invariant(context, 'useContext must be used within AddDirProvider')
+  return context
+}
+
+export const use = useContext
+
+interface AddProviderProps {
+  children: React.ReactNode
+  handle: Toolbar.DirHandle
+}
+
+export function AddProvider({ children, handle }: AddProviderProps) {
+  const dialogs = Dialogs.use()
+  const prompt = FileEditor.useCreateFileInBucket(handle.bucket, handle.path)
+
+  const createFile = React.useCallback(() => {
+    prompt.open()
+  }, [prompt])
+
+  const openUploadDialog = React.useCallback(() => {
+    dialogs.open(({ close }) => <UploadDialog handle={handle} onClose={close} />)
+  }, [dialogs, handle])
+
+  const actions = React.useMemo(
+    (): AddState => ({
+      createFile,
+      openUploadDialog,
+    }),
+    [createFile, openUploadDialog],
+  )
+
+  return (
+    <Context.Provider value={actions}>
+      {children}
+
+      {prompt.render()}
+
+      {dialogs.render({ fullWidth: true, maxWidth: 'sm' })}
+    </Context.Provider>
+  )
+}
+
+export { AddProvider as Provider }

--- a/catalog/app/containers/Bucket/Dir/Toolbar/Add/Options.tsx
+++ b/catalog/app/containers/Bucket/Dir/Toolbar/Add/Options.tsx
@@ -1,0 +1,46 @@
+import * as React from 'react'
+import * as M from '@material-ui/core'
+import {
+  CreateOutlined as IconCreateOutlined,
+  PublishOutlined as IconPublishOutlined,
+} from '@material-ui/icons'
+
+import * as Context from './Context'
+
+const LIST_ITEM_TYPOGRAPHY_PROPS = { noWrap: true } as const
+
+interface MenuItemProps {
+  icon: React.ReactElement
+  primary: string
+  onClick: () => void
+}
+
+function MenuItem({ icon, primary, onClick }: MenuItemProps) {
+  return (
+    <M.ListItem button onClick={onClick}>
+      <M.ListItemIcon>{icon}</M.ListItemIcon>
+      <M.ListItemText
+        primary={primary}
+        primaryTypographyProps={LIST_ITEM_TYPOGRAPHY_PROPS}
+      />
+    </M.ListItem>
+  )
+}
+
+export default function AddOptions() {
+  const { createFile, openUploadDialog } = Context.use()
+  return (
+    <M.List dense>
+      <MenuItem
+        icon={<IconCreateOutlined />}
+        primary="Create text file"
+        onClick={createFile}
+      />
+      <MenuItem
+        icon={<IconPublishOutlined />}
+        primary="Upload files"
+        onClick={openUploadDialog}
+      />
+    </M.List>
+  )
+}

--- a/catalog/app/containers/Bucket/Dir/Toolbar/Add/UploadDialog.tsx
+++ b/catalog/app/containers/Bucket/Dir/Toolbar/Add/UploadDialog.tsx
@@ -1,0 +1,173 @@
+import { join } from 'path'
+
+import * as React from 'react'
+import * as M from '@material-ui/core'
+import * as Lab from '@material-ui/lab'
+
+import { useUploads } from 'containers/Bucket/PackageDialog/Uploads'
+import * as FI from 'containers/Bucket/PackageDialog/FilesInput'
+import type * as Toolbar from 'containers/Bucket/Toolbar'
+import Log from 'utils/Logging'
+import * as s3paths from 'utils/s3paths'
+
+interface LocalEntry {
+  file: FI.LocalFile
+  path: string
+}
+
+const useUploadDialogStyles = M.makeStyles((t) => ({
+  drop: {
+    height: t.spacing(60),
+    marginBottom: t.spacing(1),
+  },
+  alert: {
+    marginBottom: t.spacing(2),
+  },
+}))
+
+const toFilesState = (added: FI.FilesState['added']): FI.FilesState => ({
+  added,
+  existing: {},
+  deleted: {},
+})
+
+type UploadState =
+  | { _tag: 'idle' }
+  | { _tag: 'uploading' }
+  | { _tag: 'success'; count: number }
+  | { _tag: 'error'; error: Error }
+
+interface UploadDialogProps {
+  handle: Toolbar.DirHandle
+  initial?: FI.FilesState['added']
+  onClose: (reason?: 'upload-success') => void
+}
+
+export default function UploadDialog({
+  handle,
+  initial = {},
+  onClose,
+}: UploadDialogProps) {
+  const [value, setValue] = React.useState<FI.FilesState['added']>(initial)
+  const classes = useUploadDialogStyles()
+
+  const [uploadState, setUploadState] = React.useState<UploadState>({ _tag: 'idle' })
+
+  const submitting = uploadState._tag === 'uploading'
+  const meta = React.useMemo(
+    () => ({
+      initial: toFilesState(initial),
+      submitting,
+    }),
+    [initial, submitting],
+  )
+
+  const { progress, remove, removeByPrefix, reset, upload } = useUploads()
+  const onFilesAction = React.useMemo(
+    () =>
+      FI.FilesAction.match({
+        _: () => {},
+        Revert: remove,
+        RevertDir: removeByPrefix,
+        Reset: reset,
+      }),
+    [remove, removeByPrefix, reset],
+  )
+
+  const onUpload = React.useCallback(async () => {
+    setUploadState({ _tag: 'uploading' })
+
+    const files = Object.entries(value).map(
+      ([path, file]) => ({ path, file }) as LocalEntry,
+    )
+    try {
+      const uploadedEntries = await upload({
+        files,
+        bucket: handle.bucket,
+        getCanonicalKey: (key) => s3paths.withoutPrefix('/', join(handle.path, key)),
+        getMeta: () => null,
+      })
+      setUploadState({ _tag: 'success', count: Object.keys(uploadedEntries).length })
+    } catch (e) {
+      Log.error(e)
+      const error = e instanceof Error ? e : new Error('Upload failed')
+      setUploadState({ _tag: 'error', error })
+    }
+  }, [handle, upload, value])
+
+  const handleClose = React.useCallback(() => {
+    if (uploadState._tag === 'uploading') return
+    if (uploadState._tag === 'success') {
+      onClose('upload-success')
+    } else {
+      onClose()
+    }
+  }, [onClose, uploadState])
+
+  const input = React.useMemo(
+    () => ({
+      value: toFilesState(value),
+      // Trigger value update, because hashing finishes on the same objects
+      onChange: (s: FI.FilesState) => setValue({ ...s.added }),
+    }),
+    [value],
+  )
+
+  const showUploadUI = uploadState._tag === 'idle' || uploadState._tag === 'uploading'
+
+  return (
+    <>
+      <M.DialogContent>
+        {uploadState._tag === 'success' && (
+          <Lab.Alert severity="success" className={classes.alert}>
+            Successfully uploaded {uploadState.count} file
+            {uploadState.count !== 1 ? 's' : ''}!
+          </Lab.Alert>
+        )}
+
+        {uploadState._tag === 'error' && (
+          <Lab.Alert
+            severity="error"
+            className={classes.alert}
+            onClose={() => setUploadState({ _tag: 'idle' })}
+          >
+            <Lab.AlertTitle>Upload Failed</Lab.AlertTitle>
+            {uploadState.error.message}
+          </Lab.Alert>
+        )}
+
+        {showUploadUI && (
+          <FI.FilesInput
+            className={classes.drop}
+            input={input}
+            meta={meta}
+            onFilesAction={onFilesAction}
+            title="Upload files"
+            totalProgress={progress}
+            validationErrors={null}
+            noMeta
+          />
+        )}
+      </M.DialogContent>
+      <M.DialogActions>
+        <M.Button
+          color="primary"
+          onClick={handleClose}
+          disabled={uploadState._tag === 'uploading'}
+        >
+          {uploadState._tag === 'success' ? 'Close' : 'Cancel'}
+        </M.Button>
+        {uploadState._tag !== 'success' && (
+          <M.Button
+            color="primary"
+            variant="contained"
+            disabled={!Object.keys(value).length || uploadState._tag === 'uploading'}
+            onClick={onUpload}
+          >
+            {uploadState._tag === 'uploading' ? 'Uploading...' : 'Upload'}
+          </M.Button>
+        )}
+      </M.DialogActions>
+    </>
+  )
+}

--- a/catalog/app/containers/Bucket/Dir/Toolbar/Add/index.ts
+++ b/catalog/app/containers/Bucket/Dir/Toolbar/Add/index.ts
@@ -1,0 +1,3 @@
+export { default as UploadDialog } from './UploadDialog'
+export * as Context from './Context'
+export { default as Options } from './Options'


### PR DESCRIPTION
## Summary
- Implements Add button functionality with file creation and upload options
- Adds AddOptions component with create text file and upload files menu items
- Provides Context provider integrating with FileEditor for text file creation
- Includes comprehensive UploadDialog with drag-and-drop file upload interface
- Features upload progress tracking, error handling, and success notifications
- Uses Material-UI components for consistent styling and user experience

## Dependencies
- Depends on PR #4498 (base structure)
- Uses existing FileEditor, PackageDialog/Uploads, and FilesInput components

## Test plan
- [ ] Add button renders with proper options menu
- [ ] Create text file option opens FileEditor correctly
- [ ] Upload files dialog accepts drag-and-drop and file selection
- [ ] Upload progress is shown during file uploads
- [ ] Error handling works for failed uploads
- [ ] Success notification appears after successful uploads

🤖 Generated with [Claude Code](https://claude.ai/code)