### PR TITLE
Provide `name` for `Me` query, since we use it as a cache key

### DIFF
--- a/catalog/CHANGELOG.md
+++ b/catalog/CHANGELOG.md
@@ -18,6 +18,7 @@ where verb is one of
 
 ## Changes
 
+- [Fixed] Fix GraphQL cache key for user data to properly show logged-in state ([#4527](https://github.com/quiltdata/quilt/pull/4527))
 - [Added] Qurator devtools: model override, session recording ([#4467](https://github.com/quiltdata/quilt/pull/4467))
 - [Changed] Adjust GQL schema for the upstream changes and handle search timeouts ([#4477](https://github.com/quiltdata/quilt/pull/4477))
 - [Fixed] Correctly sign and proxy S3 requests and URIs in OPEN mode ([#4470](https://github.com/quiltdata/quilt/pull/4470))

--- a/catalog/app/website/pages/Landing/gql/IsAdmin.generated.ts
+++ b/catalog/app/website/pages/Landing/gql/IsAdmin.generated.ts
@@ -7,7 +7,9 @@ export type website_pages_Landing_gql_IsAdminQueryVariables = Types.Exact<{
 }>
 
 export type website_pages_Landing_gql_IsAdminQuery = { readonly __typename: 'Query' } & {
-  readonly me: Types.Maybe<{ readonly __typename: 'Me' } & Pick<Types.Me, 'isAdmin'>>
+  readonly me: Types.Maybe<
+    { readonly __typename: 'Me' } & Pick<Types.Me, 'isAdmin' | 'name'>
+  >
 }
 
 export const website_pages_Landing_gql_IsAdminDocument = {
@@ -25,7 +27,10 @@ export const website_pages_Landing_gql_IsAdminDocument = {
             name: { kind: 'Name', value: 'me' },
             selectionSet: {
               kind: 'SelectionSet',
-              selections: [{ kind: 'Field', name: { kind: 'Name', value: 'isAdmin' } }],
+              selections: [
+                { kind: 'Field', name: { kind: 'Name', value: 'isAdmin' } },
+                { kind: 'Field', name: { kind: 'Name', value: 'name' } },
+              ],
             },
           },
         ],

--- a/catalog/app/website/pages/Landing/gql/IsAdmin.graphql
+++ b/catalog/app/website/pages/Landing/gql/IsAdmin.graphql
@@ -1,5 +1,6 @@
 query {
   me {
     isAdmin
+    name
   }
 }


### PR DESCRIPTION
- [x] [Changelog](../tree/master/docs/CHANGELOG.md) entry (skip if change is not significant to end users, e.g. docs only)
