### PR TITLE
refactor(catalog): add bucket context and S3 config factory

### DIFF
--- a/catalog/app/containers/Bucket/Bucket.tsx
+++ b/catalog/app/containers/Bucket/Bucket.tsx
@@ -6,7 +6,7 @@ import Layout, { Container } from 'components/Layout'
 import Placeholder from 'components/Placeholder'
 import { useBucketStrict } from 'containers/Bucket/Routes'
 import { NotFoundInTabs } from 'containers/NotFound'
-import { useBucketExistence } from 'utils/BucketCache'
+import { useBucketExistence, useGetCachedBucketRegion } from 'utils/BucketCache'
 import * as NamedRoutes from 'utils/NamedRoutes'
 import * as BucketPreferences from 'utils/BucketPreferences'
 import MetaTitle from 'utils/MetaTitle'
@@ -14,6 +14,7 @@ import * as RT from 'utils/reactTools'
 
 import * as AssistantContext from './AssistantContext'
 import * as BucketNav from './BucketNav'
+import { BucketContextProvider } from './context'
 import type { RouteMap } from './Routes'
 import * as Selection from './Selection'
 import { displayError } from './errors'
@@ -57,7 +58,7 @@ function BucketLayout({ bucket, children }: BucketLayoutProps) {
           </M.AppBar>
           <Container>
             {bucketExistenceData.case({
-              Ok: () => children,
+              Ok: () => <BucketReady bucket={bucket}>{children}</BucketReady>,
               Err: displayError(),
               _: () => <SuspensePlaceholder />,
             })}
@@ -68,7 +69,29 @@ function BucketLayout({ bucket, children }: BucketLayoutProps) {
   )
 }
 
+function BucketReady({ bucket, children }: BucketLayoutProps) {
+  const getCachedBucketRegion = useGetCachedBucketRegion()
+  const config = React.useMemo(
+    () => ({ region: getCachedBucketRegion(bucket) }),
+    [bucket, getCachedBucketRegion],
+  )
+
+  return (
+    <BucketContextProvider bucket={bucket} config={config}>
+      {children}
+    </BucketContextProvider>
+  )
+}
+
 export default function Bucket() {
+  return (
+    <BucketContextProvider>
+      <BucketInner />
+    </BucketContextProvider>
+  )
+}
+
+function BucketInner() {
   const bucket = useBucketStrict()
 
   const { paths } = NamedRoutes.use<RouteMap>()

--- a/catalog/app/containers/Bucket/Dir.tsx
+++ b/catalog/app/containers/Bucket/Dir.tsx
@@ -20,6 +20,7 @@ import * as Listing from './Listing'
 import * as FI from './PackageDialog/Inputs/Files/State'
 import * as Selection from './Selection'
 import Summary from './Summary'
+import { useBucketContext } from './context'
 import * as DirToolbar from './Dir/Toolbar'
 import { displayError } from './errors'
 import * as requests from './requests'
@@ -158,17 +159,17 @@ const useStyles = M.makeStyles((t) => ({
 }))
 
 interface DirParams {
-  bucket: string
   path?: string
 }
 
 export default function Dir() {
-  const { bucket, path: encodedPath = '' } = RRDom.useParams<DirParams>()
+  const { name: bucket } = useBucketContext()
+  const { path: encodedPath = '' } = RRDom.useParams<DirParams>()
   const l = RRDom.useLocation()
-  invariant(!!bucket, '`bucket` must be defined')
 
   const classes = useStyles()
-  const s3 = AWS.S3.use()
+  const { config } = useBucketContext()
+  const s3 = AWS.S3.use(config)
   const { prefix } = parseSearch(l.search, true)
   const path = s3paths.decode(encodedPath)
 

--- a/catalog/app/containers/Bucket/Dir/Toolbar/CreatePackage/useSuccessors.spec.ts
+++ b/catalog/app/containers/Bucket/Dir/Toolbar/CreatePackage/useSuccessors.spec.ts
@@ -1,7 +1,9 @@
+import * as React from 'react'
 import { renderHook } from '@testing-library/react-hooks'
 import { describe, it, expect, vi } from 'vitest'
 import dedent from 'dedent'
 
+import { BucketContextProvider } from 'containers/Bucket/context'
 import { FileNotFound } from 'containers/Bucket/errors'
 import Log from 'utils/Logging'
 import * as Request from 'utils/useRequest'
@@ -21,6 +23,11 @@ vi.mock('utils/AWS', () => ({ S3: { use: () => s3 } }))
 
 describe('useSuccessors integration tests', () => {
   const CURRENT_BUCKET = 'foo-bucket'
+  const wrapper = ({ children }: React.PropsWithChildren<{}>) =>
+    React.createElement(BucketContextProvider, {
+      bucket: CURRENT_BUCKET,
+      children,
+    })
 
   const SUCCESSOR_FOR_CURRENT_BUCKET = {
     copyData: true,
@@ -45,7 +52,7 @@ describe('useSuccessors integration tests', () => {
         promise: () => new Promise((resolve) => setTimeout(() => resolve(null), 1000)),
       })
 
-      const { result } = renderHook(() => useSuccessors(CURRENT_BUCKET))
+      const { result } = renderHook(() => useSuccessors(CURRENT_BUCKET), { wrapper })
 
       expect(result.current).toBe(Request.Loading)
     })
@@ -59,8 +66,9 @@ describe('useSuccessors integration tests', () => {
         promise: () => Promise.reject(testError),
       })
 
-      const { result, waitForValueToChange } = renderHook(() =>
-        useSuccessors(CURRENT_BUCKET),
+      const { result, waitForValueToChange } = renderHook(
+        () => useSuccessors(CURRENT_BUCKET),
+        { wrapper },
       )
 
       await waitForValueToChange(() => result.current, { timeout: 5000 })
@@ -79,8 +87,9 @@ describe('useSuccessors integration tests', () => {
             name: Test Workflow
       `)
 
-      const { result, waitForValueToChange } = renderHook(() =>
-        useSuccessors(CURRENT_BUCKET),
+      const { result, waitForValueToChange } = renderHook(
+        () => useSuccessors(CURRENT_BUCKET),
+        { wrapper },
       )
       await waitForValueToChange(() => result.current, { timeout: 5000 })
 
@@ -92,8 +101,9 @@ describe('useSuccessors integration tests', () => {
         promise: () => Promise.reject(new FileNotFound('Object not found')),
       })
 
-      const { result, waitForValueToChange } = renderHook(() =>
-        useSuccessors(CURRENT_BUCKET),
+      const { result, waitForValueToChange } = renderHook(
+        () => useSuccessors(CURRENT_BUCKET),
+        { wrapper },
       )
 
       await waitForValueToChange(() => result.current, { timeout: 5000 })
@@ -103,8 +113,9 @@ describe('useSuccessors integration tests', () => {
     it('should handle empty workflow config when file exists but is empty', async () => {
       mockS3ConfigYaml('')
 
-      const { result, waitForValueToChange } = renderHook(() =>
-        useSuccessors(CURRENT_BUCKET),
+      const { result, waitForValueToChange } = renderHook(
+        () => useSuccessors(CURRENT_BUCKET),
+        { wrapper },
       )
 
       await waitForValueToChange(() => result.current, { timeout: 5000 })
@@ -128,8 +139,9 @@ describe('useSuccessors integration tests', () => {
             name: Test Workflow
       `)
 
-      const { result, waitForValueToChange } = renderHook(() =>
-        useSuccessors(CURRENT_BUCKET),
+      const { result, waitForValueToChange } = renderHook(
+        () => useSuccessors(CURRENT_BUCKET),
+        { wrapper },
       )
       await waitForValueToChange(() => result.current, { timeout: 5000 })
 
@@ -173,8 +185,9 @@ describe('useSuccessors integration tests', () => {
             name: Test Workflow
       `)
 
-      const { result, waitForValueToChange } = renderHook(() =>
-        useSuccessors(CURRENT_BUCKET),
+      const { result, waitForValueToChange } = renderHook(
+        () => useSuccessors(CURRENT_BUCKET),
+        { wrapper },
       )
 
       await waitForValueToChange(() => result.current, { timeout: 5000 })

--- a/catalog/app/containers/Bucket/Dir/Toolbar/CreatePackage/useSuccessors.ts
+++ b/catalog/app/containers/Bucket/Dir/Toolbar/CreatePackage/useSuccessors.ts
@@ -4,9 +4,11 @@ import { workflowsConfig } from 'containers/Bucket/requests'
 import * as AWS from 'utils/AWS'
 import * as Request from 'utils/useRequest'
 import type { Successor } from 'utils/workflows'
+import { useBucketContext } from 'containers/Bucket/context'
 
 export default function useSuccessors(bucket: string): Request.Result<Successor[]> {
-  const s3 = AWS.S3.use()
+  const { config } = useBucketContext()
+  const s3 = AWS.S3.use(config)
   const req = React.useCallback(() => workflowsConfig({ s3, bucket }), [bucket, s3])
   const data = Request.use(req)
 

--- a/catalog/app/containers/Bucket/FallbackToDir.tsx
+++ b/catalog/app/containers/Bucket/FallbackToDir.tsx
@@ -9,6 +9,7 @@ import * as s3paths from 'utils/s3paths'
 import * as Request from 'utils/useRequest'
 import assertNever from 'utils/assertNever'
 
+import { useBucketContext } from './context'
 import * as requests from './requests'
 import { displayError } from './errors'
 
@@ -18,7 +19,8 @@ const File = Symbol('file')
 
 // If object exists, then this is 100% an object page
 function useIsObject(handle: Model.S3.S3ObjectLocation) {
-  const s3 = AWS.S3.use()
+  const { config } = useBucketContext()
+  const s3 = AWS.S3.use(config)
   const { bucket, key, version } = handle
   const req = React.useCallback(
     () =>

--- a/catalog/app/containers/Bucket/File/File.jsx
+++ b/catalog/app/containers/Bucket/File/File.jsx
@@ -31,6 +31,7 @@ import FallbackToDir from '../FallbackToDir'
 import Section from '../Section'
 import renderPreview from '../renderPreview'
 import * as requests from '../requests'
+import { useBucketContext } from '../context'
 import { useViewModes } from '../viewModes'
 
 import Analytics from './Analytics'
@@ -53,7 +54,8 @@ const useVersionInfoStyles = M.makeStyles(({ typography }) => ({
 }))
 
 function VersionInfo({ bucket, path, version }) {
-  const s3 = AWS.S3.use()
+  const { config } = useBucketContext()
+  const s3 = AWS.S3.use(config)
   const { urls } = NamedRoutes.use()
   const { push } = Notifications.use()
 
@@ -293,12 +295,14 @@ const useStyles = M.makeStyles((t) => ({
 
 function File() {
   const location = RRDom.useLocation()
-  const { bucket, path: encodedPath } = RRDom.useParams()
+  const { name: bucket } = useBucketContext()
+  const { path: encodedPath } = RRDom.useParams()
 
   const { version, mode } = parseSearch(location.search)
   const classes = useStyles()
   const { urls } = NamedRoutes.use()
-  const s3 = AWS.S3.use()
+  const { config } = useBucketContext()
+  const s3 = AWS.S3.use(config)
   const { prefs } = BucketPreferences.use()
 
   const path = s3paths.decode(encodedPath)
@@ -520,7 +524,8 @@ function File() {
 }
 
 export default function FileWrapper() {
-  const { bucket, path: key } = RRDom.useParams()
+  const { name: bucket } = useBucketContext()
+  const { path: key } = RRDom.useParams()
   const location = RRDom.useLocation()
   const { version } = parseSearch(location.search)
   const handle = React.useMemo(() => ({ bucket, key, version }), [bucket, key, version])

--- a/catalog/app/containers/Bucket/Meta.tsx
+++ b/catalog/app/containers/Bucket/Meta.tsx
@@ -11,6 +11,7 @@ import type { MetaBlockPreferences } from 'utils/BucketPreferences'
 import { useData } from 'utils/Data'
 import type { JsonRecord } from 'utils/types'
 
+import { useBucketContext } from './context'
 import * as requests from './requests'
 import Section from './Section'
 
@@ -155,7 +156,8 @@ interface ObjectMetaProps {
 }
 
 export function ObjectMeta({ handle }: ObjectMetaProps) {
-  const s3 = AWS.S3.use()
+  const { config } = useBucketContext()
+  const s3 = AWS.S3.use(config)
   const metaData = useData(requests.objectMeta, {
     s3,
     handle,
@@ -185,7 +187,8 @@ interface ObjectTagsProps {
 }
 
 export function ObjectTags({ handle }: ObjectTagsProps) {
-  const s3 = AWS.S3.use()
+  const { config } = useBucketContext()
+  const s3 = AWS.S3.use(config)
   const tagsData = useData(requests.objectTags, {
     s3,
     handle,

--- a/catalog/app/containers/Bucket/Overview/Header.tsx
+++ b/catalog/app/containers/Bucket/Overview/Header.tsx
@@ -18,6 +18,7 @@ import assertNever from 'utils/assertNever'
 import { readableBytes, readableQuantity, formatQuantity } from 'utils/string'
 import useConst from 'utils/useConstant'
 
+import { useBucketContext } from '../context'
 import * as requests from '../requests'
 
 import { ColorPool, makeColorPool } from './ColorPool'
@@ -275,7 +276,8 @@ function StatsItemSkeleton() {
 }
 
 function useStats(bucket: string) {
-  const s3 = AWS.S3.use()
+  const { config } = useBucketContext()
+  const s3 = AWS.S3.use(config)
   const req = APIConnector.use()
   const statsData = useData(requests.bucketStats, { req, s3, bucket })
   const countQuery = GQL.useQuery(STAT_COUNTS_QUERY, { buckets: [bucket] })

--- a/catalog/app/containers/Bucket/Overview/Overview.tsx
+++ b/catalog/app/containers/Bucket/Overview/Overview.tsx
@@ -1,6 +1,5 @@
 import type AWSSDK from 'aws-sdk'
 import * as React from 'react'
-import { useParams } from 'react-router-dom'
 import * as M from '@material-ui/core'
 
 import cfg from 'constants/config'
@@ -15,6 +14,7 @@ import * as GQL from 'utils/GraphQL'
 import * as Gallery from '../Gallery'
 import * as Summarize from '../Summarize'
 import * as requests from '../requests'
+import { useBucketContext } from '../context'
 
 import Header from './Header'
 import BUCKET_QUERY from './gql/Bucket.generated'
@@ -95,9 +95,10 @@ function ThumbnailsWrapper({
 }
 
 export default function Overview() {
-  const { bucket } = useParams<{ bucket: string }>()
+  const { name: bucket } = useBucketContext()
 
-  const s3 = AWS.S3.use()
+  const { config } = useBucketContext()
+  const s3 = AWS.S3.use(config)
   const { bucket: bucketData } = GQL.useQueryS(BUCKET_QUERY, { bucket })
   const inStack = !!bucketData
   const description = bucketData?.description

--- a/catalog/app/containers/Bucket/PackageCompare/router.ts
+++ b/catalog/app/containers/Bucket/PackageCompare/router.ts
@@ -5,9 +5,9 @@ import * as RRDom from 'react-router-dom'
 import * as NamedRoutes from 'utils/NamedRoutes'
 import type { PackageHandle } from 'utils/packageHandle'
 import parseSearch from 'utils/parseSearch'
+import { useBucketContext } from '../context'
 
 interface PackageCompareParams {
-  bucket: string
   name: string
   baseHash: string
   otherHash: string
@@ -19,9 +19,9 @@ type Pair = [PackageHandle, PackageHandle]
 export const isPair = (x: Single | Pair): x is Pair => x.length > 1
 
 export function useRouter() {
-  const { bucket, name, baseHash, otherHash } = RRDom.useParams<PackageCompareParams>()
+  const { name: bucket } = useBucketContext()
+  const { name, baseHash, otherHash } = RRDom.useParams<PackageCompareParams>()
 
-  invariant(!!bucket, '`bucket` must be defined')
   invariant(!!name, '`name` must be defined')
   invariant(!!baseHash, '`baseHash` must be defined')
 

--- a/catalog/app/containers/Bucket/PackageDialog/Inputs/Files/S3FilePicker.tsx
+++ b/catalog/app/containers/Bucket/PackageDialog/Inputs/Files/S3FilePicker.tsx
@@ -19,6 +19,7 @@ import type * as Model from 'model'
 
 import * as Listing from '../../../Listing'
 import * as Selection from '../../../Selection'
+import { useBucketContext } from '../../../context'
 import { displayError } from '../../../errors'
 import * as requests from '../../../requests'
 
@@ -119,8 +120,7 @@ function BucketSelect({ bucket, buckets, selectBucket }: BucketSelectProps) {
   const classes = useBucketSelectStyles()
 
   const { handle } = BucketPreferences.use()
-  const { bucket: currentBucket } = RRDom.useParams<{ bucket: string }>()
-  invariant(currentBucket, '`currentBucket` must be defined')
+  const { name: currentBucket } = useBucketContext()
 
   const toConfig = FileEditorRoutes.useEditBucketFile(
     handle || { bucket: currentBucket, key: quiltConfigs.bucketPreferences[0] },

--- a/catalog/app/containers/Bucket/PackageDialog/State/schema.spec.ts
+++ b/catalog/app/containers/Bucket/PackageDialog/State/schema.spec.ts
@@ -1,7 +1,10 @@
+import * as React from 'react'
 import { act, renderHook } from '@testing-library/react-hooks'
 import { describe, it, expect, vi } from 'vitest'
 
 import noop from 'utils/noop'
+import { BucketContextProvider } from 'containers/Bucket/context'
+
 import { mkMetaValidator, useMetadataSchema, useEntriesSchema, Ready } from './schema'
 
 vi.mock('constants/config', () => ({ default: {} }))
@@ -18,6 +21,9 @@ vi.mock('../../requests', () => ({
   metadataSchema: ({ s3, ...rest }: any) => Promise.resolve(metadataSchema({ ...rest })),
   objectSchema: ({ s3, ...rest }: any) => Promise.resolve(objectSchema({ ...rest })),
 }))
+
+const wrapper = ({ children }: React.PropsWithChildren<{}>) =>
+  React.createElement(BucketContextProvider, { bucket: 'test-bucket', children })
 
 describe('containers/Bucket/PackageDialog/State/schema', () => {
   describe('mkMetaValidator', () => {
@@ -54,14 +60,14 @@ describe('containers/Bucket/PackageDialog/State/schema', () => {
 
   describe('useMetadataSchema', () => {
     it('should return ready when no workflow', () => {
-      const { result } = renderHook(() => useMetadataSchema())
+      const { result } = renderHook(() => useMetadataSchema(), { wrapper })
 
       expect(result.current).toEqual(Ready())
     })
 
     it('should return ready when workflow has no schema', () => {
       const workflow = { name: 'test' } as any
-      const { result } = renderHook(() => useMetadataSchema(workflow))
+      const { result } = renderHook(() => useMetadataSchema(workflow), { wrapper })
 
       expect(result.current).toEqual(Ready())
     })
@@ -69,7 +75,10 @@ describe('containers/Bucket/PackageDialog/State/schema', () => {
     it('should call metadataSchema with correct parameters from workflow', async () => {
       const workflow = { schema: { url: 'https://example.com/schema.json' } } as any
 
-      const { waitForNextUpdate, unmount } = renderHook(() => useMetadataSchema(workflow))
+      const { waitForNextUpdate, unmount } = renderHook(
+        () => useMetadataSchema(workflow),
+        { wrapper },
+      )
 
       await act(() => waitForNextUpdate())
 
@@ -82,14 +91,14 @@ describe('containers/Bucket/PackageDialog/State/schema', () => {
 
   describe('useEntriesSchema', () => {
     it('should return ready when no workflow', () => {
-      const { result } = renderHook(() => useEntriesSchema())
+      const { result } = renderHook(() => useEntriesSchema(), { wrapper })
 
       expect(result.current).toEqual(Ready())
     })
 
     it('should return ready when workflow has no entriesSchema', () => {
       const workflow = { name: 'test' } as any
-      const { result } = renderHook(() => useEntriesSchema(workflow))
+      const { result } = renderHook(() => useEntriesSchema(workflow), { wrapper })
 
       expect(result.current).toEqual(Ready())
     })
@@ -97,7 +106,10 @@ describe('containers/Bucket/PackageDialog/State/schema', () => {
     it('should call objectSchema with correct parameters from workflow', async () => {
       const workflow = { entriesSchema: 'https://example.com/entries.json' } as any
 
-      const { waitForNextUpdate, unmount } = renderHook(() => useEntriesSchema(workflow))
+      const { waitForNextUpdate, unmount } = renderHook(
+        () => useEntriesSchema(workflow),
+        { wrapper },
+      )
       await act(() => waitForNextUpdate())
 
       expect(objectSchema).toHaveBeenCalledWith({

--- a/catalog/app/containers/Bucket/PackageDialog/State/schema.ts
+++ b/catalog/app/containers/Bucket/PackageDialog/State/schema.ts
@@ -11,6 +11,7 @@ import {
 import * as Request from 'utils/useRequest'
 import * as Types from 'utils/types'
 import * as workflows from 'utils/workflows'
+import { useBucketContext } from 'containers/Bucket/context'
 
 import { metadataSchema, objectSchema } from '../../requests'
 
@@ -40,7 +41,8 @@ export function mkMetaValidator(schema?: JsonSchema) {
 }
 
 export function useMetadataSchema(workflow?: workflows.Workflow): SchemaStatus {
-  const s3 = AWS.S3.use()
+  const { config } = useBucketContext()
+  const s3 = AWS.S3.use(config)
   const schemaUrl = workflow?.schema?.url
   const req = React.useCallback(() => metadataSchema({ s3, schemaUrl }), [schemaUrl, s3])
   const result = Request.use(req, !!schemaUrl)
@@ -55,7 +57,8 @@ export function useMetadataSchema(workflow?: workflows.Workflow): SchemaStatus {
 }
 
 export function useEntriesSchema(workflow?: workflows.Workflow): SchemaStatus {
-  const s3 = AWS.S3.use()
+  const { config } = useBucketContext()
+  const s3 = AWS.S3.use(config)
   const schemaUrl = workflow?.entriesSchema || ''
   const req = React.useCallback(() => objectSchema({ s3, schemaUrl }), [schemaUrl, s3])
   const result = Request.use(req, !!schemaUrl)

--- a/catalog/app/containers/Bucket/PackageDialog/State/workflow.ts
+++ b/catalog/app/containers/Bucket/PackageDialog/State/workflow.ts
@@ -3,6 +3,7 @@ import * as React from 'react'
 import * as AWS from 'utils/AWS'
 import * as Request from 'utils/useRequest'
 import * as workflows from 'utils/workflows'
+import { useBucketContext } from 'containers/Bucket/context'
 
 import * as requests from '../../requests'
 
@@ -38,7 +39,8 @@ export function useWorkflowsConfig(
   open: boolean,
   { bucket }: PackageDst,
 ): WorkflowsConfigStatus {
-  const s3 = AWS.S3.use()
+  const { config } = useBucketContext()
+  const s3 = AWS.S3.use(config)
   const req = React.useCallback(
     () => requests.workflowsConfig({ s3, bucket }),
     [bucket, s3],

--- a/catalog/app/containers/Bucket/PackageDialog/Uploads.tsx
+++ b/catalog/app/containers/Bucket/PackageDialog/Uploads.tsx
@@ -12,6 +12,7 @@ import * as s3paths from 'utils/s3paths'
 import * as Types from 'utils/types'
 import useMemoEq from 'utils/useMemoEq'
 
+import { useBucketContext } from '../context'
 import type { LocalFile } from './Inputs/Files/Input'
 
 interface UploadResult extends S3.ManagedUpload.SendData {
@@ -50,7 +51,8 @@ const computeTotalProgress = (uploads: UploadsState): UploadTotalProgress =>
   )
 
 export function useUploads() {
-  const s3 = AWS.S3.use()
+  const { config } = useBucketContext()
+  const s3 = AWS.S3.use(config)
 
   const [uploads, setUploads] = React.useState<UploadsState>({})
   const progress = React.useMemo(() => computeTotalProgress(uploads), [uploads])

--- a/catalog/app/containers/Bucket/PackageRevisions/PackageRevisions.tsx
+++ b/catalog/app/containers/Bucket/PackageRevisions/PackageRevisions.tsx
@@ -26,6 +26,7 @@ import usePrevious from 'utils/usePrevious'
 import * as PD from '../PackageDialog'
 import Pagination from '../Pagination'
 import WithPackagesSupport from '../WithPackagesSupport'
+import { useBucketContext } from '../context'
 import { displayError } from '../errors'
 
 import REVISION_COUNT_QUERY from './gql/RevisionCount.generated'
@@ -541,9 +542,9 @@ export function PackageRevisions({ bucket, name, page }: PackageRevisionsProps) 
 }
 
 export default function PackageRevisionsWrapper() {
-  const { bucket, name } = RRDom.useParams<{ bucket: string; name: string }>()
+  const { name: bucket } = useBucketContext()
+  const { name } = RRDom.useParams<{ name: string }>()
   const location = RRDom.useLocation()
-  invariant(!!bucket, '`bucket` must be defined')
   invariant(!!name, '`name` must be defined')
 
   const { p } = parseSearch(location.search, true)

--- a/catalog/app/containers/Bucket/PackageTree/PackageTree.tsx
+++ b/catalog/app/containers/Bucket/PackageTree/PackageTree.tsx
@@ -46,6 +46,7 @@ import * as Successors from '../Successors'
 import Summary from '../Summary'
 import AssistButton from '../Toolbar/Assist'
 import WithPackagesSupport from '../WithPackagesSupport'
+import { useBucketContext } from '../context'
 import * as errors from '../errors'
 import renderPreview from '../renderPreview'
 import * as requests from '../requests'
@@ -715,7 +716,8 @@ function FileDisplay({
   crumbs,
   file,
 }: FileDisplayProps) {
-  const s3 = AWS.S3.use()
+  const { config } = useBucketContext()
+  const s3 = AWS.S3.use(config)
   const history = RRDom.useHistory()
   const { urls } = NamedRoutes.use<RouteMap>()
   const classes = useFileDisplayStyles()
@@ -1199,21 +1201,19 @@ function PackageTreeQueries({
 }
 
 interface PackageTreeRouteParams {
-  bucket: string
   name: string
   revision?: string
   path?: string
 }
 
 export default function PackageTreeWrapper() {
+  const { name: bucket } = useBucketContext()
   const {
-    bucket,
     name,
     revision: hashOrTag = 'latest',
     path: encodedPath = '',
   } = RRDom.useParams<PackageTreeRouteParams>()
   const location = RRDom.useLocation()
-  invariant(!!bucket, '`bucket` must be defined')
   invariant(!!name, '`name` must be defined')
 
   const path = s3paths.decode(encodedPath)

--- a/catalog/app/containers/Bucket/Queries/Athena/model/state.spec.tsx
+++ b/catalog/app/containers/Bucket/Queries/Athena/model/state.spec.tsx
@@ -4,6 +4,7 @@ import { act, renderHook } from '@testing-library/react-hooks'
 import { describe, expect, it, vi } from 'vitest'
 
 import noop from 'utils/noop'
+import { BucketContextProvider } from 'containers/Bucket/context'
 
 import * as Model from './'
 
@@ -69,14 +70,24 @@ describe('app/containers/Queries/Athena/model/state', () => {
     }
     const tree = () =>
       render(
-        <Model.Provider preferences={{}}>
-          <Component />
-        </Model.Provider>,
+        <BucketContextProvider>
+          <Model.Provider preferences={{}}>
+            <Component />
+          </Model.Provider>
+        </BucketContextProvider>,
       )
     expect(tree).toThrow('`bucket` must be defined')
   })
 
   it('load workgroups and set current workgroup', async () => {
+    Object.defineProperty(window, 'localStorage', {
+      configurable: true,
+      value: {
+        getItem: vi.fn(() => null),
+        removeItem: vi.fn(),
+        setItem: vi.fn(),
+      },
+    })
     listWorkGroups.mockImplementation(() => ({
       promise: () =>
         Promise.resolve({
@@ -109,7 +120,9 @@ describe('app/containers/Queries/Athena/model/state', () => {
       promise: () => Promise.resolve({ DataCatalogsSummary: [] }),
     }))
     const wrapper = ({ children }: { children: React.ReactNode }) => (
-      <Model.Provider preferences={{}}>{children}</Model.Provider>
+      <BucketContextProvider>
+        <Model.Provider preferences={{}}>{children}</Model.Provider>
+      </BucketContextProvider>
     )
     const { result, waitFor, unmount } = renderHook(() => Model.useState(), { wrapper })
     await act(async () => {

--- a/catalog/app/containers/Bucket/Queries/Athena/model/state.tsx
+++ b/catalog/app/containers/Bucket/Queries/Athena/model/state.tsx
@@ -5,6 +5,8 @@ import * as RRDom from 'react-router-dom'
 import type * as BucketPreferences from 'utils/BucketPreferences'
 import * as NamedRoutes from 'utils/NamedRoutes'
 
+import { useBucketContext } from '../../../context'
+
 import * as requests from './requests'
 import * as Model from './utils'
 
@@ -70,17 +72,12 @@ interface ProviderProps {
 
 export function Provider({ preferences, children }: ProviderProps) {
   const { urls } = NamedRoutes.use()
+  const { name: bucket } = useBucketContext()
 
-  const {
-    bucket,
-    queryExecutionId,
-    workgroup: workgroupId,
-  } = RRDom.useParams<{
-    bucket: string
+  const { queryExecutionId, workgroup: workgroupId } = RRDom.useParams<{
     queryExecutionId?: string
     workgroup?: requests.Workgroup
   }>()
-  invariant(!!bucket, '`bucket` must be defined')
 
   const execution = requests.useWaitForQueryExecution(queryExecutionId)
 

--- a/catalog/app/containers/Bucket/Queries/ElasticSearch.tsx
+++ b/catalog/app/containers/Bucket/Queries/ElasticSearch.tsx
@@ -1,9 +1,9 @@
-import invariant from 'invariant'
 import * as R from 'ramda'
 import * as React from 'react'
-import { useParams } from 'react-router-dom'
 import * as M from '@material-ui/core'
 import * as Lab from '@material-ui/lab'
+
+import { useBucketContext } from '../context'
 
 import QueryResult from './QueryResult'
 import QuerySelect from './QuerySelect'
@@ -186,8 +186,7 @@ const isButtonDisabled = (
 ): boolean => !!error || !!resultsData.case({ Pending: R.T, _: R.F })
 
 export default function ElastiSearch() {
-  const { bucket } = useParams<{ bucket: string }>()
-  invariant(!!bucket, '`bucket` must be defined')
+  const { name: bucket } = useBucketContext()
 
   const classes = useStyles()
 

--- a/catalog/app/containers/Bucket/Queries/Queries.tsx
+++ b/catalog/app/containers/Bucket/Queries/Queries.tsx
@@ -1,10 +1,11 @@
-import invariant from 'invariant'
 import * as React from 'react'
-import { Redirect, Route, Switch, useParams } from 'react-router-dom'
+import { Redirect, Route, Switch } from 'react-router-dom'
 import * as M from '@material-ui/core'
 
 import MetaTitle from 'utils/MetaTitle'
 import * as NamedRoutes from 'utils/NamedRoutes'
+
+import { useBucketContext } from '../context'
 
 import Athena from './Athena'
 import ElasticSearch from './ElasticSearch'
@@ -16,8 +17,7 @@ const useStyles = M.makeStyles((t) => ({
 }))
 
 export default function Queries() {
-  const { bucket } = useParams<{ bucket: string }>()
-  invariant(!!bucket, '`bucket` must be defined')
+  const { name: bucket } = useBucketContext()
 
   const classes = useStyles()
   const { paths, urls } = NamedRoutes.use()

--- a/catalog/app/containers/Bucket/Queries/requests/queriesConfig.ts
+++ b/catalog/app/containers/Bucket/Queries/requests/queriesConfig.ts
@@ -3,6 +3,7 @@ import * as R from 'ramda'
 import * as quiltConfigs from 'constants/quiltConfigs'
 import * as errors from 'containers/Bucket/errors'
 import * as requests from 'containers/Bucket/requests'
+import { useBucketContext } from 'containers/Bucket/context'
 import * as AWS from 'utils/AWS'
 import { useData } from 'utils/Data'
 import * as YAML from 'utils/yaml'
@@ -65,6 +66,7 @@ export const queriesConfig = async ({
 }
 
 export function useQueriesConfig(bucket: string): AsyncData<Query[]> {
-  const s3 = AWS.S3.use()
+  const { config } = useBucketContext()
+  const s3 = AWS.S3.use(config)
   return useData(queriesConfig, { s3, bucket })
 }

--- a/catalog/app/containers/Bucket/Queries/requests/query.ts
+++ b/catalog/app/containers/Bucket/Queries/requests/query.ts
@@ -1,5 +1,6 @@
 import * as errors from 'containers/Bucket/errors'
 import * as requests from 'containers/Bucket/requests'
+import { useBucketContext } from 'containers/Bucket/context'
 import * as AWS from 'utils/AWS'
 import { useData } from 'utils/Data'
 import * as s3paths from 'utils/s3paths'
@@ -41,6 +42,7 @@ export const query = async ({ s3, queryUrl }: QueryArgs): Promise<ElasticSearchQ
 }
 
 export function useQuery(queryUrl: string): AsyncData<ElasticSearchQuery> {
-  const s3 = AWS.S3.use()
+  const { config } = useBucketContext()
+  const s3 = AWS.S3.use(config)
   return useData(query, { s3, queryUrl }, { noAutoFetch: !queryUrl })
 }

--- a/catalog/app/containers/Bucket/Routes.ts
+++ b/catalog/app/containers/Bucket/Routes.ts
@@ -1,10 +1,10 @@
 import * as Eff from 'effect'
 import { Schema as S } from 'effect'
 import invariant from 'invariant'
-import { useParams } from 'react-router-dom'
 
 import * as routes from 'constants/routes'
 import * as Nav from 'utils/Navigation'
+import { useBucketContext } from './context'
 
 export interface RouteMap {
   bucketDir: routes.BucketDirArgs
@@ -23,8 +23,7 @@ export interface RouteMap {
 }
 
 export function useBucketSafe() {
-  const { bucket } = useParams<{ bucket?: string }>()
-  return bucket
+  return useBucketContext().name
 }
 
 export function useBucketStrict() {

--- a/catalog/app/containers/Bucket/Successors.tsx
+++ b/catalog/app/containers/Bucket/Successors.tsx
@@ -11,6 +11,7 @@ import { useData } from 'utils/Data'
 import StyledLink from 'utils/StyledLink'
 import * as workflows from 'utils/workflows'
 
+import { useBucketContext } from './context'
 import * as ERRORS from './errors'
 import * as requests from './requests'
 
@@ -85,7 +86,8 @@ function useSuccessors(
   bucket: string,
   { strict = false, noAutoFetch = false }: { strict?: boolean; noAutoFetch?: boolean },
 ): workflows.Successor[] | Error | undefined {
-  const s3 = AWS.S3.use()
+  const { config } = useBucketContext()
+  const s3 = AWS.S3.use(config)
   const data = useData(requests.workflowsConfig, { s3, bucket, strict }, { noAutoFetch })
   return React.useMemo(
     () =>

--- a/catalog/app/containers/Bucket/Summarize.tsx
+++ b/catalog/app/containers/Bucket/Summarize.tsx
@@ -29,6 +29,7 @@ import * as s3paths from 'utils/s3paths'
 
 import * as requests from './requests'
 import * as errors from './errors'
+import { useBucketContext } from './context'
 
 interface S3Handle extends LogicalKeyResolver.S3SummarizeHandle {
   error?: errors.BucketError
@@ -645,7 +646,8 @@ interface SummaryNestedProps {
 }
 
 export function SummaryNested({ handle, mkUrl, packageHandle }: SummaryNestedProps) {
-  const s3 = AWS.S3.use()
+  const { config } = useBucketContext()
+  const s3 = AWS.S3.use(config)
   const resolveLogicalKey = LogicalKeyResolver.use()
   const data = useData(requests.summarize, { s3, handle, resolveLogicalKey })
   return data.case({

--- a/catalog/app/containers/Bucket/Toolbar/DeleteDialog.tsx
+++ b/catalog/app/containers/Bucket/Toolbar/DeleteDialog.tsx
@@ -9,6 +9,8 @@ import * as Model from 'model'
 import * as AWS from 'utils/AWS'
 import Log from 'utils/Logging'
 
+import { useBucketContext } from '../context'
+
 const useDeleteDialogStyles = M.makeStyles({
   deleted: {
     textDecoration: 'line-through',
@@ -54,7 +56,8 @@ export default function DeleteDialog({ close, handles }: DeleteDialogProps) {
     [resolvedObjects],
   )
 
-  const s3 = AWS.S3.use()
+  const { config } = useBucketContext()
+  const s3 = AWS.S3.use(config)
   const getFiles = useFilesListing()
 
   React.useEffect(() => {

--- a/catalog/app/containers/Bucket/Workflows/index.tsx
+++ b/catalog/app/containers/Bucket/Workflows/index.tsx
@@ -1,4 +1,3 @@
-import invariant from 'invariant'
 import * as React from 'react'
 import * as RR from 'react-router-dom'
 import * as M from '@material-ui/core'
@@ -12,6 +11,7 @@ import * as Workflows from 'utils/workflows'
 
 import { displayError } from '../errors'
 import * as requests from '../requests'
+import { useBucketContext } from '../context'
 
 import Detail from './Detail'
 import * as Layout from './Layout'
@@ -91,10 +91,11 @@ function WorkflowsInner({ config, bucket, slug }: WorkflowsInnerProps) {
 }
 
 export default function WorkflowsRoot() {
-  const { bucket, slug } = RR.useParams<{ bucket: string; slug?: string }>()
-  invariant(!!bucket, '`bucket` must be defined')
+  const { name: bucket } = useBucketContext()
+  const { slug } = RR.useParams<{ slug?: string }>()
 
-  const s3 = AWS.S3.use()
+  const { config: bucketConfig } = useBucketContext()
+  const s3 = AWS.S3.use(bucketConfig)
   const data = useData(requests.workflowsConfig, { s3, bucket })
 
   const title = React.useMemo(() => {

--- a/catalog/app/containers/Bucket/context.spec.tsx
+++ b/catalog/app/containers/Bucket/context.spec.tsx
@@ -1,0 +1,39 @@
+import * as React from 'react'
+import { renderHook } from '@testing-library/react-hooks'
+import { MemoryRouter, Route } from 'react-router-dom'
+import { describe, expect, it } from 'vitest'
+
+import { BucketContextProvider, useBucketContext } from './context'
+
+describe('containers/Bucket/context', () => {
+  it('resolves bucket name from the route', () => {
+    const wrapper = ({ children }: React.PropsWithChildren<{}>) => (
+      <MemoryRouter initialEntries={['/b/test-bucket']}>
+        <Route path="/b/:bucket">
+          <BucketContextProvider>{children}</BucketContextProvider>
+        </Route>
+      </MemoryRouter>
+    )
+
+    const { result } = renderHook(() => useBucketContext(), { wrapper })
+
+    expect(result.current).toStrictEqual({ name: 'test-bucket', config: {} })
+  })
+
+  it('uses explicit bucket config when provided', () => {
+    const wrapper = ({ children }: React.PropsWithChildren<{}>) => (
+      <MemoryRouter>
+        <BucketContextProvider bucket="test-bucket" config={{ region: 'us-west-2' }}>
+          {children}
+        </BucketContextProvider>
+      </MemoryRouter>
+    )
+
+    const { result } = renderHook(() => useBucketContext(), { wrapper })
+
+    expect(result.current).toStrictEqual({
+      name: 'test-bucket',
+      config: { region: 'us-west-2' },
+    })
+  })
+})

--- a/catalog/app/containers/Bucket/context.tsx
+++ b/catalog/app/containers/Bucket/context.tsx
@@ -19,9 +19,11 @@ interface BucketContextProviderProps {
 
 const Context = React.createContext<BucketContextValue | undefined>(undefined)
 
+const EMPTY_CONFIG: BucketConfig = {}
+
 export function BucketContextProvider({
   bucket: bucketProp,
-  config = {},
+  config = EMPTY_CONFIG,
   children,
 }: BucketContextProviderProps) {
   if (bucketProp) {

--- a/catalog/app/containers/Bucket/context.tsx
+++ b/catalog/app/containers/Bucket/context.tsx
@@ -1,0 +1,69 @@
+import * as React from 'react'
+import invariant from 'invariant'
+import { useParams } from 'react-router-dom'
+
+export interface BucketConfig {
+  region?: string
+}
+
+export interface BucketContextValue {
+  name: string
+  config: BucketConfig
+}
+
+interface BucketContextProviderProps {
+  bucket?: string
+  config?: BucketConfig
+  children: React.ReactNode
+}
+
+const Context = React.createContext<BucketContextValue | undefined>(undefined)
+
+export function BucketContextProvider({
+  bucket: bucketProp,
+  config = {},
+  children,
+}: BucketContextProviderProps) {
+  if (bucketProp) {
+    return (
+      <BucketContextValueProvider name={bucketProp} config={config}>
+        {children}
+      </BucketContextValueProvider>
+    )
+  }
+
+  return (
+    <BucketRouteContextProvider config={config}>{children}</BucketRouteContextProvider>
+  )
+}
+
+function BucketRouteContextProvider({
+  config,
+  children,
+}: Required<Pick<BucketContextProviderProps, 'config' | 'children'>>) {
+  const { bucket: routeBucket } = useParams<{ bucket?: string }>()
+  invariant(!!routeBucket, '`bucket` must be defined')
+
+  return (
+    <BucketContextValueProvider name={routeBucket} config={config}>
+      {children}
+    </BucketContextValueProvider>
+  )
+}
+
+function BucketContextValueProvider({
+  name,
+  config,
+  children,
+}: BucketContextValue & { children: React.ReactNode }) {
+  const value = React.useMemo(() => ({ name, config }), [name, config])
+
+  return <Context.Provider value={value}>{children}</Context.Provider>
+}
+
+export function useBucketContext() {
+  const context = React.useContext(Context)
+  if (!context)
+    throw new Error('useBucketContext must be used inside BucketContextProvider')
+  return context
+}

--- a/catalog/app/containers/Bucket/requests/bucketListing.ts
+++ b/catalog/app/containers/Bucket/requests/bucketListing.ts
@@ -9,6 +9,7 @@ import type * as Model from 'model'
 import * as AWS from 'utils/AWS'
 import * as s3paths from 'utils/s3paths'
 
+import { useBucketContext } from '../context'
 import * as errors from '../errors'
 
 import { decodeS3Key } from './utils'
@@ -145,7 +146,8 @@ export const bucketListing = async ({
     .catch(errors.catchErrors())
 
 export function useBucketListing() {
-  const s3: S3 = AWS.S3.use()
+  const { config } = useBucketContext()
+  const s3: S3 = AWS.S3.use(config)
   return React.useCallback(
     (params: BucketListingParams) => bucketListing({ s3, ...params }),
     [s3],
@@ -154,7 +156,8 @@ export function useBucketListing() {
 
 // TODO: add entry with size from <Listing /> but try to re-use existing types
 function useHeadFile() {
-  const s3: S3 = AWS.S3.use()
+  const { config } = useBucketContext()
+  const s3: S3 = AWS.S3.use(config)
   return React.useCallback(
     async ({
       bucket,

--- a/catalog/app/utils/AWS/S3.jsx
+++ b/catalog/app/utils/AWS/S3.jsx
@@ -126,10 +126,15 @@ export const Provider = function S3Provider({ children, ...overrides }) {
     { ...awsCfg, ...DEFAULT_OPTS, ...overrides },
     (opts) => {
       const clients = {}
-      return (region) => {
-        const r = region || opts.region
+      return (bucketConfig) => {
+        const r =
+          typeof bucketConfig === 'string'
+            ? bucketConfig
+            : bucketConfig?.region || opts.region
         if (!clients[r]) {
-          clients[r] = new SmartS3({ ...opts, region: r })
+          const configOverrides =
+            typeof bucketConfig === 'string' ? {} : bucketConfig || {}
+          clients[r] = new SmartS3({ ...opts, ...configOverrides, region: r })
         }
         return clients[r]
       }
@@ -141,9 +146,9 @@ export const Provider = function S3Provider({ children, ...overrides }) {
 
 // Returns an S3 client for the default region (cfg.region).
 // Use useS3Factory() when you need a client for a specific bucket region.
-export function useS3() {
+export function useS3(bucketConfig) {
   const factory = useS3Factory()
-  return factory()
+  return factory(bucketConfig)
 }
 
 // Returns a factory (region?) => S3Client that caches clients per region.


### PR DESCRIPTION
## Current pain
Bucket-route components repeatedly read `useParams().bucket`, and S3 clients are created without a single bucket-config-aware path. That makes region/presign behavior easy to drift as more bucket-specific configuration is introduced.

## Changes
- Add `BucketContextProvider` and `useBucketContext()` for the bucket route subtree.
- Mount the provider at `containers/Bucket/Bucket.tsx`, reusing existing bucket existence/cache plumbing without adding a fetch.
- Replace direct bucket param reads under `containers/Bucket/*` with `useBucketContext()` where they read the route bucket.
- Extend the existing `useS3Factory()` / `useS3()` path to accept bucket config and preserve the old region-string/default behavior.
- Route bucket read-site S3 consumers through `useBucketContext().config`.
- Add hook/provider tests and update direct hook tests to mount the provider.

## Bucket context inventory
Direct bucket route reads were replaced in overview, dir/file, package tree/revisions/compare, queries, workflows, and package-dialog/file-picker paths. `Bucket.tsx` remains the route owner and provider mount point.

## S3 construction inventory
No separate S3 factory was added. Existing `utils/AWS/S3.jsx` remains the construction point; bucket subtree `AWS.S3.use()` call sites now pass bucket context config.

## Verification
- `npm run lint`
- `npm run test:only -- app/containers/Bucket/context.spec.tsx app/containers/Bucket/Queries/Athena/model/state.spec.tsx app/containers/Bucket/PackageDialog/State/schema.spec.ts app/containers/Bucket/PackageDialog/State/params.spec.ts app/containers/Bucket/Dir/Toolbar/CreatePackage/useSuccessors.spec.ts --no-cache` — 37 passed
- `NODE_OPTIONS="--localstorage-file=/tmp/quilt-catalog-vitest-localstorage.json" npm test` currently fails in unrelated suites under Node 26/npm 11:
  - `app/utils/spreadsheets/spreadsheets.spec.ts`: date expectations off by one day for ODS/FODS/CSV cases
  - `app/containers/Bucket/Queries/Athena/model/requests.spec.ts`: two `useQueryRun` async timing tests time out

## Pre-merge stack verification
Not run yet. Before merge: workflow-dispatch an interim catalog image for this branch, pin the immutable tag on the shared test stack, and record the test-stack URL/image tag here.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR centralizes bucket route reads into a `BucketContextProvider` / `useBucketContext()` hook pair, replacing scattered `useParams().bucket` calls across the bucket subtree and routing all S3 client construction through a bucket-config-aware `useS3(bucketConfig)` path.

- **New context module** (`context.tsx`): introduces `BucketContextProvider` (auto-reads `:bucket` from route params or accepts explicit `bucket` + `config` props) and `useBucketContext()` consumed by ~20 files previously doing direct `useParams` reads.
- **S3 factory extension** (`S3.jsx`): `useS3` / the internal factory now accept a `BucketConfig` object (or legacy region string) so that bucket-specific region is forwarded to the cached client; backward-compatible with callers that pass nothing.
- **Double-provider in `Bucket.tsx`**: an outer route-based provider lets `BucketInner` call `useBucketStrict()`, while a separate inner provider (mounted after `useBucketExistence` resolves) supplies the cached region config to the actual page components.

<h3>Confidence Score: 4/5</h3>

The refactor is mechanically correct and well-tested; the two-provider nesting in Bucket.tsx is a design choice that works today but leaves a latent trap for future components added in the wrong layer.

The migration is broad (30+ files) but each change is a straightforward substitution. The main fragility is that `config = {}` in `BucketContextProvider` creates a new object reference on every render, defeating the `useMemo` in `BucketContextValueProvider` and causing unnecessary context re-renders for all consumers of the outer provider. The double-provider pattern is functional but requires contributors to understand which layer they're adding code to.

catalog/app/containers/Bucket/context.tsx (config default stability) and catalog/app/containers/Bucket/Bucket.tsx (two-layer provider structure).

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| catalog/app/containers/Bucket/context.tsx | New file: implements BucketContextProvider and useBucketContext; the `config = {}` default creates an unstable object reference on each render, defeating the useMemo inside BucketContextValueProvider. |
| catalog/app/containers/Bucket/Bucket.tsx | Mounts two nested BucketContextProviders: an outer one (no config) for BucketInner and an inner region-aware one inside BucketReady; components between the two layers silently get the empty-config provider. |
| catalog/app/utils/AWS/S3.jsx | Extended useS3/useS3Factory to accept bucketConfig (string | object | undefined) with backward-compatible string-region path; cache key is still region only, which is correct given the current BucketConfig shape. JSDoc comment not updated. |
| catalog/app/containers/Bucket/Routes.ts | useBucketSafe now delegates to useBucketContext().name instead of useParams; contract changes from returning undefined to throwing if used outside the provider, but the only call site is useBucketStrict which re-validated anyway. |
| catalog/app/containers/Bucket/context.spec.tsx | New test file covering route-based and explicit-prop provider paths; covers the happy paths but lacks a test for the useBucketContext error when no provider is present. |
| catalog/app/containers/Bucket/Queries/Athena/model/state.tsx | Replaces direct useParams bucket read with useBucketContext; removes invariant that is now enforced by the provider. |
| catalog/app/containers/Bucket/Dir.tsx | Replaced useParams bucket read with useBucketContext and passes bucket config to AWS.S3.use(); straightforward migration. |

</details>



<!-- greptile_failed_comments -->
<details open><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `catalog/app/utils/AWS/S3.jsx`, line 154-156 ([link](https://github.com/quiltdata/quilt/blob/c87027dd5f0f213b95b0d9a653556112bfbed806/catalog/app/utils/AWS/S3.jsx#L154-L156)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> The JSDoc comment for `useS3Factory` still documents the old `(region?) => S3Client` signature. The factory returned now accepts a `bucketConfig` argument that can be a region string, a `BucketConfig` object, or `undefined`, so the comment should be updated to avoid misleading callers who consult it.

</details>

<!-- /greptile_failed_comments -->

<sub>Reviews (1): Last reviewed commit: ["refactor(catalog): add bucket context an..."](https://github.com/quiltdata/quilt/commit/c87027dd5f0f213b95b0d9a653556112bfbed806) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=34299174)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->