### PR TITLE
Bucket toolbar: CreatePackage functionality (workflow integration)

### DIFF
--- a/catalog/app/containers/Bucket/Dir/Toolbar/CreatePackage/Options.tsx
+++ b/catalog/app/containers/Bucket/Dir/Toolbar/CreatePackage/Options.tsx
@@ -1,0 +1,82 @@
+import * as React from 'react'
+import * as M from '@material-ui/core'
+import * as Lab from '@material-ui/lab'
+
+import { EmptySlot, ErrorSlot } from 'containers/Bucket/Successors'
+import * as Request from 'utils/useRequest'
+import * as workflows from 'utils/workflows'
+
+const LIST_ITEM_TYPOGRAPHY_PROPS = { noWrap: true }
+
+const useStyles = M.makeStyles((t) => ({
+  root: {
+    minWidth: t.spacing(40),
+  },
+}))
+
+interface CreatePackageOptionsProps {
+  onChange: (x: workflows.Successor) => void
+  successors: Request.Result<workflows.Successor[]>
+}
+
+export default function CreatePackageOptions({
+  onChange,
+  successors,
+}: CreatePackageOptionsProps) {
+  const classes = useStyles()
+  if (successors === Request.Idle) return null
+
+  if (successors instanceof Error) {
+    return (
+      <div className={classes.root}>
+        <ErrorSlot error={successors} />
+      </div>
+    )
+  }
+
+  if (successors === Request.Loading) {
+    return (
+      <M.List dense className={classes.root}>
+        <M.ListItem>
+          <M.ListItemText primary={<Lab.Skeleton />} secondary={<Lab.Skeleton />} />
+        </M.ListItem>
+        <M.ListItem>
+          <M.ListItemText primary={<Lab.Skeleton />} secondary={<Lab.Skeleton />} />
+        </M.ListItem>
+        <M.ListItem>
+          <M.ListItemText primary={<Lab.Skeleton />} secondary={<Lab.Skeleton />} />
+        </M.ListItem>
+      </M.List>
+    )
+  }
+
+  if (!successors.length) {
+    return (
+      <div className={classes.root}>
+        <EmptySlot />
+      </div>
+    )
+  }
+
+  return (
+    <M.List dense className={classes.root}>
+      {successors.map((successor) => (
+        <M.ListItem
+          key={successor.slug}
+          onClick={(event) => {
+            event.stopPropagation()
+            onChange(successor)
+          }}
+          button
+        >
+          <M.ListItemText
+            primary={successor.name}
+            primaryTypographyProps={LIST_ITEM_TYPOGRAPHY_PROPS}
+            secondary={successor.url}
+            secondaryTypographyProps={LIST_ITEM_TYPOGRAPHY_PROPS}
+          />
+        </M.ListItem>
+      ))}
+    </M.List>
+  )
+}

--- a/catalog/app/containers/Bucket/Dir/Toolbar/CreatePackage/index.ts
+++ b/catalog/app/containers/Bucket/Dir/Toolbar/CreatePackage/index.ts
@@ -1,0 +1,2 @@
+export { default as Options } from './Options'
+export { default as useSuccessors } from './useSuccessors'

--- a/catalog/app/containers/Bucket/Dir/Toolbar/CreatePackage/useSuccessors.ts
+++ b/catalog/app/containers/Bucket/Dir/Toolbar/CreatePackage/useSuccessors.ts
@@ -1,0 +1,18 @@
+import * as React from 'react'
+
+import { workflowsConfig } from 'containers/Bucket/requests'
+import * as AWS from 'utils/AWS'
+import * as Request from 'utils/useRequest'
+import type { Successor } from 'utils/workflows'
+
+export default function useSuccessors(bucket: string): Request.Result<Successor[]> {
+  const s3 = AWS.S3.use()
+  const req = React.useCallback(() => workflowsConfig({ s3, bucket }), [bucket, s3])
+  const data = Request.use(req)
+
+  if (data instanceof Error || data === Request.Idle || data === Request.Loading) {
+    return data
+  }
+
+  return data.successors
+}


### PR DESCRIPTION
## Summary
- Implements CreatePackage button functionality with workflow-based package creation
- Adds CreatePackageOptions component with workflow successor selection interface
- Provides useSuccessors hook for fetching workflow configurations from bucket settings
- Includes comprehensive state management for loading, error, and empty successor states
- Features workflow metadata display with successor name and URL information
- Integrates with existing workflow configuration system and successor patterns

## Dependencies
- Depends on PR #4498 (base structure) 
- Uses existing workflow utilities, Successors components, and Request patterns

## Test plan
- [ ] CreatePackage button renders correctly with proper variant based on selection state
- [ ] Workflow successors load correctly for buckets with workflow configuration  
- [ ] Loading state displays skeleton placeholders appropriately
- [ ] Error state shows proper error handling for failed workflow fetches
- [ ] Empty state displays when no workflow successors are configured
- [ ] Successor selection triggers package creation with correct workflow parameters

🤖 Generated with [Claude Code](https://claude.ai/code)