### PR TITLE
Catalog: clarify revision link tooltip (catalog URL, not canonical URI)

### DIFF
--- a/catalog/app/containers/Bucket/PackageTree/RevisionInfo.tsx
+++ b/catalog/app/containers/Bucket/PackageTree/RevisionInfo.tsx
@@ -89,7 +89,7 @@ export default function RevisionInfo({
     (e: React.MouseEvent) => {
       e.preventDefault()
       copyToClipboard(getHttpsUri(h), { container: containerRef?.current || undefined })
-      push('Canonical URI copied to clipboard')
+      push('Catalog URL copied to clipboard')
     }
 
   const comparePair: [string, string] | null = React.useMemo(() => {
@@ -122,7 +122,7 @@ export default function RevisionInfo({
       {!!hash && (
         <M.IconButton
           size="small"
-          title="Copy package revision's canonical catalog URI to the clipboard"
+          title="Copy package revision's catalog URL to the clipboard"
           href={getHttpsUri(hash)}
           onClick={copyHttpsUri(hash)}
           className={classes.shortcut}
@@ -165,7 +165,7 @@ export default function RevisionInfo({
                     />
                     <M.ListItemSecondaryAction>
                       <M.IconButton
-                        title="Copy package revision's canonical catalog URI to the clipboard"
+                        title="Copy package revision's catalog URL to the clipboard"
                         href={getHttpsUri(r.hash)}
                         onClick={copyHttpsUri(r.hash, listRef)}
                       >


### PR DESCRIPTION
## Summary

- The link-icon button next to a package revision in `RevisionInfo` copies the catalog HTTPS URL (e.g. `https://<catalog>/b/<bucket>/packages/<ns>/<pkg>/tree/<hash>/`), but the tooltip and toast called it a "canonical URI" — which users reasonably read as a `quilt+s3://` package URI.
- Retitle tooltip and toast to say "catalog URL" so the label matches what lands on the clipboard. No behavior change.

Original feature: #1990 (2020). The label has been misleading since it was introduced.

## Test plan

- [ ] Open a package revision in the catalog; hover the link icon next to the revision — tooltip reads "Copy package revision's catalog URL to the clipboard"
- [ ] Click it — toast reads "Catalog URL copied to clipboard"; clipboard contains the catalog deep-link URL
- [ ] Same checks from the revision list popover

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes a misleading label in `RevisionInfo.tsx` by renaming the tooltip and toast text from "canonical URI" / "canonical catalog URI" to "catalog URL", correctly reflecting that the copied value is a catalog HTTPS deep-link, not a `quilt+s3://` URI. No behavior or logic changes.

<h3>Confidence Score: 5/5</h3>

Safe to merge — purely cosmetic label fix with no code logic changes.

All three changes are string literals in UI text (one toast message, two tooltip titles). No runtime behavior, data flow, or API contracts are affected. No P0/P1 findings.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| catalog/app/containers/Bucket/PackageTree/RevisionInfo.tsx | Three string-only changes: toast message and two tooltip `title` attributes updated from "canonical URI/catalog URI" to "catalog URL". No logic, API, or behavior changes. |

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    actor User
    participant IconButton
    participant Clipboard
    participant Toast

    User->>IconButton: hover
    IconButton-->>User: tooltip "Copy package revision's catalog URL to the clipboard"
    User->>IconButton: click
    IconButton->>Clipboard: copyToClipboard(getHttpsUri(hash))
    IconButton->>Toast: push("Catalog URL copied to clipboard")
    Toast-->>User: "Catalog URL copied to clipboard"
```

<sub>Reviews (1): Last reviewed commit: ["Catalog: clarify revision link tooltip (..."](https://github.com/quiltdata/quilt/commit/4cb8c64c0a854790202c92f706c2b54d6a63ff2e) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=29030265)</sub>

<!-- /greptile_comment -->