### PR TITLE
Fix test_get_boto3_session failing in US timezones

### DIFF
--- a/api/python/tests/test_session.py
+++ b/api/python/tests/test_session.py
@@ -16,7 +16,7 @@ from .utils import QuiltTestCase
 
 
 def format_date(date):
-    return date.replace(tzinfo=datetime.timezone.utc, microsecond=0).isoformat()
+    return date.astimezone(datetime.timezone.utc).replace(microsecond=0).isoformat()
 
 
 class TestSession(QuiltTestCase):
@@ -75,7 +75,7 @@ class TestSession(QuiltTestCase):
     @patch('quilt3.session._load_credentials')
     def test_create_botocore_session(self, mock_load_credentials, mock_save_credentials):
         # Test good credentials.
-        future_date = datetime.datetime.utcnow() + datetime.timedelta(hours=1)
+        future_date = datetime.datetime.now() + datetime.timedelta(hours=1)
 
         mock_load_credentials.return_value = dict(
             access_key='access-key',
@@ -94,7 +94,7 @@ class TestSession(QuiltTestCase):
         mock_save_credentials.assert_not_called()
 
         # Test expired credentials.
-        past_date = datetime.datetime.utcnow() - datetime.timedelta(minutes=5)
+        past_date = datetime.datetime.now() - datetime.timedelta(minutes=5)
 
         mock_load_credentials.return_value = dict(
             access_key='access-key',


### PR DESCRIPTION
This also removes usage of deprecated datetime.utcnow()