### PR TITLE
Per-bucket Iceberg: retarget QueryMaker to per-bucket tables

### DIFF
--- a/.github/workflows/deploy-lambdas.yaml
+++ b/.github/workflows/deploy-lambdas.yaml
@@ -1,12 +1,10 @@
 name: Deploy lambdas to S3 and ECR
 
+# TEMP: dev-only build for the iceberg-per-bucket branch — builds the iceberg
+# lambda, prefixes the S3 key with `dev-`, and uploads only to us-east-2 (the
+# stack/pkg-tbl dev stack's region). Revert this commit before merging to master.
 on:
-  push:
-    branches:
-      - master
-    paths:
-      - '.github/workflows/deploy-lambdas.yaml'
-      - 'lambdas/**'
+  workflow_dispatch: {}
 
 jobs:
   deploy-lambda-s3:
@@ -14,16 +12,7 @@ jobs:
       fail-fast: false
       matrix:
         path:
-          - access_counts
-          - es_ingest
           - iceberg
-          - pkgevents
-          - pkgpush
-          - preview
-          - s3hash
-          - status_reports
-          - manifest_indexer
-          - transcode
     runs-on: ubuntu-latest
     # These permissions are needed to interact with GitHub's OIDC Token endpoint.
     permissions:
@@ -47,50 +36,8 @@ jobs:
         uses: aws-actions/configure-aws-credentials@v6
         with:
           role-to-assume: arn:aws:iam::730278974607:role/github/GitHub-Quilt
-          aws-region: us-east-1
-      - name: Upload zips to Prod S3
+          aws-region: us-east-2
+      - name: Upload zip to dev stack region (us-east-2) with dev- prefix
         run: |
-          s3_key="${{ matrix.path }}/${{ github.sha }}.zip"
-          ./lambdas/scripts/upload_zip.sh ./out.zip "$AWS_REGION" "$s3_key"
-      - name: Configure AWS credentials from GovCloud account
-        uses: aws-actions/configure-aws-credentials@v6
-        with:
-          role-to-assume: arn:aws-us-gov:iam::313325871032:role/github/GitHub-Quilt
-          aws-region: us-gov-east-1
-      - name: Upload zips to GovCloud S3
-        run: |
-          s3_key="${{ matrix.path }}/${{ github.sha }}.zip"
-          ./lambdas/scripts/upload_zip.sh ./out.zip "$AWS_REGION" "$s3_key"
-
-  deploy-lambda-ecr:
-    strategy:
-      fail-fast: false
-      matrix:
-        path:
-          - indexer
-          - thumbnail
-          - tabular_preview
-    runs-on: ubuntu-latest
-    # These permissions are needed to interact with GitHub's OIDC Token endpoint.
-    permissions:
-      id-token: write
-      contents: read
-    steps:
-      - uses: actions/checkout@v6
-      - name: Build Docker image
-        working-directory: ./lambdas/${{ matrix.path }}
-        run: docker buildx build -t "quiltdata/lambdas/${{ matrix.path }}:${{ github.sha }}" -f Dockerfile .
-      - name: Configure AWS credentials from Prod account
-        uses: aws-actions/configure-aws-credentials@v6
-        with:
-          role-to-assume: arn:aws:iam::730278974607:role/github/GitHub-Quilt
-          aws-region: us-east-1
-      - name: Push Docker image to Prod ECR
-        run: ./lambdas/scripts/upload_ecr.sh 730278974607 "quiltdata/lambdas/${{ matrix.path }}:${{ github.sha }}"
-      - name: Configure AWS credentials from GovCloud account
-        uses: aws-actions/configure-aws-credentials@v6
-        with:
-          role-to-assume: arn:aws-us-gov:iam::313325871032:role/github/GitHub-Quilt
-          aws-region: us-gov-east-1
-      - name: Push Docker image to GovCloud ECR
-        run: ./lambdas/scripts/upload_ecr.sh 313325871032 "quiltdata/lambdas/${{ matrix.path }}:${{ github.sha }}"
+          s3_key="${{ matrix.path }}/dev-${{ github.sha }}.zip"
+          aws s3 cp --acl public-read ./out.zip "s3://quilt-lambda-us-east-2/$s3_key"

--- a/lambdas/iceberg/pyproject.toml
+++ b/lambdas/iceberg/pyproject.toml
@@ -27,4 +27,4 @@ test = [
 default-groups = ["test"]
 
 [tool.uv.sources]
-quilt-shared = { url = "https://github.com/quiltdata/quilt/archive/f90584485ba84a9d46fe4c7014f858a4b57738bd.zip", subdirectory = "py-shared" }
+quilt-shared = { url = "https://github.com/quiltdata/quilt/archive/9d86f0880003fa1e60dae9830ac4d7abeb6dbb5d.zip", subdirectory = "py-shared" }

--- a/lambdas/iceberg/uv.lock
+++ b/lambdas/iceberg/uv.lock
@@ -17,30 +17,6 @@ wheels = [
 ]
 
 [[package]]
-name = "boto3-stubs"
-version = "1.40.52"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "botocore-stubs" },
-    { name = "types-s3transfer" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/00/7b/92a266747a504c09c40a382364e5f041a58acc2959f2920aa9b4ccf5e9db/boto3_stubs-1.40.52.tar.gz", hash = "sha256:bd20a7bc9122bb1b939195431b9d3f540b1ef050103bc1720d786960907464fd", size = 100895, upload-time = "2025-10-14T20:45:42.254Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/43/cf/d08cd0df2639896db574490181c363fc491404607b867a1bf04a623c4a19/boto3_stubs-1.40.52-py3-none-any.whl", hash = "sha256:5e2b74b7b5ad71ca2b8c35a8d3bf1e4ef60317b1682b5e7dda9f16a1c0b43844", size = 69709, upload-time = "2025-10-14T20:45:33.777Z" },
-]
-
-[package.optional-dependencies]
-athena = [
-    { name = "mypy-boto3-athena" },
-]
-s3 = [
-    { name = "mypy-boto3-s3" },
-]
-sts = [
-    { name = "mypy-boto3-sts" },
-]
-
-[[package]]
 name = "botocore"
 version = "1.40.52"
 source = { registry = "https://pypi.org/simple" }
@@ -126,33 +102,6 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/00/2a/e867e8531cf3e36b41201936b7fa7ba7b5702dbef42922193f05c8976cd6/jmespath-1.0.1.tar.gz", hash = "sha256:90261b206d6defd58fdd5e85f478bf633a2901798906be2ad389150c5c60edbe", size = 25843, upload-time = "2022-06-17T18:00:12.224Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/31/b4/b9b800c45527aadd64d5b442f9b932b00648617eb5d63d2c7a6587b7cafc/jmespath-1.0.1-py3-none-any.whl", hash = "sha256:02e2e4cc71b5bcab88332eebf907519190dd9e6e82107fa7f83b1003a6252980", size = 20256, upload-time = "2022-06-17T18:00:10.251Z" },
-]
-
-[[package]]
-name = "mypy-boto3-athena"
-version = "1.40.0"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/9b/9c/a16a597632e24f5e3ad30fe1e5f570e2bdaf713297013d81d7001bfbfabc/mypy_boto3_athena-1.40.0.tar.gz", hash = "sha256:da8429f556bcd857b2c9fed9133ef0bfecb898e2b74e9679f3aaafcc26702bf1", size = 36614, upload-time = "2025-07-31T19:36:39.469Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/f4/a0/7a10865896ddf356c735b1d8ba5ec509386540e89d552bd0108674cda30f/mypy_boto3_athena-1.40.0-py3-none-any.whl", hash = "sha256:3fc5e4b294248663a6030bb5f13e94f199ebcca4f4f43bfcd30705ce47d28008", size = 40986, upload-time = "2025-07-31T19:36:37.666Z" },
-]
-
-[[package]]
-name = "mypy-boto3-s3"
-version = "1.40.26"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/00/b8/55d21ed9ca479df66d9892212ba7d7977850ef17aa80a83e3f11f31190fd/mypy_boto3_s3-1.40.26.tar.gz", hash = "sha256:8d2bfd1052894d0e84c9fb9358d838ba0eed0265076c7dd7f45622c770275c99", size = 75948, upload-time = "2025-09-08T20:12:21.405Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/85/a5/dba3384423834009bdd41c7021de5c663468a0e7bc4071cb301721e52a99/mypy_boto3_s3-1.40.26-py3-none-any.whl", hash = "sha256:6d055d16ef89a0133ade92f6b4f09603e4acc31a0f5e8f846edf4eb48f17b5a7", size = 82762, upload-time = "2025-09-08T20:12:19.338Z" },
-]
-
-[[package]]
-name = "mypy-boto3-sts"
-version = "1.40.0"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/39/32/8dce999ed05c797000ce70287f3e82025a98514781c303c7f8fe42f7b327/mypy_boto3_sts-1.40.0.tar.gz", hash = "sha256:eb55e50960ae6194d09488464c302196392df712a6a5f4308b6a0e24244cfd5c", size = 16577, upload-time = "2025-07-31T19:52:23.924Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/78/f8/38dae2983d72ea4fff75b235d42d3b1ecad407e0136f4951bfd9016ecaea/mypy_boto3_sts-1.40.0-py3-none-any.whl", hash = "sha256:fff731694cab2474bf7e7d3344b049b4ac0272d76b72fc4f7e4ae543ead8a5e6", size = 20192, upload-time = "2025-07-31T19:52:21.353Z" },
 ]
 
 [[package]]
@@ -251,26 +200,26 @@ wheels = [
 [[package]]
 name = "quilt-shared"
 version = "0.1.0"
-source = { url = "https://github.com/quiltdata/quilt/archive/f90584485ba84a9d46fe4c7014f858a4b57738bd.zip", subdirectory = "py-shared" }
-sdist = { hash = "sha256:f7d07fe2710e63e446e6e0c6d052f9856c7747c7ea378a5b3eafe57d7941e11a" }
+source = { url = "https://github.com/quiltdata/quilt/archive/9d86f0880003fa1e60dae9830ac4d7abeb6dbb5d.zip", subdirectory = "py-shared" }
+sdist = { hash = "sha256:71a20aa60911c9ecbe277ee64c5c0b4ee61016dfd76b94de328c047f8a75a57c" }
 
 [package.optional-dependencies]
 boto = [
     { name = "boto3" },
-    { name = "boto3-stubs", extra = ["athena", "s3", "sts"] },
     { name = "types-aiobotocore", extra = ["s3"] },
+    { name = "types-boto3", extra = ["athena", "s3", "sts"] },
 ]
 
 [package.metadata]
 requires-dist = [
     { name = "aws-requests-auth", marker = "extra == 'es'", specifier = "~=0.4.2" },
     { name = "boto3", marker = "extra == 'boto'", specifier = "~=1.34" },
-    { name = "boto3-stubs", extras = ["athena", "s3", "sts"], marker = "extra == 'boto'", specifier = "~=1.34" },
     { name = "elasticsearch", marker = "extra == 'es'", specifier = "~=6.8" },
     { name = "orjson", marker = "extra == 'es'", specifier = "~=3.10" },
     { name = "pydantic", marker = "extra == 'pydantic'", specifier = "~=2.10" },
-    { name = "quilt3", marker = "extra == 'quilt'", specifier = "~=5.4" },
+    { name = "quilt3", marker = "extra == 'quilt'", specifier = ">=7,<8" },
     { name = "types-aiobotocore", extras = ["s3"], marker = "extra == 'boto'", specifier = "~=2.11" },
+    { name = "types-boto3", extras = ["athena", "s3", "sts"], marker = "extra == 'boto'", specifier = "~=1.34" },
     { name = "typing-extensions", marker = "extra == 'pydantic'", specifier = "~=4.9" },
 ]
 provides-extras = ["pydantic", "boto", "quilt", "es"]
@@ -316,7 +265,7 @@ test = [
 [package.metadata]
 requires-dist = [
     { name = "boto3", specifier = ">=1.40.41,<2.0.0" },
-    { name = "quilt-shared", extras = ["boto"], url = "https://github.com/quiltdata/quilt/archive/f90584485ba84a9d46fe4c7014f858a4b57738bd.zip", subdirectory = "py-shared" },
+    { name = "quilt-shared", extras = ["boto"], url = "https://github.com/quiltdata/quilt/archive/9d86f0880003fa1e60dae9830ac4d7abeb6dbb5d.zip", subdirectory = "py-shared" },
 ]
 
 [package.metadata.requires-dev]
@@ -360,6 +309,57 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/60/19/a3a6377c9e2e389c1421c033a1830c29cac08f2e1e05a082ea84eb22c75f/types_awscrt-0.28.1.tar.gz", hash = "sha256:66d77ec283e1dc907526a44511a12624118723a396c36d3f3dd9855cb614ce14", size = 17410, upload-time = "2025-10-11T21:55:07.443Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/ea/c7/0266b797d19b82aebe0e177efe35de7aabdc192bc1605ce3309331f0a505/types_awscrt-0.28.1-py3-none-any.whl", hash = "sha256:d88f43ef779f90b841ba99badb72fe153077225a4e426ae79e943184827b4443", size = 41851, upload-time = "2025-10-11T21:55:06.235Z" },
+]
+
+[[package]]
+name = "types-boto3"
+version = "1.43.16"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "botocore-stubs" },
+    { name = "types-s3transfer" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/40/8c/1b4ce1e00d90c877a8994bd141e654bd0e8ecde223b075d040b46cf93d21/types_boto3-1.43.16.tar.gz", hash = "sha256:d7f26a163666d78a94733d22250d7e44602c48fc2acad5df4d967f0db4785181", size = 102983, upload-time = "2026-05-27T19:38:13.166Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/28/1c/5b4fe1944511eed187672f75473b67f1a6c20ba19f0e51e72d02a7d83323/types_boto3-1.43.16-py3-none-any.whl", hash = "sha256:16913c6f345e07d2ac51ff212a462044cbd3f33b0ed59d965cc3a5510d3f776b", size = 70562, upload-time = "2026-05-27T19:38:10.257Z" },
+]
+
+[package.optional-dependencies]
+athena = [
+    { name = "types-boto3-athena" },
+]
+s3 = [
+    { name = "types-boto3-s3" },
+]
+sts = [
+    { name = "types-boto3-sts" },
+]
+
+[[package]]
+name = "types-boto3-athena"
+version = "1.43.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d7/71/67629ddd2f2846bb0a608fafef1e1407e74b71aa6b7820386501472ca8e7/types_boto3_athena-1.43.0.tar.gz", hash = "sha256:830e4176ee70ad87bbcf7c82be177df1d856d9a43c98de03d7083d46aa9b5928", size = 37721, upload-time = "2026-04-29T22:59:07.156Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/53/bd/6314de5fa247c28704f8ed17a5057d853d7b46348bdcaa37a4857261cc65/types_boto3_athena-1.43.0-py3-none-any.whl", hash = "sha256:b245dab78dc29237d9769e99ed5e6db48ec91290d8767610e77f4b118b7ddba6", size = 41996, upload-time = "2026-04-29T22:59:04.712Z" },
+]
+
+[[package]]
+name = "types-boto3-s3"
+version = "1.43.14"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/3c/79/ddd397734d7c6368492447c95be54e76158e7dc0d4e616117bf2b2430af0/types_boto3_s3-1.43.14.tar.gz", hash = "sha256:50d1fc0082f07be097184cf647e2dec6101fd1f8378a6c353100ccd067b95e4d", size = 76899, upload-time = "2026-05-22T20:48:17.311Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/af/ff/d841790d6fcc72616feb5a00b8548cdd878b50b4f31ed998bf8d9d52c47e/types_boto3_s3-1.43.14-py3-none-any.whl", hash = "sha256:a80ddd1a290dbbbb244868466621ea772c36f6647327637b89423f53e34ea0a1", size = 84098, upload-time = "2026-05-22T20:48:15.127Z" },
+]
+
+[[package]]
+name = "types-boto3-sts"
+version = "1.43.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/4d/a7/ea448e34f9b519b68505df256e8cc185d60ef8aeb41552553f66da5a7b35/types_boto3_sts-1.43.0.tar.gz", hash = "sha256:d8e0061fed51bb246bd966b9968104bc44411450faa8848f26170bf271913ab1", size = 16823, upload-time = "2026-04-29T23:07:24.448Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/56/18/167b2aae0614a6f4d7fe11f85517d3f4ba56e1b0807534a172a9dfe6f4c5/types_boto3_sts-1.43.0-py3-none-any.whl", hash = "sha256:ce21eab88182d8fef3795e6517d3da90da367c1e5db34fc2281c0e7ba218cb65", size = 20831, upload-time = "2026-04-29T23:07:23.152Z" },
 ]
 
 [[package]]

--- a/py-shared/src/quilt_shared/iceberg_queries.py
+++ b/py-shared/src/quilt_shared/iceberg_queries.py
@@ -7,112 +7,101 @@ class QueryMaker:
     def __init__(self, *, user_athena_db: str):
         self.user_athena_db = user_athena_db
 
+    @staticmethod
+    def _table(bucket: str, table: str) -> str:
+        # Per-bucket table name in IcebergDatabase. Raw bucket name (no
+        # sanitization), quoted at the call site.
+        return f"{bucket}_{table}"
+
     def package_revision_add_bucket(self, *, bucket: str) -> str:
         return f"""
-        MERGE INTO package_revision AS t
+        MERGE INTO "{self._table(bucket, "package_revision")}" AS t
         USING (
             SELECT
-                '{bucket}' AS bucket,
                 regexp_extract("$path", '^s3://[^/]+/[^/]+/[^/]+/([^/]+/[^/]+)', 1) AS pkg_name,
                 from_unixtime(CAST(regexp_extract("$path", '[^/]+$') AS bigint)) AS timestamp,
                 top_hash
             FROM "{self.user_athena_db}"."{bucket}_packages"
             WHERE TRY_CAST(regexp_extract("$path", '[^/]+$') AS bigint) IS NOT NULL
         ) AS s
-        ON t.bucket = s.bucket AND t.pkg_name = s.pkg_name AND t.timestamp = s.timestamp
+        ON t.pkg_name = s.pkg_name AND t.timestamp = s.timestamp
         WHEN MATCHED THEN
             UPDATE SET top_hash = s.top_hash
         WHEN NOT MATCHED THEN
-            INSERT (bucket, pkg_name, timestamp, top_hash)
-            VALUES (s.bucket, s.pkg_name, s.timestamp, s.top_hash)
+            INSERT (pkg_name, timestamp, top_hash)
+            VALUES (s.pkg_name, s.timestamp, s.top_hash)
         """
 
     def package_revision_add_single(self, *, bucket: str, pkg_name: str, pointer: str, top_hash: str) -> str:
         return f"""
-        MERGE INTO package_revision AS t
+        MERGE INTO "{self._table(bucket, "package_revision")}" AS t
         USING (
             SELECT
-                '{bucket}' AS bucket,
                 '{pkg_name}' AS pkg_name,
                 from_unixtime({pointer}) AS timestamp,
                 '{top_hash}' AS top_hash
         ) AS s
-        ON t.bucket = s.bucket AND t.pkg_name = s.pkg_name AND t.timestamp = s.timestamp
+        ON t.pkg_name = s.pkg_name AND t.timestamp = s.timestamp
         WHEN MATCHED THEN
             UPDATE SET top_hash = s.top_hash
         WHEN NOT MATCHED THEN
-            INSERT (bucket, pkg_name, timestamp, top_hash)
-            VALUES (s.bucket, s.pkg_name, s.timestamp, s.top_hash)
-        """
-
-    def package_revision_delete_bucket(self, *, bucket: str) -> str:
-        return f"""
-        DELETE FROM package_revision
-        WHERE bucket = '{bucket}'
+            INSERT (pkg_name, timestamp, top_hash)
+            VALUES (s.pkg_name, s.timestamp, s.top_hash)
         """
 
     def package_revision_delete_single(self, *, bucket: str, pkg_name: str, pointer: str) -> str:
         return f"""
-        DELETE FROM package_revision
-        WHERE bucket = '{bucket}' AND pkg_name = '{pkg_name}' AND timestamp = from_unixtime({pointer})
+        DELETE FROM "{self._table(bucket, "package_revision")}"
+        WHERE pkg_name = '{pkg_name}' AND timestamp = from_unixtime({pointer})
         """
 
     def package_tag_add_bucket(self, *, bucket: str) -> str:
         return f"""
-        MERGE INTO package_tag AS t
+        MERGE INTO "{self._table(bucket, "package_tag")}" AS t
         USING (
             SELECT
-                '{bucket}' AS bucket,
                 regexp_extract("$path", '^s3://[^/]+/[^/]+/[^/]+/([^/]+/[^/]+)', 1) AS pkg_name,
                 regexp_extract("$path", '[^/]+$') AS tag_name,
                 top_hash
             FROM "{self.user_athena_db}"."{bucket}_packages"
             WHERE TRY_CAST(regexp_extract("$path", '[^/]+$') AS bigint) IS NULL
         ) AS s
-        ON t.bucket = s.bucket AND t.pkg_name = s.pkg_name AND t.tag_name = s.tag_name
+        ON t.pkg_name = s.pkg_name AND t.tag_name = s.tag_name
         WHEN MATCHED THEN
             UPDATE SET top_hash = s.top_hash
         WHEN NOT MATCHED THEN
-            INSERT (bucket, pkg_name, tag_name, top_hash)
-            VALUES (s.bucket, s.pkg_name, s.tag_name, s.top_hash)
+            INSERT (pkg_name, tag_name, top_hash)
+            VALUES (s.pkg_name, s.tag_name, s.top_hash)
         """
 
     def package_tag_add_single(self, *, bucket: str, pkg_name: str, pointer: str, top_hash: str) -> str:
         return f"""
-        MERGE INTO package_tag AS t
+        MERGE INTO "{self._table(bucket, "package_tag")}" AS t
         USING (
             SELECT
-                '{bucket}' AS bucket,
                 '{pkg_name}' AS pkg_name,
                 '{pointer}' AS tag_name,
                 '{top_hash}' AS top_hash
         ) AS s
-        ON t.bucket = s.bucket AND t.pkg_name = s.pkg_name AND t.tag_name = s.tag_name
+        ON t.pkg_name = s.pkg_name AND t.tag_name = s.tag_name
         WHEN MATCHED THEN
             UPDATE SET top_hash = s.top_hash
         WHEN NOT MATCHED THEN
-            INSERT (bucket, pkg_name, tag_name, top_hash)
-            VALUES (s.bucket, s.pkg_name, s.tag_name, s.top_hash)
-        """
-
-    def package_tag_delete_bucket(self, *, bucket: str) -> str:
-        return f"""
-        DELETE FROM package_tag
-        WHERE bucket = '{bucket}'
+            INSERT (pkg_name, tag_name, top_hash)
+            VALUES (s.pkg_name, s.tag_name, s.top_hash)
         """
 
     def package_tag_delete_single(self, *, bucket: str, pkg_name: str, pointer: str) -> str:
         return f"""
-        DELETE FROM package_tag
-        WHERE bucket = '{bucket}' AND pkg_name = '{pkg_name}' AND tag_name = '{pointer}'
+        DELETE FROM "{self._table(bucket, "package_tag")}"
+        WHERE pkg_name = '{pkg_name}' AND tag_name = '{pointer}'
         """
 
     def package_manifest_add_bucket(self, *, bucket: str) -> str:
         return f"""
-        MERGE INTO package_manifest AS t
+        MERGE INTO "{self._table(bucket, "package_manifest")}" AS t
         USING (
             SELECT
-                '{bucket}' AS bucket,
                 regexp_extract("$path", '[^/]+$') AS top_hash,
                 message,
                 user_meta AS metadata
@@ -121,20 +110,19 @@ class QueryMaker:
                 -- filter out bogus manifests i.e. parquet files
                 AND regexp_like("$path", '/[a-z0-9]{{64}}$')
         ) AS s
-        ON t.bucket = s.bucket AND t.top_hash = s.top_hash
+        ON t.top_hash = s.top_hash
         WHEN MATCHED THEN
             UPDATE SET message = s.message, metadata = s.metadata
         WHEN NOT MATCHED THEN
-            INSERT (bucket, top_hash, message, metadata)
-            VALUES (s.bucket, s.top_hash, s.message, s.metadata)
+            INSERT (top_hash, message, metadata)
+            VALUES (s.top_hash, s.message, s.metadata)
         """
 
     def package_manifest_add_single(self, *, bucket: str, top_hash: str) -> str:
         return f"""
-        MERGE INTO package_manifest AS t
+        MERGE INTO "{self._table(bucket, "package_manifest")}" AS t
         USING (
             SELECT
-                '{bucket}' AS bucket,
                 regexp_extract("$path", '[^/]+$') AS top_hash,
                 message,
                 user_meta AS metadata
@@ -142,32 +130,25 @@ class QueryMaker:
             WHERE logical_key IS NULL
                 AND "$path" = 's3://{bucket}/{const.MANIFESTS_PREFIX}{top_hash}'
         ) AS s
-        ON t.bucket = s.bucket AND t.top_hash = s.top_hash
+        ON t.top_hash = s.top_hash
         WHEN MATCHED THEN
             UPDATE SET message = s.message, metadata = s.metadata
         WHEN NOT MATCHED THEN
-            INSERT (bucket, top_hash, message, metadata)
-            VALUES (s.bucket, s.top_hash, s.message, s.metadata)
-        """
-
-    def package_manifest_delete_bucket(self, *, bucket: str) -> str:
-        return f"""
-        DELETE FROM package_manifest
-        WHERE bucket = '{bucket}'
+            INSERT (top_hash, message, metadata)
+            VALUES (s.top_hash, s.message, s.metadata)
         """
 
     def package_manifest_delete_single(self, *, bucket: str, top_hash: str) -> str:
         return f"""
-        DELETE FROM package_manifest
-        WHERE bucket = '{bucket}' AND top_hash = '{top_hash}'
+        DELETE FROM "{self._table(bucket, "package_manifest")}"
+        WHERE top_hash = '{top_hash}'
         """
 
     def package_entry_add_bucket(self, *, bucket: str) -> str:
         return f"""
-        MERGE INTO package_entry AS t
+        MERGE INTO "{self._table(bucket, "package_entry")}" AS t
         USING (
             SELECT
-                '{bucket}' AS bucket,
                 regexp_extract("$path", '[^/]+$') AS top_hash,
                 logical_key,
                 physical_keys[1] AS physical_key,
@@ -180,22 +161,21 @@ class QueryMaker:
                 -- filter out bogus manifests i.e. parquet files
                 AND regexp_like("$path", '/[a-z0-9]{{64}}$')
         ) AS s
-        ON t.bucket = s.bucket AND t.top_hash = s.top_hash AND t.logical_key = s.logical_key
+        ON t.top_hash = s.top_hash AND t.logical_key = s.logical_key
         WHEN MATCHED THEN
             UPDATE SET physical_key = s.physical_key, hash_type = s.hash_type, hash_value = s.hash_value,
                 size = s.size, metadata = s.metadata
         WHEN NOT MATCHED THEN
-            INSERT (bucket, top_hash, logical_key, physical_key, hash_type, hash_value, size, metadata)
-            VALUES (s.bucket, s.top_hash, s.logical_key,
+            INSERT (top_hash, logical_key, physical_key, hash_type, hash_value, size, metadata)
+            VALUES (s.top_hash, s.logical_key,
                 s.physical_key, s.hash_type, s.hash_value, s.size, s.metadata)
         """
 
     def package_entry_add_single(self, *, bucket: str, top_hash: str) -> str:
         return f"""
-        MERGE INTO package_entry AS t
+        MERGE INTO "{self._table(bucket, "package_entry")}" AS t
         USING (
             SELECT
-                '{bucket}' AS bucket,
                 regexp_extract("$path", '[^/]+$') AS top_hash,
                 logical_key,
                 physical_keys[1] AS physical_key,
@@ -207,24 +187,18 @@ class QueryMaker:
             WHERE logical_key IS NOT NULL
                 AND "$path" = 's3://{bucket}/{const.MANIFESTS_PREFIX}{top_hash}'
         ) AS s
-        ON t.bucket = s.bucket AND t.top_hash = s.top_hash AND t.logical_key = s.logical_key
+        ON t.top_hash = s.top_hash AND t.logical_key = s.logical_key
         WHEN MATCHED THEN
             UPDATE SET physical_key = s.physical_key, hash_type = s.hash_type, hash_value = s.hash_value,
                 size = s.size, metadata = s.metadata
         WHEN NOT MATCHED THEN
-            INSERT (bucket, top_hash, logical_key, physical_key, hash_type, hash_value, size, metadata)
-            VALUES (s.bucket, s.top_hash, s.logical_key,
+            INSERT (top_hash, logical_key, physical_key, hash_type, hash_value, size, metadata)
+            VALUES (s.top_hash, s.logical_key,
                 s.physical_key, s.hash_type, s.hash_value, s.size, s.metadata)
-        """
-
-    def package_entry_delete_bucket(self, *, bucket: str) -> str:
-        return f"""
-        DELETE FROM package_entry
-        WHERE bucket = '{bucket}'
         """
 
     def package_entry_delete_single(self, *, bucket: str, top_hash: str) -> str:
         return f"""
-        DELETE FROM package_entry
-        WHERE bucket = '{bucket}' AND top_hash = '{top_hash}'
+        DELETE FROM "{self._table(bucket, "package_entry")}"
+        WHERE top_hash = '{top_hash}'
         """

--- a/py-shared/tests/test_iceberg_queries.py
+++ b/py-shared/tests/test_iceberg_queries.py
@@ -11,30 +11,22 @@ def qm():
 def test_package_revision_add_bucket_smoke(qm):
     sql = qm.package_revision_add_bucket(bucket="bucket1")
     assert isinstance(sql, str)
-    assert "MERGE INTO package_revision" in sql
-    assert "bucket1" in sql
+    assert 'MERGE INTO "bucket1_package_revision"' in sql
 
 
 def test_package_revision_add_single_smoke(qm):
     sql = qm.package_revision_add_single(bucket="bucket1", pkg_name="pkg", pointer="123", top_hash="abc")
     assert isinstance(sql, str)
-    assert "MERGE INTO package_revision" in sql
+    assert 'MERGE INTO "bucket1_package_revision"' in sql
     assert "pkg" in sql
     assert "123" in sql
     assert "abc" in sql
 
 
-def test_package_revision_delete_bucket_smoke(qm):
-    sql = qm.package_revision_delete_bucket(bucket="bucket1")
-    assert isinstance(sql, str)
-    assert "DELETE FROM package_revision" in sql
-    assert "bucket1" in sql
-
-
 def test_package_revision_delete_single_smoke(qm):
     sql = qm.package_revision_delete_single(bucket="bucket1", pkg_name="pkg", pointer="123")
     assert isinstance(sql, str)
-    assert "DELETE FROM package_revision" in sql
+    assert 'DELETE FROM "bucket1_package_revision"' in sql
     assert "pkg" in sql
     assert "123" in sql
 
@@ -42,30 +34,22 @@ def test_package_revision_delete_single_smoke(qm):
 def test_package_tag_add_bucket_smoke(qm):
     sql = qm.package_tag_add_bucket(bucket="bucket1")
     assert isinstance(sql, str)
-    assert "MERGE INTO package_tag" in sql
-    assert "bucket1" in sql
+    assert 'MERGE INTO "bucket1_package_tag"' in sql
 
 
 def test_package_tag_add_single_smoke(qm):
     sql = qm.package_tag_add_single(bucket="bucket1", pkg_name="pkg", pointer="tag", top_hash="abc")
     assert isinstance(sql, str)
-    assert "MERGE INTO package_tag" in sql
+    assert 'MERGE INTO "bucket1_package_tag"' in sql
     assert "pkg" in sql
     assert "tag" in sql
     assert "abc" in sql
 
 
-def test_package_tag_delete_bucket_smoke(qm):
-    sql = qm.package_tag_delete_bucket(bucket="bucket1")
-    assert isinstance(sql, str)
-    assert "DELETE FROM package_tag" in sql
-    assert "bucket1" in sql
-
-
 def test_package_tag_delete_single_smoke(qm):
     sql = qm.package_tag_delete_single(bucket="bucket1", pkg_name="pkg", pointer="tag")
     assert isinstance(sql, str)
-    assert "DELETE FROM package_tag" in sql
+    assert 'DELETE FROM "bucket1_package_tag"' in sql
     assert "pkg" in sql
     assert "tag" in sql
 
@@ -73,56 +57,38 @@ def test_package_tag_delete_single_smoke(qm):
 def test_package_manifest_add_bucket_smoke(qm):
     sql = qm.package_manifest_add_bucket(bucket="bucket1")
     assert isinstance(sql, str)
-    assert "MERGE INTO package_manifest" in sql
-    assert "bucket1" in sql
+    assert 'MERGE INTO "bucket1_package_manifest"' in sql
 
 
 def test_package_manifest_add_single_smoke(qm):
     sql = qm.package_manifest_add_single(bucket="bucket1", top_hash="abc")
     assert isinstance(sql, str)
-    assert "MERGE INTO package_manifest" in sql
-    assert "bucket1" in sql
+    assert 'MERGE INTO "bucket1_package_manifest"' in sql
     assert "abc" in sql
-
-
-def test_package_manifest_delete_bucket_smoke(qm):
-    sql = qm.package_manifest_delete_bucket(bucket="bucket1")
-    assert isinstance(sql, str)
-    assert "DELETE FROM package_manifest" in sql
-    assert "bucket1" in sql
 
 
 def test_package_manifest_delete_single_smoke(qm):
     sql = qm.package_manifest_delete_single(bucket="bucket1", top_hash="abc")
     assert isinstance(sql, str)
-    assert "DELETE FROM package_manifest" in sql
+    assert 'DELETE FROM "bucket1_package_manifest"' in sql
     assert "abc" in sql
 
 
 def test_package_entry_add_bucket_smoke(qm):
     sql = qm.package_entry_add_bucket(bucket="bucket1")
     assert isinstance(sql, str)
-    assert "MERGE INTO package_entry" in sql
-    assert "bucket1" in sql
+    assert 'MERGE INTO "bucket1_package_entry"' in sql
 
 
 def test_package_entry_add_single_smoke(qm):
     sql = qm.package_entry_add_single(bucket="bucket1", top_hash="abc")
     assert isinstance(sql, str)
-    assert "MERGE INTO package_entry" in sql
-    assert "bucket1" in sql
+    assert 'MERGE INTO "bucket1_package_entry"' in sql
     assert "abc" in sql
-
-
-def test_package_entry_delete_bucket_smoke(qm):
-    sql = qm.package_entry_delete_bucket(bucket="bucket1")
-    assert isinstance(sql, str)
-    assert "DELETE FROM package_entry" in sql
-    assert "bucket1" in sql
 
 
 def test_package_entry_delete_single_smoke(qm):
     sql = qm.package_entry_delete_single(bucket="bucket1", top_hash="abc")
     assert isinstance(sql, str)
-    assert "DELETE FROM package_entry" in sql
+    assert 'DELETE FROM "bucket1_package_entry"' in sql
     assert "abc" in sql


### PR DESCRIPTION
**Draft / WIP.** Query-generation side of the per-bucket Iceberg pivot. Coordinated with **quiltdata/enterprise** (DDL/lifecycle/views/grants) and **quiltdata/deployment** (IAM), branch `iceberg-per-bucket`.

### Changes
- `py-shared/src/quilt_shared/iceberg_queries.py` — `QueryMaker` MERGE/DELETE now target `{bucket}_{table}`; the `bucket` column is dropped from SELECT/ON/INSERT/WHERE (the per-bucket table identity carries it). Source reads (`{bucket}_manifests`/`{bucket}_packages`) and the iceberg lambda's routing are unchanged.
- Removed the now-dead `*_delete_bucket` methods (whole-bucket teardown is a `DROP TABLE` on the registry side); `*_delete_single` (used by the lambda) retained.

### Tests
Iceberg lambda `pytest` → 11 passed; `py-shared/tests/test_iceberg_queries.py` (exercises the local edit) → 12 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)