### PR TITLE
docs: correct Elasticsearch version reference to 7.10

### DIFF
--- a/api/python/quilt3/api.py
+++ b/api/python/quilt3/api.py
@@ -176,8 +176,8 @@ def search(query: T.Union[str, dict], limit: int = 10) -> T.List[dict]:
 
     Query Syntax:
         [Query String Query](
-            https://www.elastic.co/guide/en/elasticsearch/reference/6.8/query-dsl-query-string-query.html)
-        [Query DSL](https://www.elastic.co/guide/en/elasticsearch/reference/6.8/query-dsl.html)
+            https://www.elastic.co/guide/en/elasticsearch/reference/7.10/query-dsl-query-string-query.html)
+        [Query DSL](https://www.elastic.co/guide/en/elasticsearch/reference/7.10/query-dsl.html)
 
     Index schemas and search examples can be found in the
     [Quilt Search documentation](https://docs.quilt.bio/quilt-platform-catalog-user/search).

--- a/api/python/quilt3/bucket.py
+++ b/api/python/quilt3/bucket.py
@@ -48,8 +48,8 @@ class Bucket:
 
         Query Syntax:
             [Query String Query](
-                https://www.elastic.co/guide/en/elasticsearch/reference/6.8/query-dsl-query-string-query.html)
-            [Query DSL](https://www.elastic.co/guide/en/elasticsearch/reference/6.8/query-dsl.html)
+                https://www.elastic.co/guide/en/elasticsearch/reference/7.10/query-dsl-query-string-query.html)
+            [Query DSL](https://www.elastic.co/guide/en/elasticsearch/reference/7.10/query-dsl.html)
 
         Index schemas and search examples can be found in the
         [Quilt Search documentation](https://docs.quilt.bio/quilt-platform-catalog-user/search).

--- a/docs/Catalog/Search.md
+++ b/docs/Catalog/Search.md
@@ -33,8 +33,8 @@ The search page in the catalog, accessible from the search button in the top men
 way for searching objects and packages in an Amazon S3
 bucket.
 
-NOTE: Quilt uses Elasticsearch 6.8 [query string
-syntax](https://www.elastic.co/guide/en/elasticsearch/reference/6.8/query-dsl-query-string-query.html#query-string-syntax).
+NOTE: Quilt uses Elasticsearch 7.10 [query string
+syntax](https://www.elastic.co/guide/en/elasticsearch/reference/7.10/query-dsl-query-string-query.html#query-string-syntax).
 
 The following are all valid search parameters:
 
@@ -121,18 +121,18 @@ and query parameters.
 Quilt Elasticsearch queries support the following keys:
 
 * `index` — comma-separated list of indexes to search ([learn
-more](https://www.elastic.co/guide/en/elasticsearch/reference/6.8/multi-index.html))
+more](https://www.elastic.co/guide/en/elasticsearch/reference/7.10/multi-index.html))
 * `filter_path` — to reducing response nesting, ([learn
-more](https://www.elastic.co/guide/en/elasticsearch/reference/6.8/common-options.html#common-options-response-filtering))
+more](https://www.elastic.co/guide/en/elasticsearch/reference/7.10/common-options.html#common-options-response-filtering))
 * `_source` — boolean that adds or removes the `_source` field, or
 a list of fields to return ([learn
-more](https://www.elastic.co/guide/en/elasticsearch/reference/6.8/search-request-source-filtering.html))
+more](https://www.elastic.co/guide/en/elasticsearch/reference/7.10/search-request-source-filtering.html))
 * `size` — limits the number of hits ([learn
-more](https://www.elastic.co/guide/en/elasticsearch/reference/6.8/search-uri-request.html))
+more](https://www.elastic.co/guide/en/elasticsearch/reference/7.10/search-uri-request.html))
 * `from` — starting offset for pagination ([learn
-more](https://www.elastic.co/guide/en/elasticsearch/reference/6.8/search-uri-request.html))
+more](https://www.elastic.co/guide/en/elasticsearch/reference/7.10/search-uri-request.html))
 * `body` — the search query body as a JSON dictionary ([learn
-more](https://www.elastic.co/guide/en/elasticsearch/reference/6.8/search-request-body.html))
+more](https://www.elastic.co/guide/en/elasticsearch/reference/7.10/search-request-body.html))
 
 ### Secure Search
 

--- a/docs/api-reference/Bucket.md
+++ b/docs/api-reference/Bucket.md
@@ -25,8 +25,8 @@ __Arguments__
 
 Query Syntax:
     [Query String Query](
-        https://www.elastic.co/guide/en/elasticsearch/reference/6.8/query-dsl-query-string-query.html)
-    [Query DSL](https://www.elastic.co/guide/en/elasticsearch/reference/6.8/query-dsl.html)
+        https://www.elastic.co/guide/en/elasticsearch/reference/7.10/query-dsl-query-string-query.html)
+    [Query DSL](https://www.elastic.co/guide/en/elasticsearch/reference/7.10/query-dsl.html)
 
 Index schemas and search examples can be found in the
 [Quilt Search documentation](https://docs.quilt.bio/quilt-platform-catalog-user/search).

--- a/docs/api-reference/api.md
+++ b/docs/api-reference/api.md
@@ -135,8 +135,8 @@ __Arguments__
 
 Query Syntax:
     [Query String Query](
-        https://www.elastic.co/guide/en/elasticsearch/reference/6.8/query-dsl-query-string-query.html)
-    [Query DSL](https://www.elastic.co/guide/en/elasticsearch/reference/6.8/query-dsl.html)
+        https://www.elastic.co/guide/en/elasticsearch/reference/7.10/query-dsl-query-string-query.html)
+    [Query DSL](https://www.elastic.co/guide/en/elasticsearch/reference/7.10/query-dsl.html)
 
 Index schemas and search examples can be found in the
 [Quilt Search documentation](https://docs.quilt.bio/quilt-platform-catalog-user/search).

--- a/docs/walkthrough/working-with-elasticsearch.md
+++ b/docs/walkthrough/working-with-elasticsearch.md
@@ -34,8 +34,8 @@ select, edit, and execute.
 ## Managing Elasticsearch
 
 <!-- markdownlint-disable-next-line MD013 -->
-Quilt uses Amazon Elasticsearch 6.7
-([docs](https://www.elastic.co/guide/en/elasticsearch/reference/6.7/index.html)).
+Quilt uses Amazon Elasticsearch 7.10
+([docs](https://www.elastic.co/guide/en/elasticsearch/reference/7.10/index.html)).
 
 1. If your Quilt stack uses private endpoints for Elasticsearch you will need to
    connect to the cluster from a machine in the same VPC as the cluster.

--- a/docs/walkthrough/working-with-the-catalog.md
+++ b/docs/walkthrough/working-with-the-catalog.md
@@ -29,7 +29,7 @@ You can also browse the underlying S3 objects using the "Bucket" tab.
 
 Catalogs also enable you to search the contents of your bucket. We support both
 unstructured (e.g. "`San Francisco`") and structured with
-[Query String Queries](https://www.elastic.co/guide/en/elasticsearch/reference/6.7/query-dsl-query-string-query.html#query-string-syntax)
+[Query String Queries](https://www.elastic.co/guide/en/elasticsearch/reference/7.10/query-dsl-query-string-query.html#query-string-syntax)
 (e.g. "`metadata_key: metadata_value`") search. Hits are previewed right in the
 search results.
 


### PR DESCRIPTION
## Summary
Align Elasticsearch documentation references (prose notes, elastic.co reference links, and `quilt3.search` docstrings) with the version actually shipped by Quilt stacks — 7.10.

## Test plan
- [ ] Confirm rendered page at docs.quilt.bio/quilt-platform-catalog-user/search shows the correct version after sync.
- [ ] Spot-check updated elastic.co links resolve to 7.10 reference pages.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This docs-only PR updates Elasticsearch version references from 6.7/6.8 to 7.10 across seven files — docstrings in `api.py` and `bucket.py`, rendered Markdown docs, and the API reference pages. The changes are internally consistent and correct for the files touched.

There are a handful of stale 6.7/6.8 elastic.co URLs still present in files outside this PR's scope (`catalog/app/containers/Search/FilterWidget.tsx` lines 59 and 85, `lambdas/indexer/src/t4_lambda_es_indexer/document_queue.py` lines 148 and 174, and `lambdas/indexer/test/test_index.py` lines 479 and 499). These were not part of the stated scope but may be worth a follow-up. Additionally, the Python client dependency remains pinned at `elasticsearch ~= 6.8` (`py-shared/pyproject.toml`, various `uv.lock` files) while the docs now advertise server version 7.10 — this is a separate concern but worth tracking.

<h3>Confidence Score: 5/5</h3>

Safe to merge — pure documentation update with correct, consistent version number changes across all targeted files.

All seven changed files contain only version-string and URL substitutions (6.7/6.8 → 7.10) with no logic, API surface, or runtime behavior affected. The remaining stale references and client-library pin are out of scope for this PR and are P2 follow-up items, not blockers.

No files in this PR require special attention. Follow-up candidates outside the PR: catalog/app/containers/Search/FilterWidget.tsx, lambdas/indexer/src/t4_lambda_es_indexer/document_queue.py, lambdas/indexer/test/test_index.py, py-shared/pyproject.toml.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| api/python/quilt3/api.py | Updated two elastic.co docstring URLs from 6.8 to 7.10; change is correct and complete for this file. |
| api/python/quilt3/bucket.py | Updated two elastic.co docstring URLs from 6.8 to 7.10; mirrors the api.py change correctly. |
| docs/Catalog/Search.md | Updated prose note and six elastic.co links from 6.8 to 7.10; all occurrences in this file are addressed. |
| docs/walkthrough/working-with-elasticsearch.md | Changed prose version reference and docs link from 6.7 to 7.10; correctly targeted. |
| docs/walkthrough/working-with-the-catalog.md | Updated single Query String Queries link from 6.7 to 7.10. |
| docs/api-reference/Bucket.md | Updated two elastic.co reference links from 6.8 to 7.10. |
| docs/api-reference/api.md | Updated two elastic.co reference links from 6.8 to 7.10. |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[User reads docs / calls quilt3 API] --> B{Which entry point?}
    B --> C[quilt3.search / Bucket.search docstring]
    B --> D[docs/Catalog/Search.md]
    B --> E[docs/walkthrough/working-with-elasticsearch.md]
    B --> F[docs/walkthrough/working-with-the-catalog.md]
    B --> G[docs/api-reference/api.md + Bucket.md]
    C -->|elastic.co links| H[Elasticsearch 7.10 reference docs]
    D -->|elastic.co links| H
    E -->|elastic.co links| H
    F -->|elastic.co link| H
    G -->|elastic.co links| H
    subgraph Not updated in this PR
        I[catalog/app/containers/Search/FilterWidget.tsx 6.8 comment URLs]
        J[lambdas/indexer/document_queue.py 6.7 comment URLs]
        K[lambdas/indexer/test/test_index.py 6.7 comment URLs]
        L[py-shared/pyproject.toml elasticsearch ~= 6.8 client]
    end
```

<sub>Reviews (2): Last reviewed commit: ["docs: update remaining Elasticsearch 6.x..."](https://github.com/quiltdata/quilt/commit/bc5679a858185deccc00c5152c6f0b4b2124b17f) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=29183240)</sub>

<!-- /greptile_comment -->