### PR TITLE
chore: add CHANGELOG entry for #4781

### DIFF
--- a/catalog/CHANGELOG.md
+++ b/catalog/CHANGELOG.md
@@ -18,6 +18,7 @@ where verb is one of
 
 ## Changes
 
+- [Added] Theme editor: drag-and-drop logo upload writes to the service bucket (`catalog/logo.<ext>`); the URL field remains for externally hosted logos ([#4781](https://github.com/quiltdata/quilt/pull/4781))
 - [Added] Qurator: connect to the Quilt Platform MCP Server for ~25 tools (packages, search, S3, Athena, tabulator, `get_resource`); per-connector status with reconnect / continue-without controls in the chat input ([#4840](https://github.com/quiltdata/quilt/pull/4840))
 - [Changed] Qurator: replace `catalog_global_getObject` with `catalog_preview` (single `s3_uri` input); returns thumbnail-resized images, native Bedrock `Document` blocks for ≤500 KiB PDFs / Office docs, and language-tagged text ([#4840](https://github.com/quiltdata/quilt/pull/4840))
 - [Removed] Drop unused `linkedData` / `overviewUrl` code paths from the catalog: admin form fields, JSON-LD mounts, and the precomputed-summary S3 fetch branches ([#4856](https://github.com/quiltdata/quilt/pull/4856))


### PR DESCRIPTION
Follow-up to #4781 — adds the missing CHANGELOG entry for the theme-editor logo file upload.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds a single missing `CHANGELOG.md` entry for #4781 (theme-editor logo drag-and-drop upload). The new line follows the documented format (`[Verb] description ([#N](...))`) and is correctly inserted at the top of the `## Changes` list.

<h3>Confidence Score: 5/5</h3>

Safe to merge — documentation-only change with no code impact.

Single CHANGELOG line addition that conforms to the file's stated format; no logic, security, or correctness concerns.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| catalog/CHANGELOG.md | Adds a missing CHANGELOG entry for PR #4781 (theme editor drag-and-drop logo upload); entry follows the required format and is placed at the top of the list. |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A["PR #4781 merged\n(theme-editor logo upload)"] -->|CHANGELOG entry missing| B["PR #4866\nAdd missing CHANGELOG entry"]
    B --> C["catalog/CHANGELOG.md\nLine 21: [Added] entry inserted"]
    C --> D["CHANGELOG up-to-date"]
```

<sub>Reviews (1): Last reviewed commit: ["chore: add CHANGELOG entry for #4781"](https://github.com/quiltdata/quilt/commit/c6e2e4d223fe2cce510946959ca5fed374a38db7) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=30230721)</sub>

<!-- /greptile_comment -->