### PR TITLE
s3-proxy: expose x-amz-restore header via CORS

### DIFF
--- a/s3-proxy/nginx.conf
+++ b/s3-proxy/nginx.conf
@@ -38,7 +38,7 @@ http {
             add_header 'Access-Control-Allow-Methods' $http_access_control_request_method always;
             add_header 'Access-Control-Allow-Origin' '*' always;
             add_header 'Access-Control-Max-Age' '3000' always;
-            add_header 'Access-Control-Expose-Headers' 'Content-Length, Content-Range, ETag, x-amz-meta-helium, x-amz-bucket-region, x-amz-delete-marker, x-amz-request-id, x-amz-version-id, x-amz-storage-class' always;
+            add_header 'Access-Control-Expose-Headers' 'Content-Length, Content-Range, ETag, x-amz-meta-helium, x-amz-bucket-region, x-amz-delete-marker, x-amz-request-id, x-amz-version-id, x-amz-storage-class, x-amz-restore' always;
 
             # Return success on OPTIONS.
             if ($request_method = 'OPTIONS') {


### PR DESCRIPTION
## Summary

Adds `x-amz-restore` to `Access-Control-Expose-Headers` in `s3-proxy/nginx.conf`, so browser JS can read S3 object restore (Glacier rehydration) state from cross-origin HEAD responses.

Split out from #4921 (Glacier rehydration UX). `s3-proxy` is a separately built and deployed component from the catalog bundle, so this is kept as its own independently reviewable, revertable, and deployable PR.

## Test plan

- [ ] Deploy s3-proxy, issue a cross-origin HEAD against a restored/restoring Glacier object, confirm `x-amz-restore` is readable from the browser.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds `x-amz-restore` to the `Access-Control-Expose-Headers` list in the s3-proxy nginx configuration, enabling browser JavaScript to read the Glacier rehydration/restore status from cross-origin HEAD responses.

- The single-line change appends `x-amz-restore` to the existing comma-separated expose-headers list in the S3-proxying `location` block.
- The surrounding config already strips `Access-Control-Expose-Headers` from upstream S3 responses via `proxy_hide_header` (line 59), so there is no risk of duplicate headers.

<h3>Confidence Score: 5/5</h3>

This is a safe, purely additive one-line change to the CORS expose-headers list with no functional side effects.

The change appends one well-known, read-only Amazon S3 response header (x-amz-restore) to the existing expose list. It does not alter any routing, authentication, or proxying logic. The existing proxy_hide_header directives already prevent duplicate headers from upstream, so the addition slots in cleanly.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| s3-proxy/nginx.conf | Adds `x-amz-restore` to `Access-Control-Expose-Headers`; change is minimal, correct, and consistent with the existing header stripping (`proxy_hide_header`) that prevents duplicates. |

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant Browser
    participant s3-proxy (nginx)
    participant S3 (amazonaws.com)

    Browser->>s3-proxy (nginx): HEAD /bucket.s3.amazonaws.com/key (cross-origin)
    s3-proxy (nginx)->>S3 (amazonaws.com): Proxy HEAD request
    S3 (amazonaws.com)-->>s3-proxy (nginx): Response with x-amz-restore header
    Note over s3-proxy (nginx): proxy_hide_header strips upstream Access-Control-* headers
    Note over s3-proxy (nginx): add_header injects Access-Control-Expose-Headers (now includes x-amz-restore)
    s3-proxy (nginx)-->>Browser: Response with Access-Control-Expose-Headers: ..., x-amz-restore
    Note over Browser: JS can now read response.headers.get('x-amz-restore')
```

<sub>Reviews (1): Last reviewed commit: ["s3-proxy: expose x-amz-restore header vi..."](https://github.com/quiltdata/quilt/commit/8fe01613bf8f2af5e6d013e5f9b3d8aa85dca7a2) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=36461568)</sub>

<!-- /greptile_comment -->