### PR TITLE
docs: clarify SSO claim source and Entra guest/app-role mapping

### DIFF
--- a/docs/advanced-features/sso-permissions.md
+++ b/docs/advanced-features/sso-permissions.md
@@ -36,6 +36,11 @@ endpoint, or resolve OIDC distributed/overage claims (the `_claim_sources`
 pointer Entra emits when a user belongs to more than ~200 groups) — if a
 value is not present directly in the ID token, a mapping cannot match on it.
 
+Quilt also requests only the `openid` and `email` scopes at login, so group
+or role claims are never pulled in via a scope — they must be configured to
+be emitted into the ID token directly (e.g. via the provider's token/claim
+configuration), or the mapping will have nothing to match.
+
 A mapping can match on **any** claim in the ID token, not just `email` or
 `groups`. For example, to map on an Entra **app-role** `roles` claim (often
 more reliable than `groups` for guest/cross-tenant users, since app roles

--- a/docs/advanced-features/sso-permissions.md
+++ b/docs/advanced-features/sso-permissions.md
@@ -64,9 +64,7 @@ mappings:
 ```
 
 > Tip: To confirm exactly which claims arrive in the token, decode it at
-[jwt.ms](https://jwt.ms). The registry also logs which mappings matched at
-`DEBUG` log level (`QUILT_LOG_LEVEL=DEBUG`), though it does not log raw
-claim values.
+[jwt.ms](https://jwt.ms).
 
 > Note: By default, mappings are evaluated in order and **only the first
 matching mapping is applied** — to assign multiple roles to a user this way,

--- a/docs/advanced-features/sso-permissions.md
+++ b/docs/advanced-features/sso-permissions.md
@@ -28,6 +28,39 @@ which includes descriptions of all the fields.
 > Warning: In schemas don't forget to add claims you want to check to `required`,
 because otherwise the schema will match any ID token even if these claims are missing.
 
+### Which claims are matched
+
+Each mapping's `schema` is validated against the **decoded ID token** only.
+Quilt does **not** read the access token, call the provider's userinfo
+endpoint, or resolve OIDC distributed/overage claims (the `_claim_sources`
+pointer Entra emits when a user belongs to more than ~200 groups) — if a
+value is not present directly in the ID token, a mapping cannot match on it.
+
+A mapping can match on **any** claim in the ID token, not just `email` or
+`groups`. For example, to map on an Entra **app-role** `roles` claim (often
+more reliable than `groups` for guest/cross-tenant users, since app roles
+are defined on the resource application itself):
+
+```yaml
+mappings:
+  - schema:
+      type: object
+      properties:
+        roles:
+          type: array
+          contains:
+            const: QuiltReadWrite
+      required:
+        - roles
+    roles:
+      - ReadWriteQuiltBucket
+```
+
+> Tip: To confirm exactly which claims arrive in the token, decode it at
+[jwt.ms](https://jwt.ms). The registry also logs which mappings matched at
+`DEBUG` log level (`QUILT_LOG_LEVEL=DEBUG`), though it does not log raw
+claim values.
+
 > Note: By default, mappings are evaluated in order and **only the first
 matching mapping is applied** — to assign multiple roles to a user this way,
 include all roles in the `roles` array of a single mapping. Alternatively,

--- a/docs/advanced-features/sso-permissions.md
+++ b/docs/advanced-features/sso-permissions.md
@@ -47,6 +47,8 @@ more reliable than `groups` for guest/cross-tenant users, since app roles
 are defined on the resource application itself):
 
 ```yaml
+version: "1.0"
+default_role: ReadQuiltBucket
 mappings:
   - schema:
       type: object

--- a/docs/technical-reference.md
+++ b/docs/technical-reference.md
@@ -73,6 +73,19 @@ Add `<QuiltWebHost>/oauth-callback` to *authorized redirect URIs*.
    - Create security groups in Entra and assign users.
    - In the app registration, go to **Token configuration → Add groups claim** (or **Edit** if it already exists) and configure it to emit **Group IDs** in the **ID token**.
    - Create a [configuration file](./advanced-features/sso-permissions.md) to map Entra Group IDs to Quilt roles.
+   > **Guest / multi-tenant users:** the `groups` claim carries only groups
+   > from the tenant that issues the token. Users who sign in as **B2B guests**
+   > (e.g. employees of one company logging into another company's tenant) will
+   > **not** receive their home-tenant security groups, so group-based mappings
+   > won't match for them. For these setups, prefer **App roles**: define roles
+   > on the app registration (**App roles**), assign users/groups, and emit them
+   > via **Token configuration → Add a `roles` claim** to the ID token. App
+   > roles live on the resource application, so they populate for guests too.
+   > Then map on the `roles` claim instead of `groups` (see
+   > [SSO permissions mapping](./advanced-features/sso-permissions.md#which-claims-are-matched)).
+   > Note also that Quilt reads only the ID token, so the Entra **group
+   > overage** behavior (>~200 groups) is not resolved — another reason to use
+   > app roles at scale.
 1. Proceed to [Enabling SSO](#enabling-sso).
 
 ### Okta

--- a/docs/technical-reference.md
+++ b/docs/technical-reference.md
@@ -78,9 +78,11 @@ Add `<QuiltWebHost>/oauth-callback` to *authorized redirect URIs*.
    > (e.g. employees of one company logging into another company's tenant) will
    > **not** receive their home-tenant security groups, so group-based mappings
    > won't match for them. For these setups, prefer **App roles**: define roles
-   > on the app registration (**App roles**), assign users/groups, and emit them
-   > via **Token configuration → Add a `roles` claim** to the ID token. App
-   > roles live on the resource application, so they populate for guests too.
+   > on the app registration (**App roles**), ensure the roles are enabled, and
+   > assign users/groups to those roles. Entra includes assigned app roles in
+   > the ID token's `roles` claim; this is not configured through **Token
+   > configuration**. App roles live on the resource application, so they
+   > populate for guests too.
    > Then map on the `roles` claim instead of `groups` (see
    > [SSO permissions mapping](./advanced-features/sso-permissions.md#which-claims-are-matched)).
    > Note also that Quilt reads only the ID token, so the Entra **group


### PR DESCRIPTION
Clarifies how Quilt reads OIDC claims for SSO permission mapping, and adds Entra guidance for guest / multi-tenant deployments where the `groups` claim does not populate.

## What the docs didn't say

- SSO mappings are validated against the **decoded ID token only**. Quilt does **not** read the access token, call the userinfo endpoint, or resolve OIDC distributed/overage claims (the `_claim_sources` pointer Entra emits past ~200 groups). If a value isn't in the ID token, a mapping can't match on it.
- A mapping can match on **any** ID-token claim — not just `email`/`groups`. (Mappings are arbitrary JSON Schema validated against the whole token.)
- For Entra **B2B guest / multi-tenant** sign-ins, the `groups` claim only carries the *issuing* tenant's groups, so a guest's home-tenant security groups are absent and group-based mappings silently fail to match.

## Change

`advanced-features/sso-permissions.md`:
- New "Which claims are matched" section: ID-token-only, no userinfo/overage resolution, and match-on-any-claim with a `roles`-claim example.
- jwt.ms / `QUILT_LOG_LEVEL=DEBUG` tip for confirming what arrives in the token.

`technical-reference.md` (Entra setup):
- Guest/multi-tenant caveat on the `groups` claim, with **App roles** (`roles` claim defined on the resource app) as the recommended alternative that populates for guests, plus a note on the group-overage limit.

Docs-only; no behavior change.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Documentation-only PR that clarifies how Quilt evaluates SSO permission mappings and adds Microsoft Entra guidance for guest/multi-tenant deployments.

- **`sso-permissions.md`**: Adds a "Which claims are matched" section explaining that only the decoded ID token is inspected (no access-token, userinfo-endpoint, or overage-claim resolution), provides a `roles`-claim YAML example for Entra App roles, and adds a `jwt.ms` / `QUILT_LOG_LEVEL=DEBUG` debugging tip.
- **`technical-reference.md`**: Inserts a blockquote under the Entra groups-claim step warning that B2B-guest sign-ins won't carry home-tenant groups, and recommends App roles as the alternative that populates for guests and avoids the ~200-group overage limit; cross-links to the new section above.

<h3>Confidence Score: 5/5</h3>

Safe to merge — documentation only, no code or behavior changes.

Both changed files are Markdown documentation. The new 'Which claims are matched' section is technically accurate (ID-token-only, no userinfo/overage resolution), the YAML example is well-formed and consistent with existing examples, the anchor cross-link resolves correctly, and the Entra B2B guest guidance accurately reflects how the `groups` and `roles` claims differ across tenant boundaries.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| docs/advanced-features/sso-permissions.md | Adds 'Which claims are matched' section clarifying ID-token-only validation, app-roles YAML example, and jwt.ms/debug-log tip; no logic issues found. |
| docs/technical-reference.md | Adds a blockquote caveat about B2B-guest group claim limitations and recommends App roles as an alternative; anchor link to new sso-permissions section is correct. |

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant User
    participant IdP as Identity Provider (Entra / Okta)
    participant Registry as Quilt Registry

    User->>IdP: Login (OIDC Authorization Code flow)
    IdP-->>User: Authorization code
    User->>Registry: Authorization code
    Registry->>IdP: Exchange code for tokens
    IdP-->>Registry: ID token + Access token
    Note over Registry: Only ID token is used for mapping
    Registry->>Registry: Decode ID token claims
    Registry->>Registry: Validate each mapping schema against claims
    Note over Registry: First match (or union if union_roles:true) wins
    Registry-->>User: Assign matching Quilt roles

    Note over IdP,Registry: Entra B2B guests: groups claim = issuing-tenant only
    Note over IdP,Registry: App roles (roles claim) populate for guests too
    Note over Registry: >~200 groups → Entra overage (_claim_sources) — NOT resolved
```

<sub>Reviews (1): Last reviewed commit: ["docs: clarify SSO claim source and Entra..."](https://github.com/quiltdata/quilt/commit/9de5449a6cf8b738c8cd35774b4e82c6a252995e) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=36592620)</sub>

<!-- /greptile_comment -->