### PR TITLE
Bump nginx in s3-proxy from 1.24.0 to 1.30.2

### DIFF
--- a/s3-proxy/Dockerfile
+++ b/s3-proxy/Dockerfile
@@ -8,7 +8,7 @@ MAINTAINER Quilt Data, Inc. support@quilt.bio
 
 EXPOSE 80
 
-ENV NGINX_VERSION=1.24.0
+ENV NGINX_VERSION=1.30.2
 
 # Download and compile Nginx.
 # Dependencies:


### PR DESCRIPTION
# Description

Bumps the nginx version compiled into the `s3-proxy` image from 1.24.0 to 1.30.2 (current stable).

A customer's container scanner flagged nginx 1.24.0 as a known security risk and required at least 1.25.2; this moves to the latest stable release rather than the bare minimum so we get a longer runway before the next bump.

The image still builds from `amazonlinux:2023` and statically links the [`quiltdata/mod_zip`](https://github.com/quiltdata/mod_zip) fork (SHA `979314cc`), which compiles cleanly against 1.30.x — verified by a local `docker build` followed by `nginx -V` (all `--with-*` modules and the `mod_zip` add-on intact, configure args unchanged).

# TODO

- [x] Security: Confirm that this change meets security best practices and does not violate the security model

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR bumps the nginx version in `s3-proxy/Dockerfile` from 1.24.0 to 1.30.2 (current stable), addressing a customer container-scanner finding that flagged 1.24.0 as a known security risk. All configure flags, the `mod_zip` add-on SHA, and the `amazonlinux:2023` base image remain unchanged.

- **Version bump only**: The single changed line is `ENV NGINX_VERSION=1.30.2`; the build process, compile flags, security hardening options (`-fstack-protector-strong`, `_FORTIFY_SOURCE=2`, RELRO/NOW), and mod_zip module are all identical to the previous build.
- **Local verification confirmed**: The PR author ran a local `docker build` and checked `nginx -V` to confirm the configure args and mod_zip add-on compiled cleanly against 1.30.x.

<h3>Confidence Score: 5/5</h3>

Safe to merge — the change is a one-line nginx version bump with no alterations to the build process, configure flags, or module SHAs.

The change is a single version string update that the author already validated locally with a full docker build and nginx -V check. The build hardening flags, mod_zip SHA, and base image are untouched. No logic, configuration, or dependency structure was altered.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| s3-proxy/Dockerfile | Single-line nginx version bump from 1.24.0 to 1.30.2; build process, configure flags, and mod_zip SHA are unchanged |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A["FROM amazonlinux:2023"] --> B["dnf upgrade + install deps\n(gcc, make, openssl-devel, pcre-devel, zlib-devel...)"]
    B --> C["Download nginx-1.30.2.tar.gz\nhttp://nginx.org/download/"]
    B --> D["Download quiltdata/mod_zip\n@ SHA 979314cc (GitHub API, HTTPS)"]
    C --> E["./configure\n(--with-http_ssl_module, --with-http_v2_module,\n mod_zip add-on, security cc/ld opts)"]
    D --> E
    E --> F["make install → /usr/sbin/nginx"]
    F --> G["Strip build deps\ndnf remove gcc make *-devel"]
    G --> H["Create nginx system user\nuseradd --system --no-create-home"]
    H --> I["Copy nginx.conf.tmpl + run-nginx.sh"]
    I --> J["STOPSIGNAL SIGQUIT\nCMD exec /root/run-nginx.sh"]
```

<sub>Reviews (1): Last reviewed commit: ["Bump nginx in s3-proxy from 1.24.0 to 1...."](https://github.com/quiltdata/quilt/commit/d05ef024df86a533dcacee7a7ede1adf4b3808e3) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=34523489)</sub>

<!-- /greptile_comment -->