### PR TITLE
iceberg lambda: bump quilt-shared to per-bucket QueryMaker

### DIFF
--- a/.github/workflows/deploy-lambdas.yaml
+++ b/.github/workflows/deploy-lambdas.yaml
@@ -1,12 +1,10 @@
 name: Deploy lambdas to S3 and ECR
 
+# TEMP: dev-only build for the iceberg-per-bucket branch — builds the iceberg
+# lambda, prefixes the S3 key with `dev-`, and uploads only to us-east-2 (the
+# stack/pkg-tbl dev stack's region). Revert this commit before merging to master.
 on:
-  push:
-    branches:
-      - master
-    paths:
-      - '.github/workflows/deploy-lambdas.yaml'
-      - 'lambdas/**'
+  workflow_dispatch: {}
 
 jobs:
   deploy-lambda-s3:
@@ -14,16 +12,7 @@ jobs:
       fail-fast: false
       matrix:
         path:
-          - access_counts
-          - es_ingest
           - iceberg
-          - pkgevents
-          - pkgpush
-          - preview
-          - s3hash
-          - status_reports
-          - manifest_indexer
-          - transcode
     runs-on: ubuntu-latest
     # These permissions are needed to interact with GitHub's OIDC Token endpoint.
     permissions:
@@ -47,50 +36,8 @@ jobs:
         uses: aws-actions/configure-aws-credentials@v6
         with:
           role-to-assume: arn:aws:iam::730278974607:role/github/GitHub-Quilt
-          aws-region: us-east-1
-      - name: Upload zips to Prod S3
+          aws-region: us-east-2
+      - name: Upload zip to dev stack region (us-east-2) with dev- prefix
         run: |
-          s3_key="${{ matrix.path }}/${{ github.sha }}.zip"
-          ./lambdas/scripts/upload_zip.sh ./out.zip "$AWS_REGION" "$s3_key"
-      - name: Configure AWS credentials from GovCloud account
-        uses: aws-actions/configure-aws-credentials@v6
-        with:
-          role-to-assume: arn:aws-us-gov:iam::313325871032:role/github/GitHub-Quilt
-          aws-region: us-gov-east-1
-      - name: Upload zips to GovCloud S3
-        run: |
-          s3_key="${{ matrix.path }}/${{ github.sha }}.zip"
-          ./lambdas/scripts/upload_zip.sh ./out.zip "$AWS_REGION" "$s3_key"
-
-  deploy-lambda-ecr:
-    strategy:
-      fail-fast: false
-      matrix:
-        path:
-          - indexer
-          - thumbnail
-          - tabular_preview
-    runs-on: ubuntu-latest
-    # These permissions are needed to interact with GitHub's OIDC Token endpoint.
-    permissions:
-      id-token: write
-      contents: read
-    steps:
-      - uses: actions/checkout@v6
-      - name: Build Docker image
-        working-directory: ./lambdas/${{ matrix.path }}
-        run: docker buildx build -t "quiltdata/lambdas/${{ matrix.path }}:${{ github.sha }}" -f Dockerfile .
-      - name: Configure AWS credentials from Prod account
-        uses: aws-actions/configure-aws-credentials@v6
-        with:
-          role-to-assume: arn:aws:iam::730278974607:role/github/GitHub-Quilt
-          aws-region: us-east-1
-      - name: Push Docker image to Prod ECR
-        run: ./lambdas/scripts/upload_ecr.sh 730278974607 "quiltdata/lambdas/${{ matrix.path }}:${{ github.sha }}"
-      - name: Configure AWS credentials from GovCloud account
-        uses: aws-actions/configure-aws-credentials@v6
-        with:
-          role-to-assume: arn:aws-us-gov:iam::313325871032:role/github/GitHub-Quilt
-          aws-region: us-gov-east-1
-      - name: Push Docker image to GovCloud ECR
-        run: ./lambdas/scripts/upload_ecr.sh 313325871032 "quiltdata/lambdas/${{ matrix.path }}:${{ github.sha }}"
+          s3_key="${{ matrix.path }}/dev-${{ github.sha }}.zip"
+          aws s3 cp --acl public-read ./out.zip "s3://quilt-lambda-us-east-2/$s3_key"

--- a/.github/workflows/deploy-lambdas.yaml
+++ b/.github/workflows/deploy-lambdas.yaml
@@ -1,10 +1,12 @@
 name: Deploy lambdas to S3 and ECR
 
-# TEMP: dev-only build for the iceberg-per-bucket branch — builds the iceberg
-# lambda, prefixes the S3 key with `dev-`, and uploads only to us-east-2 (the
-# stack/pkg-tbl dev stack's region). Revert this commit before merging to master.
 on:
-  workflow_dispatch: {}
+  push:
+    branches:
+      - master
+    paths:
+      - '.github/workflows/deploy-lambdas.yaml'
+      - 'lambdas/**'
 
 jobs:
   deploy-lambda-s3:
@@ -12,7 +14,16 @@ jobs:
       fail-fast: false
       matrix:
         path:
+          - access_counts
+          - es_ingest
           - iceberg
+          - pkgevents
+          - pkgpush
+          - preview
+          - s3hash
+          - status_reports
+          - manifest_indexer
+          - transcode
     runs-on: ubuntu-latest
     # These permissions are needed to interact with GitHub's OIDC Token endpoint.
     permissions:
@@ -36,8 +47,50 @@ jobs:
         uses: aws-actions/configure-aws-credentials@v6
         with:
           role-to-assume: arn:aws:iam::730278974607:role/github/GitHub-Quilt
-          aws-region: us-east-2
-      - name: Upload zip to dev stack region (us-east-2) with dev- prefix
+          aws-region: us-east-1
+      - name: Upload zips to Prod S3
         run: |
-          s3_key="${{ matrix.path }}/dev-${{ github.sha }}.zip"
-          aws s3 cp --acl public-read ./out.zip "s3://quilt-lambda-us-east-2/$s3_key"
+          s3_key="${{ matrix.path }}/${{ github.sha }}.zip"
+          ./lambdas/scripts/upload_zip.sh ./out.zip "$AWS_REGION" "$s3_key"
+      - name: Configure AWS credentials from GovCloud account
+        uses: aws-actions/configure-aws-credentials@v6
+        with:
+          role-to-assume: arn:aws-us-gov:iam::313325871032:role/github/GitHub-Quilt
+          aws-region: us-gov-east-1
+      - name: Upload zips to GovCloud S3
+        run: |
+          s3_key="${{ matrix.path }}/${{ github.sha }}.zip"
+          ./lambdas/scripts/upload_zip.sh ./out.zip "$AWS_REGION" "$s3_key"
+
+  deploy-lambda-ecr:
+    strategy:
+      fail-fast: false
+      matrix:
+        path:
+          - indexer
+          - thumbnail
+          - tabular_preview
+    runs-on: ubuntu-latest
+    # These permissions are needed to interact with GitHub's OIDC Token endpoint.
+    permissions:
+      id-token: write
+      contents: read
+    steps:
+      - uses: actions/checkout@v6
+      - name: Build Docker image
+        working-directory: ./lambdas/${{ matrix.path }}
+        run: docker buildx build -t "quiltdata/lambdas/${{ matrix.path }}:${{ github.sha }}" -f Dockerfile .
+      - name: Configure AWS credentials from Prod account
+        uses: aws-actions/configure-aws-credentials@v6
+        with:
+          role-to-assume: arn:aws:iam::730278974607:role/github/GitHub-Quilt
+          aws-region: us-east-1
+      - name: Push Docker image to Prod ECR
+        run: ./lambdas/scripts/upload_ecr.sh 730278974607 "quiltdata/lambdas/${{ matrix.path }}:${{ github.sha }}"
+      - name: Configure AWS credentials from GovCloud account
+        uses: aws-actions/configure-aws-credentials@v6
+        with:
+          role-to-assume: arn:aws-us-gov:iam::313325871032:role/github/GitHub-Quilt
+          aws-region: us-gov-east-1
+      - name: Push Docker image to GovCloud ECR
+        run: ./lambdas/scripts/upload_ecr.sh 313325871032 "quiltdata/lambdas/${{ matrix.path }}:${{ github.sha }}"

--- a/lambdas/iceberg/CHANGELOG.md
+++ b/lambdas/iceberg/CHANGELOG.md
@@ -17,6 +17,6 @@ where verb is one of
 
 ## Changes
 
-- [Changed] Embed the per-bucket `QueryMaker` (`quilt-shared` re-pinned), so the lambda writes package-index rows to per-bucket `{bucket}_{table}` Iceberg tables. Part of the per-bucket Iceberg pivot across **quilt#4930**, **enterprise#1071**, **deployment#2436**, **tabulator#133** ([#4931](https://github.com/quiltdata/quilt/pull/4931))
+- [Changed] Update `quilt-shared` to pick up the per-bucket `QueryMaker`, so the lambda writes package-index rows to per-bucket `{bucket}_{table}` Iceberg tables. ([#4931](https://github.com/quiltdata/quilt/pull/4931))
 - [Changed] Upgrade to Python 3.13 ([#4656](https://github.com/quiltdata/quilt/pull/4656))
 - [Added] Bootstrap the change log ([#4570](https://github.com/quiltdata/quilt/pull/4570))

--- a/lambdas/iceberg/CHANGELOG.md
+++ b/lambdas/iceberg/CHANGELOG.md
@@ -17,5 +17,6 @@ where verb is one of
 
 ## Changes
 
+- [Changed] Embed the per-bucket `QueryMaker` (`quilt-shared` re-pinned), so the lambda writes package-index rows to per-bucket `{bucket}_{table}` Iceberg tables. Part of the per-bucket Iceberg pivot across **quilt#4930**, **enterprise#1071**, **deployment#2436**, **tabulator#133** ([#4931](https://github.com/quiltdata/quilt/pull/4931))
 - [Changed] Upgrade to Python 3.13 ([#4656](https://github.com/quiltdata/quilt/pull/4656))
 - [Added] Bootstrap the change log ([#4570](https://github.com/quiltdata/quilt/pull/4570))

--- a/lambdas/iceberg/pyproject.toml
+++ b/lambdas/iceberg/pyproject.toml
@@ -27,4 +27,4 @@ test = [
 default-groups = ["test"]
 
 [tool.uv.sources]
-quilt-shared = { url = "https://github.com/quiltdata/quilt/archive/b2adc010ec6ebbe52b852b05d69c436a9b430614.zip", subdirectory = "py-shared" }
+quilt-shared = { url = "https://github.com/quiltdata/quilt/archive/12bb4a331a46b3b4eb0388e81e5f2546cf17e0b4.zip", subdirectory = "py-shared" }

--- a/lambdas/iceberg/pyproject.toml
+++ b/lambdas/iceberg/pyproject.toml
@@ -27,4 +27,4 @@ test = [
 default-groups = ["test"]
 
 [tool.uv.sources]
-quilt-shared = { url = "https://github.com/quiltdata/quilt/archive/f90584485ba84a9d46fe4c7014f858a4b57738bd.zip", subdirectory = "py-shared" }
+quilt-shared = { url = "https://github.com/quiltdata/quilt/archive/b2adc010ec6ebbe52b852b05d69c436a9b430614.zip", subdirectory = "py-shared" }

--- a/lambdas/iceberg/uv.lock
+++ b/lambdas/iceberg/uv.lock
@@ -17,30 +17,6 @@ wheels = [
 ]
 
 [[package]]
-name = "boto3-stubs"
-version = "1.40.52"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "botocore-stubs" },
-    { name = "types-s3transfer" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/00/7b/92a266747a504c09c40a382364e5f041a58acc2959f2920aa9b4ccf5e9db/boto3_stubs-1.40.52.tar.gz", hash = "sha256:bd20a7bc9122bb1b939195431b9d3f540b1ef050103bc1720d786960907464fd", size = 100895, upload-time = "2025-10-14T20:45:42.254Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/43/cf/d08cd0df2639896db574490181c363fc491404607b867a1bf04a623c4a19/boto3_stubs-1.40.52-py3-none-any.whl", hash = "sha256:5e2b74b7b5ad71ca2b8c35a8d3bf1e4ef60317b1682b5e7dda9f16a1c0b43844", size = 69709, upload-time = "2025-10-14T20:45:33.777Z" },
-]
-
-[package.optional-dependencies]
-athena = [
-    { name = "mypy-boto3-athena" },
-]
-s3 = [
-    { name = "mypy-boto3-s3" },
-]
-sts = [
-    { name = "mypy-boto3-sts" },
-]
-
-[[package]]
 name = "botocore"
 version = "1.40.52"
 source = { registry = "https://pypi.org/simple" }
@@ -126,33 +102,6 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/00/2a/e867e8531cf3e36b41201936b7fa7ba7b5702dbef42922193f05c8976cd6/jmespath-1.0.1.tar.gz", hash = "sha256:90261b206d6defd58fdd5e85f478bf633a2901798906be2ad389150c5c60edbe", size = 25843, upload-time = "2022-06-17T18:00:12.224Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/31/b4/b9b800c45527aadd64d5b442f9b932b00648617eb5d63d2c7a6587b7cafc/jmespath-1.0.1-py3-none-any.whl", hash = "sha256:02e2e4cc71b5bcab88332eebf907519190dd9e6e82107fa7f83b1003a6252980", size = 20256, upload-time = "2022-06-17T18:00:10.251Z" },
-]
-
-[[package]]
-name = "mypy-boto3-athena"
-version = "1.40.0"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/9b/9c/a16a597632e24f5e3ad30fe1e5f570e2bdaf713297013d81d7001bfbfabc/mypy_boto3_athena-1.40.0.tar.gz", hash = "sha256:da8429f556bcd857b2c9fed9133ef0bfecb898e2b74e9679f3aaafcc26702bf1", size = 36614, upload-time = "2025-07-31T19:36:39.469Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/f4/a0/7a10865896ddf356c735b1d8ba5ec509386540e89d552bd0108674cda30f/mypy_boto3_athena-1.40.0-py3-none-any.whl", hash = "sha256:3fc5e4b294248663a6030bb5f13e94f199ebcca4f4f43bfcd30705ce47d28008", size = 40986, upload-time = "2025-07-31T19:36:37.666Z" },
-]
-
-[[package]]
-name = "mypy-boto3-s3"
-version = "1.40.26"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/00/b8/55d21ed9ca479df66d9892212ba7d7977850ef17aa80a83e3f11f31190fd/mypy_boto3_s3-1.40.26.tar.gz", hash = "sha256:8d2bfd1052894d0e84c9fb9358d838ba0eed0265076c7dd7f45622c770275c99", size = 75948, upload-time = "2025-09-08T20:12:21.405Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/85/a5/dba3384423834009bdd41c7021de5c663468a0e7bc4071cb301721e52a99/mypy_boto3_s3-1.40.26-py3-none-any.whl", hash = "sha256:6d055d16ef89a0133ade92f6b4f09603e4acc31a0f5e8f846edf4eb48f17b5a7", size = 82762, upload-time = "2025-09-08T20:12:19.338Z" },
-]
-
-[[package]]
-name = "mypy-boto3-sts"
-version = "1.40.0"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/39/32/8dce999ed05c797000ce70287f3e82025a98514781c303c7f8fe42f7b327/mypy_boto3_sts-1.40.0.tar.gz", hash = "sha256:eb55e50960ae6194d09488464c302196392df712a6a5f4308b6a0e24244cfd5c", size = 16577, upload-time = "2025-07-31T19:52:23.924Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/78/f8/38dae2983d72ea4fff75b235d42d3b1ecad407e0136f4951bfd9016ecaea/mypy_boto3_sts-1.40.0-py3-none-any.whl", hash = "sha256:fff731694cab2474bf7e7d3344b049b4ac0272d76b72fc4f7e4ae543ead8a5e6", size = 20192, upload-time = "2025-07-31T19:52:21.353Z" },
 ]
 
 [[package]]
@@ -251,26 +200,26 @@ wheels = [
 [[package]]
 name = "quilt-shared"
 version = "0.1.0"
-source = { url = "https://github.com/quiltdata/quilt/archive/f90584485ba84a9d46fe4c7014f858a4b57738bd.zip", subdirectory = "py-shared" }
-sdist = { hash = "sha256:f7d07fe2710e63e446e6e0c6d052f9856c7747c7ea378a5b3eafe57d7941e11a" }
+source = { url = "https://github.com/quiltdata/quilt/archive/b2adc010ec6ebbe52b852b05d69c436a9b430614.zip", subdirectory = "py-shared" }
+sdist = { hash = "sha256:5be5d5e81d0ebc1d2b4d1dc0f143566e021402f28a0fa19f2f48899f4be8fc9c" }
 
 [package.optional-dependencies]
 boto = [
     { name = "boto3" },
-    { name = "boto3-stubs", extra = ["athena", "s3", "sts"] },
     { name = "types-aiobotocore", extra = ["s3"] },
+    { name = "types-boto3", extra = ["athena", "s3", "sts"] },
 ]
 
 [package.metadata]
 requires-dist = [
     { name = "aws-requests-auth", marker = "extra == 'es'", specifier = "~=0.4.2" },
     { name = "boto3", marker = "extra == 'boto'", specifier = "~=1.34" },
-    { name = "boto3-stubs", extras = ["athena", "s3", "sts"], marker = "extra == 'boto'", specifier = "~=1.34" },
     { name = "elasticsearch", marker = "extra == 'es'", specifier = "~=6.8" },
     { name = "orjson", marker = "extra == 'es'", specifier = "~=3.10" },
     { name = "pydantic", marker = "extra == 'pydantic'", specifier = "~=2.10" },
-    { name = "quilt3", marker = "extra == 'quilt'", specifier = "~=5.4" },
+    { name = "quilt3", marker = "extra == 'quilt'", specifier = ">=7,<8" },
     { name = "types-aiobotocore", extras = ["s3"], marker = "extra == 'boto'", specifier = "~=2.11" },
+    { name = "types-boto3", extras = ["athena", "s3", "sts"], marker = "extra == 'boto'", specifier = "~=1.34" },
     { name = "typing-extensions", marker = "extra == 'pydantic'", specifier = "~=4.9" },
 ]
 provides-extras = ["pydantic", "boto", "quilt", "es"]
@@ -316,7 +265,7 @@ test = [
 [package.metadata]
 requires-dist = [
     { name = "boto3", specifier = ">=1.40.41,<2.0.0" },
-    { name = "quilt-shared", extras = ["boto"], url = "https://github.com/quiltdata/quilt/archive/f90584485ba84a9d46fe4c7014f858a4b57738bd.zip", subdirectory = "py-shared" },
+    { name = "quilt-shared", extras = ["boto"], url = "https://github.com/quiltdata/quilt/archive/b2adc010ec6ebbe52b852b05d69c436a9b430614.zip", subdirectory = "py-shared" },
 ]
 
 [package.metadata.requires-dev]
@@ -360,6 +309,57 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/60/19/a3a6377c9e2e389c1421c033a1830c29cac08f2e1e05a082ea84eb22c75f/types_awscrt-0.28.1.tar.gz", hash = "sha256:66d77ec283e1dc907526a44511a12624118723a396c36d3f3dd9855cb614ce14", size = 17410, upload-time = "2025-10-11T21:55:07.443Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/ea/c7/0266b797d19b82aebe0e177efe35de7aabdc192bc1605ce3309331f0a505/types_awscrt-0.28.1-py3-none-any.whl", hash = "sha256:d88f43ef779f90b841ba99badb72fe153077225a4e426ae79e943184827b4443", size = 41851, upload-time = "2025-10-11T21:55:06.235Z" },
+]
+
+[[package]]
+name = "types-boto3"
+version = "1.43.17"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "botocore-stubs" },
+    { name = "types-s3transfer" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/35/29/51e7690903923fc21d49c6a13dc509e26a1f1cf687437107af3a28d875cd/types_boto3-1.43.17.tar.gz", hash = "sha256:83813a4a0f0ec46f3e15ed00f0900c83bb68d047155ac9f1a0e5f82f71607fb4", size = 103049, upload-time = "2026-05-28T21:21:11.636Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/3a/af/f6e4cff6d6711ac76cd56bc4c9ad51a367ea0a149dbc6c3e423272a41dd6/types_boto3-1.43.17-py3-none-any.whl", hash = "sha256:116d7a5d01de2cf9647414736e206a97cf6e51e979c01597e9bec0d1ea104c28", size = 70628, upload-time = "2026-05-28T21:21:06.815Z" },
+]
+
+[package.optional-dependencies]
+athena = [
+    { name = "types-boto3-athena" },
+]
+s3 = [
+    { name = "types-boto3-s3" },
+]
+sts = [
+    { name = "types-boto3-sts" },
+]
+
+[[package]]
+name = "types-boto3-athena"
+version = "1.43.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d7/71/67629ddd2f2846bb0a608fafef1e1407e74b71aa6b7820386501472ca8e7/types_boto3_athena-1.43.0.tar.gz", hash = "sha256:830e4176ee70ad87bbcf7c82be177df1d856d9a43c98de03d7083d46aa9b5928", size = 37721, upload-time = "2026-04-29T22:59:07.156Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/53/bd/6314de5fa247c28704f8ed17a5057d853d7b46348bdcaa37a4857261cc65/types_boto3_athena-1.43.0-py3-none-any.whl", hash = "sha256:b245dab78dc29237d9769e99ed5e6db48ec91290d8767610e77f4b118b7ddba6", size = 41996, upload-time = "2026-04-29T22:59:04.712Z" },
+]
+
+[[package]]
+name = "types-boto3-s3"
+version = "1.43.14"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/3c/79/ddd397734d7c6368492447c95be54e76158e7dc0d4e616117bf2b2430af0/types_boto3_s3-1.43.14.tar.gz", hash = "sha256:50d1fc0082f07be097184cf647e2dec6101fd1f8378a6c353100ccd067b95e4d", size = 76899, upload-time = "2026-05-22T20:48:17.311Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/af/ff/d841790d6fcc72616feb5a00b8548cdd878b50b4f31ed998bf8d9d52c47e/types_boto3_s3-1.43.14-py3-none-any.whl", hash = "sha256:a80ddd1a290dbbbb244868466621ea772c36f6647327637b89423f53e34ea0a1", size = 84098, upload-time = "2026-05-22T20:48:15.127Z" },
+]
+
+[[package]]
+name = "types-boto3-sts"
+version = "1.43.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/4d/a7/ea448e34f9b519b68505df256e8cc185d60ef8aeb41552553f66da5a7b35/types_boto3_sts-1.43.0.tar.gz", hash = "sha256:d8e0061fed51bb246bd966b9968104bc44411450faa8848f26170bf271913ab1", size = 16823, upload-time = "2026-04-29T23:07:24.448Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/56/18/167b2aae0614a6f4d7fe11f85517d3f4ba56e1b0807534a172a9dfe6f4c5/types_boto3_sts-1.43.0-py3-none-any.whl", hash = "sha256:ce21eab88182d8fef3795e6517d3da90da367c1e5db34fc2281c0e7ba218cb65", size = 20831, upload-time = "2026-04-29T23:07:23.152Z" },
 ]
 
 [[package]]

--- a/lambdas/iceberg/uv.lock
+++ b/lambdas/iceberg/uv.lock
@@ -200,8 +200,8 @@ wheels = [
 [[package]]
 name = "quilt-shared"
 version = "0.1.0"
-source = { url = "https://github.com/quiltdata/quilt/archive/b2adc010ec6ebbe52b852b05d69c436a9b430614.zip", subdirectory = "py-shared" }
-sdist = { hash = "sha256:5be5d5e81d0ebc1d2b4d1dc0f143566e021402f28a0fa19f2f48899f4be8fc9c" }
+source = { url = "https://github.com/quiltdata/quilt/archive/12bb4a331a46b3b4eb0388e81e5f2546cf17e0b4.zip", subdirectory = "py-shared" }
+sdist = { hash = "sha256:6281f617be2cd4355bbac45e5a501ad7a24ad26208b476e6d53e630fc094b842" }
 
 [package.optional-dependencies]
 boto = [
@@ -265,7 +265,7 @@ test = [
 [package.metadata]
 requires-dist = [
     { name = "boto3", specifier = ">=1.40.41,<2.0.0" },
-    { name = "quilt-shared", extras = ["boto"], url = "https://github.com/quiltdata/quilt/archive/b2adc010ec6ebbe52b852b05d69c436a9b430614.zip", subdirectory = "py-shared" },
+    { name = "quilt-shared", extras = ["boto"], url = "https://github.com/quiltdata/quilt/archive/12bb4a331a46b3b4eb0388e81e5f2546cf17e0b4.zip", subdirectory = "py-shared" },
 ]
 
 [package.metadata.requires-dev]


### PR DESCRIPTION
Lambdas half of the per-bucket Iceberg pivot. The Iceberg lambda embeds `quilt-shared` (the `QueryMaker` SQL generator) in its build, so it must be re-pinned to the per-bucket version — otherwise the deployed lambda keeps emitting the old global-table / bucket-column MERGE/DELETE SQL and writes to the legacy tables.

### Change
- `lambdas/iceberg/pyproject.toml` + `uv.lock`: re-pin `quilt-shared` to **quilt#4930**'s merge SHA (`12bb4a3` on master) — the per-bucket `QueryMaker`.
- `lambdas/iceberg/CHANGELOG.md`: entry for the retarget.

### Tests
Iceberg lambda `pytest` → 11 passing. (The generated SQL shape is validated by quilt#4930's `test_iceberg_queries.py`.)


🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR re-pins `quilt-shared` in the Iceberg lambda from an older global-table SHA to `12bb4a33` (PR #4930's merge commit), which carries the per-bucket `QueryMaker` rewrite. The lock file is regenerated to reflect the updated dependency tree.

- `pyproject.toml`: single SHA bump for the `quilt-shared` source URL.
- `uv.lock`: the new `quilt-shared` version swaps `boto3-stubs` for `types-boto3` (upstream package rename/migration) and updates the `quilt3` optional-extra version constraint; neither affects the lambda since it only activates the `boto` extra.
- `CHANGELOG.md`: changelog entry added for the retarget.

<h3>Confidence Score: 5/5</h3>

Safe to merge once the pre-merge checklist items (deploy-lambdas.yaml revert and final SHA confirmation) are done.

The change is a single dependency re-pin to a commit that is already present in the repository (12bb4a33, merged via #4930). The lock file regeneration is mechanically consistent with the new source, and the transitive dependency swap from boto3-stubs to types-boto3 is an upstream package rename that does not alter the lambda's runtime behaviour. No logic changes are introduced in this PR.

No files require special attention — all three changed files are dependency metadata.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| lambdas/iceberg/pyproject.toml | Single-line SHA bump for quilt-shared from the old global-table commit to 12bb4a33 (the merged per-bucket QueryMaker commit). |
| lambdas/iceberg/uv.lock | Lock file regenerated: quilt-shared URL/hash updated, boto3-stubs replaced by types-boto3 (upstream rename), and quilt3 optional-extra spec widened to >=7,<8 — none of these affect the lambda's installed dependencies since only the boto extra is activated. |
| lambdas/iceberg/CHANGELOG.md | Changelog entry added for the per-bucket QueryMaker retarget, correctly linking PR #4931. |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Iceberg Lambda] -->|uses quilt-shared boto extra| B[quilt-shared @ 12bb4a33]
    B -->|provides| C[per-bucket QueryMaker]
    C -->|generates SQL for| D["{bucket}_{table} Iceberg tables"]
    B2[quilt-shared @ f905844 OLD] -.->|generated SQL for| D2[global Iceberg tables LEGACY]
    B -->|depends on| E[types-boto3 replaces boto3-stubs]
```

<sub>Reviews (5): Last reviewed commit: ["Apply suggestion from @nl0"](https://github.com/quiltdata/quilt/commit/4500be0eb85d3c7126128e54db200147a595a3a2) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=34886213)</sub>

<!-- /greptile_comment -->