### PR TITLE
docs: prefer Route 53 alias records, keep CNAME as fallback

### DIFF
--- a/docs/Catalog/Installation.md
+++ b/docs/Catalog/Installation.md
@@ -239,6 +239,7 @@ see the [Terraform README](https://github.com/quiltdata/iac/blob/main/README.md)
 
 ### DNS records
 
+<!-- markdownlint-disable-next-line no-inline-html -->
 <a id="cnames"></a>
 
 In order for your users to reach the Quilt catalog you must create three DNS

--- a/docs/Catalog/Installation.md
+++ b/docs/Catalog/Installation.md
@@ -61,7 +61,7 @@ Service Catalog).
     > Ensure that your service role is up-to-date with the example before every
     stack update so as to prevent installation failures.
 
-1. The **ability to create DNS entries**, such as CNAME records,
+1. The **ability to create DNS entries** (Route 53 alias records or CNAMEs)
 for your company's domain.
 1. **An SSL certificate in the same region as your Quilt instance** to secure the
 domain where your users will access your Quilt instance.
@@ -237,17 +237,27 @@ and not storing passwords in version control.
 > For detailed configuration options, including search sizing and common pitfalls,
 see the [Terraform README](https://github.com/quiltdata/iac/blob/main/README.md).
 
-### CNAMEs
+### DNS records
 
-In order for your users to reach the Quilt catalog you must set three CNAMEs
-that point to the `LoadBalancerDNSName` as shown below and in the Outputs
-of your stack.
+<a id="cnames"></a>
 
-| CNAME | Value |
+In order for your users to reach the Quilt catalog you must create three DNS
+records pointing to the `LoadBalancerDNSName` as shown below and in the
+Outputs of your stack.
+
+| Hostname | Target |
 | ------ | ------- |
 | `<QuiltWebHost>` Key | `LoadBalancerDNSName` |
 | `<RegistryHostName>` Key | `LoadBalancerDNSName` |
 | `<S3ProxyHost>` Key | `LoadBalancerDNSName` |
+
+If your hosted zone is in **Route 53**, we recommend Route 53 alias
+records (record type `A`, alias target = `LoadBalancerDNSName`,
+hosted zone ID = `LoadBalancerCanonicalHostedZoneID`). Aliases incur no
+per-query DNS charges and can target a zone apex.
+
+If your DNS is hosted elsewhere, use **CNAME** records pointing to
+`LoadBalancerDNSName`.
 
 Quilt is now up and running. You can click on the _QuiltWebHost_ value
 in Outputs and log in with your administrator password to invite users.
@@ -282,7 +292,7 @@ of isolated subnets and a preference for private routing.
 
 An upgrade to the 2.0 network, unlike routine Quilt upgrades, requires you to create
 a new stack with a new load balancer. You must therefore also update your
-[CNAMEs](#cnames) to point to the new load balancer.
+[DNS records](#dns-records) to point to the new load balancer.
 
 ## Create a new stack with an existing configuration
 

--- a/docs/Catalog/Installation.md
+++ b/docs/Catalog/Installation.md
@@ -245,16 +245,17 @@ In order for your users to reach the Quilt catalog you must create three DNS
 records pointing to the `LoadBalancerDNSName` as shown below and in the
 Outputs of your stack.
 
-| Hostname | Target |
-| ------ | ------- |
-| `<QuiltWebHost>` Key | `LoadBalancerDNSName` |
-| `<RegistryHostName>` Key | `LoadBalancerDNSName` |
-| `<S3ProxyHost>` Key | `LoadBalancerDNSName` |
+| Hostname         | Target                  |
+| ---------------- | ----------------------- |
+| `<QuiltWebHost>` | `<LoadBalancerDNSName>` |
+| `<RegistryHost>` | `<LoadBalancerDNSName>` |
+| `<S3ProxyHost>`  | `<LoadBalancerDNSName>` |
 
 If your hosted zone is in **Route 53**, we recommend Route 53 alias
 records (record type `A`, alias target = `LoadBalancerDNSName`,
-hosted zone ID = `LoadBalancerCanonicalHostedZoneID`). Aliases incur no
-per-query DNS charges and can target a zone apex.
+hosted zone ID = `LoadBalancerCanonicalHostedZoneID`). Route 53 doesn't
+charge for alias queries to AWS resources like ALBs, and aliases work at
+the zone apex (which CNAMEs cannot).
 
 If your DNS is hosted elsewhere, use **CNAME** records pointing to
 `LoadBalancerDNSName`.

--- a/docs/Troubleshooting.md
+++ b/docs/Troubleshooting.md
@@ -60,12 +60,12 @@ The following are common causes of failed logins. In most cases we recommend
 that you check the browser's network panel
 for details.
 
-1. SSO connector misconfigured. See [SSO](technical-reference.md#cnames) for
+1. SSO connector misconfigured. See [SSO](technical-reference.md) for
    details.
 1. SSL errors are often caused by misspelled names, or incomplete Subject
 Alternate Names. The ACM certificate for `CertificateArnELB` must cover all
-three Quilt [CNAMEs](technical-reference.md#cnames) either via a suitable `*` or
-explicit Subject Alternate Names.
+three Quilt [hostnames](Catalog/Installation.md#dns-records) either via a
+suitable `*` or explicit Subject Alternate Names.
 
 ### Changing the admin email or password
 

--- a/docs/Troubleshooting.md
+++ b/docs/Troubleshooting.md
@@ -60,8 +60,9 @@ The following are common causes of failed logins. In most cases we recommend
 that you check the browser's network panel
 for details.
 
-1. SSO connector misconfigured. See [Single sign-on (SSO)](technical-reference.md#single-sign-on-sso) for
-   details.
+1. SSO connector misconfigured.
+   See [Single sign-on (SSO)](technical-reference.md#single-sign-on-sso)
+   for details.
 1. SSL errors are often caused by misspelled names, or incomplete Subject
 Alternate Names. The ACM certificate for `CertificateArnELB` must cover all
 three Quilt [hostnames](Catalog/Installation.md#dns-records) either via a

--- a/docs/Troubleshooting.md
+++ b/docs/Troubleshooting.md
@@ -60,7 +60,7 @@ The following are common causes of failed logins. In most cases we recommend
 that you check the browser's network panel
 for details.
 
-1. SSO connector misconfigured. See [SSO](technical-reference.md) for
+1. SSO connector misconfigured. See [Single sign-on (SSO)](technical-reference.md#single-sign-on-sso) for
    details.
 1. SSL errors are often caused by misspelled names, or incomplete Subject
 Alternate Names. The ACM certificate for `CertificateArnELB` must cover all


### PR DESCRIPTION
## Summary
Aligns the catalog installation DNS guidance with the [Quilt Connect Server docs](Catalog/Connect.md#dns-configuration) and the new CFN-output policy in [deployment#2408](https://github.com/quiltdata/deployment/pull/2408): CFN output descriptions stay generic about record type; the docs are explicit.

## Customer-driven: DNS record-type guidance
Prompted by a customer (Walter Gillett) noticing that we tell people to create CNAMEs while the Connect docs (correctly) recommend Route 53 alias records. Aliases are strictly better when the hosted zone is in Route 53 (no per-query charges, zone-apex support); CNAME is the right answer when DNS is hosted elsewhere.

- [docs/Catalog/Installation.md:240](docs/Catalog/Installation.md#L240): rename section "CNAMEs" → "DNS records", recommend Route 53 alias (with `LoadBalancerCanonicalHostedZoneID` as the alias hosted zone), present CNAME as the fallback for non-Route-53 DNS.
  - Backward-compat: explicit `<a id="cnames"></a>` anchor preserved so existing cross-doc links to `#cnames` still resolve.
- [docs/Catalog/Installation.md:64](docs/Catalog/Installation.md#L64): prerequisites bullet broadened from "CNAME records" to "Route 53 alias records or CNAMEs".
- Updated the in-doc `[CNAMEs](#cnames)` link to `[DNS records](#dns-records)`.

## Opportunistic: pre-existing broken links
Noticed while auditing the DNS guidance — these were already broken on `master`, unrelated to the policy change but cheap to fix here.

- [docs/Troubleshooting.md:63](docs/Troubleshooting.md#L63): SSO link pointed to `technical-reference.md#cnames` (no such anchor); retargeted to `technical-reference.md#single-sign-on-sso`.
- [docs/Troubleshooting.md:67](docs/Troubleshooting.md#L67): "CNAMEs" link pointed to the same nonexistent anchor; retargeted to `Catalog/Installation.md#dns-records`.

## Test plan
- [ ] Render the page locally — section renders as "DNS records"
- [ ] Existing `#cnames` deep links still scroll to the section
- [ ] Troubleshooting links resolve to the right anchors

🤖 Generated with [Claude Code](https://claude.com/claude-code)