### PR TITLE
thumbnail tests: real-content fixture for the RGB montage path

### DIFF
--- a/lambdas/thumbnail/tests/test_thumbnail.py
+++ b/lambdas/thumbnail/tests/test_thumbnail.py
@@ -505,10 +505,10 @@ def test_generate_thumbnail_float_greyscale_saves_png():
 
 
 TEST_DATA_REGISTRY = "s3://quilt-test-public-data"
-TIFF_PKG = "images/bioio-tifffile", "2ddbc5ef7accb6fe8f1ef1a38b727fab667f3f907bfb6dd557250345d9785910"
+TIFF_PKG = "images/bioio-tifffile", "5fa99558a167d6430defbfa4033808c7e7004b847e94a213292c2c776ef43ac5"
 OME_TIFF_PKG = "images/bioio-ome-tiff", "6dbddd093e0a92cfc1cc5957ad7a7177ba98a0fee5d99ffaea58e30b7c46e182"
 CZI_PKG = "images/pylibczirw", "552c9290ffa24738a578c494b7fc9f95cc03e3d12d701bc0bd944f5c1c558b2c"
-THUMBS_PKG = "images/thumbs", "38e7c3406ef0828d6f9c12a7b9535f0b3425d6187a638a721ad8300043be62f8"
+THUMBS_PKG = "images/thumbs", "5ae720b35c5abc296ad5e708d3dea402bc4269c6e6f1920aa48cbc4be21ba443"
 SIZE = (1024, 768)
 
 
@@ -523,6 +523,9 @@ SIZE = (1024, 768)
         (TIFF_PKG, "s_1_t_1_c_1_z_1.tiff"),
         (TIFF_PKG, "s_1_t_1_c_1_z_1_RGB.tiff"),
         (TIFF_PKG, "s_1_t_1_c_2_z_1_RGB.tiff"),
+        # real-content variant of the above (which is all zeros, so it can't
+        # catch pixel-mangling bugs in the multi-channel RGB montage path)
+        (TIFF_PKG, "s_1_t_1_c_2_z_1_RGB_gradient.tiff"),
         # float16 RGB photo (values in [0, 1]), from tlnagy/exampletiffs
         (TIFF_PKG, "spring.tif"),
         (TIFF_PKG, "s_3_t_1_c_3_z_5.ome.tiff"),

--- a/lambdas/thumbnail/tests/test_thumbnail.py
+++ b/lambdas/thumbnail/tests/test_thumbnail.py
@@ -522,9 +522,13 @@ SIZE = (1024, 768)
         (TIFF_PKG, "s_1_t_1_c_1_z_1.ome.tiff"),
         (TIFF_PKG, "s_1_t_1_c_1_z_1.tiff"),
         (TIFF_PKG, "s_1_t_1_c_1_z_1_RGB.tiff"),
+        # all zeros; kept as a constant-input guard for the multi-channel RGB
+        # montage path (would catch e.g. a div-by-zero if normalization ever
+        # gets applied to color channels), but useless for pixel correctness
         (TIFF_PKG, "s_1_t_1_c_2_z_1_RGB.tiff"),
-        # real-content variant of the above (which is all zeros, so it can't
-        # catch pixel-mangling bugs in the multi-channel RGB montage path)
+        # real-content variant of the above with distinct channels; this is
+        # what actually pins pixel correctness of the montage (channel order,
+        # grid placement, padding)
         (TIFF_PKG, "s_1_t_1_c_2_z_1_RGB_gradient.tiff"),
         # float16 RGB photo (values in [0, 1]), from tlnagy/exampletiffs
         (TIFF_PKG, "spring.tif"),


### PR DESCRIPTION
# Description

`s_1_t_1_c_2_z_1_RGB.tiff` — the only `test_handle_image` input that combines a multi-channel montage with RGB samples — is all zeros, so its golden-master comparison reduces to "black image == black image": any bug that mangles pixel values while preserving geometry (channel order, per-channel normalization, grid placement, padding edges) passes undetected. (First item of the thumbnail-test-hygiene follow-ups from #4960.)

This adds `s_1_t_1_c_2_z_1_RGB_gradient.tiff`, a real-content variant with the same structure (OME-TIFF, `CYXS`, 2×32×32×3 uint8, read by the same `bioio-tifffile` reader) but visually distinct channels — gradients in channel 0, inverted gradient + checkerboard in channel 1 — so each montage cell is identifiable and full-range. The all-zeros original stays as a constant-input guard: it would catch e.g. a div-by-zero if normalization ever gets applied to color channels (today `norm_img` passes 3-dim slices through untouched), which the full-range gradient variant can't trip.

Shipped via new revisions of the test-data packages on `s3://quilt-test-public-data` (both built on the previously pinned revisions, which were `latest`):

- `images/bioio-tifffile` → `5fa99558` (adds the fixture)
- `images/thumbs` → `5ae720b3` (adds the reference thumbnail)

# TODO

- [x] Unit tests
- [x] Changelog entry — skipped: test-only change, not user-visible (same as #4959)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR strengthens the `test_handle_image` parametrized golden-master suite by adding a real-content fixture (`s_1_t_1_c_2_z_1_RGB_gradient.tiff`) for the multi-channel RGB montage path, where the existing all-zeros file provided no pixel-value coverage. The all-zeros file is intentionally kept with a clear comment explaining its role as a constant-input guard.

- Updates `TIFF_PKG` and `THUMBS_PKG` S3 package hashes to revisions that include the new fixture and its reference thumbnail.
- Adds the new gradient fixture as a test parameter alongside the existing all-zeros one, with comments documenting the purpose of each.

<h3>Confidence Score: 5/5</h3>

Test-only change that adds a real-content fixture and updates pinned S3 package hashes; no production code is touched.

The change adds a single parametrized test case and bumps two content-addressed S3 package hashes. Production thumbnail logic is untouched. The retained all-zeros case is correctly preserved with a documented rationale, and the new gradient fixture addresses a genuine gap in the golden-master coverage.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| lambdas/thumbnail/tests/test_thumbnail.py | Adds a real-content gradient TIFF fixture to the parametrized test, updates both S3 package hashes, and annotates the retained all-zeros fixture with clear rationale. |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[test_handle_image parametrized] --> B{fixture}
    B -->|s_1_t_1_c_2_z_1_RGB.tiff\nall zeros| C[Constant-input guard\ncatches div-by-zero on\nnormalization of RGB channels]
    B -->|s_1_t_1_c_2_z_1_RGB_gradient.tiff\nNEW: real content| D[Pixel-correctness guard\npins channel order,\ngrid placement, padding]
    C --> E[Compare against THUMBS_PKG\nreference thumbnail]
    D --> E
    E --> F[Pass / Fail]
```

<sub>Reviews (3): Last reviewed commit: ["thumbnail tests: explain why the all-zer..."](https://github.com/quiltdata/quilt/commit/41333772e89b20b358e7681a87cef718a959b857) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=36909322)</sub>

<!-- /greptile_comment -->