### PR TITLE
Fix linting issues and add test-local task

### DIFF
--- a/api/python/pyproject.toml
+++ b/api/python/pyproject.toml
@@ -107,6 +107,7 @@ dev-dependencies = [
 
 [tool.poe.tasks]
 test = "pytest --disable-warnings"
+test-local = "pytest --disable-warnings -k 'not (test_get_boto3_session)'"
 test-verbose = "pytest -v"
 test-coverage = "pytest --cov=quilt3 --cov-report=term-missing"
 lint = { shell = "pylint --rcfile=../../pylintrc --ignore=_graphql_client quilt3 && pycodestyle --config=../../setup.cfg $(find quilt3 -name '*.py' -not -path 'quilt3/admin/_graphql_client/*')" }

--- a/api/python/quilt3/main.py
+++ b/api/python/quilt3/main.py
@@ -80,7 +80,7 @@ def cmd_config_default_registry(default_remote_registry):
 
 def _test_url(url):
     try:
-        response = requests.get(url)
+        response = requests.get(url, timeout=30)
         if response.ok:
             return True
         return False

--- a/api/python/quilt3/util.py
+++ b/api/python/quilt3/util.py
@@ -371,7 +371,7 @@ def configure_from_url(catalog_url):
     # Get the new config
     config_url = catalog_url + '/config.json'
 
-    response = requests.get(config_url)
+    response = requests.get(config_url, timeout=30)
     if not response.ok:
         message = "An HTTP Error ({code}) occurred: {reason}"
         raise QuiltException(

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -1,5 +1,8 @@
 <!--pytest-codeblocks:skipfile-->
-<!-- markdownlint-disable-next-line first-line-h1 -->
+<!-- markdownlint-disable MD013 -->
+
+# CONTRIBUTING
+
 Quilt is an open source project, and we welcome contributions from the community.
 
 Contributors must adhere to the [Code of Conduct](https://github.com/quiltdata/quilt/blob/master/docs/CODE_OF_CONDUCT.md).
@@ -72,6 +75,7 @@ uv run pytest tests/test_util.py
 ```
 
 Other available tasks:
+
 - `uv run poe lint` - Run linters
 - `uv run poe format-check` - Check import sorting
 - `uv run poe build` - Build packages


### PR DESCRIPTION
## Summary
- Fix missing timeout arguments for requests.get() calls in quilt3/util.py and quilt3/main.py to resolve linting warnings
- Add test-local task that skips the 3 failing session tests for local development
- Fix formatting issues in CONTRIBUTING.md

## Test plan
- [x] Run `uv run poe lint` - passes with 10.00/10 score
- [x] Run `uv run poe test-local` - passes with 382 tests, 3 deselected
- [x] Verify original `uv run poe test` still shows the same 3 failing tests

🤖 Generated with [Claude Code](https://claude.ai/code)