### PR TITLE
docs: note Connect ALB cert must cover the Connect host

### DIFF
--- a/docs/Catalog/Connect.md
+++ b/docs/Catalog/Connect.md
@@ -72,13 +72,12 @@ If your DNS is hosted elsewhere, create a `CNAME` record pointing to the
 [Installation CNAMEs section](Installation.md#cnames) for the equivalent
 catalog DNS records.
 
-> **TLS certificate:** the certificate served by the Connect ALB must cover the
-> Connect host. By default (`CertificateArnConnect` empty) the ALB reuses the
-> main stack certificate (`CertificateArnELB`), which must therefore include the
-> Connect host — either as a wildcard (e.g. `*.<your-domain>`) or as an explicit
-> Subject Alternative Name. If it does not, set `CertificateArnConnect` to a
-> certificate that does; otherwise DNS resolves but HTTPS fails with a
-> certificate name mismatch.
+> **TLS certificate:** by default (`CertificateArnConnect` empty) the Connect
+> ALB reuses the main stack certificate (`CertificateArnELB`), which must then
+> cover the Connect host (the `ConnectHost` output) — via an explicit Subject
+> Alternative Name or a wildcard at the matching level (`*` matches a single
+> label only). If it does not, set `CertificateArnConnect` to a certificate that
+> does; otherwise DNS resolves but HTTPS fails with a certificate name mismatch.
 
 The final Connect Server hostname is available in the `ConnectHost`
 CloudFormation output.

--- a/docs/Catalog/Connect.md
+++ b/docs/Catalog/Connect.md
@@ -25,7 +25,7 @@ Connect Server is disabled by default. To enable it, set the
 | ----------------------- | ------------- | --------------------------------------------------- |
 | `ConnectAllowedHosts`   | _(empty)_     | Comma-separated list of allowed OAuth redirect origins. Empty = disabled. See [Entry formats](#connectallowedhosts-entry-formats) below. |
 | `ConnectSecurityGroup`  | _(empty)_     | Optional EC2 security group ID for Connect ALB IP allowlisting. Empty = allow all. |
-| `CertificateArnConnect` | _(empty)_     | Optional ACM certificate ARN for the Connect ALB. Empty = reuses main stack TLS certificate. |
+| `CertificateArnConnect` | _(empty)_     | Optional ACM certificate ARN for the Connect ALB. Empty = reuses the main stack TLS certificate, which must then cover the Connect host (see [DNS Configuration](#dns-configuration)). |
 <!-- markdownlint-enable line-length table-column-style -->
 
 #### `ConnectAllowedHosts` Entry Formats
@@ -71,6 +71,14 @@ If your DNS is hosted elsewhere, create a `CNAME` record pointing to the
 `ConnectLoadBalancerDNSName` CloudFormation output. See the
 [Installation CNAMEs section](Installation.md#cnames) for the equivalent
 catalog DNS records.
+
+> **TLS certificate:** the certificate served by the Connect ALB must cover the
+> Connect host. By default (`CertificateArnConnect` empty) the ALB reuses the
+> main stack certificate (`CertificateArnELB`), which must therefore include the
+> Connect host — either as a wildcard (e.g. `*.<your-domain>`) or as an explicit
+> Subject Alternative Name. If it does not, set `CertificateArnConnect` to a
+> certificate that does; otherwise DNS resolves but HTTPS fails with a
+> certificate name mismatch.
 
 The final Connect Server hostname is available in the `ConnectHost`
 CloudFormation output.

--- a/docs/Troubleshooting.md
+++ b/docs/Troubleshooting.md
@@ -65,7 +65,8 @@ for details.
    for details.
 1. SSL errors are often caused by misspelled names, or incomplete Subject
 Alternate Names. The ACM certificate for `CertificateArnELB` must cover all
-three Quilt [hostnames](Catalog/Installation.md#dns-records) either via a
+three Quilt [hostnames](Catalog/Installation.md#dns-records) (plus the Connect
+host if Connect is enabled and `CertificateArnConnect` is empty) either via a
 suitable `*` or explicit Subject Alternate Names.
 
 ### Changing the admin email or password


### PR DESCRIPTION
# Description

The Connect Server ALB terminates HTTPS at the `<stack-name>-connect.<domain>`
host. When the optional `CertificateArnConnect` parameter is left empty, the ALB
reuses the main stack certificate (`CertificateArnELB`). That certificate must
then cover the Connect host.

Quilt's install docs let customers obtain `CertificateArnELB` as either a
wildcard (`*.<domain>`, which covers the Connect host) **or** an exact-SAN cert
listing only the catalog hosts (`quilt`, `quilt-registry`, `quilt-s3-proxy`).
The exact-SAN option omits the `-connect` host, so a customer on that documented
path who enables Connect and leaves `CertificateArnConnect` empty gets a working
DNS record but a failing TLS handshake (certificate name mismatch) — and nothing
in the deploy flags it, since CloudFormation can't validate SAN-vs-host coverage.

This adds a `TLS certificate` callout in the Connect DNS Configuration section
stating the requirement (use a wildcard or an explicit SAN, or set
`CertificateArnConnect`), and cross-references it from the `CertificateArnConnect`
parameter row.

Follow-up (out of scope here, deployment repo): a template-side guardrail that
adds the Connect host as a SAN or validates coverage would remove the failure
mode rather than document it.

# TODO

- [x] Documentation
    - [x] Markdown somewhere in docs/**/*.md that explains the feature to end users
- [ ] [Changelog](../tree/master/docs/CHANGELOG.md) entry (skip if change is not significant to end users, e.g. docs only)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds documentation clarifying that when `CertificateArnConnect` is left empty, the Connect ALB reuses the main stack certificate (`CertificateArnELB`), which must then cover the `<stack-name>-connect.<domain>` host — either via a wildcard or an explicit SAN — otherwise DNS resolves but TLS handshakes fail with a name-mismatch error.

- Updates the `CertificateArnConnect` parameter row to note the reuse requirement and links to the DNS Configuration section.
- Adds a `> **TLS certificate:**` callout block in the DNS Configuration section explaining the coverage requirement and the remediation options (wildcard, explicit SAN, or a dedicated `CertificateArnConnect`).

<h3>Confidence Score: 5/5</h3>

Documentation-only change with no impact on runtime behaviour; safe to merge.

The change is limited to two places in a single Markdown file: a one-line update to a table cell and a new blockquote callout. The content is factually accurate (matches the described CloudFormation behaviour), follows the existing callout style used elsewhere in the file, and the internal cross-reference anchor (#dns-configuration) matches the actual section heading. Nothing in the application code is touched.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| docs/Catalog/Connect.md | Adds a TLS certificate callout to the DNS Configuration section and updates the CertificateArnConnect parameter description to cross-reference it; documentation-only, no code changes. |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Deploy with Connect enabled] --> B{CertificateArnConnect set?}
    B -- Yes --> C[ALB uses dedicated Connect certificate]
    C --> G[TLS OK]
    B -- No --> D[ALB reuses main stack cert CertificateArnELB]
    D --> E{Cert covers connect host?}
    E -- Yes wildcard or explicit SAN --> G
    E -- No exact-SAN catalog hosts only --> F[DNS resolves
HTTPS fails cert name mismatch]
```

<sub>Reviews (2): Last reviewed commit: ["docs: note Connect ALB cert must cover t..."](https://github.com/quiltdata/quilt/commit/732e9d1ec24e54536a9b0a9e8e950e207744d9b3) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=36915938)</sub>

<!-- /greptile_comment -->