### PR TITLE
ci: use deploy-ecr for image deploy workflows

### DIFF
--- a/.github/workflows/deploy-catalog.yaml
+++ b/.github/workflows/deploy-catalog.yaml
@@ -8,6 +8,7 @@ on:
       - '.github/workflows/deploy-catalog.yaml'
       - 'catalog/**'
       - 'shared/**'
+  workflow_dispatch:
 
 jobs:
   deploy-catalog-ecr:

--- a/.github/workflows/deploy-catalog.yaml
+++ b/.github/workflows/deploy-catalog.yaml
@@ -22,9 +22,6 @@ on:
 jobs:
   deploy-catalog-ecr:
     runs-on: ubuntu-latest
-    defaults:
-      run:
-        working-directory: catalog
     # These permissions are needed to interact with GitHub's OIDC Token endpoint.
     permissions:
       id-token: write
@@ -35,70 +32,20 @@ jobs:
       - uses: actions/checkout@v6
         with:
           ref: ${{ inputs.ref || github.ref }}
-      - name: Resolve image tag from checked-out commit
-        id: tag
-        working-directory: ${{ github.workspace }}
-        run: echo "image_tag=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
-      - run: echo "IMAGE_TAG=${{ steps.tag.outputs.image_tag }}" >> "$GITHUB_ENV"
       - uses: actions/setup-node@v6
         with:
           node-version-file: 'catalog/package.json'
           cache: 'npm'
           cache-dependency-path: 'catalog/package-lock.json'
       - run: npm ci
+        working-directory: catalog
       - run: npm run build
-      - name: Build Docker image
-        run: docker buildx build --load -t catalog:$IMAGE_TAG .
-
-      # Prod and MP both authenticate via the Prod IAM role.
-      - name: Configure AWS credentials from Prod account
-        if: contains(fromJSON(env.PUSH_TARGETS), 'prod') || contains(fromJSON(env.PUSH_TARGETS), 'mp')
-        uses: aws-actions/configure-aws-credentials@v6
+        working-directory: catalog
+      - uses: quiltdata/gh-actions/deploy-ecr@deploy-ecr
         with:
-          role-to-assume: arn:aws:iam::730278974607:role/github/GitHub-Quilt
-          aws-region: us-east-1
-      - name: Login to Prod ECR
-        if: contains(fromJSON(env.PUSH_TARGETS), 'prod')
-        id: login-prod-ecr
-        uses: aws-actions/amazon-ecr-login@v2
-      - name: Push to Prod ECR
-        if: contains(fromJSON(env.PUSH_TARGETS), 'prod')
-        env:
-          ECR_REGISTRY: ${{ steps.login-prod-ecr.outputs.registry }}
-          ECR_REPOSITORY: quiltdata/catalog
-        run: |
-          docker tag catalog:$IMAGE_TAG $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG
-          docker push $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG
-      - name: Login to MP ECR
-        if: contains(fromJSON(env.PUSH_TARGETS), 'mp')
-        id: login-mp-ecr
-        uses: aws-actions/amazon-ecr-login@v2
-        with:
-          registries: 709825985650
-      - name: Push to MP ECR
-        if: contains(fromJSON(env.PUSH_TARGETS), 'mp')
-        env:
-          ECR_REGISTRY: ${{ steps.login-mp-ecr.outputs.registry }}
-          ECR_REPOSITORY: quilt-data/quilt-payg-catalog
-        run: |
-          docker tag catalog:$IMAGE_TAG $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG
-          docker push $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG
-
-      - name: Configure AWS credentials from GovCloud account
-        if: contains(fromJSON(env.PUSH_TARGETS), 'govcloud')
-        uses: aws-actions/configure-aws-credentials@v6
-        with:
-          role-to-assume: arn:aws-us-gov:iam::313325871032:role/github/GitHub-Quilt
-          aws-region: us-gov-east-1
-      - name: Login to GovCloud ECR
-        if: contains(fromJSON(env.PUSH_TARGETS), 'govcloud')
-        id: login-govcloud-ecr
-        uses: aws-actions/amazon-ecr-login@v2
-      - name: Push to GovCloud ECR
-        if: contains(fromJSON(env.PUSH_TARGETS), 'govcloud')
-        env:
-          ECR_REGISTRY: ${{ steps.login-govcloud-ecr.outputs.registry }}
-          ECR_REPOSITORY: quiltdata/catalog
-        run: |
-          docker tag catalog:$IMAGE_TAG $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG
-          docker push $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG
+          dockerfile_path: catalog/Dockerfile
+          docker_context_path: catalog
+          image_name: quiltdata/catalog
+          mp_image_name: quilt-data/quilt-payg-catalog
+          push_targets: ${{ env.PUSH_TARGETS }}
+          role_name: Quilt

--- a/.github/workflows/deploy-catalog.yaml
+++ b/.github/workflows/deploy-catalog.yaml
@@ -9,6 +9,11 @@ on:
       - 'catalog/**'
       - 'shared/**'
   workflow_dispatch:
+    inputs:
+      push_targets:
+        description: 'JSON array of push targets (e.g. ["prod","mp","govcloud"]). [] = build only.'
+        type: string
+        default: '[]'
 
 jobs:
   deploy-catalog-ecr:
@@ -20,6 +25,9 @@ jobs:
     permissions:
       id-token: write
       contents: read
+    env:
+      PUSH_TARGETS: ${{ inputs.push_targets || '["prod","mp","govcloud"]' }}
+      IMAGE_TAG: ${{ github.sha }}
     steps:
       - uses: actions/checkout@v6
       - uses: actions/setup-node@v6
@@ -29,41 +37,58 @@ jobs:
           cache-dependency-path: 'catalog/package-lock.json'
       - run: npm ci
       - run: npm run build
+      - name: Build Docker image
+        run: docker buildx build --load -t catalog:$IMAGE_TAG .
+
+      # Prod and MP both authenticate via the Prod IAM role.
       - name: Configure AWS credentials from Prod account
+        if: contains(fromJSON(env.PUSH_TARGETS), 'prod') || contains(fromJSON(env.PUSH_TARGETS), 'mp')
         uses: aws-actions/configure-aws-credentials@v6
         with:
           role-to-assume: arn:aws:iam::730278974607:role/github/GitHub-Quilt
           aws-region: us-east-1
       - name: Login to Prod ECR
+        if: contains(fromJSON(env.PUSH_TARGETS), 'prod')
         id: login-prod-ecr
         uses: aws-actions/amazon-ecr-login@v2
+      - name: Push to Prod ECR
+        if: contains(fromJSON(env.PUSH_TARGETS), 'prod')
+        env:
+          ECR_REGISTRY: ${{ steps.login-prod-ecr.outputs.registry }}
+          ECR_REPOSITORY: quiltdata/catalog
+        run: |
+          docker tag catalog:$IMAGE_TAG $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG
+          docker push $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG
       - name: Login to MP ECR
+        if: contains(fromJSON(env.PUSH_TARGETS), 'mp')
         id: login-mp-ecr
         uses: aws-actions/amazon-ecr-login@v2
         with:
           registries: 709825985650
+      - name: Push to MP ECR
+        if: contains(fromJSON(env.PUSH_TARGETS), 'mp')
+        env:
+          ECR_REGISTRY: ${{ steps.login-mp-ecr.outputs.registry }}
+          ECR_REPOSITORY: quilt-data/quilt-payg-catalog
+        run: |
+          docker tag catalog:$IMAGE_TAG $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG
+          docker push $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG
+
       - name: Configure AWS credentials from GovCloud account
+        if: contains(fromJSON(env.PUSH_TARGETS), 'govcloud')
         uses: aws-actions/configure-aws-credentials@v6
         with:
           role-to-assume: arn:aws-us-gov:iam::313325871032:role/github/GitHub-Quilt
           aws-region: us-gov-east-1
       - name: Login to GovCloud ECR
+        if: contains(fromJSON(env.PUSH_TARGETS), 'govcloud')
         id: login-govcloud-ecr
         uses: aws-actions/amazon-ecr-login@v2
-      - name: Build and push Docker image to Prod, MP and GovCloud ECR
+      - name: Push to GovCloud ECR
+        if: contains(fromJSON(env.PUSH_TARGETS), 'govcloud')
         env:
-          ECR_REGISTRY_PROD: ${{ steps.login-prod-ecr.outputs.registry }}
-          ECR_REGISTRY_GOVCLOUD: ${{ steps.login-govcloud-ecr.outputs.registry }}
-          ECR_REGISTRY_MP: ${{ steps.login-mp-ecr.outputs.registry }}
+          ECR_REGISTRY: ${{ steps.login-govcloud-ecr.outputs.registry }}
           ECR_REPOSITORY: quiltdata/catalog
-          ECR_REPOSITORY_MP: quilt-data/quilt-payg-catalog
-          IMAGE_TAG: ${{ github.sha }}
         run: |
-          docker buildx build \
-            -t $ECR_REGISTRY_PROD/$ECR_REPOSITORY:$IMAGE_TAG \
-            -t $ECR_REGISTRY_GOVCLOUD/$ECR_REPOSITORY:$IMAGE_TAG \
-            -t $ECR_REGISTRY_MP/$ECR_REPOSITORY_MP:$IMAGE_TAG \
-            .
-          docker push $ECR_REGISTRY_PROD/$ECR_REPOSITORY:$IMAGE_TAG
-          docker push $ECR_REGISTRY_GOVCLOUD/$ECR_REPOSITORY:$IMAGE_TAG
-          docker push $ECR_REGISTRY_MP/$ECR_REPOSITORY_MP:$IMAGE_TAG
+          docker tag catalog:$IMAGE_TAG $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG
+          docker push $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG

--- a/.github/workflows/deploy-catalog.yaml
+++ b/.github/workflows/deploy-catalog.yaml
@@ -13,7 +13,7 @@ on:
       push_targets:
         description: 'JSON array of push targets (e.g. ["prod","mp","govcloud"]). [] = build only.'
         type: string
-        default: '[]'
+        default: '["prod"]'
 
 jobs:
   deploy-catalog-ecr:

--- a/.github/workflows/deploy-catalog.yaml
+++ b/.github/workflows/deploy-catalog.yaml
@@ -41,7 +41,7 @@ jobs:
         working-directory: catalog
       - run: npm run build
         working-directory: catalog
-      - uses: quiltdata/gh-actions/deploy-ecr@deploy-ecr
+      - uses: quiltdata/gh-actions/docker-build-publish@docker-build-publish
         with:
           dockerfile_path: catalog/Dockerfile
           docker_context_path: catalog

--- a/.github/workflows/deploy-catalog.yaml
+++ b/.github/workflows/deploy-catalog.yaml
@@ -10,6 +10,10 @@ on:
       - 'shared/**'
   workflow_dispatch:
     inputs:
+      ref:
+        description: 'Branch, tag, or SHA to build (defaults to dispatching ref)'
+        type: string
+        default: ''
       push_targets:
         description: 'JSON array of push targets (e.g. ["prod","mp","govcloud"]). [] = build only.'
         type: string
@@ -27,9 +31,15 @@ jobs:
       contents: read
     env:
       PUSH_TARGETS: ${{ inputs.push_targets || '["prod","mp","govcloud"]' }}
-      IMAGE_TAG: ${{ github.sha }}
     steps:
       - uses: actions/checkout@v6
+        with:
+          ref: ${{ inputs.ref || github.ref }}
+      - name: Resolve image tag from checked-out commit
+        id: tag
+        working-directory: ${{ github.workspace }}
+        run: echo "image_tag=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
+      - run: echo "IMAGE_TAG=${{ steps.tag.outputs.image_tag }}" >> "$GITHUB_ENV"
       - uses: actions/setup-node@v6
         with:
           node-version-file: 'catalog/package.json'

--- a/.github/workflows/deploy-lambdas.yaml
+++ b/.github/workflows/deploy-lambdas.yaml
@@ -77,20 +77,11 @@ jobs:
       contents: read
     steps:
       - uses: actions/checkout@v6
-      - name: Build Docker image
-        working-directory: ./lambdas/${{ matrix.path }}
-        run: docker buildx build -t "quiltdata/lambdas/${{ matrix.path }}:${{ github.sha }}" -f Dockerfile .
-      - name: Configure AWS credentials from Prod account
-        uses: aws-actions/configure-aws-credentials@v6
+      - uses: quiltdata/gh-actions/deploy-ecr@deploy-ecr
         with:
-          role-to-assume: arn:aws:iam::730278974607:role/github/GitHub-Quilt
-          aws-region: us-east-1
-      - name: Push Docker image to Prod ECR
-        run: ./lambdas/scripts/upload_ecr.sh 730278974607 "quiltdata/lambdas/${{ matrix.path }}:${{ github.sha }}"
-      - name: Configure AWS credentials from GovCloud account
-        uses: aws-actions/configure-aws-credentials@v6
-        with:
-          role-to-assume: arn:aws-us-gov:iam::313325871032:role/github/GitHub-Quilt
-          aws-region: us-gov-east-1
-      - name: Push Docker image to GovCloud ECR
-        run: ./lambdas/scripts/upload_ecr.sh 313325871032 "quiltdata/lambdas/${{ matrix.path }}:${{ github.sha }}"
+          dockerfile_path: lambdas/${{ matrix.path }}/Dockerfile
+          docker_context_path: lambdas/${{ matrix.path }}
+          image_name: quiltdata/lambdas/${{ matrix.path }}
+          push_targets: '["prod","govcloud"]'
+          multi_region: 'true'
+          role_name: Quilt

--- a/.github/workflows/deploy-lambdas.yaml
+++ b/.github/workflows/deploy-lambdas.yaml
@@ -77,7 +77,7 @@ jobs:
       contents: read
     steps:
       - uses: actions/checkout@v6
-      - uses: quiltdata/gh-actions/deploy-ecr@deploy-ecr
+      - uses: quiltdata/gh-actions/docker-build-publish@docker-build-publish
         with:
           dockerfile_path: lambdas/${{ matrix.path }}/Dockerfile
           docker_context_path: lambdas/${{ matrix.path }}

--- a/.github/workflows/deploy-s3-proxy.yaml
+++ b/.github/workflows/deploy-s3-proxy.yaml
@@ -17,7 +17,7 @@ jobs:
       contents: read
     steps:
       - uses: actions/checkout@v6
-      - uses: quiltdata/gh-actions/deploy-ecr@deploy-ecr
+      - uses: quiltdata/gh-actions/docker-build-publish@docker-build-publish
         with:
           dockerfile_path: s3-proxy/Dockerfile
           docker_context_path: s3-proxy

--- a/.github/workflows/deploy-s3-proxy.yaml
+++ b/.github/workflows/deploy-s3-proxy.yaml
@@ -11,52 +11,17 @@ on:
 jobs:
   deploy-s3-proxy:
     runs-on: ubuntu-latest
-    defaults:
-      run:
-        working-directory: s3-proxy
     # These permissions are needed to interact with GitHub's OIDC Token endpoint.
     permissions:
       id-token: write
       contents: read
     steps:
       - uses: actions/checkout@v6
-      - name: Configure AWS credentials from Prod account
-        uses: aws-actions/configure-aws-credentials@v6
+      - uses: quiltdata/gh-actions/deploy-ecr@deploy-ecr
         with:
-          role-to-assume: arn:aws:iam::730278974607:role/github/GitHub-Quilt
-          aws-region: us-east-1
-      - name: Login to Prod ECR
-        id: login-prod-ecr
-        uses: aws-actions/amazon-ecr-login@v2
-      - name: Login to MP ECR
-        id: login-mp-ecr
-        uses: aws-actions/amazon-ecr-login@v2
-        with:
-          registries: 709825985650
-      - name: Configure AWS credentials from GovCloud account
-        uses: aws-actions/configure-aws-credentials@v6
-        with:
-          role-to-assume: arn:aws-us-gov:iam::313325871032:role/github/GitHub-Quilt
-          aws-region: us-gov-east-1
-      - name: Login to GovCloud ECR
-        id: login-govcloud-ecr
-        uses: aws-actions/amazon-ecr-login@v2
-      - name: Build and push Docker image to ECR
-        env:
-          ECR_REGISTRY_PROD: ${{ steps.login-prod-ecr.outputs.registry }}
-          ECR_REGISTRY_GOVCLOUD: ${{ steps.login-govcloud-ecr.outputs.registry }}
-          ECR_REGISTRY_MP: ${{ steps.login-mp-ecr.outputs.registry }}
-          ECR_REPOSITORY: quiltdata/s3-proxy
-          ECR_REPOSITORY_MP: quilt-data/quilt-payg-s3-proxy
-          IMAGE_TAG: ${{ github.sha }}
-        run: |
-          docker buildx build \
-            -t $ECR_REGISTRY_PROD/$ECR_REPOSITORY:$IMAGE_TAG \
-            -t $ECR_REGISTRY_GOVCLOUD/$ECR_REPOSITORY:$IMAGE_TAG \
-            -t $ECR_REGISTRY_MP/$ECR_REPOSITORY_MP:$IMAGE_TAG \
-            .
-          docker push $ECR_REGISTRY_PROD/$ECR_REPOSITORY:$IMAGE_TAG
-          docker push $ECR_REGISTRY_GOVCLOUD/$ECR_REPOSITORY:$IMAGE_TAG
-          # push to MP last because it can't be re-pushed using the same tag
-          # so we can re-run the job in case something has failed
-          docker push $ECR_REGISTRY_MP/$ECR_REPOSITORY_MP:$IMAGE_TAG
+          dockerfile_path: s3-proxy/Dockerfile
+          docker_context_path: s3-proxy
+          image_name: quiltdata/s3-proxy
+          mp_image_name: quilt-data/quilt-payg-s3-proxy
+          push_targets: '["prod","govcloud","mp"]'
+          role_name: Quilt


### PR DESCRIPTION
## Summary

Migrates Quilt image deploy workflows to the unified `deploy-ecr` composite action from `quiltdata/gh-actions/deploy-ecr@deploy-ecr`.

Changed workflows:

- `.github/workflows/deploy-catalog.yaml` for `quiltdata/catalog`, including Marketplace `quilt-data/quilt-payg-catalog`
- `.github/workflows/deploy-s3-proxy.yaml` for `quiltdata/s3-proxy`, including Marketplace `quilt-data/quilt-payg-s3-proxy`
- `.github/workflows/deploy-lambdas.yaml` for `quiltdata/lambdas/{indexer,thumbnail,tabular_preview}` with `multi_region: 'true'`

This keeps caller-owned checkout/setup/pre-build behavior. Catalog still checks out `inputs.ref || github.ref`, runs Node setup, `npm ci`, and `npm run build` before invoking `deploy-ecr`. Image tags are left unset so the action resolves the checked-out `HEAD` SHA.

## Notes

This follows the migration plan in `07-unify-deploy-ecr.md`. `_VERSIONS` keys were not found in this checkout; image names were preserved from the existing workflow ECR repository values.

## Validation

- Parsed all Quilt workflow YAML files with Ruby `YAML.load_file`
- `git diff --check HEAD~1..HEAD`
- Workspace scan found no remaining `amazon-ecr-login`, `docker push`, `upload_ecr.sh`, or legacy ECR action references under `.github/workflows`