### PR TITLE
thumbnail: Pillow 13 compat — explicit I;16 conversion before PNG save

### DIFF
--- a/lambdas/thumbnail/CHANGELOG.md
+++ b/lambdas/thumbnail/CHANGELOG.md
@@ -17,7 +17,7 @@ where verb is one of
 
 ## Changes
 
-- [Fixed] Convert normalized greyscale thumbnails (montages, Z-projections) to 16-bit explicitly before PNG save, instead of relying on the implicit 32-bit clip that Pillow 13 removes ([#4967](https://github.com/quiltdata/quilt/pull/4967))
+- [Fixed] Convert normalized greyscale thumbnails (montages, Z-projections) to 16-bit explicitly before PNG save, instead of relying on the implicit clip to 16-bit that Pillow 13 removes ([#4967](https://github.com/quiltdata/quilt/pull/4967))
 - [Fixed] 500 on image formats readable by bioio-imageio but missing from its declared extensions, e.g. `.jpeg` and `.webp` ([#4963](https://github.com/quiltdata/quilt/pull/4963))
 - [Fixed] Support float and 16-bit color images instead of failing with HTTP 500 ([#4961](https://github.com/quiltdata/quilt/pull/4961))
 - [Fixed] Rescale 16-bit greyscale images by their actual value range to avoid nearly black thumbnails for low-range (e.g. 12-bit) data ([#4960](https://github.com/quiltdata/quilt/pull/4960))

--- a/lambdas/thumbnail/CHANGELOG.md
+++ b/lambdas/thumbnail/CHANGELOG.md
@@ -17,7 +17,7 @@ where verb is one of
 
 ## Changes
 
-- [Fixed] Convert normalized greyscale thumbnails (montages, Z-projections) to 16-bit explicitly before PNG save, instead of relying on the implicit 32-bit clip that Pillow 13 removes ([#????](https://github.com/quiltdata/quilt/pull/????))
+- [Fixed] Convert normalized greyscale thumbnails (montages, Z-projections) to 16-bit explicitly before PNG save, instead of relying on the implicit 32-bit clip that Pillow 13 removes ([#4967](https://github.com/quiltdata/quilt/pull/4967))
 - [Fixed] 500 on image formats readable by bioio-imageio but missing from its declared extensions, e.g. `.jpeg` and `.webp` ([#4963](https://github.com/quiltdata/quilt/pull/4963))
 - [Fixed] Support float and 16-bit color images instead of failing with HTTP 500 ([#4961](https://github.com/quiltdata/quilt/pull/4961))
 - [Fixed] Rescale 16-bit greyscale images by their actual value range to avoid nearly black thumbnails for low-range (e.g. 12-bit) data ([#4960](https://github.com/quiltdata/quilt/pull/4960))

--- a/lambdas/thumbnail/CHANGELOG.md
+++ b/lambdas/thumbnail/CHANGELOG.md
@@ -17,6 +17,7 @@ where verb is one of
 
 ## Changes
 
+- [Fixed] Convert normalized greyscale thumbnails (montages, Z-projections) to 16-bit explicitly before PNG save, instead of relying on the implicit 32-bit clip that Pillow 13 removes ([#????](https://github.com/quiltdata/quilt/pull/????))
 - [Fixed] 500 on image formats readable by bioio-imageio but missing from its declared extensions, e.g. `.jpeg` and `.webp` ([#4963](https://github.com/quiltdata/quilt/pull/4963))
 - [Fixed] Support float and 16-bit color images instead of failing with HTTP 500 ([#4961](https://github.com/quiltdata/quilt/pull/4961))
 - [Fixed] Rescale 16-bit greyscale images by their actual value range to avoid nearly black thumbnails for low-range (e.g. 12-bit) data ([#4960](https://github.com/quiltdata/quilt/pull/4960))

--- a/lambdas/thumbnail/pyproject.toml
+++ b/lambdas/thumbnail/pyproject.toml
@@ -41,5 +41,7 @@ default-groups = ["test"]
 filterwarnings = [
     # Regression guard: Pillow 13 removes saving mode "I" images as PNG, so
     # nothing in the pipeline may rely on it (handle_image converts to I;16).
+    # Delete this entry when the Pillow pin moves to 13 — the warning no
+    # longer exists there (the save is a hard error instead).
     "error:Saving I mode images as PNG",
 ]

--- a/lambdas/thumbnail/pyproject.toml
+++ b/lambdas/thumbnail/pyproject.toml
@@ -36,3 +36,10 @@ prod = [
 
 [tool.uv]
 default-groups = ["test"]
+
+[tool.pytest.ini_options]
+filterwarnings = [
+    # Regression guard: Pillow 13 removes saving mode "I" images as PNG, so
+    # nothing in the pipeline may rely on it (handle_image converts to I;16).
+    "error:Saving I mode images as PNG",
+]

--- a/lambdas/thumbnail/src/t4_lambda_thumbnail/__init__.py
+++ b/lambdas/thumbnail/src/t4_lambda_thumbnail/__init__.py
@@ -378,9 +378,9 @@ def handle_image(*, path: str, size: tuple[int, int], thumbnail_format: str):
 
     img = generate_thumbnail(img.compute(), size)
 
-    # PNG has no 32-bit depth, and Pillow 13 removes the implicit 16-bit clip
-    # it used to apply when saving mode "I" (norm_img output) as PNG. Convert
-    # explicitly — lossless, since norm_img clamps values to the uint16 range.
+    # PNG has no 32-bit depth, and Pillow 13 removes saving mode "I" images
+    # as PNG outright. Convert explicitly: I -> I;16 clamps exactly like the
+    # clip the implicit save used to apply, so the output is unchanged.
     if img.mode == "I":
         img = img.convert("I;16")
 

--- a/lambdas/thumbnail/src/t4_lambda_thumbnail/__init__.py
+++ b/lambdas/thumbnail/src/t4_lambda_thumbnail/__init__.py
@@ -378,6 +378,12 @@ def handle_image(*, path: str, size: tuple[int, int], thumbnail_format: str):
 
     img = generate_thumbnail(img.compute(), size)
 
+    # PNG has no 32-bit depth, and Pillow 13 removes the implicit 16-bit clip
+    # it used to apply when saving mode "I" (norm_img output) as PNG. Convert
+    # explicitly — lossless, since norm_img clamps values to the uint16 range.
+    if img.mode == "I":
+        img = img.convert("I;16")
+
     thumbnail_size = img.size
     # Store the bytes
     thumbnail_bytes = BytesIO()

--- a/lambdas/thumbnail/tests/test_thumbnail.py
+++ b/lambdas/thumbnail/tests/test_thumbnail.py
@@ -504,6 +504,18 @@ def test_generate_thumbnail_float_greyscale_saves_png():
     img.save(BytesIO(), "PNG")
 
 
+def test_norm_img_path_saves_16bit_png(data_dir):
+    # Pin the output depth of the normalized (mode I) path: the golden
+    # comparisons only enforce it as long as the goldens themselves stay
+    # 16-bit, so a golden regeneration could silently change it. Shipping
+    # 8-bit instead (smaller, browsers can't use more) is a fine future
+    # choice, but it has to be made consciously — flip this then.
+    _info, data = t4_lambda_thumbnail.handle_image(
+        path=str(data_dir / "cell.tiff"), size=(640, 480), thumbnail_format="PNG",
+    )
+    assert Image.open(BytesIO(data)).mode == "I;16"
+
+
 TEST_DATA_REGISTRY = "s3://quilt-test-public-data"
 TIFF_PKG = "images/bioio-tifffile", "5fa99558a167d6430defbfa4033808c7e7004b847e94a213292c2c776ef43ac5"
 OME_TIFF_PKG = "images/bioio-ome-tiff", "6dbddd093e0a92cfc1cc5957ad7a7177ba98a0fee5d99ffaea58e30b7c46e182"


### PR DESCRIPTION
# Description

Pillow 13 removes saving mode `I` (32-bit) images as PNG — previously an implicit, silent clip to 16-bit, deprecated in 12.x via python-pillow/Pillow#9023 because PNG has no 32-bit depth and the clip could silently lose data. The thumbnail lambda relies on exactly that implicit clip: `norm_img` outputs int32 (mode `I`), so on Pillow 13 every normalized greyscale thumbnail — multi-channel montages, Z-projections, greyscale CZIs — would 500 with `OSError: cannot write mode I as PNG`. Promoting the deprecation warning to an error kills 14 currently-passing test cases (including `c1_gray8.czi` — even uint8 input dies, since `norm_img` unconditionally casts to int32).

Fix: convert `I` → `I;16` explicitly in `handle_image` before the PNG save. The convert clamps out-of-range values exactly as the old implicit save did, so the output is **pixel-identical** to the old behavior: no golden files change (verified by exact comparison against the existing references). (The clamp is load-bearing — bicubic resize can overshoot the uint16 range, and 2D int32 sources skip `norm_img` entirely.) A `filterwarnings` regression guard (`"error:Saving I mode images as PNG"`) in pytest config keeps the deprecated path from creeping back while we're still on Pillow 12; on Pillow 13 the hard error takes over.

Considered and deferred: normalizing to uint8 in `norm_img` instead, which would additionally halve thumbnail payloads (these paths currently ship 16-bit greyscale PNGs that browsers quantize to 8-bit anyway), kill mode `I` entirely, and make `generate_thumbnail`'s resampler-fallback chain provably dead. That's a behavior change requiring regeneration of 14 goldens plus an `images/thumbs` package revision — split out as separate work so this compatibility fix stays zero-churn.

# TODO

- [x] Unit tests — regression guard via `filterwarnings`; all 14 affected cases pass under it (and fail without the fix)
- [x] Changelog entry

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds an explicit `I` → `I;16` conversion in `handle_image` before saving to PNG, fixing a breaking change in Pillow 13 where the prior implicit 32-bit-to-16-bit clip was removed. A `filterwarnings = error` guard in pytest prevents the deprecated path from silently re-entering the pipeline while still on Pillow 12.

- **`__init__.py`**: After `generate_thumbnail` returns a mode-`I` image, `img.convert("I;16")` is called before `img.save(...)`. The conversion is lossless because `norm_img` already clamps int32 values to the uint16 range (0–65 535). Thumbnail resize continues in mode `I` as before; only the save step changes.
- **`pyproject.toml`**: Adds `filterwarnings = ["error:Saving I mode images as PNG"]` under `[tool.pytest.ini_options]` to catch any future regression while Pillow 12 is still in use.
- **`CHANGELOG.md`**: Entry added for the fix.

<h3>Confidence Score: 5/5</h3>

Safe to merge — the conversion is lossless, pixel output is identical to the old implicit behaviour, and the regression guard in pytest is wired correctly.

The fix is narrow and well-scoped: norm_img already clamps int32 values to [0, 65535] before the thumbnail pipeline, so converting from mode I to I;16 is provably lossless. The only call site for handle_image always passes thumbnail_format='PNG', so there is no risk of applying a 16-bit greyscale conversion before a format that does not support it. The filterwarnings guard is syntactically correct and will catch any future accidental regression on Pillow 12.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| lambdas/thumbnail/src/t4_lambda_thumbnail/__init__.py | Adds a 5-line I→I;16 conversion guard before PNG save; logically correct and lossless given norm_img's clamping guarantee. |
| lambdas/thumbnail/pyproject.toml | Adds filterwarnings = error for the Pillow I-mode PNG deprecation warning; correct pytest.ini_options syntax and pattern. |
| lambdas/thumbnail/CHANGELOG.md | Changelog entry added in the correct section with an appropriate description and PR link. |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[handle_image called] --> B[read_image / format_aicsimage_to_prepped]
    B --> C[generate_thumbnail\nresize in mode I]
    C --> D{img.mode == 'I'?}
    D -- Yes --> E["img.convert('I;16')\n(NEW — explicit lossless clip)"]
    D -- No --> F[img.save as PNG]
    E --> F
    F --> G[Return info + bytes]

    style E fill:#d4edda,stroke:#28a745
```

<sub>Reviews (2): Last reviewed commit: ["thumbnail: fill in PR number in CHANGELO..."](https://github.com/quiltdata/quilt/commit/0105804781a7ce2908317eb8dbba72c6e0d186a4) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=36935034)</sub>

<!-- /greptile_comment -->

