### PR TITLE
fix reference in Query.md

### DIFF
--- a/docs/Catalog/Query.md
+++ b/docs/Catalog/Query.md
@@ -7,7 +7,7 @@ queries that you run.
 The Catalog's Queries tab allows you to run Athena queries against your S3
 buckets, and any other data sources your users have access to. There are
 prebuilt tables for packages and objects, and you can create your own tables and
-views. See, for example, [Tabulator](advanced-features/tabulator.md).
+views. See, for example, [Tabulator](../advanced-features/tabulator.md).
 
 NOTE: This page describes how to use Athena for precise querying of specific
 tables and fields. For full-text searching using Elasticsearch, see the


### PR DESCRIPTION
<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>


Fixed broken markdown reference in `Query.md` by correcting the relative path to `tabulator.md`.

- Changed link from `advanced-features/tabulator.md` to `../advanced-features/tabulator.md`
- The file is located at `docs/Catalog/Query.md` and needs `..` to navigate up to the `docs` directory before accessing `advanced-features`
- Verified that the target file exists at the correct location

<h3>Confidence Score: 5/5</h3>


- This PR is safe to merge with no risk
- The change is a simple and correct documentation fix that adds a missing parent directory reference (`..`) to a broken markdown link, with no functional code changes
- No files require special attention

<h3>Important Files Changed</h3>



File Analysis



| Filename | Score | Overview |
|----------|-------|----------|
| docs/Catalog/Query.md | 5/5 | Fixed broken markdown link by adding missing `..` prefix to reference tabulator.md in parent directory |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant Dev as Developer
    participant Doc as Query.md
    participant Parser as Markdown Parser
    participant Target as tabulator.md
    
    Dev->>Doc: Identify broken link
    Note over Doc: Old: advanced-features/tabulator.md
    Dev->>Doc: Add parent directory prefix
    Note over Doc: New: ../advanced-features/tabulator.md
    Doc->>Parser: Process relative link
    Parser->>Target: Resolve path
    Target-->>Parser: File found
    Parser-->>Doc: Valid reference
```

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->