### PR TITLE
thumbnail tests: isolate quilt3 login state in conftest

### DIFF
--- a/lambdas/thumbnail/tests/conftest.py
+++ b/lambdas/thumbnail/tests/conftest.py
@@ -61,6 +61,9 @@ def isolated_quilt3_state(tmp_path_factory):
         mp.setattr(quilt3.session, "AUTH_PATH", base / "auth.json")
         mp.setattr(quilt3.session, "CREDENTIALS_PATH", base / "credentials.json")
         mp.setattr(quilt3.util, "CONFIG_PATH", base / "config.yml")
+        # Drop any requests session quilt3 may have cached before the paths
+        # were redirected (e.g. from import- or collection-time access).
+        quilt3.session.clear_session()
         yield
 
 

--- a/lambdas/thumbnail/tests/conftest.py
+++ b/lambdas/thumbnail/tests/conftest.py
@@ -53,13 +53,15 @@ def isolated_quilt3_state(tmp_path_factory):
     # an unreachable catalog otherwise replaces the whole AWS credential chain
     # (quilt3.session.create_botocore_session) and breaks the package-based
     # tests with DNS/auth errors before any S3 request is made.
+    # Unlike api/python/tests (which mock platformdirs wholesale), only the
+    # login state is redirected, so the package download cache stays warm
+    # across local runs.
     base = tmp_path_factory.mktemp("quilt3-state")
-    mp = pytest.MonkeyPatch()
-    mp.setattr(quilt3.session, "AUTH_PATH", base / "auth.json")
-    mp.setattr(quilt3.session, "CREDENTIALS_PATH", base / "credentials.json")
-    mp.setattr(quilt3.util, "CONFIG_PATH", base / "config.yml")
-    yield
-    mp.undo()
+    with pytest.MonkeyPatch.context() as mp:
+        mp.setattr(quilt3.session, "AUTH_PATH", base / "auth.json")
+        mp.setattr(quilt3.session, "CREDENTIALS_PATH", base / "credentials.json")
+        mp.setattr(quilt3.util, "CONFIG_PATH", base / "config.yml")
+        yield
 
 
 @pytest.fixture(scope="function", autouse=True)

--- a/lambdas/thumbnail/tests/conftest.py
+++ b/lambdas/thumbnail/tests/conftest.py
@@ -1,5 +1,8 @@
 import pytest
 
+import quilt3.session
+import quilt3.util
+
 
 def pytest_addoption(parser):
     parser.addoption(
@@ -42,6 +45,21 @@ def pytest_configure(config):
         markers_to_exclude.append('loffice')
 
     config.option.markexpr = ' and '.join([f'not {m}' for m in markers_to_exclude])
+
+
+@pytest.fixture(scope="session", autouse=True)
+def isolated_quilt3_state(tmp_path_factory):
+    # Make quilt3 behave as if never logged in: a stale `quilt3 login` against
+    # an unreachable catalog otherwise replaces the whole AWS credential chain
+    # (quilt3.session.create_botocore_session) and breaks the package-based
+    # tests with DNS/auth errors before any S3 request is made.
+    base = tmp_path_factory.mktemp("quilt3-state")
+    mp = pytest.MonkeyPatch()
+    mp.setattr(quilt3.session, "AUTH_PATH", base / "auth.json")
+    mp.setattr(quilt3.session, "CREDENTIALS_PATH", base / "credentials.json")
+    mp.setattr(quilt3.util, "CONFIG_PATH", base / "config.yml")
+    yield
+    mp.undo()
 
 
 @pytest.fixture(scope="function", autouse=True)


### PR DESCRIPTION
# Description

The package-based tests (`test_handle_image`) consult the developer's ambient quilt3 login before touching S3: `quilt3.session.create_botocore_session()` replaces the **entire** AWS credential chain with a catalog-backed `QuiltProvider` whenever a saved login (`credentials.json` in quilt3's user state dir) exists. The provider's token refresh calls the logged-in catalog's registry — so a stale `quilt3 login` against a torn-down or unreachable catalog fails every package test with `socket.gaierror` before any S3 request, with no fallback to working ambient credentials. CI never sees this (clean environment, and the test bucket is public so the anonymous fallback suffices), making it a local-only trap that hits exactly the people debugging the tests. (Second item of the thumbnail-test-hygiene follow-ups from #4960.)

Fix: a session-scoped autouse conftest fixture that points quilt3's state paths (`quilt3.session.AUTH_PATH`/`CREDENTIALS_PATH`, `quilt3.util.CONFIG_PATH`) at an empty temp dir, so quilt3 behaves as if never logged in and credential resolution falls through to the normal chain. The constants are read through module globals at call time, so patching the module attributes lands (the one `from .util import CONFIG_PATH` snapshot, in `quilt3.api`, is only used by the `quilt3.config()` writer path the tests never call). The developer's real quilt3 state and the package download cache are untouched.

Verified by running `test_handle_image` with a real stale login in `$HOME`: fails with DNS errors on master (all 27 cases), passes with this fixture (16 passed, 8 large-file skips, 5 xfails).

# TODO

- [x] Unit tests — covered by the existing suite running under the fixture
- [x] Changelog entry — skipped: test-only change, not user-visible

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds a session-scoped autouse fixture to `lambdas/thumbnail/tests/conftest.py` that redirects `quilt3`'s auth/credentials/config paths to a fresh temp directory, preventing a stale `quilt3 login` from poisoning the AWS credential chain in package-based tests.

- **`isolated_quilt3_state` fixture**: patches `quilt3.session.AUTH_PATH`, `quilt3.session.CREDENTIALS_PATH`, and `quilt3.util.CONFIG_PATH` to point at an empty temp dir, so `_load_credentials()` returns `{}` and `create_botocore_session` falls through to the normal credential chain instead of registering a `QuiltProvider` that contacts an unreachable catalog.
- **Scope and cleanup**: uses `tmp_path_factory` (correct for session scope), `pytest.MonkeyPatch()` instantiated directly (correct for session scope, since the `monkeypatch` fixture is function-scoped), and `mp.undo()` in teardown.

<h3>Confidence Score: 5/5</h3>

Test-only change that isolates quilt3 login state in a temporary directory; the developer's real credentials and the package cache are untouched, and teardown restores the original module attributes.

The fixture uses the right scope (session), the right factory (tmp_path_factory), and the right MonkeyPatch instantiation (direct pytest.MonkeyPatch() rather than the function-scoped monkeypatch fixture). The one known snapshot (quilt3.api.CONFIG_PATH imported via from .util import) is correctly called out in the PR description and is only exercised by the quilt3.config() writer path, which no thumbnail test invokes.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| lambdas/thumbnail/tests/conftest.py | Adds session-scoped autouse fixture that isolates quilt3 login state by redirecting auth/credentials/config paths to a temp dir; approach is correct and cleanup is properly handled. |

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant TestSuite
    participant isolated_quilt3_state
    participant quilt3.session
    participant quilt3.util
    participant TempDir

    TestSuite->>isolated_quilt3_state: session start (autouse)
    isolated_quilt3_state->>TempDir: tmp_path_factory.mktemp("quilt3-state")
    isolated_quilt3_state->>quilt3.session: setattr AUTH_PATH to temp/auth.json
    isolated_quilt3_state->>quilt3.session: setattr CREDENTIALS_PATH to temp/credentials.json
    isolated_quilt3_state->>quilt3.util: setattr CONFIG_PATH to temp/config.yml

    Note over quilt3.session: _load_credentials() returns empty dict
    Note over quilt3.session: create_botocore_session skips QuiltProvider

    TestSuite->>quilt3.session: Package.install / Package.browse
    quilt3.session-->>TestSuite: uses ambient AWS credentials

    TestSuite->>isolated_quilt3_state: session end
    isolated_quilt3_state->>quilt3.session: mp.undo() restore original paths
    isolated_quilt3_state->>quilt3.util: mp.undo() restore original CONFIG_PATH
```

<sub>Reviews (2): Last reviewed commit: ["thumbnail tests: isolate quilt3 login st..."](https://github.com/quiltdata/quilt/commit/b1a57cdb519548d3be1d416325b0c3ca98ccfd5e) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=36923633)</sub>

<!-- /greptile_comment -->