### PR TITLE
py-shared: retarget QueryMaker to per-bucket Iceberg tables

### DIFF
--- a/py-shared/CHANGELOG.md
+++ b/py-shared/CHANGELOG.md
@@ -17,6 +17,7 @@ where verb is one of
 
 ## Changes
 
+- [Changed] `QueryMaker` retargeted to per-bucket Iceberg tables (`{bucket}_{table}`): the `bucket` column is dropped from `SELECT`/`ON`/`INSERT`/`WHERE` across `*_add_single` / `*_add_bucket` / `*_delete_single`; the `{bucket}_manifests` / `{bucket}_packages` source reads are unchanged. The now-dead `*_delete_bucket` methods are removed (whole-bucket teardown is `DROP TABLE` on the registry side). Part of the per-bucket Iceberg pivot across **quilt/iceberg-per-bucket-lambdas**, **enterprise#1071**, **deployment#2436**, **tabulator#133**, **enterprise#1075** ([#4930](https://github.com/quiltdata/quilt/pull/4930))
 - [Added] Add CRC64NVME checksum type support ([#4623](https://github.com/quiltdata/quilt/pull/4623))
 - [Added] Add utilities for Athena/Iceberg ([#4570](https://github.com/quiltdata/quilt/pull/4570))
 - [Added] Add various utilities for ES ingest ([#4433](https://github.com/quiltdata/quilt/pull/4433))

--- a/py-shared/CHANGELOG.md
+++ b/py-shared/CHANGELOG.md
@@ -17,7 +17,7 @@ where verb is one of
 
 ## Changes
 
-- [Changed] **BREAKING**: `QueryMaker` retargeted to per-bucket Iceberg tables (`{bucket}_{table}`): the `bucket` column is dropped from `SELECT`/`ON`/`INSERT`/`WHERE` across `*_add_single` / `*_add_bucket` / `*_delete_single`; the `{bucket}_manifests` / `{bucket}_packages` source reads are unchanged. The now-dead `*_delete_bucket` methods are removed (whole-bucket teardown is `DROP TABLE` on the registry side). Part of the per-bucket Iceberg pivot across **quilt/iceberg-per-bucket-lambdas**, **enterprise#1071**, **deployment#2436**, **tabulator#133**, **enterprise#1075** ([#4930](https://github.com/quiltdata/quilt/pull/4930))
+- [Changed] **BREAKING**: Retarget `QueryMaker` to per-bucket Iceberg tables (`{bucket}_{table}`) ([#4930](https://github.com/quiltdata/quilt/pull/4930))
 - [Added] Add CRC64NVME checksum type support ([#4623](https://github.com/quiltdata/quilt/pull/4623))
 - [Added] Add utilities for Athena/Iceberg ([#4570](https://github.com/quiltdata/quilt/pull/4570))
 - [Added] Add various utilities for ES ingest ([#4433](https://github.com/quiltdata/quilt/pull/4433))

--- a/py-shared/CHANGELOG.md
+++ b/py-shared/CHANGELOG.md
@@ -17,7 +17,7 @@ where verb is one of
 
 ## Changes
 
-- [Changed] `QueryMaker` retargeted to per-bucket Iceberg tables (`{bucket}_{table}`): the `bucket` column is dropped from `SELECT`/`ON`/`INSERT`/`WHERE` across `*_add_single` / `*_add_bucket` / `*_delete_single`; the `{bucket}_manifests` / `{bucket}_packages` source reads are unchanged. The now-dead `*_delete_bucket` methods are removed (whole-bucket teardown is `DROP TABLE` on the registry side). Part of the per-bucket Iceberg pivot across **quilt/iceberg-per-bucket-lambdas**, **enterprise#1071**, **deployment#2436**, **tabulator#133**, **enterprise#1075** ([#4930](https://github.com/quiltdata/quilt/pull/4930))
+- [Changed] **BREAKING**: `QueryMaker` retargeted to per-bucket Iceberg tables (`{bucket}_{table}`): the `bucket` column is dropped from `SELECT`/`ON`/`INSERT`/`WHERE` across `*_add_single` / `*_add_bucket` / `*_delete_single`; the `{bucket}_manifests` / `{bucket}_packages` source reads are unchanged. The now-dead `*_delete_bucket` methods are removed (whole-bucket teardown is `DROP TABLE` on the registry side). Part of the per-bucket Iceberg pivot across **quilt/iceberg-per-bucket-lambdas**, **enterprise#1071**, **deployment#2436**, **tabulator#133**, **enterprise#1075** ([#4930](https://github.com/quiltdata/quilt/pull/4930))
 - [Added] Add CRC64NVME checksum type support ([#4623](https://github.com/quiltdata/quilt/pull/4623))
 - [Added] Add utilities for Athena/Iceberg ([#4570](https://github.com/quiltdata/quilt/pull/4570))
 - [Added] Add various utilities for ES ingest ([#4433](https://github.com/quiltdata/quilt/pull/4433))

--- a/py-shared/src/quilt_shared/iceberg_queries.py
+++ b/py-shared/src/quilt_shared/iceberg_queries.py
@@ -7,112 +7,101 @@ class QueryMaker:
     def __init__(self, *, user_athena_db: str):
         self.user_athena_db = user_athena_db
 
+    @staticmethod
+    def _table(bucket: str, table: str) -> str:
+        # Per-bucket table name in IcebergDatabase. Raw bucket name (no
+        # sanitization), quoted at the call site.
+        return f"{bucket}_{table}"
+
     def package_revision_add_bucket(self, *, bucket: str) -> str:
         return f"""
-        MERGE INTO package_revision AS t
+        MERGE INTO "{self._table(bucket, "package_revision")}" AS t
         USING (
             SELECT
-                '{bucket}' AS bucket,
                 regexp_extract("$path", '^s3://[^/]+/[^/]+/[^/]+/([^/]+/[^/]+)', 1) AS pkg_name,
                 from_unixtime(CAST(regexp_extract("$path", '[^/]+$') AS bigint)) AS timestamp,
                 top_hash
             FROM "{self.user_athena_db}"."{bucket}_packages"
             WHERE TRY_CAST(regexp_extract("$path", '[^/]+$') AS bigint) IS NOT NULL
         ) AS s
-        ON t.bucket = s.bucket AND t.pkg_name = s.pkg_name AND t.timestamp = s.timestamp
+        ON t.pkg_name = s.pkg_name AND t.timestamp = s.timestamp
         WHEN MATCHED THEN
             UPDATE SET top_hash = s.top_hash
         WHEN NOT MATCHED THEN
-            INSERT (bucket, pkg_name, timestamp, top_hash)
-            VALUES (s.bucket, s.pkg_name, s.timestamp, s.top_hash)
+            INSERT (pkg_name, timestamp, top_hash)
+            VALUES (s.pkg_name, s.timestamp, s.top_hash)
         """
 
     def package_revision_add_single(self, *, bucket: str, pkg_name: str, pointer: str, top_hash: str) -> str:
         return f"""
-        MERGE INTO package_revision AS t
+        MERGE INTO "{self._table(bucket, "package_revision")}" AS t
         USING (
             SELECT
-                '{bucket}' AS bucket,
                 '{pkg_name}' AS pkg_name,
                 from_unixtime({pointer}) AS timestamp,
                 '{top_hash}' AS top_hash
         ) AS s
-        ON t.bucket = s.bucket AND t.pkg_name = s.pkg_name AND t.timestamp = s.timestamp
+        ON t.pkg_name = s.pkg_name AND t.timestamp = s.timestamp
         WHEN MATCHED THEN
             UPDATE SET top_hash = s.top_hash
         WHEN NOT MATCHED THEN
-            INSERT (bucket, pkg_name, timestamp, top_hash)
-            VALUES (s.bucket, s.pkg_name, s.timestamp, s.top_hash)
-        """
-
-    def package_revision_delete_bucket(self, *, bucket: str) -> str:
-        return f"""
-        DELETE FROM package_revision
-        WHERE bucket = '{bucket}'
+            INSERT (pkg_name, timestamp, top_hash)
+            VALUES (s.pkg_name, s.timestamp, s.top_hash)
         """
 
     def package_revision_delete_single(self, *, bucket: str, pkg_name: str, pointer: str) -> str:
         return f"""
-        DELETE FROM package_revision
-        WHERE bucket = '{bucket}' AND pkg_name = '{pkg_name}' AND timestamp = from_unixtime({pointer})
+        DELETE FROM "{self._table(bucket, "package_revision")}"
+        WHERE pkg_name = '{pkg_name}' AND timestamp = from_unixtime({pointer})
         """
 
     def package_tag_add_bucket(self, *, bucket: str) -> str:
         return f"""
-        MERGE INTO package_tag AS t
+        MERGE INTO "{self._table(bucket, "package_tag")}" AS t
         USING (
             SELECT
-                '{bucket}' AS bucket,
                 regexp_extract("$path", '^s3://[^/]+/[^/]+/[^/]+/([^/]+/[^/]+)', 1) AS pkg_name,
                 regexp_extract("$path", '[^/]+$') AS tag_name,
                 top_hash
             FROM "{self.user_athena_db}"."{bucket}_packages"
             WHERE TRY_CAST(regexp_extract("$path", '[^/]+$') AS bigint) IS NULL
         ) AS s
-        ON t.bucket = s.bucket AND t.pkg_name = s.pkg_name AND t.tag_name = s.tag_name
+        ON t.pkg_name = s.pkg_name AND t.tag_name = s.tag_name
         WHEN MATCHED THEN
             UPDATE SET top_hash = s.top_hash
         WHEN NOT MATCHED THEN
-            INSERT (bucket, pkg_name, tag_name, top_hash)
-            VALUES (s.bucket, s.pkg_name, s.tag_name, s.top_hash)
+            INSERT (pkg_name, tag_name, top_hash)
+            VALUES (s.pkg_name, s.tag_name, s.top_hash)
         """
 
     def package_tag_add_single(self, *, bucket: str, pkg_name: str, pointer: str, top_hash: str) -> str:
         return f"""
-        MERGE INTO package_tag AS t
+        MERGE INTO "{self._table(bucket, "package_tag")}" AS t
         USING (
             SELECT
-                '{bucket}' AS bucket,
                 '{pkg_name}' AS pkg_name,
                 '{pointer}' AS tag_name,
                 '{top_hash}' AS top_hash
         ) AS s
-        ON t.bucket = s.bucket AND t.pkg_name = s.pkg_name AND t.tag_name = s.tag_name
+        ON t.pkg_name = s.pkg_name AND t.tag_name = s.tag_name
         WHEN MATCHED THEN
             UPDATE SET top_hash = s.top_hash
         WHEN NOT MATCHED THEN
-            INSERT (bucket, pkg_name, tag_name, top_hash)
-            VALUES (s.bucket, s.pkg_name, s.tag_name, s.top_hash)
-        """
-
-    def package_tag_delete_bucket(self, *, bucket: str) -> str:
-        return f"""
-        DELETE FROM package_tag
-        WHERE bucket = '{bucket}'
+            INSERT (pkg_name, tag_name, top_hash)
+            VALUES (s.pkg_name, s.tag_name, s.top_hash)
         """
 
     def package_tag_delete_single(self, *, bucket: str, pkg_name: str, pointer: str) -> str:
         return f"""
-        DELETE FROM package_tag
-        WHERE bucket = '{bucket}' AND pkg_name = '{pkg_name}' AND tag_name = '{pointer}'
+        DELETE FROM "{self._table(bucket, "package_tag")}"
+        WHERE pkg_name = '{pkg_name}' AND tag_name = '{pointer}'
         """
 
     def package_manifest_add_bucket(self, *, bucket: str) -> str:
         return f"""
-        MERGE INTO package_manifest AS t
+        MERGE INTO "{self._table(bucket, "package_manifest")}" AS t
         USING (
             SELECT
-                '{bucket}' AS bucket,
                 regexp_extract("$path", '[^/]+$') AS top_hash,
                 message,
                 user_meta AS metadata
@@ -121,20 +110,19 @@ class QueryMaker:
                 -- filter out bogus manifests i.e. parquet files
                 AND regexp_like("$path", '/[a-z0-9]{{64}}$')
         ) AS s
-        ON t.bucket = s.bucket AND t.top_hash = s.top_hash
+        ON t.top_hash = s.top_hash
         WHEN MATCHED THEN
             UPDATE SET message = s.message, metadata = s.metadata
         WHEN NOT MATCHED THEN
-            INSERT (bucket, top_hash, message, metadata)
-            VALUES (s.bucket, s.top_hash, s.message, s.metadata)
+            INSERT (top_hash, message, metadata)
+            VALUES (s.top_hash, s.message, s.metadata)
         """
 
     def package_manifest_add_single(self, *, bucket: str, top_hash: str) -> str:
         return f"""
-        MERGE INTO package_manifest AS t
+        MERGE INTO "{self._table(bucket, "package_manifest")}" AS t
         USING (
             SELECT
-                '{bucket}' AS bucket,
                 regexp_extract("$path", '[^/]+$') AS top_hash,
                 message,
                 user_meta AS metadata
@@ -142,32 +130,25 @@ class QueryMaker:
             WHERE logical_key IS NULL
                 AND "$path" = 's3://{bucket}/{const.MANIFESTS_PREFIX}{top_hash}'
         ) AS s
-        ON t.bucket = s.bucket AND t.top_hash = s.top_hash
+        ON t.top_hash = s.top_hash
         WHEN MATCHED THEN
             UPDATE SET message = s.message, metadata = s.metadata
         WHEN NOT MATCHED THEN
-            INSERT (bucket, top_hash, message, metadata)
-            VALUES (s.bucket, s.top_hash, s.message, s.metadata)
-        """
-
-    def package_manifest_delete_bucket(self, *, bucket: str) -> str:
-        return f"""
-        DELETE FROM package_manifest
-        WHERE bucket = '{bucket}'
+            INSERT (top_hash, message, metadata)
+            VALUES (s.top_hash, s.message, s.metadata)
         """
 
     def package_manifest_delete_single(self, *, bucket: str, top_hash: str) -> str:
         return f"""
-        DELETE FROM package_manifest
-        WHERE bucket = '{bucket}' AND top_hash = '{top_hash}'
+        DELETE FROM "{self._table(bucket, "package_manifest")}"
+        WHERE top_hash = '{top_hash}'
         """
 
     def package_entry_add_bucket(self, *, bucket: str) -> str:
         return f"""
-        MERGE INTO package_entry AS t
+        MERGE INTO "{self._table(bucket, "package_entry")}" AS t
         USING (
             SELECT
-                '{bucket}' AS bucket,
                 regexp_extract("$path", '[^/]+$') AS top_hash,
                 logical_key,
                 physical_keys[1] AS physical_key,
@@ -180,22 +161,21 @@ class QueryMaker:
                 -- filter out bogus manifests i.e. parquet files
                 AND regexp_like("$path", '/[a-z0-9]{{64}}$')
         ) AS s
-        ON t.bucket = s.bucket AND t.top_hash = s.top_hash AND t.logical_key = s.logical_key
+        ON t.top_hash = s.top_hash AND t.logical_key = s.logical_key
         WHEN MATCHED THEN
             UPDATE SET physical_key = s.physical_key, hash_type = s.hash_type, hash_value = s.hash_value,
                 size = s.size, metadata = s.metadata
         WHEN NOT MATCHED THEN
-            INSERT (bucket, top_hash, logical_key, physical_key, hash_type, hash_value, size, metadata)
-            VALUES (s.bucket, s.top_hash, s.logical_key,
+            INSERT (top_hash, logical_key, physical_key, hash_type, hash_value, size, metadata)
+            VALUES (s.top_hash, s.logical_key,
                 s.physical_key, s.hash_type, s.hash_value, s.size, s.metadata)
         """
 
     def package_entry_add_single(self, *, bucket: str, top_hash: str) -> str:
         return f"""
-        MERGE INTO package_entry AS t
+        MERGE INTO "{self._table(bucket, "package_entry")}" AS t
         USING (
             SELECT
-                '{bucket}' AS bucket,
                 regexp_extract("$path", '[^/]+$') AS top_hash,
                 logical_key,
                 physical_keys[1] AS physical_key,
@@ -207,24 +187,18 @@ class QueryMaker:
             WHERE logical_key IS NOT NULL
                 AND "$path" = 's3://{bucket}/{const.MANIFESTS_PREFIX}{top_hash}'
         ) AS s
-        ON t.bucket = s.bucket AND t.top_hash = s.top_hash AND t.logical_key = s.logical_key
+        ON t.top_hash = s.top_hash AND t.logical_key = s.logical_key
         WHEN MATCHED THEN
             UPDATE SET physical_key = s.physical_key, hash_type = s.hash_type, hash_value = s.hash_value,
                 size = s.size, metadata = s.metadata
         WHEN NOT MATCHED THEN
-            INSERT (bucket, top_hash, logical_key, physical_key, hash_type, hash_value, size, metadata)
-            VALUES (s.bucket, s.top_hash, s.logical_key,
+            INSERT (top_hash, logical_key, physical_key, hash_type, hash_value, size, metadata)
+            VALUES (s.top_hash, s.logical_key,
                 s.physical_key, s.hash_type, s.hash_value, s.size, s.metadata)
-        """
-
-    def package_entry_delete_bucket(self, *, bucket: str) -> str:
-        return f"""
-        DELETE FROM package_entry
-        WHERE bucket = '{bucket}'
         """
 
     def package_entry_delete_single(self, *, bucket: str, top_hash: str) -> str:
         return f"""
-        DELETE FROM package_entry
-        WHERE bucket = '{bucket}' AND top_hash = '{top_hash}'
+        DELETE FROM "{self._table(bucket, "package_entry")}"
+        WHERE top_hash = '{top_hash}'
         """

--- a/py-shared/tests/test_iceberg_queries.py
+++ b/py-shared/tests/test_iceberg_queries.py
@@ -11,30 +11,22 @@ def qm():
 def test_package_revision_add_bucket_smoke(qm):
     sql = qm.package_revision_add_bucket(bucket="bucket1")
     assert isinstance(sql, str)
-    assert "MERGE INTO package_revision" in sql
-    assert "bucket1" in sql
+    assert 'MERGE INTO "bucket1_package_revision"' in sql
 
 
 def test_package_revision_add_single_smoke(qm):
     sql = qm.package_revision_add_single(bucket="bucket1", pkg_name="pkg", pointer="123", top_hash="abc")
     assert isinstance(sql, str)
-    assert "MERGE INTO package_revision" in sql
+    assert 'MERGE INTO "bucket1_package_revision"' in sql
     assert "pkg" in sql
     assert "123" in sql
     assert "abc" in sql
 
 
-def test_package_revision_delete_bucket_smoke(qm):
-    sql = qm.package_revision_delete_bucket(bucket="bucket1")
-    assert isinstance(sql, str)
-    assert "DELETE FROM package_revision" in sql
-    assert "bucket1" in sql
-
-
 def test_package_revision_delete_single_smoke(qm):
     sql = qm.package_revision_delete_single(bucket="bucket1", pkg_name="pkg", pointer="123")
     assert isinstance(sql, str)
-    assert "DELETE FROM package_revision" in sql
+    assert 'DELETE FROM "bucket1_package_revision"' in sql
     assert "pkg" in sql
     assert "123" in sql
 
@@ -42,30 +34,22 @@ def test_package_revision_delete_single_smoke(qm):
 def test_package_tag_add_bucket_smoke(qm):
     sql = qm.package_tag_add_bucket(bucket="bucket1")
     assert isinstance(sql, str)
-    assert "MERGE INTO package_tag" in sql
-    assert "bucket1" in sql
+    assert 'MERGE INTO "bucket1_package_tag"' in sql
 
 
 def test_package_tag_add_single_smoke(qm):
     sql = qm.package_tag_add_single(bucket="bucket1", pkg_name="pkg", pointer="tag", top_hash="abc")
     assert isinstance(sql, str)
-    assert "MERGE INTO package_tag" in sql
+    assert 'MERGE INTO "bucket1_package_tag"' in sql
     assert "pkg" in sql
     assert "tag" in sql
     assert "abc" in sql
 
 
-def test_package_tag_delete_bucket_smoke(qm):
-    sql = qm.package_tag_delete_bucket(bucket="bucket1")
-    assert isinstance(sql, str)
-    assert "DELETE FROM package_tag" in sql
-    assert "bucket1" in sql
-
-
 def test_package_tag_delete_single_smoke(qm):
     sql = qm.package_tag_delete_single(bucket="bucket1", pkg_name="pkg", pointer="tag")
     assert isinstance(sql, str)
-    assert "DELETE FROM package_tag" in sql
+    assert 'DELETE FROM "bucket1_package_tag"' in sql
     assert "pkg" in sql
     assert "tag" in sql
 
@@ -73,56 +57,38 @@ def test_package_tag_delete_single_smoke(qm):
 def test_package_manifest_add_bucket_smoke(qm):
     sql = qm.package_manifest_add_bucket(bucket="bucket1")
     assert isinstance(sql, str)
-    assert "MERGE INTO package_manifest" in sql
-    assert "bucket1" in sql
+    assert 'MERGE INTO "bucket1_package_manifest"' in sql
 
 
 def test_package_manifest_add_single_smoke(qm):
     sql = qm.package_manifest_add_single(bucket="bucket1", top_hash="abc")
     assert isinstance(sql, str)
-    assert "MERGE INTO package_manifest" in sql
-    assert "bucket1" in sql
+    assert 'MERGE INTO "bucket1_package_manifest"' in sql
     assert "abc" in sql
-
-
-def test_package_manifest_delete_bucket_smoke(qm):
-    sql = qm.package_manifest_delete_bucket(bucket="bucket1")
-    assert isinstance(sql, str)
-    assert "DELETE FROM package_manifest" in sql
-    assert "bucket1" in sql
 
 
 def test_package_manifest_delete_single_smoke(qm):
     sql = qm.package_manifest_delete_single(bucket="bucket1", top_hash="abc")
     assert isinstance(sql, str)
-    assert "DELETE FROM package_manifest" in sql
+    assert 'DELETE FROM "bucket1_package_manifest"' in sql
     assert "abc" in sql
 
 
 def test_package_entry_add_bucket_smoke(qm):
     sql = qm.package_entry_add_bucket(bucket="bucket1")
     assert isinstance(sql, str)
-    assert "MERGE INTO package_entry" in sql
-    assert "bucket1" in sql
+    assert 'MERGE INTO "bucket1_package_entry"' in sql
 
 
 def test_package_entry_add_single_smoke(qm):
     sql = qm.package_entry_add_single(bucket="bucket1", top_hash="abc")
     assert isinstance(sql, str)
-    assert "MERGE INTO package_entry" in sql
-    assert "bucket1" in sql
+    assert 'MERGE INTO "bucket1_package_entry"' in sql
     assert "abc" in sql
-
-
-def test_package_entry_delete_bucket_smoke(qm):
-    sql = qm.package_entry_delete_bucket(bucket="bucket1")
-    assert isinstance(sql, str)
-    assert "DELETE FROM package_entry" in sql
-    assert "bucket1" in sql
 
 
 def test_package_entry_delete_single_smoke(qm):
     sql = qm.package_entry_delete_single(bucket="bucket1", top_hash="abc")
     assert isinstance(sql, str)
-    assert "DELETE FROM package_entry" in sql
+    assert 'DELETE FROM "bucket1_package_entry"' in sql
     assert "abc" in sql


### PR DESCRIPTION
### Changes
- `py-shared/src/quilt_shared/iceberg_queries.py` — `QueryMaker` MERGE/DELETE now target `{bucket}_{table}`; the `bucket` column is dropped from SELECT/ON/INSERT/WHERE (the per-bucket table identity carries it). Source reads (`{bucket}_manifests`/`{bucket}_packages`) and the iceberg lambda's routing are unchanged.
- Removed the now-dead `*_delete_bucket` methods (whole-bucket teardown is a `DROP TABLE` on the registry side); `*_delete_single` (used by the lambda) retained.

### Tests
`py-shared/tests/test_iceberg_queries.py` (exercises the local edit) → **12 passed**.

### Why a separate PR
py-shared and the iceberg lambda are pinned/published independently, so they merge separately. The lambda companion is #4931.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR retargets `QueryMaker` from a shared, bucket-column-keyed Iceberg schema to a per-bucket table layout where the table name itself encodes the bucket (e.g., `bucket1_package_revision`). The `bucket` column is removed from all MERGE/DELETE operations, and the four `*_delete_bucket` methods are dropped because whole-bucket teardown is now handled as a `DROP TABLE` on the registry side.

- **`iceberg_queries.py`**: New `_table(bucket, table)` static helper drives per-bucket table naming; all eight MERGE targets and four DELETE targets updated; four `*_delete_bucket` methods removed.
- **`test_iceberg_queries.py`**: Smoke-test assertions tightened to the new quoted identifier pattern (e.g., `'MERGE INTO "bucket1_package_revision"'`); four now-deleted-method tests removed.
- **`CHANGELOG.md`**: Breaking-change entry added with a PR link.

<h3>Confidence Score: 5/5</h3>

Safe to merge; the logic change is internally consistent and all 12 tests pass.

Every MERGE and DELETE target is updated symmetrically to the new per-bucket table scheme, the bucket column is removed consistently from SELECT/ON/INSERT/WHERE, the _table() helper is straightforward, and S3 bucket-name character constraints make the double-quote-wrapped identifier safe. The deleted *_delete_bucket methods are confirmed dead by the PR description. Tests are appropriately tightened to the new naming convention.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| py-shared/src/quilt_shared/iceberg_queries.py | Core change: adds _table() helper to build per-bucket table names and updates all MERGE/DELETE targets accordingly; removes bucket column from SELECT/ON/INSERT/WHERE and drops all *_delete_bucket methods. |
| py-shared/tests/test_iceberg_queries.py | Tests updated to assert the new quoted bucket1_{table} naming convention; four *_delete_bucket smoke tests removed. |
| py-shared/CHANGELOG.md | CHANGELOG entry added correctly marking this as a BREAKING change with a PR link. |

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant Lambda as Iceberg Lambda
    participant QM as QueryMaker
    participant Athena as Athena
    participant IcebergDB as IcebergDB (per-bucket tables)

    Lambda->>QM: "package_revision_add_bucket(bucket="b1")"
    QM-->>Lambda: MERGE INTO "b1_package_revision" ...
    Lambda->>Athena: Execute SQL
    Athena->>IcebergDB: MERGE INTO "b1_package_revision"

    Lambda->>QM: "package_revision_delete_single(bucket="b1", ...)"
    QM-->>Lambda: DELETE FROM "b1_package_revision" WHERE ...
    Lambda->>Athena: Execute SQL
    Athena->>IcebergDB: DELETE FROM "b1_package_revision"

    note over Lambda,IcebergDB: Whole-bucket teardown (DROP TABLE) handled by registry — not QueryMaker
```

<sub>Reviews (3): Last reviewed commit: ["trim cl entry"](https://github.com/quiltdata/quilt/commit/a3183d92cf910e31ada4986d5755ce3bc6e6262e) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=34876817)</sub>

<!-- /greptile_comment -->