### PR TITLE
Fix Windows virtual environment cleanup in CI

### DIFF
--- a/.github/workflows/py-ci.yml
+++ b/.github/workflows/py-ci.yml
@@ -88,33 +88,16 @@ jobs:
     steps:
       - uses: actions/checkout@v5
       - uses: astral-sh/setup-uv@v6
-      - name: Run Pytest
-        run: uv run --python ${{ matrix.python-version }} poe test-cov --cov-report xml
-      - name: Clean up virtual environment (Windows)
+      - name: Run Pytest (Windows)
         if: runner.os == 'Windows'
         run: |
-          # Force remove the virtual environment on Windows to avoid permission issues
-          if (Test-Path .venv) {
-            Write-Host "Cleaning up virtual environment..."
-            try {
-              Remove-Item -Path .venv -Recurse -Force -ErrorAction Stop
-              Write-Host "Virtual environment cleaned up successfully"
-            }
-            catch {
-              Write-Host "Warning: Failed to clean up virtual environment: $($_.Exception.Message)"
-              # Try alternative cleanup method
-              try {
-                Get-ChildItem .venv -Recurse | Remove-Item -Force -Recurse -ErrorAction Ignore
-                Write-Host "Alternative cleanup method succeeded"
-              }
-              catch {
-                Write-Host "Alternative cleanup also failed, but this is non-critical"
-              }
-            }
-          } else {
-            Write-Host "No virtual environment found to clean up"
-          }
+          # Use --no-project to avoid uv trying to manage virtual environment
+          # This prevents the "Access is denied" error during uv execution
+          uv run --no-project --python ${{ matrix.python-version }} --with pytest --with pytest-cov --with responses --with ruff --with quilt3[pyarrow,anndata] pytest --cov=. --cov-report=term-missing --cov-report xml
         shell: powershell
+      - name: Run Pytest (Unix)
+        if: runner.os != 'Windows'
+        run: uv run --python ${{ matrix.python-version }} poe test-cov --cov-report xml
       - uses: codecov/codecov-action@v5
         env:
           CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/py-ci.yml
+++ b/.github/workflows/py-ci.yml
@@ -95,7 +95,24 @@ jobs:
         run: |
           # Force remove the virtual environment on Windows to avoid permission issues
           if (Test-Path .venv) {
-            Remove-Item -Path .venv -Recurse -Force -ErrorAction SilentlyContinue
+            Write-Host "Cleaning up virtual environment..."
+            try {
+              Remove-Item -Path .venv -Recurse -Force -ErrorAction Stop
+              Write-Host "Virtual environment cleaned up successfully"
+            }
+            catch {
+              Write-Host "Warning: Failed to clean up virtual environment: $($_.Exception.Message)"
+              # Try alternative cleanup method
+              try {
+                Get-ChildItem .venv -Recurse | Remove-Item -Force -Recurse -ErrorAction Ignore
+                Write-Host "Alternative cleanup method succeeded"
+              }
+              catch {
+                Write-Host "Alternative cleanup also failed, but this is non-critical"
+              }
+            }
+          } else {
+            Write-Host "No virtual environment found to clean up"
           }
         shell: powershell
       - uses: codecov/codecov-action@v5

--- a/.github/workflows/py-ci.yml
+++ b/.github/workflows/py-ci.yml
@@ -90,6 +90,14 @@ jobs:
       - uses: astral-sh/setup-uv@v6
       - name: Run Pytest
         run: uv run --python ${{ matrix.python-version }} poe test-cov --cov-report xml
+      - name: Clean up virtual environment (Windows)
+        if: runner.os == 'Windows'
+        run: |
+          # Force remove the virtual environment on Windows to avoid permission issues
+          if (Test-Path .venv) {
+            Remove-Item -Path .venv -Recurse -Force -ErrorAction SilentlyContinue
+          }
+        shell: powershell
       - uses: codecov/codecov-action@v5
         env:
           CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}


### PR DESCRIPTION
## Summary
- Add Windows-specific step to forcefully remove virtual environment after tests
- Fixes "Access is denied" errors when uv tries to clean up mid-run on Windows systems:

```log
Installed 56 packages in 871ms
Poe => pytest --cov=. --cov-report=term-missing --cov-report xml
Using CPython 3.11.9 interpreter at: C:\hostedtoolcache\windows\Python\3.11.9\x64\python.exe
error: failed to remove directory `D:\a\quilt\quilt\api\python\.venv\Scripts`: Access is denied. (os error 5)
```

NOTE: This actually happens *during* the run for some reason, so the post-step cleanup does not help.

## Test plan
- [ ] Verify Windows CI tests pass without cleanup errors
- [ ] Confirm Linux tests continue to work normally
- [ ] Ensure [PySearch PR](https://github.com/quiltdata/quilt/pull/4482) passes Windows tests successfully

🤖 Generated with [Claude Code](https://claude.ai/code)