### PR TITLE
docs: use CNAME for Connect DNS configuration

### DIFF
--- a/docs/Catalog/Connect.md
+++ b/docs/Catalog/Connect.md
@@ -56,14 +56,21 @@ HTTPS clients and a custom scheme (`cursor://`) for desktop clients.
 
 ## DNS Configuration
 
-After deploying with Connect enabled, create a DNS alias record for your
-Connect subdomain (typically `<stack-name>-connect.<your-domain>`):
+After deploying with Connect enabled, create a DNS record for your
+Connect subdomain (typically `<stack-name>-connect.<your-domain>`).
+
+If your hosted zone is in **Route 53**, we recommend an alias record:
 
 | Route 53 Field  | Value                                                   |
 | --------------- | ------------------------------------------------------- |
 | Record type     | `A` (alias)                                             |
 | Alias target    | `ConnectLoadBalancerDNSName` CloudFormation output      |
 | Hosted zone ID  | `ConnectLoadBalancerCanonicalHostedZoneID` output       |
+
+If your DNS is hosted elsewhere, create a `CNAME` record pointing to the
+`ConnectLoadBalancerDNSName` CloudFormation output. See the
+[Installation CNAMEs section](Installation.md#cnames) for the equivalent
+catalog DNS records.
 
 The final Connect Server hostname is available in the `ConnectHost`
 CloudFormation output.

--- a/docs/Catalog/Installation.md
+++ b/docs/Catalog/Installation.md
@@ -243,14 +243,15 @@ see the [Terraform README](https://github.com/quiltdata/iac/blob/main/README.md)
 <a id="cnames"></a>
 
 In order for your users to reach the Quilt catalog you must create three DNS
-records pointing to the `LoadBalancerDNSName` as shown below and in the
-Outputs of your stack.
+records (four if Connect is enabled) pointing to the `LoadBalancerDNSName` as
+shown below and in the Outputs of your stack.
 
-| Hostname         | Target                  |
-| ---------------- | ----------------------- |
-| `<QuiltWebHost>` | `<LoadBalancerDNSName>` |
-| `<RegistryHost>` | `<LoadBalancerDNSName>` |
-| `<S3ProxyHost>`  | `<LoadBalancerDNSName>` |
+| Hostname                               | Target                         |
+| -------------------------------------- | ------------------------------ |
+| `<QuiltWebHost>`                       | `<LoadBalancerDNSName>`        |
+| `<RegistryHost>`                       | `<LoadBalancerDNSName>`        |
+| `<S3ProxyHost>`                        | `<LoadBalancerDNSName>`        |
+| `<ConnectHost>` _(if Connect enabled)_ | `<ConnectLoadBalancerDNSName>` |
 
 If your hosted zone is in **Route 53**, we recommend Route 53 alias
 records (record type `A`, alias target = `LoadBalancerDNSName`,

--- a/docs/Catalog/MCP-Server.md
+++ b/docs/Catalog/MCP-Server.md
@@ -183,7 +183,7 @@ Each user must authorize their MCP connection once:
 **Web clients (e.g. Claude.ai):**
 
 1. Log in to your Quilt stack as usual (e.g. via Okta SSO)
-2. Go to [Settings -> Connectors](https://claude.ai/settings/connectors)
+2. Go to [Customize -> Connectors](https://claude.ai/customize/connectors)
 3. Click **Connect**
 
 **Desktop clients (e.g. Cursor):** the OAuth flow starts automatically the


### PR DESCRIPTION
## Summary

- Replace the Route 53-specific alias A record instructions with a simple `CNAME` pointing to `ConnectLoadBalancerDNSName`
- CNAME works universally, including when Route 53 is in a different AWS account than the Quilt stack

## Test plan
- [ ] Review docs render correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR simplifies the DNS configuration documentation for Quilt Connect Server by replacing the Route 53-specific alias A record setup (which required both `ConnectLoadBalancerDNSName` and `ConnectLoadBalancerCanonicalHostedZoneID`) with a single, universally compatible `CNAME` record pointing to `ConnectLoadBalancerDNSName`.

**Key changes:**
- Removes the Route 53-specific DNS table (record type `A`/alias, alias target, hosted zone ID fields)
- Replaces it with a concise prose instruction to create a `CNAME` pointing to `ConnectLoadBalancerDNSName`
- The `ConnectHost` output reference is preserved
- The simplification directly supports cross-account deployments where Route 53 may not be in the same AWS account as the Quilt stack

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge — it is a documentation-only change with no code impact.
- The change is purely documentation, technically accurate (CNAME to an ELB DNS name is valid for subdomains and works across all DNS providers), and the Connect subdomain pattern (`<stack-name>-connect.<your-domain>`) is always a subdomain, so the CNAME restriction on zone-apex records is not a concern here.
- No files require special attention.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| docs/Catalog/Connect.md | Documentation-only change replacing the Route 53-specific alias A record DNS setup table with a concise CNAME instruction that works universally across DNS providers and AWS accounts. |

</details>



<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A["Deploy Quilt Stack\nwith ConnectAllowedHosts set"] --> B["CloudFormation Outputs Available:\n• ConnectLoadBalancerDNSName\n• ConnectHost"]
    B --> C["Create DNS CNAME Record\n(any DNS provider / any AWS account)"]
    C --> D["CNAME: <stack>-connect.<domain>\n→ ConnectLoadBalancerDNSName"]
    D --> E["Connect Server reachable at\nConnectHost URL"]
    E --> F["AI clients (Claude.ai, etc.)\ncan integrate via MCP"]
```

<sub>Last reviewed commit: c3d6b50</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->