### PR TITLE
Docs: CHANGELOG + Qurator.md entries for #4840

### DIFF
--- a/catalog/CHANGELOG.md
+++ b/catalog/CHANGELOG.md
@@ -18,7 +18,7 @@ where verb is one of
 
 ## Changes
 
-- [Added] Qurator: connect to the Quilt Platform MCP Server for ~25 tools (packages, search, S3, Athena, tabulator, `get_resource`); per-connector status with reconnect / continue-without / acknowledge controls in the chat input ([#4840](https://github.com/quiltdata/quilt/pull/4840))
+- [Added] Qurator: connect to the Quilt Platform MCP Server for ~25 tools (packages, search, S3, Athena, tabulator, `get_resource`); per-connector status with reconnect / continue-without controls in the chat input ([#4840](https://github.com/quiltdata/quilt/pull/4840))
 - [Changed] Qurator: replace `catalog_global_getObject` with `catalog_preview` (single `s3_uri` input); returns thumbnail-resized images, native Bedrock `Document` blocks for ≤500 KiB PDFs / Office docs, and language-tagged text ([#4840](https://github.com/quiltdata/quilt/pull/4840))
 - [Removed] Drop unused `linkedData` / `overviewUrl` code paths from the catalog: admin form fields, JSON-LD mounts, and the precomputed-summary S3 fetch branches ([#4856](https://github.com/quiltdata/quilt/pull/4856))
 - [Fixed] Admin Users / Policies panels: drop phantom permission rows referencing a just-removed bucket (cache was not cascading the removal through `Policy.permissions` / `ManagedRole.permissions`) ([#4855](https://github.com/quiltdata/quilt/pull/4855))

--- a/catalog/CHANGELOG.md
+++ b/catalog/CHANGELOG.md
@@ -18,6 +18,8 @@ where verb is one of
 
 ## Changes
 
+- [Added] Qurator: connect to the Quilt Platform MCP Server for ~25 tools (packages, search, S3, Athena, tabulator, `get_resource`); per-connector status with reconnect / continue-without / acknowledge controls in the chat input ([#4840](https://github.com/quiltdata/quilt/pull/4840))
+- [Changed] Qurator: replace `catalog_global_getObject` with `catalog_preview` (single `s3_uri` input); returns thumbnail-resized images, native Bedrock `Document` blocks for ≤500 KiB PDFs / Office docs, and language-tagged text ([#4840](https://github.com/quiltdata/quilt/pull/4840))
 - [Removed] Drop unused `linkedData` / `overviewUrl` code paths from the catalog: admin form fields, JSON-LD mounts, and the precomputed-summary S3 fetch branches ([#4856](https://github.com/quiltdata/quilt/pull/4856))
 - [Fixed] Admin Users / Policies panels: drop phantom permission rows referencing a just-removed bucket (cache was not cascading the removal through `Policy.permissions` / `ManagedRole.permissions`) ([#4855](https://github.com/quiltdata/quilt/pull/4855))
 - [Changed] Migrate user-facing bucket queries to the new role-scoped `buckets` / `bucket` GraphQL type; admins in a scoped managed role now see only role-permitted buckets in navbar / listings / deep-links (admin panel unchanged) ([#4839](https://github.com/quiltdata/quilt/pull/4839))

--- a/docs/Catalog/Qurator.md
+++ b/docs/Catalog/Qurator.md
@@ -20,11 +20,27 @@ or request key insights from a specific dataset.
   asthma treatments?” or “Summarize research on BRCA1 mutations.”
 - **Instant Summaries**: Quickly digest scientific papers, datasets, or reports
   without reading everything.
+- **Platform Tools via MCP**: Search packages and S3 objects, browse and create
+  packages, read objects, run Athena SQL, and manage Tabulator tables — all
+  through the same [Quilt Platform MCP Server](MCP-Server.md) used by external
+  MCP clients.
 - **Fine-Grained Permissions with RAG**: Ensure Retrieval-Augmented Generation
   only queries the data you're authorized to access, ensuring compliance with
   strict organizational policies
 - **Secure Cloud Environment**: Work within your private AWS cloud, ensuring
   data stays secure while using state-of-the-art AI models.
+
+### Connector Status
+
+Qurator's chat input shows the live connection status of each tool backend
+(e.g. the Platform MCP Server). When a backend is unhealthy the input is
+gated and inline actions appear in the helper-text region:
+
+- `connecting…` / `reconnecting…` — auto-progressing, no action required.
+- `couldn't connect` — click **reconnect** to retry, or **continue without**
+  to proceed with reduced tool access for the rest of the conversation.
+- `unavailable` — sticky after acknowledgement; click **reconnect** to try
+  again at any time.
 
 ## Getting Started
 

--- a/docs/Catalog/Qurator.md
+++ b/docs/Catalog/Qurator.md
@@ -38,9 +38,9 @@ gated and inline actions appear in the helper-text region:
 
 - `connecting…` / `reconnecting…` — auto-progressing, no action required.
 - `couldn't connect` — click **reconnect** to retry, or **continue without**
-  to proceed with reduced tool access for the rest of the conversation.
-- `unavailable` — sticky after acknowledgement; click **reconnect** to try
-  again at any time.
+  to proceed with reduced tool access for the rest of the conversation. The
+  latter dismisses the error and moves the connector to `unavailable`.
+- `unavailable` — sticky; click **reconnect** to try again at any time.
 
 ## Getting Started
 


### PR DESCRIPTION
## Summary

Adds the missing user-visible documentation for [#4840](https://github.com/quiltdata/quilt/pull/4840) (Qurator: wire in Platform MCP Server tools), which currently ships no `catalog/CHANGELOG.md` entry and no `docs/Catalog/Qurator.md` update despite changing user-facing behavior.

- **`catalog/CHANGELOG.md`** — two entries pinned to #4840:
  - `[Added]` Qurator connects to the Quilt Platform MCP Server (~25 tools) with a connector-status surface in the chat input.
  - `[Changed]` `catalog_global_getObject` is reshaped into `catalog_preview` (single `s3_uri` input; thumbnail-resized images, native Bedrock `Document` blocks for ≤500 KiB PDFs / Office docs, language-tagged text).
- **`docs/Catalog/Qurator.md`**:
  - New "Platform Tools via MCP" bullet under **Key Features** that links to the existing [MCP-Server.md](MCP-Server.md) page rather than re-documenting the platform tool surface.
  - New `### Connector Status` subsection describing the chat-input status states (`connecting…` / `couldn't connect` / `unavailable`) and the inline **reconnect** / **continue without** / **acknowledge** controls.

Targeted at `feat/qurator-mcp` so the docs land together with #4840 rather than as a separate post-merge PR against master.

## Test plan

- [x] `git diff --stat` shows only `catalog/CHANGELOG.md` and `docs/Catalog/Qurator.md`.
- [ ] Verify rendered Qurator.md (gitbook / docs site) — no broken anchors; `MCP-Server.md` link resolves.
- [ ] Reviewer sanity-check on the changelog wording (Added vs. Changed split, level of detail).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This is a documentation-only PR that adds a `catalog/CHANGELOG.md` entry and expands `docs/Catalog/Qurator.md` to cover the MCP Server integration and Connector Status UI shipped in #4840. The `MCP-Server.md` link resolves correctly, and all changelog entries follow the established format.

<h3>Confidence Score: 4/5</h3>

Safe to merge; docs-only change with one minor documentation gap.

Only P2 findings; the sole issue is a missing mention of the acknowledge action in the Connector Status state machine description.

docs/Catalog/Qurator.md — Connector Status section is missing the acknowledge control.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| catalog/CHANGELOG.md | Two new entries for #4840 added at the top of the Changes list, correctly following the established format with verb, description, and PR link. |
| docs/Catalog/Qurator.md | New "Platform Tools via MCP" bullet and "Connector Status" subsection added; MCP-Server.md link resolves correctly, but the acknowledge action is omitted from the Connector Status state descriptions. |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Chat Input] --> B{MCP Connector Status}
    B -->|healthy| C[Normal chat / tool access]
    B -->|connecting… / reconnecting…| D[Auto-progressing — no action]
    B -->|couldn't connect| E{User action}
    E -->|reconnect| B
    E -->|continue without| F[Reduced tool access — rest of conversation]
    E -->|acknowledge ⚠️ undocumented| G[unavailable state]
    G -->|reconnect| B
```

<sub>Reviews (1): Last reviewed commit: ["Docs: CHANGELOG + Qurator.md entries for..."](https://github.com/quiltdata/quilt/commit/7d7775add0cc7d14e1f638f70cebdebb7cc3ec7c) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=30101857)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->