### PR TITLE
Qurator MCP: tighten retry and bootstrap failure handling

### DIFF
--- a/catalog/app/components/Assistant/Model/Connectors/Connectors.spec.ts
+++ b/catalog/app/components/Assistant/Model/Connectors/Connectors.spec.ts
@@ -43,6 +43,14 @@ const transportError: Connectors.BackendError = {
   _tag: 'Transport',
   message: 'down',
   transient: true,
+  retryable: true,
+}
+
+const httpTransportError: Connectors.BackendError = {
+  _tag: 'Transport',
+  message: 'HTTP 500',
+  transient: true,
+  retryable: false,
 }
 
 const authError: Connectors.BackendError = {
@@ -151,6 +159,29 @@ describe('Connectors', () => {
           if (failed._tag !== 'Failed') return
           expect(failed.acked).toBe(false)
           expect(failed.error._tag).toBe('Auth')
+        }),
+      ))
+
+    it('Connecting → Failed{acked:false} when initial bootstrap times out', () =>
+      runWithTest(
+        Eff.Effect.gen(function* () {
+          const runtime = yield* Connectors.buildConnectorRuntime(
+            baseConfig(
+              stubBackend({
+                initialize: () => Eff.Effect.never,
+              }),
+            ),
+          )
+          const reachFailed = yield* Eff.Effect.fork(
+            awaitState(runtime, (s) => s._tag === 'Failed'),
+          )
+          yield* TestClock.adjust(Eff.Duration.seconds(60))
+          const failed = yield* Eff.Fiber.join(reachFailed)
+          expect(failed._tag).toBe('Failed')
+          if (failed._tag !== 'Failed') return
+          expect(failed.acked).toBe(false)
+          expect(failed.error._tag).toBe('Transport')
+          expect(failed.error.cause).toBe('ConnectingTimeout')
         }),
       ))
 
@@ -626,6 +657,29 @@ describe('Connectors', () => {
           const result = yield* runtime.callTool('foo', {}, { retryOnTransport: true })
           expect(result.status).toBe('success')
           expect(attempts).toBe(2)
+        }),
+      ))
+
+    it('retryOnTransport does not retry non-retryable HTTP transport responses', () =>
+      runWithTest(
+        Eff.Effect.gen(function* () {
+          let attempts = 0
+          const runtime = yield* Connectors.buildConnectorRuntime(
+            baseConfig(
+              stubBackend({
+                ping: () => Eff.Effect.void,
+                callTool: () =>
+                  Eff.Effect.suspend(() => {
+                    attempts += 1
+                    return Eff.Effect.fail(httpTransportError)
+                  }),
+              }),
+            ),
+          )
+          yield* awaitState(runtime, (s) => s._tag === 'Ready')
+          const result = yield* runtime.callTool('foo', {}, { retryOnTransport: true })
+          expect(result.status).toBe('error')
+          expect(attempts).toBe(1)
         }),
       ))
 

--- a/catalog/app/components/Assistant/Model/Connectors/Connectors.ts
+++ b/catalog/app/components/Assistant/Model/Connectors/Connectors.ts
@@ -65,7 +65,8 @@ export interface BackendError {
    * Whether a read-only tool call may retry this error once before
    * reporting it. This is narrower than `transient`: an HTTP 5xx response
    * still indicates degraded transport health, but the server may already
-   * have executed the request before returning the response.
+   * have executed the request before returning the response. Defaults to
+   * false when omitted.
    */
   readonly retryable?: boolean
   /**
@@ -330,6 +331,7 @@ const transientError = (cause: string, message: string): BackendError => ({
   _tag: 'Transport',
   message,
   transient: true,
+  retryable: false,
   cause,
 })
 

--- a/catalog/app/components/Assistant/Model/Connectors/Connectors.ts
+++ b/catalog/app/components/Assistant/Model/Connectors/Connectors.ts
@@ -62,6 +62,13 @@ export interface BackendError {
    */
   readonly transient?: boolean
   /**
+   * Whether a read-only tool call may retry this error once before
+   * reporting it. This is narrower than `transient`: an HTTP 5xx response
+   * still indicates degraded transport health, but the server may already
+   * have executed the request before returning the response.
+   */
+  readonly retryable?: boolean
+  /**
    * Optional wire-level error tag (e.g., MCP's `McpTransportError`).
    * Surfaced in DevTools detail / hover; not used for control flow.
    */
@@ -270,6 +277,7 @@ export class Connectors extends Eff.Context.Tag('Connectors')<
 const HEARTBEAT_CADENCE = Eff.Duration.seconds(30)
 const HEARTBEAT_TIMEOUT = Eff.Duration.seconds(5)
 const HEALTH_THRESHOLD = 2
+const BOOTSTRAP_TIMEOUT = Eff.Duration.seconds(60)
 
 /**
  * Disconnected-mode probe parameters (D24, qhq-5d0.6). The lifecycle
@@ -392,7 +400,7 @@ const makeConnectorCallTool =
       if (
         opts.retryOnTransport &&
         Eff.Either.isLeft(result) &&
-        result.left.transient === true
+        result.left.retryable === true
       ) {
         result = yield* attempt
       }
@@ -638,7 +646,14 @@ export const manageConnector = (
     while (true) {
       yield* Eff.SubscriptionRef.set(state, ConnectorState.Connecting())
       yield* resetHealth(health)
-      const initial = yield* bootstrap(config, callTool).pipe(Eff.Effect.either)
+      const initial = yield* bootstrap(config, callTool).pipe(
+        Eff.Effect.timeoutFail({
+          duration: BOOTSTRAP_TIMEOUT,
+          onTimeout: (): BackendError =>
+            transientError('ConnectingTimeout', 'initial connection timed out'),
+        }),
+        Eff.Effect.either,
+      )
       if (Eff.Either.isLeft(initial)) {
         yield* Eff.SubscriptionRef.set(
           state,
@@ -742,7 +757,7 @@ export const buildConnectorRuntime = (
             consecutiveFailures: HEALTH_THRESHOLD,
             lastError: transientError('UserRetry', 'force reconnect requested'),
           })
-        } else {
+        } else if (current._tag === 'Failed') {
           yield* Eff.Queue.offer(controls, 'retry')
         }
       }),

--- a/catalog/app/components/Assistant/Model/Connectors/Mcp.spec.ts
+++ b/catalog/app/components/Assistant/Model/Connectors/Mcp.spec.ts
@@ -222,6 +222,35 @@ describe('Connectors/Mcp', () => {
       }
     })
 
+    it('marks HTTP responses as transient health failures but not retryable', async () => {
+      const { fetchSpy } = captureCalls(
+        () =>
+          new Response('already executed', {
+            status: 500,
+            headers: { 'content-type': 'text/plain' },
+          }),
+      )
+
+      const backend = Mcp.bearerPassthru({
+        url: 'https://example.invalid/mcp',
+        getToken: () => Eff.Effect.succeed('t'),
+      })
+      const exit = await Eff.Effect.runPromiseExit(
+        withFetch(backend.callTool('maybe_write', {}), fetchSpy),
+      )
+
+      expect(Eff.Exit.isFailure(exit)).toBe(true)
+      if (Eff.Exit.isFailure(exit)) {
+        const failure = Eff.Cause.failureOption(exit.cause)
+        if (Eff.Option.isSome(failure)) {
+          expect(failure.value._tag).toBe('Transport')
+          expect(failure.value.transient).toBe(true)
+          expect(failure.value.retryable).toBe(false)
+          expect(failure.value.cause).toBe('McpTransportError')
+        }
+      }
+    })
+
     it('listResources hits resources/list and decodes the directory', async () => {
       const { fetchSpy, calls } = captureCalls(
         () =>

--- a/catalog/app/components/Assistant/Model/Connectors/Mcp.ts
+++ b/catalog/app/components/Assistant/Model/Connectors/Mcp.ts
@@ -602,6 +602,7 @@ const adaptError = (e: McpError): BackendError => ({
   _tag: ERROR_TAG_MAP[e._tag],
   message: e.message,
   transient: e._tag === 'McpTransportError',
+  retryable: e._tag === 'McpTransportError' && e.status === undefined,
   cause: e._tag,
 })
 


### PR DESCRIPTION
## Summary

Addresses the two concrete risks found while reviewing PR #4840:

- Narrow read-only retry-once so HTTP response failures still count as transport health degradation, but are not retried after the server may have executed the request.
- Add a bounded initial `Connecting` bootstrap timeout and make retry during `Connecting` a true no-op.

## Code changes

### 1. Split transport health from retry eligibility

`BackendError` now has an optional `retryable` flag in addition to `transient`.

- `transient` still means the error contributes to connector health and can move the connector toward `Disconnected`.
- `retryable` now means a read-only tool call may retry the failed request once.

The MCP adapter sets:

- fetch-layer failures / network failures: `transient: true`, `retryable: true`
- HTTP non-2xx responses: `transient: true`, `retryable: false`

`makeConnectorCallTool` now checks `result.left.retryable === true` before retrying, instead of checking `transient === true`.

This preserves the health behavior for HTTP 500/502/503 responses while avoiding duplicate execution when a server returns an error response after already applying a tool call.

### 2. Bound initial bootstrap while `Connecting`

The reconnect path already had a 60s outer timeout, but the initial `Connecting` bootstrap did not. This PR wraps the initial `bootstrap(config, callTool)` call in a 60s `timeoutFail` and maps timeout to a synthetic transport error:

- `_tag: Transport`
- `cause: ConnectingTimeout`
- message: `initial connection timed out`

If bootstrap hangs, the connector now transitions to `Failed{acked:false}` instead of blocking the assistant indefinitely in `Connecting`.

### 3. Make retry from `Connecting` a true no-op

The previous implementation described `Connecting` retry as a no-op, but the code still queued a retry token in the shared controls queue. That token was later drained on Failed entry, so it usually did not change behavior, but it made the implementation harder to reason about.

`retry` now only queues a control token when the current state is `Failed`. For `Connecting`, it does nothing.

## Why this shape

These changes are small but not completely trivial. The important distinction is that `transient` and `retryable` are not the same thing:

- A 500 response is a useful health signal, so it should remain transient.
- A 500 response is not safe evidence that the operation did not run, so it should not drive retry-once.

An alternative would be to reclassify HTTP non-2xx responses as `Protocol` or `Application`, but that would hide real transport degradation from connector health. Another alternative would be to retry only selected 5xx statuses, but status code alone still does not prove the server did not execute the request. The explicit `retryable` flag keeps those semantics separate and local.

For `Connecting`, interrupt-and-restart retry would be a larger lifecycle change. This PR takes the smaller fix: bound the initial attempt and align the implementation with the documented no-op behavior. A later UX change can add “stuck connecting” affordances if needed.

## Context

This is a child PR against `feat/qurator-mcp`, following the review artifacts from the Qurator UI package:

- [07-code-review-concerns.md](https://nightly.quilttest.com/b/quilt-dev/packages/proj/260408-qurator-ui/tree/latest/tools/07-code-review-concerns.md)
- [08-code-review-report.md](https://nightly.quilttest.com/b/quilt-dev/packages/proj/260408-qurator-ui/tree/latest/tools/08-code-review-report.md)

## Test plan

- [x] `npm run test:only -- app/components/Assistant/Model/Connectors/Mcp.spec.ts app/components/Assistant/Model/Connectors/Connectors.spec.ts`
- [x] `npm run test:only -- app/components/Assistant/Model/Conversation.spec.ts`
- [x] `npm run lint:prettier -- app/components/Assistant/Model/Connectors/Connectors.ts app/components/Assistant/Model/Connectors/Mcp.ts app/components/Assistant/Model/Connectors/Connectors.spec.ts app/components/Assistant/Model/Connectors/Mcp.spec.ts`
- [x] `npm run lint:eslint -- app/components/Assistant/Model/Connectors/Connectors.ts app/components/Assistant/Model/Connectors/Mcp.ts app/components/Assistant/Model/Connectors/Connectors.spec.ts app/components/Assistant/Model/Connectors/Mcp.spec.ts`

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR tightens two failure-handling gaps in the MCP connector lifecycle: it narrows the read-only retry from any `transient` error to only `retryable` errors (excluding HTTP responses where the server may have already executed), and adds a bounded 60-second bootstrap timeout that sends the connector directly to `Failed{acked:false}` rather than hanging forever in `Connecting`. As a clean-up, `retry()` called during `Connecting` is now a true no-op instead of buffering a stale control token that would fire on the next `Failed` entry without user interaction.

<h3>Confidence Score: 4/5</h3>

Safe to merge — logic is sound, tests cover all three new behaviors, and no regressions in the health/lifecycle paths.

No P0 or P1 issues found. The `retryable` narrowing, bootstrap timeout, and Connecting no-op are all correctly implemented and tested. One P2 observation: lifecycle-synthesized errors from `transientError` leave `retryable` as `undefined` (not `false`), while `adaptError` always sets an explicit `false` — a small semantic inconsistency that works correctly because the check is `=== true`, but could cause confusion for future backend implementors reading the interface.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| catalog/app/components/Assistant/Model/Connectors/Connectors.ts | Adds `retryable` field to BackendError, narrows retry condition from `transient` to `retryable`, adds 60s bootstrap timeout, and makes `retry()` during Connecting a true no-op. |
| catalog/app/components/Assistant/Model/Connectors/Mcp.ts | Sets `retryable: true` only for transport errors without an HTTP status code; HTTP 5xx responses get `retryable: false` while remaining `transient: true` for health-degradation purposes. |
| catalog/app/components/Assistant/Model/Connectors/Connectors.spec.ts | Adds test for Connecting→Failed on bootstrap timeout and test verifying HTTP transport errors are not retried by retryOnTransport. |
| catalog/app/components/Assistant/Model/Connectors/Mcp.spec.ts | Adds test verifying HTTP 500 responses produce `transient:true, retryable:false` — confirming health counts but no retry for responses with an HTTP status. |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[retryOnTransport=true\ntool call fails] --> B{retryable === true?}
    B -- "yes\n(network-level, no HTTP status)" --> C[Retry once]
    C --> D{2nd attempt\nresult?}
    D -- success --> E[resetHealth\nreturn result]
    D -- "failure\n(transient)" --> F[Bump health counter\nreturn Tool.fail]
    D -- "failure\n(non-transient)" --> G[No health bump\nreturn Tool.fail]
    B -- "no\n(HTTP 5xx, status set)" --> H[No retry]
    H --> I{transient?}
    I -- "yes\n(HTTP 5xx is transient)" --> F
    I -- no --> G

    subgraph Bootstrap
        J[Connecting] -- "≤ 60s" --> K{bootstrap\nsucceeds?}
        K -- yes --> L[Ready]
        K -- "no / timeout" --> M["Failed acked=false\nCause: ConnectingTimeout"]
        M --> N{user retry?}
        N -- yes --> J
    end

    subgraph retry_semantics["retry() semantics"]
        O[retry called] --> P{current state?}
        P -- Ready/Disconnected --> Q[Degrade health to threshold]
        P -- Failed --> R[Queue retry control]
        P -- Connecting --> S[no-op]
    end
```

<sub>Reviews (1): Last reviewed commit: ["Fix Qurator MCP retry and bootstrap time..."](https://github.com/quiltdata/quilt/commit/d92fae14ab7bf72c8f41315e3d38841f97b3d7aa) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=30099209)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->