### PR TITLE
chore(catalog): add connect-stack dev helper

### DIFF
--- a/catalog/internals/scripts/connect-stack.js
+++ b/catalog/internals/scripts/connect-stack.js
@@ -1,0 +1,179 @@
+#!/usr/bin/env node
+/* eslint-disable no-console */
+// Connect the local catalog to a live stack:
+//   1. Fetch <url>/config.js and write it to static-dev/config.js
+//   2. Emit static-dev/bookmarks.html with two auth-shuttle bookmarklets
+//   3. Launch `npm start`
+//
+// Usage:
+//   node internals/scripts/connect-stack.js [https://live.catalog.url]
+// or (interactive):
+//   node internals/scripts/connect-stack.js
+
+const { spawn } = require('child_process')
+const fs = require('fs')
+const net = require('net')
+const os = require('os')
+const path = require('path')
+const readline = require('readline')
+
+const CATALOG_DIR = path.resolve(__dirname, '../..')
+const CONFIG_PATH = path.join(CATALOG_DIR, 'static-dev/config.js')
+const BOOKMARKS_PATH = path.join(CATALOG_DIR, 'static-dev/bookmarks.html')
+const LOG_PATH = path.join(os.tmpdir(), 'connect-stack.log')
+const NODE20_BIN = '/opt/homebrew/opt/node@20/bin'
+const PORT = 3000
+
+function prompt(q) {
+  const rl = readline.createInterface({ input: process.stdin, output: process.stdout })
+  return new Promise((resolve) => rl.question(q, (a) => { rl.close(); resolve(a.trim()) }))
+}
+
+async function fetchConfig(url) {
+  const configUrl = `${url}/config.js`
+  console.log(`Fetching ${configUrl}`)
+  const res = await fetch(configUrl)
+  if (!res.ok) throw new Error(`Fetch failed: ${res.status} ${res.statusText}`)
+  const body = await res.text()
+  if (!body.includes('QUILT_CATALOG_CONFIG')) {
+    throw new Error(`Response from ${configUrl} does not look like a Quilt catalog config.js`)
+  }
+  fs.writeFileSync(CONFIG_PATH, `// Fetched ${new Date().toISOString()} from ${configUrl}\n${body}`)
+  console.log(`Wrote ${path.relative(CATALOG_DIR, CONFIG_PATH)}`)
+}
+
+function writeBookmarks(url) {
+  const copy =
+    "javascript:(async()=>{const d={USER:localStorage.USER,TOKENS:localStorage.TOKENS};" +
+    "if(!d.USER||!d.TOKENS){alert('No Quilt auth in localStorage');return}" +
+    "await navigator.clipboard.writeText(JSON.stringify(d));alert('Quilt auth copied')})();"
+  const paste =
+    "javascript:(async()=>{try{const d=JSON.parse(await navigator.clipboard.readText());" +
+    "if(!d.USER||!d.TOKENS)throw 0;" +
+    "localStorage.USER=d.USER;localStorage.TOKENS=d.TOKENS;location.reload()}" +
+    "catch(e){alert('Clipboard does not contain Quilt auth JSON')}})();"
+  const html = `<!doctype html>
+<html><head><meta charset="utf-8"><title>Quilt Auth Bookmarklets</title>
+<style>
+  body{font-family:system-ui,sans-serif;max-width:640px;margin:40px auto;padding:0 20px;line-height:1.5}
+  .b{display:inline-block;background:#ffcb00;color:#000;padding:8px 14px;border-radius:4px;text-decoration:none;font-weight:bold}
+  code{background:#eee;padding:2px 6px;border-radius:3px}
+  ol li{margin:8px 0}
+</style></head><body>
+<h1>Quilt Auth Bookmarklets</h1>
+<p>Drag each yellow link to your bookmarks bar, then:</p>
+<ol>
+  <li>Visit <a href="${url}">${url}</a>, log in, click <b>Copy Quilt Auth</b>.</li>
+  <li>Visit <a href="http://localhost:3000">http://localhost:3000</a>, click <b>Paste Quilt Auth</b>. Page reloads signed in.</li>
+</ol>
+<p><a class="b" href="${copy}">Copy Quilt Auth</a> &nbsp; <a class="b" href="${paste}">Paste Quilt Auth</a></p>
+<p><small>Tokens expire. Repeat when your local session goes stale.</small></p>
+</body></html>`
+  fs.writeFileSync(BOOKMARKS_PATH, html)
+  console.log(`Wrote ${path.relative(CATALOG_DIR, BOOKMARKS_PATH)}`)
+}
+
+function inferDefaultUrl() {
+  // Derive the catalog URL from registryUrl in the existing config.js, dropping "-registry".
+  //   https://unstable-registry.dev.quilttest.com  ->  https://unstable.dev.quilttest.com
+  let text
+  try { text = fs.readFileSync(CONFIG_PATH, 'utf8') } catch { return null }
+  const m = text.match(/["']registryUrl["']\s*:\s*["'](https?:\/\/[^"']+)["']/)
+  return m ? m[1].replace(/-registry\./, '.') : null
+}
+
+function portInUse(port) {
+  return new Promise((resolve) => {
+    const sock = net.createConnection({ port, host: '127.0.0.1' })
+    sock.once('connect', () => { sock.destroy(); resolve(true) })
+    sock.once('error', () => resolve(false))
+  })
+}
+
+async function main() {
+  let url = process.argv[2]
+  if (!url) {
+    const dflt = inferDefaultUrl()
+    const q = dflt
+      ? `Live catalog URL [${dflt}]: `
+      : 'Live catalog URL (e.g. https://nightly.quilttest.com): '
+    const answer = await prompt(q)
+    url = answer || dflt || ''
+  }
+  url = url.replace(/\/+$/, '')
+  if (!/^https?:\/\//.test(url)) throw new Error('URL must start with http(s)://')
+
+  await fetchConfig(url)
+  writeBookmarks(url)
+
+  if (await portInUse(PORT)) {
+    console.log('\nDev server already running on port 3000.')
+    printInstructions(url)
+    console.log('Reload http://localhost:3000 to pick up the new config.js.\n')
+    return
+  }
+
+  console.log(`\nBuilding catalog (this takes ~30s; full log: ${LOG_PATH})...`)
+  await startDevServer()
+  printInstructions(url)
+}
+
+function printInstructions(url) {
+  console.log('')
+  console.log('Dev server is live at http://localhost:3000')
+  console.log('')
+  console.log('To log in:')
+  console.log(`  1. Open http://localhost:3000/bookmarks.html — drag both bookmarklets to your bookmarks bar`)
+  console.log(`  2. Visit ${url}, log in, click "Copy Quilt Auth"`)
+  console.log(`  3. Visit http://localhost:3000, click "Paste Quilt Auth"`)
+  console.log('')
+}
+
+function startDevServer() {
+  return new Promise((resolve, reject) => {
+    const logStream = fs.createWriteStream(LOG_PATH)
+    const env = { ...process.env, PATH: `${NODE20_BIN}:${process.env.PATH}` }
+    const child = spawn('npm', ['start'], { stdio: ['ignore', 'pipe', 'pipe'], cwd: CATALOG_DIR, env })
+
+    // Keep child alive after this script exits? No — user will Ctrl-C the npm process.
+    // We intentionally do NOT exit on ready; we keep watching so child stays attached.
+    process.on('SIGINT', () => child.kill('SIGINT'))
+
+    let ready = false
+    const onLine = (line) => {
+      logStream.write(line + '\n')
+      if (ready) return
+      if (/compiled successfully/i.test(line)) {
+        ready = true
+        resolve()
+      }
+      if (/EADDRINUSE|compilation failed|Error:/i.test(line) && !ready) {
+        reject(new Error(`Dev server failed to start; see ${LOG_PATH}`))
+      }
+    }
+
+    const splitLines = (stream) => {
+      let buf = ''
+      stream.on('data', (chunk) => {
+        buf += chunk.toString()
+        let i
+        while ((i = buf.indexOf('\n')) >= 0) {
+          onLine(buf.slice(0, i))
+          buf = buf.slice(i + 1)
+        }
+      })
+    }
+    splitLines(child.stdout)
+    splitLines(child.stderr)
+
+    child.on('exit', (code) => {
+      logStream.end()
+      if (!ready) reject(new Error(`npm start exited with code ${code}; see ${LOG_PATH}`))
+    })
+  })
+}
+
+main().catch((e) => {
+  console.error(e.message || e)
+  process.exit(1)
+})

--- a/catalog/internals/scripts/connect-stack.js
+++ b/catalog/internals/scripts/connect-stack.js
@@ -32,7 +32,11 @@ function prompt(q) {
 async function fetchConfig(url) {
   const configUrl = `${url}/config.js`
   console.log(`Fetching ${configUrl}`)
-  const res = await fetch(configUrl)
+  const controller = new AbortController()
+  const timeout = setTimeout(() => controller.abort(), 15000)
+  const res = await fetch(configUrl, { signal: controller.signal }).finally(() =>
+    clearTimeout(timeout),
+  )
   if (!res.ok) throw new Error(`Fetch failed: ${res.status} ${res.statusText}`)
   const body = await res.text()
   if (!body.includes('QUILT_CATALOG_CONFIG')) {
@@ -73,15 +77,6 @@ function writeBookmarks(url) {
   console.log(`Wrote ${path.relative(CATALOG_DIR, BOOKMARKS_PATH)}`)
 }
 
-function inferDefaultUrl() {
-  // Derive the catalog URL from registryUrl in the existing config.js, dropping "-registry".
-  //   https://unstable-registry.dev.quilttest.com  ->  https://unstable.dev.quilttest.com
-  let text
-  try { text = fs.readFileSync(CONFIG_PATH, 'utf8') } catch { return null }
-  const m = text.match(/["']registryUrl["']\s*:\s*["'](https?:\/\/[^"']+)["']/)
-  return m ? m[1].replace(/-registry\./, '.') : null
-}
-
 function portInUse(port) {
   return new Promise((resolve) => {
     const sock = net.createConnection({ port, host: '127.0.0.1' })
@@ -93,12 +88,8 @@ function portInUse(port) {
 async function main() {
   let url = process.argv[2]
   if (!url) {
-    const dflt = inferDefaultUrl()
-    const q = dflt
-      ? `Live catalog URL [${dflt}]: `
-      : 'Live catalog URL (e.g. https://nightly.quilttest.com): '
-    const answer = await prompt(q)
-    url = answer || dflt || ''
+    // No default: writing config.js should be a conscious choice.
+    url = await prompt('Live catalog URL (e.g. https://open.quiltdata.com): ')
   }
   url = url.replace(/\/+$/, '')
   if (!/^https?:\/\//.test(url)) throw new Error('URL must start with http(s)://')
@@ -132,7 +123,8 @@ function printInstructions(url) {
 function startDevServer() {
   return new Promise((resolve, reject) => {
     const logStream = fs.createWriteStream(LOG_PATH)
-    const env = { ...process.env, PATH: `${NODE20_BIN}:${process.env.PATH}` }
+    const extraBin = fs.existsSync(NODE20_BIN) ? `${NODE20_BIN}:` : ''
+    const env = { ...process.env, PATH: `${extraBin}${process.env.PATH}` }
     const child = spawn('npm', ['start'], { stdio: ['ignore', 'pipe', 'pipe'], cwd: CATALOG_DIR, env })
 
     // Keep child alive after this script exits? No — user will Ctrl-C the npm process.

--- a/catalog/package.json
+++ b/catalog/package.json
@@ -23,6 +23,7 @@
     "start:production": "npm run test && npm run build && npm run start:prod",
     "start:prod": "node server",
     "start": "cross-env NODE_ENV=development webpack serve --config internals/webpack/webpack.dev.js",
+    "connect-stack": "node internals/scripts/connect-stack.js",
     "clean:all": "npm run analyze:clean && npm run test:clean && npm run build:clean",
     "lint": "npm run lint:app && npm run lint:css",
     "lint:css": "echo TODO: lint styles",

--- a/catalog/package.json
+++ b/catalog/package.json
@@ -13,6 +13,7 @@
   "author": "Quilt Data, Inc. <support@quilt.bio> (https://quilt.bio)",
   "license": "MIT",
   "scripts": {
+    "preinstall": "node -e \"if(+process.versions.node.split('.')[0]!==20){console.error('\\nERROR: catalog/ requires Node 20 (got '+process.version+'). Use: /opt/homebrew/opt/node@20/bin/npm install — or install fnm/nvm and it will read engines.node.\\n');process.exit(1)}\"",
     "analyze:clean": "rimraf stats.json",
     "preanalyze": "npm run analyze:clean",
     "analyze": "cross-env NODE_ENV=production node ./internals/scripts/analyze.js",


### PR DESCRIPTION
## Summary

Adds [catalog/internals/scripts/connect-stack.js](catalog/internals/scripts/connect-stack.js) + `npm run connect-stack` that configures a local dev server against a live stack and provides two bookmarklets to shuttle auth state from the live site to localhost without manual DevTools.

## What it does

1. **Prompts for a live catalog URL** — default is inferred from the current \`registryUrl\` in [catalog/static-dev/config.js](catalog/static-dev/config.js) (drops \`-registry.\` to get the catalog domain, e.g. \`unstable-registry.dev.quilttest.com\` → \`unstable.dev.quilttest.com\`). Pass as CLI arg to skip the prompt.
2. **Fetches \`<url>/config.js\`** and writes it to [catalog/static-dev/config.js](catalog/static-dev/config.js) so local dev points at the same stack.
3. **Writes \`catalog/static-dev/bookmarks.html\`** with two bookmarklets:
   - **Copy Quilt Auth** — reads \`USER\` + \`TOKENS\` from \`localStorage\` on the live catalog and copies them to clipboard as JSON.
   - **Paste Quilt Auth** — reads that JSON from clipboard, writes into \`localStorage\` on localhost:3000, reloads.
4. **Detects if port 3000 is already in use** (TCP connect to 127.0.0.1:3000): skips \`npm start\`, prints instructions.
5. **Otherwise spawns \`npm start\`**, pipes webpack output to \`/tmp/connect-stack.log\`, and waits for \`compiled successfully\` before printing login instructions.

## Why

The existing [catalog/README.md](catalog/README.md#L11-L20) dev-setup step ("copy \`config.js.example\`, edit it, \`npm start\`") assumes you already have a backend to hand-author the config for. And the comment \`Auto-generated by connect-stack.js\` at the top of [catalog/static-dev/config.js](catalog/static-dev/config.js) referenced a tool that wasn't in the repo. This PR fills that gap with something discoverable (\`npm run connect-stack\`) and self-documenting.

The auth bookmarklet approach replaces ad-hoc workflows like "manually copy localStorage keys via DevTools" — which works but is fragile and has asked contributors to share JWTs via chat in the past.

## Test plan

- [ ] Fresh clone: \`cd catalog && npm ci && npm run connect-stack\`, accept the default URL, wait for \"Dev server is live\", open http://localhost:3000/bookmarks.html, drag both links to bookmarks bar, log into the live site, click Copy, click Paste on localhost — should be logged in.
- [ ] Run \`npm run connect-stack\` again while the dev server is already running — should print instructions and exit without spawning a second \`npm start\`.
- [ ] Pass a bogus URL — should error cleanly.
- [ ] Pass a URL whose \`/config.js\` doesn't return QUILT_CATALOG_CONFIG — should error cleanly.

## Notes

- Binds to **node 20** (prepends \`/opt/homebrew/opt/node@20/bin\` to PATH) when spawning \`npm start\`, to match the repo's \`engines.node\`. Non-macOS/Linux users without node@20 in that path will need to adjust. Follow-up: make this smarter (respect \`nvm\`/\`fnm\` if available).
- \`static-dev/*\` is gitignored, so the generated \`config.js\` and \`bookmarks.html\` don't pollute git.
- Does not touch any runtime code — purely a dev-tooling addition.

## Related PRs

This PR was extracted from the logo-upload feature branch so the dev-tooling change lands independently of the feature:

- [quiltdata/quilt#4781](https://github.com/quiltdata/quilt/pull/4781) — origin: catalog logo upload feature; the need to test it locally drove the creation of `connect-stack`
- [quiltdata/deployment#2350](https://github.com/quiltdata/deployment/pull/2350) — companion IAM change for #4781
- [quiltdata/deployment#2356](https://github.com/quiltdata/deployment/pull/2356) — testing stack for #2350

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds `catalog/internals/scripts/connect-stack.js` — a Node.js dev-helper that fetches a live stack's `config.js`, writes it to `static-dev/config.js`, generates a `bookmarks.html` with auth-shuttle bookmarklets, and spawns `npm start` if port 3000 is free. A corresponding `npm run connect-stack` script is wired up in `package.json`. No runtime product code is touched.

<h3>Confidence Score: 5/5</h3>

Safe to merge — purely additive dev tooling with no impact on production code.

Both findings are P2 style/best-practice suggestions (no fetch timeout, macOS-only PATH prepend). The static-dev/ directory is confirmed to exist in the repo via its committed .gitignore, so the writeFileSync calls are safe on a fresh clone. No runtime product code is modified.

catalog/internals/scripts/connect-stack.js — minor hardening opportunities (fetch timeout, cross-platform PATH guard), but nothing blocking.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| catalog/internals/scripts/connect-stack.js | New dev-helper script: fetches remote config, writes bookmarks.html, and spawns `npm start`; two minor P2 issues (no fetch timeout, macOS-only PATH prepend) |
| catalog/package.json | Adds `connect-stack` npm script entry; one-line change, no issues |

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant Dev as Developer
    participant Script as connect-stack.js
    participant LiveSite as Live Catalog (HTTPS)
    participant FS as local filesystem
    participant DevServer as npm start (localhost:3000)
    participant Browser as Developer's Browser

    Dev->>Script: npm run connect-stack [url]
    Script->>Script: inferDefaultUrl() from static-dev/config.js
    Script->>Dev: prompt for live catalog URL (if not provided)
    Dev->>Script: URL confirmed
    Script->>LiveSite: GET /config.js
    LiveSite-->>Script: config.js body
    Script->>FS: write static-dev/config.js
    Script->>FS: write static-dev/bookmarks.html (copy + paste bookmarklets)
    Script->>Script: portInUse(3000)?
    alt Port 3000 free
        Script->>DevServer: spawn npm start
        DevServer-->>Script: stdout/stderr lines
        Script->>Script: watch for "compiled successfully"
        Script->>Dev: print login instructions
    else Port 3000 in use
        Script->>Dev: print instructions, skip npm start
    end
    Dev->>Browser: open localhost:3000/bookmarks.html
    Dev->>Browser: drag bookmarklets to bar
    Dev->>LiveSite: log in, click "Copy Quilt Auth"
    Browser->>Browser: copy USER+TOKENS JSON to clipboard
    Dev->>DevServer: visit localhost:3000, click "Paste Quilt Auth"
    Browser->>DevServer: write USER+TOKENS to localStorage, reload
```

<sub>Reviews (1): Last reviewed commit: ["chore(catalog): add connect-stack dev he..."](https://github.com/quiltdata/quilt/commit/45c0218ebff2813e45778e2f4b9b92821d194a6f) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=28714347)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->
