### PR TITLE
enable E501 in ruff

### DIFF
--- a/py-shared/src/quilt_shared/athena.py
+++ b/py-shared/src/quilt_shared/athena.py
@@ -110,7 +110,8 @@ class QueryRunner:
         results: list[QueryExecutionTypeDef | None] = [None] * len(query_list)
 
         remaining_queries = list(enumerate(query_list))
-        remaining_queries.reverse()  # Just to make unit tests more sane: we use pop() later, so keep the order the same.
+        # Just to make unit tests more sane: we use pop() later, so keep the order the same.
+        remaining_queries.reverse()
         pending_execution_ids = {}
 
         while remaining_queries or pending_execution_ids:

--- a/ruff.toml
+++ b/ruff.toml
@@ -24,7 +24,6 @@ select = [
 
 # Ignore rules that were disabled in pylint or would cause too many changes
 ignore = [
-    "E501",  # line-too-long (already handled by line-length setting)
     "E731",  # lambda assignment
     "B008",  # function calls in argument defaults
     "B904",  # raise without from


### PR DESCRIPTION
<!-- greptile_comment -->

<h2>Greptile Overview</h2>

Updated On: 2025-10-15 13:11:15 UTC

<h3>Summary</h3>

Enabled E501 (line-too-long) enforcement in ruff by removing it from the ignore list, ensuring all Python code adheres to the 119-character line limit.

- Removed E501 from `ruff.toml` ignore list to enforce line length checks
- Fixed the one existing violation in `athena.py` by moving an inline comment to a separate line

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with no risk
- The changes are purely cosmetic - enabling a linter rule and fixing the single violation by reformatting a comment. No functional code was modified, and the change improves code quality enforcement going forward.
- No files require special attention

<h3>Important Files Changed</h3>



File Analysis



| Filename | Score | Overview |
|----------|-------|----------|
| ruff.toml | 5/5 | Removed E501 (line-too-long) from ignored rules to enforce line length limit |
| py-shared/src/quilt_shared/athena.py | 5/5 | Split overly long comment line to comply with 119 character limit |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant Dev as Developer
    participant Ruff as Ruff Linter
    participant Code as Codebase
    
    Dev->>Ruff: Remove E501 from ignore list
    Note over Ruff: E501 (line-too-long) now enforced
    Ruff->>Code: Scan for lines > 119 chars
    Code-->>Ruff: Found line 113 in athena.py (122 chars)
    Dev->>Code: Split comment to separate lines
    Note over Code: Line 113: comment moved<br/>Line 114: code remains
    Ruff->>Code: Re-scan all files
    Code-->>Ruff: All lines comply with 119 char limit
    Ruff-->>Dev: Linting passes ✓
```

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->