### PR TITLE
S3 Proxy: expose x-amz-restore response header via CORS

### DIFF
--- a/s3-proxy/nginx.conf
+++ b/s3-proxy/nginx.conf
@@ -38,7 +38,7 @@ http {
             add_header 'Access-Control-Allow-Methods' $http_access_control_request_method always;
             add_header 'Access-Control-Allow-Origin' '*' always;
             add_header 'Access-Control-Max-Age' '3000' always;
-            add_header 'Access-Control-Expose-Headers' 'Content-Length, Content-Range, ETag, x-amz-meta-helium, x-amz-bucket-region, x-amz-delete-marker, x-amz-request-id, x-amz-version-id, x-amz-storage-class' always;
+            add_header 'Access-Control-Expose-Headers' 'Content-Length, Content-Range, ETag, x-amz-meta-helium, x-amz-bucket-region, x-amz-delete-marker, x-amz-request-id, x-amz-version-id, x-amz-storage-class, x-amz-restore' always;
 
             # Return success on OPTIONS.
             if ($request_method = 'OPTIONS') {


### PR DESCRIPTION
## Summary

Adds `x-amz-restore` to the s3-proxy `Access-Control-Expose-Headers` allowlist so the browser can read an object's Glacier / Deep Archive restore state from the `x-amz-restore` HEAD response header cross-origin.

Split out of #4921 (Catalog: Glacier rehydration UX) so this s3-proxy image change — a separately built and deployed component — is independently reviewable, revertable, and deployable.

## Why

The catalog rehydration flow distinguishes archived / restoring / restored objects by reading `x-amz-restore` on the file-detail HEAD. Browsers strip non-allowlisted headers from cross-origin responses, so without this the file page can't tell an in-progress / completed restore from a still-archived object.

## Test plan

- [ ] CORS preflight + HEAD against a restored object surfaces `x-amz-restore` to browser JS

Refs #4921.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR exposes the `x-amz-restore` response header via the s3-proxy `Access-Control-Expose-Headers` list so that browser JavaScript can read Glacier/Deep Archive restore state from cross-origin HEAD responses.

- Appends `x-amz-restore` to the single `Access-Control-Expose-Headers` directive in `s3-proxy/nginx.conf` (the S3 reverse-proxy location block). No other config, logic, or deploy artifact is touched.
- This is a prerequisite split out from the parent catalog Glacier rehydration UX work (#4921) so the proxy image can be built, deployed, and reverted independently.

<h3>Confidence Score: 5/5</h3>

Safe to merge — adds one header name to an existing allowlist with no functional, security, or behavioral risk to existing proxy flows.

The change is a one-word addition to a static string in nginx config. Adding a header to Access-Control-Expose-Headers only makes that header readable to browser JS; it does not alter what S3 returns, does not bypass any auth, and does not affect non-Glacier objects (the header is simply absent for those). All existing exposed headers remain unchanged, and the proxy_hide_header directives that strip upstream CORS headers are unaffected.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| s3-proxy/nginx.conf | Appends `x-amz-restore` to the `Access-Control-Expose-Headers` list; minimal, targeted, and correct change. |

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant Browser
    participant S3Proxy as s3-proxy (nginx)
    participant S3 as AWS S3

    Browser->>S3Proxy: HEAD /bucket.s3.amazonaws.com/key
    S3Proxy->>S3: HEAD /key (proxied)
    S3-->>S3Proxy: "200 OK x-amz-restore: ongoing-request="false", expiry-date="..." x-amz-storage-class: GLACIER"
    S3Proxy-->>Browser: "200 OK Access-Control-Expose-Headers: ..., x-amz-restore x-amz-restore: ongoing-request="false""
    Note over Browser: JS can now read x-amz-restore to determine restore state
```

<sub>Reviews (1): Last reviewed commit: ["s3-proxy: expose x-amz-restore response ..."](https://github.com/quiltdata/quilt/commit/faa003fbe918fc2257b2e8ce87fafe94d4ef3ad8) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=36462784)</sub>

<!-- /greptile_comment -->