### PR TITLE
Catalog: cascade bucketRemove through cached Policy/Role permissions

### DIFF
--- a/catalog/CHANGELOG.md
+++ b/catalog/CHANGELOG.md
@@ -18,6 +18,7 @@ where verb is one of
 
 ## Changes
 
+- [Fixed] Admin Users / Policies panels: drop phantom permission rows referencing a just-removed bucket (cache was not cascading the removal through `Policy.permissions` / `ManagedRole.permissions`) ([#4855](https://github.com/quiltdata/quilt/pull/4855))
 - [Changed] Migrate user-facing bucket queries to the new role-scoped `buckets` / `bucket` GraphQL type; admins in a scoped managed role now see only role-permitted buckets in navbar / listings / deep-links (admin panel unchanged) ([#4839](https://github.com/quiltdata/quilt/pull/4839))
 - [Fixed] Refresh navbar bucket selector after bucket removal and after policy / role / user-role edits that change the caller's managed-role bucket set ([#4839](https://github.com/quiltdata/quilt/pull/4839))
 - [Added] HubSpot tracking ([#4807](https://github.com/quiltdata/quilt/pull/4807))

--- a/catalog/app/utils/GraphQL/Provider.tsx
+++ b/catalog/app/utils/GraphQL/Provider.tsx
@@ -225,12 +225,12 @@ export default function GraphQLProvider({ children }: React.PropsWithChildren<{}
                 R.evolve({ buckets: R.reject(R.propEq('name', vars.name)) }),
               )
               cache.invalidate({ __typename: 'Bucket', name: vars.name })
-              // Registry cascade-deletes the RolePolicyBucketPermission rows
-              // for the removed bucket, but the cached PolicyBucketPermission
-              // / RoleBucketPermission entries (keyed {bucketName}/{id}) are
-              // not reachable via the Bucket-entity invalidation above —
-              // strip them from every cached Policy.permissions and
-              // ManagedRole.permissions array.
+              // Server cascade-deletes the PolicyBucketPermission /
+              // RoleBucketPermission rows for the removed bucket, but the
+              // cached entries (keyed {bucketName}/{id}) are not reachable
+              // via the Bucket-entity invalidation above — strip them from
+              // every cached Policy.permissions and ManagedRole.permissions
+              // array.
               const stripBucket = R.reject(R.pathEq(['bucket', 'name'], vars.name))
               cache.updateQuery(
                 {

--- a/catalog/app/utils/GraphQL/Provider.tsx
+++ b/catalog/app/utils/GraphQL/Provider.tsx
@@ -21,6 +21,10 @@ const USERS_QUERY = urql.gql`{ admin { user { list { name } } } }`
 const DEFAULT_ROLE_QUERY = urql.gql`{ defaultRole { id } }`
 
 // Invalidate all cached variants of a root Query field (args-aware).
+// Marks cached variants stale so the next read refetches; does NOT
+// reliably notify active subscribers on urql 2.x + graphcache 4.x.
+// Use refetchRootField when a subscriber must see the new data
+// without re-navigation.
 function invalidateRootField(cache: GraphCache.Cache, fieldName: string) {
   for (const f of cache.inspectFields('Query')) {
     if (f.fieldName === fieldName) {
@@ -221,6 +225,29 @@ export default function GraphQLProvider({ children }: React.PropsWithChildren<{}
                 R.evolve({ buckets: R.reject(R.propEq('name', vars.name)) }),
               )
               cache.invalidate({ __typename: 'Bucket', name: vars.name })
+              // Registry cascade-deletes the RolePolicyBucketPermission rows
+              // for the removed bucket, but the cached PolicyBucketPermission
+              // / RoleBucketPermission entries (keyed {bucketName}/{id}) are
+              // not reachable via the Bucket-entity invalidation above —
+              // strip them from every cached Policy.permissions and
+              // ManagedRole.permissions array.
+              const stripBucket = R.reject(R.pathEq(['bucket', 'name'], vars.name))
+              cache.updateQuery(
+                {
+                  query: urql.gql`{ policies { id permissions { bucket { name } } } }`,
+                },
+                R.evolve({
+                  policies: R.map(R.evolve({ permissions: stripBucket })),
+                }),
+              )
+              cache.updateQuery(
+                {
+                  query: urql.gql`{ roles { id ... on ManagedRole { permissions { bucket { name } } } } }`,
+                },
+                R.evolve({
+                  roles: R.map(R.evolve({ permissions: stripBucket })),
+                }),
+              )
             },
             policyCreateManaged: (result, _vars, cache) => {
               const policy = result.policyCreateManaged as any


### PR DESCRIPTION
## Summary

Fixes a regression from #4839: after migrating bucket mutations to `cache.updateQuery`, the cached `PolicyBucketPermission` / `RoleBucketPermission` entries (keyed `{bucketName}/{policyOrRoleId}`) were left dangling on bucket removal — admin Users / Policies panels kept showing phantom permission rows referencing the deleted bucket until a full page reload.

The server cascade-deletes these permission rows on `bucketRemove`, but the client-side `cache.invalidate({__typename: 'Bucket', name})` only evicts the `Bucket` entity — it does not reach the `Policy.permissions` / `ManagedRole.permissions` arrays that embed a nested `bucket { name }`.

This change mirrors the `policyDelete` / `roleDelete` cascade pattern already in the file: after the existing Bucket-entity invalidation, strip any permission whose `bucket.name` matches the removed name from every cached `Policy.permissions` and `ManagedRole.permissions`.

Also cross-references `invalidateRootField` → `refetchRootField` in a doc-comment: the former marks fields stale but does not reliably notify active subscribers on urql 2.x + graphcache 4.x. Addresses drernie's review nit on #4839.

Out of scope: `bucketAdd` does not need a counterpart — a new bucket has no policy attachments yet, so there's nothing to cascade.

## Test plan

Verified end-to-end on a dev stack:

- [x] Admin: a policy grants access to two buckets; assigned to a managed role. `/admin/users` Policies / Roles panels render the permission rows and summary counts correctly.
- [x] Navigate to `/admin/buckets`, remove one of the buckets.
- [x] Navigate back to `/admin/users` without reloading — policy `Buckets` count drops 2 → 1, role `Buckets` count drops 2 → 1, and the policy Edit dialog lists only the remaining bucket. No console errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes a regression from #4839 where `bucketRemove` did not cascade through the normalized graphcache: the `Bucket`-entity invalidation only evicted the `Bucket` node, leaving stale `PolicyBucketPermission` / `RoleBucketPermission` entries dangling in every cached `Policy.permissions` and `ManagedRole.permissions` array. The fix adds two `cache.updateQuery` calls that strip any permission whose `bucket.name` matches the removed bucket, mirroring the existing `policyDelete` / `roleDelete` cascade pattern exactly. A clarifying doc-comment is also added to `invalidateRootField` distinguishing it from `refetchRootField`.

<h3>Confidence Score: 5/5</h3>

Safe to merge — the fix is narrowly scoped, follows established cache-update patterns, and the only finding is a cosmetic comment typo.

All findings are P2. The cache cascade logic mirrors the existing policyDelete/roleDelete pattern exactly, uses the same Ramda idioms already present throughout the file, and handles the ManagedRole inline-fragment case correctly (R.evolve is a no-op for UnmanagedRole entries that lack a permissions field). No new null-safety concern is introduced beyond what already exists in every other updateQuery call in the file.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| catalog/app/utils/GraphQL/Provider.tsx | Adds cache cascade for bucketRemove: strips stale PolicyBucketPermission / RoleBucketPermission entries from every Policy.permissions and ManagedRole.permissions array after a bucket is deleted; follows the established policyDelete/roleDelete pattern. Also adds a clarifying doc-comment on invalidateRootField vs refetchRootField. |
| catalog/CHANGELOG.md | Adds a [Fixed] changelog entry for the phantom permission row regression. No issues. |

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant UI as Admin UI
    participant Cache as urql graphcache
    participant Server as Registry API

    UI->>Server: bucketRemove(name)
    Server-->>UI: BucketRemoveSuccess
    Note over Cache: Existing invalidations
    Cache->>Cache: updateQuery(bucketConfigs) — remove bucket
    Cache->>Cache: updateQuery(buckets) — remove bucket
    Cache->>Cache: invalidate(Bucket entity)
    Note over Cache: New cascade (this PR)
    Cache->>Cache: updateQuery(policies.permissions) — strip where bucket.name == removed
    Cache->>Cache: updateQuery(roles.permissions) — strip ManagedRole permissions where bucket.name == removed
    Note over UI: Policy/Role permission counts update immediately
```

<sub>Reviews (1): Last reviewed commit: ["CHANGELOG: entry for #4855"](https://github.com/quiltdata/quilt/commit/7b5b234cd8d21a8e542f66d47c56a3e345efb60a) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=29461092)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->