### PR TITLE
switch to renovatebot for dockerfile updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,28 +9,3 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
-
-  - package-ecosystem: "docker"
-    directory: "/lambdas/indexer"
-    schedule:
-      interval: "daily"
-    ignore:
-      - dependency-name: "lambda/python"
-        update-types:
-          - "version-update:semver-major"
-          - "version-update:semver-minor"
-
-  - package-ecosystem: "docker"
-    directory: "/lambdas/thumbnail"
-    schedule:
-      interval: "daily"
-
-  - package-ecosystem: "docker"
-    directory: "/catalog"
-    schedule:
-      interval: "daily"
-
-  - package-ecosystem: "docker"
-    directory: "/s3-proxy"
-    schedule:
-      interval: "daily"

--- a/renovate.json
+++ b/renovate.json
@@ -7,10 +7,31 @@
     ":dependencyDashboardApproval"
   ],
   "enabledManagers": [
-    "npm"
+    "npm",
+    "dockerfile"
   ],
   "rangeStrategy": "bump",
   "labels": [
     "js dependencies"
+  ],
+  "packageRules": [
+    {
+      "matchManagers": ["dockerfile"],
+      "labels": ["docker"],
+      "major": {
+        "enabled": false
+      },
+      "additionalBranchPrefix": "{{packageFileDir}}-",
+      "commitMessageSuffix": " in /{{packageFileDir}}",
+      "dependencyDashboardCategory": "docker"
+    },
+    {
+      "matchManagers": ["dockerfile"],
+      "matchPackageNames": ["public.ecr.aws/lambda/python"],
+      "minor": {
+        "enabled": false
+      },
+      "separateMinorPatch": true
+    }
   ]
 }


### PR DESCRIPTION
<!-- greptile_comment -->

<h2>Greptile Overview</h2>

Updated On: 2025-10-14 15:36:08 UTC

<h3>Summary</h3>

This PR migrates Docker dependency updates from Dependabot to Renovatebot. The change removes 4 Docker ecosystem entries from Dependabot configuration (indexer, thumbnail, catalog, and s3-proxy directories) and adds equivalent configuration to Renovate with more granular control.

Key changes:
- Removed all Docker-related Dependabot configurations while keeping GitHub Actions updates
- Added `dockerfile` manager to Renovate's enabled managers
- Configured Docker updates to disable major version updates globally
- Added special rule for `public.ecr.aws/lambda/python` images to also disable minor updates (matching previous Dependabot behavior)
- Set up branch prefixes and commit message suffixes to include directory paths for better organization
- Grouped Docker updates in a separate dependency dashboard category

<h3>Confidence Score: 4/5</h3>

- This PR is safe to merge with low risk - it's a straightforward configuration migration
- Score reflects a clean migration that preserves existing update policies. Confidence reduced slightly because the "docker" label referenced in renovate.json:20 may need to be created in the repository if it doesn't exist, and the base label "js dependencies" should potentially be updated to reflect both JS and Docker dependencies
- No files require special attention - both configuration changes are straightforward

<h3>Important Files Changed</h3>



File Analysis



| Filename | Score | Overview |
|----------|-------|----------|
| .github/dependabot.yml | 5/5 | Removed all Docker ecosystem configurations from Dependabot (4 directories), keeping only GitHub Actions updates |
| renovate.json | 4/5 | Added dockerfile manager with rules to disable major updates and disable minor updates for lambda/python images |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant GH as GitHub
    participant DB as Dependabot
    participant RB as Renovatebot
    participant Repo as Repository
    
    Note over GH,Repo: Before this PR
    GH->>DB: Trigger daily check (Docker)
    DB->>Repo: Check Dockerfiles in 4 directories
    DB->>Repo: Create PRs for updates (filtered)
    
    Note over GH,Repo: After this PR
    GH->>RB: Trigger check (Docker)
    RB->>Repo: Scan all Dockerfiles
    RB->>RB: Apply package rules (disable major/minor)
    RB->>Repo: Create PRs with docker label
    RB->>Repo: Add to dependency dashboard
    
    Note over GH,DB: Dependabot still handles GitHub Actions weekly
```

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->