### PR TITLE
Redirect `package-name?action=revisePackage` to `package-name/add`

### DIFF
--- a/catalog/CHANGELOG.md
+++ b/catalog/CHANGELOG.md
@@ -18,6 +18,7 @@ where verb is one of
 
 ## Changes
 
+- [Fixed] Restored `package-name?action=revisePackage` URL but redirect to new `package-name/add` ([#4628](https://github.com/quiltdata/quilt/pull/4628))
 - [Added] Package Dialog can now reuse manifest from existing packages when entering their names ([#4564](https://github.com/quiltdata/quilt/pull/4564))
 - [Changed] Refactor Package Dialog: add centralized state management with strict TypeScript typing and remove "react-final-form" ([#4564](https://github.com/quiltdata/quilt/pull/4564))
 - [Fixed] Correct code sample for downloading an S3 file via AWS CLI ([#4613](https://github.com/quiltdata/quilt/pull/4613))

--- a/catalog/app/containers/Bucket/PackageTree/PackageTree.tsx
+++ b/catalog/app/containers/Bucket/PackageTree/PackageTree.tsx
@@ -62,6 +62,16 @@ import DIR_QUERY from './gql/Dir.generated'
 import FILE_QUERY from './gql/File.generated'
 import DELETE_REVISION from './gql/DeleteRevision.generated'
 
+interface LegacyRevisePackageRedirectProps {
+  bucket: string
+  name: string
+}
+
+function LegacyRevisePackageRedirect({ bucket, name }: LegacyRevisePackageRedirectProps) {
+  const { urls } = NamedRoutes.use()
+  return <RRDom.Redirect to={urls.bucketPackageAddFiles(bucket, name)} />
+}
+
 interface RouteArgs {
   bucket: string
   name: string
@@ -1191,7 +1201,11 @@ export default function PackageTreeWrapper() {
 
   const path = s3paths.decode(encodedPath)
   // TODO: mode is "switch view mode" action, ex. mode=json, or type=json, or type=application/json
-  const { resolvedFrom, mode } = parseSearch(location.search, true)
+  const { action, resolvedFrom, mode } = parseSearch(location.search, true)
+
+  if (action === 'revisePackage')
+    return <LegacyRevisePackageRedirect bucket={bucket} name={name} />
+
   return (
     <>
       <MetaTitle>{[`${name}@${R.take(10, hashOrTag)}/${path}`, bucket]}</MetaTitle>


### PR DESCRIPTION
- [x] [Changelog](../tree/master/docs/CHANGELOG.md) entry (skip if change is not significant to end users, e.g. docs only)

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

Updated On: 2025-10-31 14:17:43 UTC

<h3>Greptile Summary</h3>


Restores backward compatibility for legacy `?action=revisePackage` URLs by redirecting them to the new `/add` route.

- In PR #4564, the Package Dialog was refactored and the `revisePackage` action handling was removed
- This broke existing bookmarks and external links using `package-name?action=revisePackage`
- The fix adds a simple redirect component that detects the legacy query parameter and redirects to the modern route
- The implementation is clean: extracts `action` from query params, checks if it equals `'revisePackage'`, and renders a redirect to `bucketPackageAddFiles`
- Properly maintains the `bucket` and `name` parameters during the redirect

<h3>Confidence Score: 5/5</h3>


- This PR is safe to merge with minimal risk
- The implementation is straightforward and follows React Router patterns already used in the same file. The redirect logic is simple, well-scoped, and preserves all necessary parameters (bucket and name). The change restores functionality without modifying existing code paths.
- No files require special attention

<h3>Important Files Changed</h3>



File Analysis



| Filename | Score | Overview |
|----------|-------|----------|
| catalog/app/containers/Bucket/PackageTree/PackageTree.tsx | 5/5 | Adds redirect from legacy `?action=revisePackage` query param to new `/add` route for backward compatibility |
| catalog/CHANGELOG.md | 5/5 | Documents the backward compatibility fix for legacy `revisePackage` URLs |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant User
    participant Browser
    participant PackageTreeWrapper
    participant LegacyRedirect as LegacyRevisePackageRedirect
    participant Router as React Router
    
    User->>Browser: Navigate to package-name?action=revisePackage
    Browser->>PackageTreeWrapper: Load component with query params
    PackageTreeWrapper->>PackageTreeWrapper: Parse location.search for action
    
    alt action === 'revisePackage'
        PackageTreeWrapper->>LegacyRedirect: Render redirect component
        LegacyRedirect->>Router: <Redirect to={bucketPackageAddFiles(bucket, name)} />
        Router->>Browser: Redirect to package-name/add
        Browser->>User: Show package add/revise UI
    else action !== 'revisePackage'
        PackageTreeWrapper->>Browser: Render normal package tree view
        Browser->>User: Show package tree
    end
```

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->