### PR TITLE
fix(admin): qualify builtins.list in buckets.list annotation for Python 3.14

### DIFF
--- a/api/python/quilt3/admin/buckets.py
+++ b/api/python/quilt3/admin/buckets.py
@@ -1,3 +1,4 @@
+import builtins
 import typing as T
 
 from .. import _graphql_client
@@ -18,7 +19,7 @@ def get(name: str) -> T.Optional[types.Bucket]:
     return types.Bucket(**result.model_dump())
 
 
-def list() -> list[types.Bucket]:
+def list() -> builtins.list[types.Bucket]:
     """
     List all bucket configurations in the registry.
     """

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -16,6 +16,12 @@ Entries inside each section should be ordered by type:
 
 # Changelog
 
+## unreleased - YYYY-MM-DD
+
+### Python API
+
+* [Fixed] `quilt3.admin.buckets.list` no longer raises `TypeError` when its type hints are introspected on Python 3.14 ([#4940](https://github.com/quiltdata/quilt/pull/4940))
+
 ## 7.3.0 - 2026-04-07
 
 ### Python API


### PR DESCRIPTION
# Description

`quilt3.admin.buckets` defines a public function named `list` whose return annotation used the builtin `list[...]`:

```python
def list() -> list[types.Bucket]:
```

Under Python 3.14's lazy annotation evaluation (PEP 649/749), the annotation is resolved against the module globals — where `list` now refers to the function, not the builtin — so any access to the function's annotations raises:

```
TypeError: 'function' object is not subscriptable
```

It worked on ≤3.13 only because annotations were evaluated eagerly at definition time, before the name `list` was rebound to the function. The failure is dormant until something introspects the type hints:

```python
import quilt3.admin.buckets as b
b.list.__annotations__            # raises on 3.14
inspect.signature(b.list)         # raises on 3.14
typing.get_type_hints(b.list)     # raises on 3.14
```

This affects doc generation, IDEs, and any `get_type_hints`-based tooling on Python 3.14.

## Fix

Qualify the builtin as `builtins.list[types.Bucket]`, which resolves correctly under both eager (≤3.13) and lazy (3.14) evaluation. This keeps modern PEP 585 generics rather than reverting to the deprecated `typing.List` used by the sibling admin modules.

`from __future__ import annotations` was considered but is only a partial fix — it stops `__annotations__`/`inspect.signature` from crashing but leaves `typing.get_type_hints()` raising, since it still evaluates the string against the shadowed global.

Verified on Python 3.14 that `__annotations__`, `inspect.signature`, and `typing.get_type_hints` all resolve to `list[quilt3.admin.types.Bucket]` after the change.

# TODO

- [x] Unit tests — n/a (annotation-only fix; verified via introspection on 3.14)
- [x] Security: no security impact (type annotation only)
- [x] [Changelog](../tree/master/docs/CHANGELOG.md) entry

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes a Python 3.14 compatibility issue in `quilt3/admin/buckets.py` where the `list` function's return annotation `list[types.Bucket]` would fail under PEP 649/749 lazy annotation evaluation because the module-level name `list` is rebound to the function itself, making `list[...]` raise `TypeError: 'function' object is not subscriptable`.

- Adds `import builtins` and qualifies the return annotation as `builtins.list[types.Bucket]`, which resolves correctly under both eager (≤3.13) and lazy (3.14) evaluation without reverting to the deprecated `typing.List` form.
- The sibling admin modules (`users.py`, `roles.py`, `policies.py`) already use `T.List[...]` for their `list()` functions, so they are unaffected by this issue.

<h3>Confidence Score: 5/5</h3>

Safe to merge — the change is a two-line annotation-only fix with no runtime behavior impact.

The fix is minimal and targeted: qualifying `list` as `builtins.list` in the return annotation correctly resolves the Python 3.14 lazy evaluation issue without touching any runtime logic. The sibling modules are unaffected since they already use `typing.List`. No side effects expected.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| api/python/quilt3/admin/buckets.py | Adds `import builtins` and qualifies the return annotation of `list()` as `builtins.list[types.Bucket]` to fix Python 3.14 lazy annotation resolution failure. Change is minimal and correct. |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A["Python resolves annotation\n'list[types.Bucket]'"] --> B{Python version?}
    B -->|"≤ 3.13\n(eager eval at definition time)"| C["'list' = builtin list ✓"]
    B -->|"3.14+\n(lazy eval, PEP 649/749)"| D["'list' = module function ✗\nTypeError: not subscriptable"]
    C --> E["Annotation resolves correctly"]
    D --> F["Fix: builtins.list[types.Bucket]"]
    F --> G["'builtins.list' always = builtin list ✓\nAnnotation resolves correctly on all versions"]
```

<sub>Reviews (1): Last reviewed commit: ["docs: add changelog entry for buckets.li..."](https://github.com/quiltdata/quilt/commit/2f5146028fb3f51c2ee4e5e298f3e5b3a3376719) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=35322638)</sub>

<!-- /greptile_comment -->