### PR TITLE
Update RO-Crate manifest filename to metadata

### DIFF
--- a/docs/Catalog/Packaging.md
+++ b/docs/Catalog/Packaging.md
@@ -35,7 +35,7 @@ same bucket with the name `omics-quilt/3395667`.
 ### Workflow Run RO-Crate
 
 When enabled, this will create a package from the enclosing folder when an
-`ro-crate-manifest.json` file is written to a bucket that is already part of the
+`ro-crate-metadata.json` file is written to a bucket that is already part of the
 stack.
 
 [RO-Crate](https://www.researchobject.org/ro-crate/) is a metadata standard for
@@ -72,7 +72,7 @@ get for free at [the ORCID website](https://orcid.org/).
 
 The package will be created in the same bucket as the `outdir`, with the package
 name inferred from the S3 key. For example, if the key is
-`my/s3/folder/ro-crate-manifest.json`, the package name will be `my_s3/folder`.
+`my/s3/folder/ro-crate-metadata.json`, the package name will be `my_s3/folder`.
 
 ## Architecture
 


### PR DESCRIPTION
## Summary
- Updated documentation to reflect the correct RO-Crate filename convention
- Changed references from `ro-crate-manifest.json` to `ro-crate-metadata.json` to align with RO-Crate standards

## Changes
- Updated docs/Catalog/Packaging.md to use the standard `ro-crate-metadata.json` filename instead of `ro-crate-manifest.json`

## Context
The RO-Crate specification uses `ro-crate-metadata.json` as the standard metadata file name. This PR updates our documentation to reflect the correct naming convention.

🤖 Generated with [Claude Code](https://claude.ai/code)