### PR TITLE
enable C4{00,01,05,13,14} in ruff

### DIFF
--- a/api/python/quilt3/formats.py
+++ b/api/python/quilt3/formats.py
@@ -395,7 +395,7 @@ class BaseFormatHandler(ABC):
             raise TypeError("No `name` attribute has been defined for {!r}".format(type(self).__name__))
 
         # add user extensions if given
-        self.handled_extensions = set(ext.lstrip('.').lower() for ext in self.handled_extensions)
+        self.handled_extensions = {ext.lstrip('.').lower() for ext in self.handled_extensions}
         self.handled_extensions.update(ext.lstrip('.').lower() for ext in handled_extensions)
 
         # add user types if given

--- a/api/python/quilt3/packages.py
+++ b/api/python/quilt3/packages.py
@@ -1726,7 +1726,7 @@ class Package:
             elif entry != other_entry:
                 modified.append(lk)
 
-        added = list(sorted(other_entries))
+        added = sorted(other_entries)
 
         return added, modified, deleted
 

--- a/api/python/quilt3/util.py
+++ b/api/python/quilt3/util.py
@@ -487,10 +487,10 @@ def quiltignore_filter(paths, ignore, url_scheme):
                 # e.g. both foo and foo/ will match the ignore rule "foo"
                 # but only foo/ will match the ignore rule "foo/"
                 if fnmatch(pkg_dir.as_posix() + "/", ignore_rule) or fnmatch(pkg_dir.as_posix(), ignore_rule):
-                    files = set(n for n in files if pkg_dir not in n.parents)
+                    files = {n for n in files if pkg_dir not in n.parents}
                     dirs = dirs - {pkg_dir}
 
-            files = set(n for n in files if not fnmatch(n, ignore_rule))
+            files = {n for n in files if not fnmatch(n, ignore_rule)}
 
         return files.union(dirs)
     else:

--- a/api/python/tests/test_data_transfer.py
+++ b/api/python/tests/test_data_transfer.py
@@ -155,13 +155,11 @@ class DataTransferTest(QuiltTestCase):
 
     def test_list_local_url(self):
         dir_path = DATA_DIR / 'dir'
-        contents = set(list(data_transfer.list_url(PhysicalKey.from_path(dir_path))))
-        assert contents == set(
-            [
-                ('foo.txt', 4),
-                ('x/blah.txt', 6),
-            ]
-        )
+        contents = set(data_transfer.list_url(PhysicalKey.from_path(dir_path)))
+        assert contents == {
+            ("foo.txt", 4),
+            ("x/blah.txt", 6),
+        }
 
     def test_etag(self):
         assert data_transfer._calculate_etag(DATA_DIR / 'small_file.csv') == '"0bec5bf6f93c547bc9c6774acaf85e1a"'

--- a/api/python/tests/test_formats.py
+++ b/api/python/tests/test_formats.py
@@ -34,7 +34,7 @@ def test_formats_for_obj():
     assert FormatRegistry.for_ext('npy')[0] is fmt
 
     expected_string_fmt_names = ['utf-8', 'unicode', 'json']
-    found_string_fmt_names = list(f.name for f in FormatRegistry.for_obj('blah'))
+    found_string_fmt_names = [f.name for f in FormatRegistry.for_obj('blah')]
     assert found_string_fmt_names == expected_string_fmt_names
 
     bytes_obj = fmt.serialize(arr)[0]

--- a/lambdas/preview/test/test_index.py
+++ b/lambdas/preview/test/test_index.py
@@ -67,7 +67,7 @@ class TestIndex():
         fcs_files = list(parent.glob("*.fcs"))
         extended = False
         if (
-                set(os.path.split(f)[1] for f in fcs_files)
+                {os.path.split(f)[1] for f in fcs_files}
                 != {
                     'accuri-ao1.fcs',
                     'bad.fcs',

--- a/ruff.toml
+++ b/ruff.toml
@@ -43,12 +43,7 @@ ignore = [
     "B018",  # Found useless expression
     "B023",  # Function definition does not bind loop variable
     "B028",  # No explicit stacklevel keyword argument found
-    "C400",  # Unnecessary generator (rewrite as a list comprehension)
-    "C401",  # Unnecessary generator (rewrite as a set comprehension)
-    "C405",  # Unnecessary list literal (rewrite as a set literal)
     "C408",  # Unnecessary dict() call (rewrite as a literal)
-    "C413",  # Unnecessary list() call around sorted()
-    "C414",  # Unnecessary list() call within set()
     "E402",  # Module level import not at top of file
     "F401",  # Imported but unused
     "F841",  # Local variable assigned but never used


### PR DESCRIPTION
<!-- greptile_comment -->

<h2>Greptile Overview</h2>

Updated On: 2025-10-15 12:40:41 UTC

<h3>Summary</h3>

Enabled five ruff comprehension rules (C400, C401, C405, C413, C414) to enforce more Pythonic code style.

**Changes made:**
- **ruff.toml**: Removed C4{00,01,05,13,14} from ignore list to enable comprehension style checks
- **Code updates**: Applied automatic fixes across 6 Python files
  - Converted `set(generator)` to `{set comprehensions}` (more readable and slightly faster)
  - Converted `list(generator)` to `[list comprehensions]` 
  - Removed unnecessary `list()` wrapper around `sorted()` (already returns list)
  - Converted `set([list])` to `{set literal}` in tests

All changes are purely stylistic refactors with identical semantics - no logic changes.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with no risk - purely stylistic refactoring
- All changes are automated ruff fixes that preserve exact semantics. The conversions (generator→comprehension, removing redundant wrappers) are well-established Python idioms with identical behavior. No logic changes, only style improvements.
- No files require special attention

<h3>Important Files Changed</h3>



File Analysis



| Filename | Score | Overview |
|----------|-------|----------|
| ruff.toml | 5/5 | Enabled C4{00,01,05,13,14} rules by removing them from ignore list, improves code style |
| api/python/quilt3/formats.py | 5/5 | Converted `set(generator)` to set comprehension on line 398, semantically identical |
| api/python/quilt3/packages.py | 5/5 | Removed unnecessary `list()` wrapper around `sorted()` on line 1729, no behavior change |
| api/python/quilt3/util.py | 5/5 | Converted two `set(generator)` calls to set comprehensions on lines 490 and 493, identical semantics |
| api/python/tests/test_data_transfer.py | 5/5 | Removed unnecessary `list()` wrapper and converted list literal to set literal in test, preserves test logic |
| api/python/tests/test_formats.py | 5/5 | Converted `list(generator)` to list comprehension on line 37, identical behavior |
| lambdas/preview/test/test_index.py | 5/5 | Converted `set(generator)` to set comprehension on line 70, semantically equivalent |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant Dev as Developer
    participant Ruff as Ruff Linter
    participant Config as ruff.toml
    participant Code as Python Files
    
    Dev->>Config: Remove C4{00,01,05,13,14} from ignore list
    Dev->>Ruff: Run ruff check --fix
    Ruff->>Config: Read enabled rules
    Config-->>Ruff: C400, C401, C405, C413, C414 enabled
    
    Ruff->>Code: Scan for violations
    Code-->>Ruff: Found 10 fixable issues
    
    Ruff->>Code: Apply C400/C401: set(gen) → {comprehension}
    Ruff->>Code: Apply C413: list(sorted()) → sorted()
    Ruff->>Code: Apply C405: set([list]) → {literal}
    
    Code-->>Ruff: All fixes applied
    Ruff-->>Dev: 10 issues fixed, 0 remaining
    Dev->>Dev: Commit changes
```

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->