### PR TITLE
disable fail-fast in deploy-lambdas workflow

### DIFF
--- a/.github/workflows/deploy-lambdas.yaml
+++ b/.github/workflows/deploy-lambdas.yaml
@@ -11,6 +11,7 @@ on:
 jobs:
   deploy-lambda-s3:
     strategy:
+      fail-fast: false
       matrix:
         path:
           - access_counts
@@ -69,6 +70,7 @@ jobs:
 
   deploy-lambda-ecr:
     strategy:
+      fail-fast: false
       matrix:
         path:
           - indexer


### PR DESCRIPTION
# Description

This is mostly to fix indexer deploy job [canceled](https://github.com/quiltdata/quilt/actions/runs/18848933475/job/53780306406) because thumbnail started to [fail](https://github.com/quiltdata/quilt/actions/runs/18848933475/job/53780306347) for some reason (it should be fixed in https://github.com/quiltdata/quilt/pull/4609)

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

Updated On: 2025-10-27 17:13:24 UTC

<h3>Greptile Summary</h3>


Disables fail-fast behavior in both deployment strategy matrices to ensure independent lambda deployments continue even if one fails.

- Adds `fail-fast: false` to `deploy-lambda-s3` job matrix (11 lambdas)
- Adds `fail-fast: false` to `deploy-lambda-ecr` job matrix (2 lambdas)
- Prevents cascading job cancellations when individual lambda deployments fail

<h3>Confidence Score: 5/5</h3>


- This PR is safe to merge with minimal risk
- The change is a simple, well-understood GitHub Actions configuration adjustment that improves deployment reliability without affecting code logic or infrastructure
- No files require special attention

<h3>Important Files Changed</h3>



File Analysis



| Filename | Score | Overview |
|----------|-------|----------|
| .github/workflows/deploy-lambdas.yaml | 5/5 | Added `fail-fast: false` to both deployment strategy matrices to prevent one job failure from canceling others |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant GH as GitHub Actions
    participant S3Jobs as S3 Deploy Jobs (11)
    participant ECRJobs as ECR Deploy Jobs (2)
    participant ProdAWS as Prod AWS
    participant GovAWS as GovCloud AWS

    Note over GH: Push to master branch
    Note over GH: Trigger deploy-lambdas workflow

    par S3 Lambda Deployments
        GH->>S3Jobs: Start matrix jobs (fail-fast: false)
        loop Each lambda (access_counts, es_ingest, etc.)
            S3Jobs->>S3Jobs: Build zip package
            S3Jobs->>ProdAWS: Upload to S3
            S3Jobs->>GovAWS: Upload to S3
        end
        Note over S3Jobs: Jobs continue even if one fails
    and ECR Lambda Deployments
        GH->>ECRJobs: Start matrix jobs (fail-fast: false)
        loop Each lambda (indexer, thumbnail)
            ECRJobs->>ECRJobs: Build Docker image
            ECRJobs->>ProdAWS: Push to ECR
            ECRJobs->>GovAWS: Push to ECR
        end
        Note over ECRJobs: Jobs continue even if one fails
    end
```

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->