### PR TITLE
catalog: redirect to /login on AUTH_REFRESH_FAILED; guard first-login race

### DIFF
--- a/catalog/app/containers/Auth/urqlExchange.spec.ts
+++ b/catalog/app/containers/Auth/urqlExchange.spec.ts
@@ -37,6 +37,11 @@ describe('containers/Auth/urqlExchange', () => {
       expect(isAuthLostError(err)).toBe(true)
     })
 
+    it('flags legacy Not logged in message (no extension)', () => {
+      const err = combinedError([{ message: 'Not logged in' }])
+      expect(isAuthLostError(err)).toBe(true)
+    })
+
     it('does not flag unrelated errors', () => {
       const err = combinedError([
         { message: 'something else', extensions: { code: 'INTERNAL_SERVER_ERROR' } },
@@ -67,6 +72,14 @@ describe('containers/Auth/urqlExchange', () => {
     it('false when there are no graphQL errors', () => {
       const err = combinedError([])
       expect(isOnlyNotLoggedIn(err)).toBe(false)
+    })
+
+    it('true for legacy `Not logged in` message without extension', () => {
+      // Older registry builds reply without extensions.code; the race
+      // suppression must still apply so users mid-handshake don't get
+      // bounced.
+      const err = combinedError([{ message: 'Not logged in' }])
+      expect(isOnlyNotLoggedIn(err)).toBe(true)
     })
   })
 })

--- a/catalog/app/containers/Auth/urqlExchange.spec.ts
+++ b/catalog/app/containers/Auth/urqlExchange.spec.ts
@@ -1,0 +1,72 @@
+import { describe, it, expect } from 'vitest'
+import { CombinedError } from 'urql'
+
+import { isAuthLostError, isOnlyNotLoggedIn } from './urqlExchange'
+
+const combinedError = (
+  graphQLErrors: { message: string; extensions?: Record<string, unknown> }[] = [],
+  networkError?: Error,
+) => new CombinedError({ graphQLErrors, networkError })
+
+describe('containers/Auth/urqlExchange', () => {
+  describe('isAuthLostError', () => {
+    it('flags AUTH_REFRESH_FAILED extension code', () => {
+      const err = combinedError([
+        {
+          message: 'Failed to refresh SSO access token',
+          extensions: { code: 'AUTH_REFRESH_FAILED' },
+        },
+      ])
+      expect(isAuthLostError(err)).toBe(true)
+    })
+
+    it('flags NOT_LOGGED_IN extension code', () => {
+      const err = combinedError([
+        { message: 'Not logged in', extensions: { code: 'NOT_LOGGED_IN' } },
+      ])
+      expect(isAuthLostError(err)).toBe(true)
+    })
+
+    it('flags legacy Token invalid message', () => {
+      const err = combinedError([{ message: 'Token invalid.' }])
+      expect(isAuthLostError(err)).toBe(true)
+    })
+
+    it('flags legacy Failed to refresh message (no extension)', () => {
+      const err = combinedError([{ message: 'Failed to refresh SSO access token' }])
+      expect(isAuthLostError(err)).toBe(true)
+    })
+
+    it('does not flag unrelated errors', () => {
+      const err = combinedError([
+        { message: 'something else', extensions: { code: 'INTERNAL_SERVER_ERROR' } },
+      ])
+      expect(isAuthLostError(err)).toBe(false)
+    })
+  })
+
+  describe('isOnlyNotLoggedIn', () => {
+    it('true when every error is NOT_LOGGED_IN', () => {
+      const err = combinedError([
+        { message: 'Not logged in', extensions: { code: 'NOT_LOGGED_IN' } },
+      ])
+      expect(isOnlyNotLoggedIn(err)).toBe(true)
+    })
+
+    it('false when any error is something else', () => {
+      const err = combinedError([
+        { message: 'Not logged in', extensions: { code: 'NOT_LOGGED_IN' } },
+        {
+          message: 'Failed to refresh',
+          extensions: { code: 'AUTH_REFRESH_FAILED' },
+        },
+      ])
+      expect(isOnlyNotLoggedIn(err)).toBe(false)
+    })
+
+    it('false when there are no graphQL errors', () => {
+      const err = combinedError([])
+      expect(isOnlyNotLoggedIn(err)).toBe(false)
+    })
+  })
+})

--- a/catalog/app/containers/Auth/urqlExchange.tsx
+++ b/catalog/app/containers/Auth/urqlExchange.tsx
@@ -48,12 +48,16 @@ export function isAuthLostError(error: urql.CombinedError): boolean {
   })
 }
 
-// True when every GraphQL error in the response carries the NOT_LOGGED_IN
-// code — i.e. the request reached the registry with no Authorization
-// header at all. This is the shape the post-OAuth-callback hydration
-// race produces; AUTH_REFRESH_FAILED has a different shape and is not
-// suppressed by this check.
+// True when every signal in the response says "no Authorization header
+// was sent" — i.e. the request reached the registry unauthenticated.
+// This is the shape the post-OAuth-callback hydration race produces.
+// Covers the typed NOT_LOGGED_IN extension code AND the pre-typed
+// `[GraphQL] Not logged in` message (older registry builds during the
+// rollout). AUTH_REFRESH_FAILED implies a token was sent and rejected,
+// which is never racy, so it is intentionally not covered here.
+const LEGACY_NOT_LOGGED_IN_MESSAGE = '[GraphQL] Not logged in'
 export function isOnlyNotLoggedIn(error: urql.CombinedError): boolean {
+  if (error.message === LEGACY_NOT_LOGGED_IN_MESSAGE) return true
   if (error.graphQLErrors.length === 0) return false
   return error.graphQLErrors.every(
     (e) => (e.extensions as { code?: string } | undefined)?.code === 'NOT_LOGGED_IN',

--- a/catalog/app/containers/Auth/urqlExchange.tsx
+++ b/catalog/app/containers/Auth/urqlExchange.tsx
@@ -8,6 +8,7 @@ import defer from 'utils/defer'
 
 import * as actions from './actions'
 import { InvalidToken } from './errors'
+import * as selectors from './selectors'
 
 interface AuthTokens {
   token: string
@@ -25,6 +26,40 @@ interface AuthContext {
 // TODO: dedupe
 const makeHeadersFromTokens = (t?: AuthTokens) => t && { Authorization: t.token }
 
+// Error codes the registry sets in GraphQL error extensions when the
+// caller's session can't be used. Treating these as "session lost" lets
+// the catalog clear local tokens and redirect to /login instead of
+// rendering a generic error banner (Vir incident 2026-04).
+const AUTH_LOST_CODES = new Set(['AUTH_REFRESH_FAILED', 'NOT_LOGGED_IN'])
+
+// Legacy registry replies that pre-date the typed error codes above.
+// Match exactly to avoid swallowing unrelated errors.
+const LEGACY_AUTH_LOST_MESSAGES = new Set([
+  '[GraphQL] Token invalid.',
+  '[GraphQL] Not logged in',
+  '[GraphQL] Failed to refresh SSO access token',
+])
+
+export function isAuthLostError(error: urql.CombinedError): boolean {
+  if (LEGACY_AUTH_LOST_MESSAGES.has(error.message)) return true
+  return error.graphQLErrors.some((e) => {
+    const code = (e.extensions as { code?: string } | undefined)?.code
+    return code != null && AUTH_LOST_CODES.has(code)
+  })
+}
+
+// True when every GraphQL error in the response carries the NOT_LOGGED_IN
+// code — i.e. the request reached the registry with no Authorization
+// header at all. This is the shape the post-OAuth-callback hydration
+// race produces; AUTH_REFRESH_FAILED has a different shape and is not
+// suppressed by this check.
+export function isOnlyNotLoggedIn(error: urql.CombinedError): boolean {
+  if (error.graphQLErrors.length === 0) return false
+  return error.graphQLErrors.every(
+    (e) => (e.extensions as { code?: string } | undefined)?.code === 'NOT_LOGGED_IN',
+  )
+}
+
 const getFetchOptions = (op: urql.Operation) =>
   typeof op.context.fetchOptions === 'function'
     ? op.context.fetchOptions()
@@ -32,6 +67,12 @@ const getFetchOptions = (op: urql.Operation) =>
 
 export function useAuthExchange() {
   const dispatch = redux.useDispatch()
+
+  // Subscribe so the ref stays current; handleResult reads it
+  // synchronously when a response lands.
+  const waiting = redux.useSelector(selectors.waiting)
+  const waitingRef = React.useRef(waiting)
+  waitingRef.current = waiting
 
   const getTokens = React.useCallback(() => {
     const { resolver, promise } = defer<AuthTokens>()
@@ -74,7 +115,16 @@ export function useAuthExchange() {
             ? ctx.auth
             : R.defaultTo(ctx.auth?.handleInvalidToken, true)
 
-        if (handleInvalidToken && r.error.message === '[GraphQL] Token invalid.') {
+        if (handleInvalidToken && isAuthLostError(r.error)) {
+          // Suppress NOT_LOGGED_IN while an auth handshake is in flight:
+          // GraphQL queries from a freshly-mounted SPA can race the
+          // post-OAuth-callback POST /api/login. Treating the racing 401
+          // as "auth lost" would clear tokens and bounce the user back to
+          // /login mid-handshake. AUTH_REFRESH_FAILED is never racy
+          // (it implies a token was sent and rejected) so we still redirect.
+          if (isOnlyNotLoggedIn(r.error) && waitingRef.current) {
+            return r
+          }
           dispatch(actions.authLost(new InvalidToken({ originalError: r.error })))
           // never resolve on auth error
           return new Promise<urql.OperationResult>(() => {})


### PR DESCRIPTION
## Summary

- Detect typed auth errors (`AUTH_REFRESH_FAILED`, `NOT_LOGGED_IN`) on GraphQL responses via `graphQLErrors[].extensions.code` and dispatch `authLost` so the user is bounced to `/login` instead of seeing a generic error banner.
- Keep legacy message matchers (`Token invalid.`, `Not logged in`, `Failed to refresh SSO access token`) for compatibility while the registry change rolls out.
- Suppress `NOT_LOGGED_IN` while a sign-in handshake is in flight (redux state `SIGNING_IN` / `REFRESHING`) — fixes the post-OAuth-callback hydration race that the [KB workarounds](https://kb.quilt.bio/why-does-okta-sso-login-fail-until-the-page-is-refreshed) didn't fully address.

## Context

Vir reported a "session goes dead and only a manual sign-in recovers" symptom: catalog held a session whose Okta refresh token had been rejected, every GraphQL call 401'd `Failed to refresh SSO access token`, and the catalog rendered a generic error instead of guiding the user back to login.

Sibling registry PR: https://github.com/quiltdata/enterprise/pull/1073

## Files

- `app/containers/Auth/urqlExchange.tsx` — new `isAuthLostError` / `isOnlyNotLoggedIn` helpers, subscribed-to `waiting` flag via a ref to gate the race-prone code.
- `app/containers/Auth/urqlExchange.spec.ts` — unit coverage for both helpers.

## Test plan

- [x] `npx vitest run app/containers/Auth/urqlExchange.spec.ts` passes (8 tests)
- [x] `tsc --noEmit` — no new errors in changed files
- [ ] Manual: revoke a refresh token on a staging stack, observe catalog redirects to /login on next GraphQL call
- [ ] Manual: complete an Okta sign-in flow and confirm no flicker / no spurious redirect during the post-callback handshake

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR broadens auth-error handling in the urql exchange: it detects typed registry error codes (`AUTH_REFRESH_FAILED`, `NOT_LOGGED_IN`) in addition to legacy message strings, dispatches `authLost` to redirect expired sessions to `/login`, and suppresses `NOT_LOGGED_IN` during `SIGNING_IN`/`REFRESHING` to prevent false redirects from the post-OAuth-callback race.

- `isAuthLostError` unifies typed extension codes and legacy message strings into a single predicate; `isOnlyNotLoggedIn` identifies the specific race-prone error shape so it can be gated by `waitingRef.current`.
- The `waitingRef` pattern (ref updated every render, read synchronously in the async callback) is the correct way to avoid stale-closure issues in this exchange.
- The race suppression only fires when the registry sends the new typed `NOT_LOGGED_IN` extension code; legacy `[GraphQL] Not logged in` messages (no extension) will still dispatch `authLost` during a handshake until the sibling registry PR is fully deployed.

<h3>Confidence Score: 4/5</h3>

Safe to merge; the auth-redirect path is preserved for all production cases and the race guard adds a narrow, well-commented suppression window.

The core logic is correct: the waitingRef pattern avoids stale closures, authLost is still dispatched for every non-suppressed auth error, and existing legacy message matching is preserved. The only gap is that the first-login race fix is silently ineffective against legacy-format registries during the rollout window.

urqlExchange.tsx lines 125-127 — the race-suppression branch — deserves a second look to confirm expected behavior during the registry upgrade window.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| catalog/app/containers/Auth/urqlExchange.tsx | Adds isAuthLostError/isOnlyNotLoggedIn helpers, broadens auth-error detection from a single legacy message to typed extension codes, and suppresses NOT_LOGGED_IN during SIGNING_IN/REFRESHING via a ref-based state snapshot. Logic is sound but the race-suppression only fires when the registry sends the new typed code. |
| catalog/app/containers/Auth/urqlExchange.spec.ts | New test file covering both helpers with 8 cases; missing one path: legacy [GraphQL] Not logged in message (no extension code) inside isAuthLostError. |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[GraphQL response lands in handleResult] --> B{r.error?}
    B -- No --> Z[return r]
    B -- Yes --> C{handleInvalidToken?}
    C -- No --> Z
    C -- Yes --> D{isAuthLostError?}
    D -- No --> Z
    D -- Yes --> E{isOnlyNotLoggedIn?}
    E -- No --> G[dispatch authLost]
    E -- Yes --> F{waitingRef.current?}
    F -- Yes --> H[Suppress - return r]
    F -- No --> G
```

<sub>Reviews (1): Last reviewed commit: ["catalog: redirect to /login on AUTH\_REFR..."](https://github.com/quiltdata/quilt/commit/3863911ab7ac50e0a4f6ec9dd804386ec2014203) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=34286516)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->