### PR TITLE
fix(telemetry): preserve function signature in ApiTelemetry decorator

### DIFF
--- a/api/python/quilt3/telemetry.py
+++ b/api/python/quilt3/telemetry.py
@@ -1,5 +1,6 @@
 import atexit
 import functools
+import inspect
 import os
 import platform
 import sys
@@ -139,6 +140,12 @@ class ApiTelemetry:
                 # TODO(armand): This string matching is extremely brittle. Fix ASAP
                 ApiTelemetry.telemetry_disabled = True
             return results
+
+        # Preserve explicit signature so inspect.signature() works through @classmethod
+        try:
+            decorated.__signature__ = inspect.signature(func)
+        except (ValueError, TypeError):
+            pass
 
         return decorated
 

--- a/api/python/tests/test_telemetry.py
+++ b/api/python/tests/test_telemetry.py
@@ -61,6 +61,26 @@ class TelemetryTest(unittest.TestCase):
         decorated = ApiTelemetry(mock.sentinel.API_NAME)(func)
         assert inspect.signature(decorated) == inspect.signature(func)
 
+    def test_signature_does_not_require_following_wrapped(self):
+        """
+        Regression guard for the real fix. ``functools.wraps`` only sets
+        ``__wrapped__``, so ``inspect.signature()`` recovers the original
+        parameters *only* when it follows that chain. The explicit
+        ``__signature__`` assignment is what makes the signature resolvable
+        without following ``__wrapped__`` — the path pydoc-markdown's gendocs
+        build takes for ``@classmethod``-wrapped APIs like ``Package.install``.
+
+        Without the fix this asserts ``(*args, **kwargs)``; with it, the real
+        signature. (The default ``follow_wrapped=True`` masks the bug, which
+        is why the test above passes either way.)
+        """
+
+        def func(a, b, c=1, *, d=2):
+            pass
+
+        decorated = ApiTelemetry(mock.sentinel.API_NAME)(func)
+        assert inspect.signature(decorated, follow_wrapped=False) == inspect.signature(func)
+
     def test_unintrospectable_signature(self):
         """
         When the wrapped function's signature can't be introspected, the

--- a/api/python/tests/test_telemetry.py
+++ b/api/python/tests/test_telemetry.py
@@ -60,3 +60,20 @@ class TelemetryTest(unittest.TestCase):
 
         decorated = ApiTelemetry(mock.sentinel.API_NAME)(func)
         assert inspect.signature(decorated) == inspect.signature(func)
+
+    def test_unintrospectable_signature(self):
+        """
+        When the wrapped function's signature can't be introspected, the
+        decorator swallows the error and returns a working callable that
+        simply doesn't expose an explicit __signature__.
+        """
+
+        def func():
+            pass
+
+        with mock.patch('quilt3.telemetry.inspect.signature', side_effect=ValueError):
+            decorated = ApiTelemetry(mock.sentinel.API_NAME)(func)
+
+        assert not hasattr(decorated, '__signature__')
+        decorated()
+        self.mock_report_api_use.assert_called_once_with(mock.sentinel.API_NAME, mock.ANY)

--- a/api/python/tests/test_telemetry.py
+++ b/api/python/tests/test_telemetry.py
@@ -1,3 +1,4 @@
+import inspect
 import unittest
 from unittest import mock
 
@@ -47,3 +48,15 @@ class TelemetryTest(unittest.TestCase):
         new_session_id = self.mock_report_api_use.call_args[0][1]
 
         assert new_session_id != session_id
+
+    def test_preserves_signature(self):
+        """
+        The decorator exposes the wrapped function's signature so that
+        inspect.signature() works (e.g. through @classmethod, as pydoc-markdown relies on).
+        """
+
+        def func(a, b, c=1, *, d=2):
+            pass
+
+        decorated = ApiTelemetry(mock.sentinel.API_NAME)(func)
+        assert inspect.signature(decorated) == inspect.signature(func)

--- a/api/python/tests/test_telemetry.py
+++ b/api/python/tests/test_telemetry.py
@@ -51,8 +51,10 @@ class TelemetryTest(unittest.TestCase):
 
     def test_preserves_signature(self):
         """
-        The decorator exposes the wrapped function's signature so that
-        inspect.signature() works (e.g. through @classmethod, as pydoc-markdown relies on).
+        The decorator exposes the wrapped function's signature to
+        inspect.signature(). Note this passes even without the fix, since
+        inspect.signature() follows __wrapped__ by default; see
+        test_signature_does_not_require_following_wrapped for the real guard.
         """
 
         def func(a, b, c=1, *, d=2):


### PR DESCRIPTION
# Description

The `ApiTelemetry` decorator wraps functions with `functools.wraps` but does not expose an explicit `__signature__`. As a result, `inspect.signature()` fails to resolve the underlying signature through a `@classmethod`, which breaks pydoc-markdown doc generation (`gendocs/build.py`).

This sets `decorated.__signature__` from the wrapped function so introspection works through `@classmethod`, and adds a focused regression test.

This is the first of a series of small, atomic PRs carved out of a larger packaging/hygiene branch. It is dependency-free and independently useful (it also unblocks a later local-catalog PR).

# TODO

- [x] Unit tests — `tests/test_telemetry.py::TelemetryTest::test_preserves_signature`
- [x] Security: no security impact (pure introspection metadata)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes `ApiTelemetry.__call__` to explicitly set `decorated.__signature__` after `functools.wraps`, so `inspect.signature()` resolves the correct signature when the decorated function is further wrapped by `@classmethod` (as needed by pydoc-markdown). A regression test is included, though it does not exercise the specific `@classmethod` failure path.

- **`telemetry.py`**: Assigns `decorated.__signature__ = inspect.signature(func)` inside a `try/except (ValueError, TypeError)` after the `functools.wraps` wrapper is built; the fix is minimal and side-effect-free.
- **`test_telemetry.py`**: Adds `test_preserves_signature` that verifies the signature is preserved on a plain wrapped function, but omits the `@classmethod` chain that was the original failure scenario.

<h3>Confidence Score: 4/5</h3>

The production change is a small, non-breaking addition with a silent fallback; safe to merge, but the test only partially validates the stated fix.

The explicit `__signature__` assignment is the correct pattern and introduces no runtime risk. The test exercises a path that already worked via `__wrapped__` before the fix, so the `@classmethod` failure case that motivated the change is not concretely guarded against regressions.

api/python/tests/test_telemetry.py — the new test should cover the `@classmethod` scenario to serve as a true regression guard for the reported breakage.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| api/python/quilt3/telemetry.py | Adds explicit `__signature__` assignment after `functools.wraps` in `ApiTelemetry.__call__`, wrapped in a defensive try/except to handle cases where `inspect.signature` cannot resolve the function. |
| api/python/tests/test_telemetry.py | Adds `test_preserves_signature` which verifies the decorator preserves the wrapped function's signature on a plain function; the actual failure case (through `@classmethod`) is not covered by the new test. |

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant Caller
    participant classmethod
    participant decorated
    participant func

    Note over Caller,func: Before fix — __signature__ not set
    Caller->>classmethod: inspect.signature(Foo.method)
    classmethod->>decorated: follow __wrapped__
    decorated-->>Caller: ❌ ValueError (fails through classmethod)

    Note over Caller,func: After fix — __signature__ explicitly set
    Caller->>classmethod: inspect.signature(Foo.method)
    classmethod->>decorated: read __signature__
    decorated-->>Caller: "✅ Signature(a, b, c=1, *, d=2)"
```

<sub>Reviews (1): Last reviewed commit: ["fix(telemetry): preserve function signat..."](https://github.com/quiltdata/quilt/commit/51a88c1b7a4cf833c57c9da4b5e15c18da348520) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=35030483)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->