### PR TITLE
chore: restrict Dependabot to security-only PRs

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,3 +9,20 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+    open-pull-requests-limit: 0
+    commit-message:
+      prefix: "security(actions)"
+    labels:
+      - "dependencies"
+      - "security"
+
+  - package-ecosystem: "pip"
+    directory: "/lambdas/manifest_indexer"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 0
+    commit-message:
+      prefix: "security(pip)"
+    labels:
+      - "dependencies"
+      - "security"

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -16,6 +16,10 @@ Entries inside each section should be ordered by type:
 
 # Changelog
 
+## unreleased
+
+* [Changed] Dependabot: only allow security update PRs, prefix titles with `security(...)` for clarity
+
 ## 7.2.0 - 2026-01-28
 
 ### Python API


### PR DESCRIPTION
## Summary
- Set `open-pull-requests-limit: 0` to block routine version update PRs (security updates bypass this limit)
- Add `commit-message.prefix` (`security(actions)`, `security(pip)`) so security PRs are clearly labeled
- Add `pip` ecosystem for `lambdas/manifest_indexer` dependencies
- Update CHANGELOG

## Test plan
- [ ] Verify no new routine Dependabot PRs are opened
- [ ] Verify security update PRs still come through with `security(...)` prefix

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR restricts Dependabot to security-only PRs by setting `open-pull-requests-limit: 0` on both the `github-actions` and a new `pip` ecosystem entry for `lambdas/manifest_indexer`. The approach is correct — GitHub's Dependabot docs confirm security updates bypass the `open-pull-requests-limit: 0` restriction regardless of the value set.

<h3>Confidence Score: 5/5</h3>

Safe to merge — the configuration change is correct and achieves the stated goal of limiting Dependabot to security PRs only.

All remaining findings are P2: one speculative concern about uv.lock compatibility (Dependabot has added uv support so this is likely fine) and one observation about incomplete coverage of other lambda directories. Neither blocks the intent of this PR.

No files require special attention; .github/dependabot.yml is the only substantive change and the logic is sound.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| .github/dependabot.yml | Adds open-pull-requests-limit: 0 to restrict routine updates and a new pip ecosystem entry for lambdas/manifest_indexer; the pip/uv compatibility and incomplete coverage of other lambda dirs are minor open questions. |
| docs/CHANGELOG.md | Adds a correct unreleased changelog entry describing the Dependabot scope restriction. |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Dependabot scheduled scan] --> B{Ecosystem: github-actions or pip}
    B --> C{Security vulnerability detected?}
    C -->|Yes| D[Bypass open-pull-requests-limit: 0]
    D --> E[Open PR with security prefix label]
    C -->|No - routine update| F[open-pull-requests-limit: 0 blocks PR]
    F --> G[No PR created]
    E --> H{pip ecosystem?}
    H -->|Yes| I[Updates pyproject.toml + uv.lock?]
    H -->|No - github-actions| J[Updates workflow action versions]
```

<sub>Reviews (1): Last reviewed commit: ["chore: restrict Dependabot to security-o..."](https://github.com/quiltdata/quilt/commit/0a3f33d83df92ae9fed30d1ea0caf1afd22f2450) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=27536499)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->