### PR TITLE
thumbnail: assert expected status codes in test_generate_thumbnail

### DIFF
--- a/lambdas/thumbnail/tests/test_thumbnail.py
+++ b/lambdas/thumbnail/tests/test_thumbnail.py
@@ -92,20 +92,10 @@ def test_403():
         ("generated.ome.tiff", {"size": "w256h256"}, "generated-256.png", [1, 6, 36, 76, 68], [224, 167], None, 200),
         ("sat_rgb.tiff", {"size": "w256h256"}, "sat_rgb-256.png", [256, 256, 4], [256, 256], None, 200),
         ("single_cell.ome.tiff", {"size": "w256h256"}, "single_cell.png", [1, 6, 40, 152, 126], [256, 205], None, 200),
-        # Test for statusCode error
-        pytest.param(
-            "empty.png",
-            {"size": "w32h32"},
-            None, None, None, None, 500,
-            marks=pytest.mark.xfail(raises=AssertionError)
-        ),
-        # Test known bad file
-        pytest.param(
-            "cell.png",
-            {"size": "w1h1"},
-            None, None, None, None, 400,
-            marks=pytest.mark.xfail(raises=AssertionError)
-        ),
+        # Unreadable image -> 500
+        ("empty.png", {"size": "w32h32"}, None, None, None, None, 500),
+        # Unsupported size -> 400
+        ("cell.png", {"size": "w1h1"}, None, None, None, None, 400),
         # The following PDF tests should only run if poppler-utils is installed;
         # then call `pytest --poppler` to execute
         pytest.param(
@@ -172,8 +162,10 @@ def test_generate_thumbnail(
     else:
         response = t4_lambda_thumbnail.lambda_handler(event, None)
 
-    # Assert the request was handled with no errors
-    assert response["statusCode"] == 200, f"response: {response}"
+    assert response["statusCode"] == status, f"response: {response}"
+    if status != 200:
+        return
+
     # only check the body and expected image if it's a successful call
     # Parse the body / the returned thumbnail
     body = read_body(response)

--- a/lambdas/thumbnail/tests/test_thumbnail.py
+++ b/lambdas/thumbnail/tests/test_thumbnail.py
@@ -164,9 +164,12 @@ def test_generate_thumbnail(
 
     assert response["statusCode"] == status, f"response: {response}"
     if status != 200:
+        # Error bodies are plain-text messages produced by the @api/@validate
+        # decorators, unlike the JSON shape checked in test_403.
+        assert response["headers"]["Content-Type"] == "text/plain"
+        assert read_body(response)
         return
 
-    # only check the body and expected image if it's a successful call
     # Parse the body / the returned thumbnail
     body = read_body(response)
     # Assert basic metadata was filled properly


### PR DESCRIPTION
# Description

The `status` parameter of `test_generate_thumbnail` was never used: the test asserted `statusCode == 200` unconditionally, and the two error-case rows (`empty.png` → 500, `w1h1` → 400) were marked `xfail(raises=AssertionError)`, so they only verified the status is *not* 200 — a wrong error code (e.g. a 400 turning into a 500) would pass unnoticed.

Assert the parametrized `status` directly, drop the `xfail` markers, and skip body/image checks for non-200 rows.

# TODO

- [x] Unit tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR tightens the `test_generate_thumbnail` parametrized test so that error-case rows (empty PNG → 500, unsupported size → 400) now assert the exact expected status code instead of relying on `xfail(raises=AssertionError)`, which only confirmed the code wasn't 200.

- The two error parametrize entries are converted from `pytest.param(..., marks=pytest.mark.xfail(raises=AssertionError))` to plain tuples, so failures are now genuine test failures rather than silently-passing xfails.
- The single hardcoded `assert response["statusCode"] == 200` is replaced with `assert response["statusCode"] == status`, followed by an early return that skips body/image validation for non-200 cases — mirroring the pattern already used in `test_403`.

<h3>Confidence Score: 5/5</h3>

Safe to merge — a focused test-quality fix with no production code changes.

The change is confined to the test file and directly fixes a real gap: error-case rows previously passed as long as any AssertionError was raised, meaning a wrong status code (e.g., 400 silently becoming 500) would go undetected. The new assertion explicitly checks the parametrized status value, and the early return keeps the rest of the test logic clean and unchanged for success cases.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| lambdas/thumbnail/tests/test_thumbnail.py | Replaced xfail-marked error parametrize entries with plain tuples and changed the status assertion from a hardcoded 200 to the parametrized `status` value, with an early return that skips body checks for non-200 responses. |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[parametrized test case] --> B[mock HTTP GET with file bytes]
    B --> C[invoke lambda_handler]
    C --> D{assert statusCode == status}
    D -->|fails| E[test FAILS - wrong status code]
    D -->|passes & status != 200| F[early return - no body checks]
    D -->|passes & status == 200| G[parse response body]
    G --> H[assert thumbnail_size / original_size]
    H --> I{PDF/PPTX input?}
    I -->|yes| J[np.allclose pixel comparison]
    I -->|no| K[BioImage pixel-exact comparison]
```

<sub>Reviews (1): Last reviewed commit: ["thumbnail: assert expected status codes ..."](https://github.com/quiltdata/quilt/commit/d681d68e5949f89392c40b8db56a4e77bdb4e469) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=36675122)</sub>

<!-- /greptile_comment -->