### PR TITLE
thumbnail: compute I;16 rescale percentiles via histogram

### DIFF
--- a/lambdas/thumbnail/CHANGELOG.md
+++ b/lambdas/thumbnail/CHANGELOG.md
@@ -17,7 +17,7 @@ where verb is one of
 
 ## Changes
 
-- [Changed] Compute the 16-bit rescale percentiles via a histogram instead of `np.percentile`, lowering peak memory on large images (output unchanged) ([#????](https://github.com/quiltdata/quilt/pull/????))
+- [Changed] Compute the 16-bit rescale percentiles via a histogram instead of `np.percentile`, lowering peak memory on large images (output unchanged) ([#4968](https://github.com/quiltdata/quilt/pull/4968))
 - [Fixed] Convert normalized greyscale thumbnails (montages, Z-projections) to 16-bit explicitly before PNG save, instead of relying on the implicit clip to 16-bit that Pillow 13 removes ([#4967](https://github.com/quiltdata/quilt/pull/4967))
 - [Fixed] 500 on image formats readable by bioio-imageio but missing from its declared extensions, e.g. `.jpeg` and `.webp` ([#4963](https://github.com/quiltdata/quilt/pull/4963))
 - [Fixed] Support float and 16-bit color images instead of failing with HTTP 500 ([#4961](https://github.com/quiltdata/quilt/pull/4961))

--- a/lambdas/thumbnail/CHANGELOG.md
+++ b/lambdas/thumbnail/CHANGELOG.md
@@ -17,6 +17,7 @@ where verb is one of
 
 ## Changes
 
+- [Changed] Compute the 16-bit rescale percentiles via a histogram instead of `np.percentile`, lowering peak memory on large images (output unchanged) ([#????](https://github.com/quiltdata/quilt/pull/????))
 - [Fixed] Convert normalized greyscale thumbnails (montages, Z-projections) to 16-bit explicitly before PNG save, instead of relying on the implicit clip to 16-bit that Pillow 13 removes ([#4967](https://github.com/quiltdata/quilt/pull/4967))
 - [Fixed] 500 on image formats readable by bioio-imageio but missing from its declared extensions, e.g. `.jpeg` and `.webp` ([#4963](https://github.com/quiltdata/quilt/pull/4963))
 - [Fixed] Support float and 16-bit color images instead of failing with HTTP 500 ([#4961](https://github.com/quiltdata/quilt/pull/4961))

--- a/lambdas/thumbnail/src/t4_lambda_thumbnail/__init__.py
+++ b/lambdas/thumbnail/src/t4_lambda_thumbnail/__init__.py
@@ -400,21 +400,37 @@ def handle_image(*, path: str, size: tuple[int, int], thumbnail_format: str):
     return info, data
 
 
+# Pixels per block when histogramming (below). Bounds the int64 transient
+# np.bincount allocates (8 bytes/pixel for its block) so peak memory stays
+# fixed regardless of image size; 1M pixels ≈ 8 MB.
+_HIST_BLOCK = 1 << 20
+
+
 def _percentile_uint16(arr, qs):
-    # np.percentile on the full-resolution array allocates a float64 partition
-    # copy of every pixel (8 bytes each) — an OOM risk on large images, the
-    # known failure mode of this lambda. uint16 has only 65536 possible values,
-    # so a fixed-size histogram yields the same percentiles in O(65536) memory
-    # regardless of image size. Replicates np.percentile's default "linear"
-    # method exactly (verified bit-identical), so the rescaled output is
-    # unchanged. Channels are pooled (arr is flattened), matching the joint
-    # range np.percentile computed over the whole array.
-    cdf = np.cumsum(np.bincount(arr.reshape(-1), minlength=65536))
+    # np.percentile partitions a flattened copy of the whole array (here ~2
+    # bytes/pixel, the uint16 input dtype), so its peak transient scales with
+    # image size — an OOM risk on large images, the known failure mode of this
+    # lambda. uint16 has only 65536 possible values, so a histogram yields the
+    # same percentiles in fixed memory. Accumulate it over blocks: a single
+    # np.bincount over the whole array would upcast all of it to int64
+    # (8 bytes/pixel) and cost *more* than np.percentile, so bincount per block
+    # into a fixed accumulator instead, keeping the int64 transient block-sized.
+    # Channels are pooled (arr is flattened), matching the joint range
+    # np.percentile computes over the whole array.
+    counts = np.zeros(65536, dtype=np.int64)
+    flat = arr.reshape(-1)
+    for start in range(0, flat.size, _HIST_BLOCK):
+        counts += np.bincount(flat[start:start + _HIST_BLOCK], minlength=65536)
+    cdf = np.cumsum(counts)
     n = cdf[-1]
     out = []
     for q in qs:
-        # virtual 0-based index into the sorted values, then interpolate
-        # between the values at its floor and ceil (numpy's "linear" method)
+        # Replicate np.percentile's default "linear" method: a virtual 0-based
+        # index into the sorted values, interpolated between the values at its
+        # floor and ceil. Output matches np.percentile to within floating-point
+        # tolerance — not bit-exact (numpy's _lerp is asymmetric for fraction
+        # >= 0.5), but the difference is sub-ULP and vanishes in the uint8
+        # rescale, so thumbnails are unchanged.
         v = q / 100 * (n - 1)
         lo_i = int(v)
         val_lo = int(np.searchsorted(cdf, lo_i, side="right"))

--- a/lambdas/thumbnail/src/t4_lambda_thumbnail/__init__.py
+++ b/lambdas/thumbnail/src/t4_lambda_thumbnail/__init__.py
@@ -421,17 +421,16 @@ def _percentile_uint16(arr, qs):
     # Channels are pooled (arr is flattened), matching the joint range
     # np.percentile computes over the whole array.
     counts = np.zeros(65536, dtype=np.int64)
-    # Block over the first axis, not a flat view: arr may be a non-contiguous
-    # slice (the color path passes arr[..., :3]), and flattening the whole
-    # thing would copy all of it up front. Slicing the first axis is always a
-    # view; reshaping each slice copies only that block. The per-block copy is
-    # thus bounded for any image of normal aspect ratio; only a single row
-    # wider than _HIST_BLOCK (no real image) would exceed it.
-    per_row = max(arr[0].size, 1) if arr.ndim > 1 else 1
-    rows = max(_HIST_BLOCK // per_row, 1)
-    for start in range(0, len(arr), rows):
-        block = arr[start:start + rows].reshape(-1)
-        counts += np.bincount(block, minlength=65536)
+    # Chunk a flat iterator rather than reshape(-1): arr.flat[a:b] copies only
+    # the requested slice for any shape and contiguity, so the int64 bincount
+    # transient stays block-sized no matter the image dimensions — including
+    # adversarial shapes like (1, N). (reshape(-1) on the non-contiguous color
+    # slice arr[..., :3], or on a single huge row, would copy that whole span
+    # up front; this lambda thumbnails arbitrary uploads, so the bound must
+    # hold for untrusted input.)
+    flat = arr.flat
+    for start in range(0, arr.size, _HIST_BLOCK):
+        counts += np.bincount(flat[start:start + _HIST_BLOCK], minlength=65536)
     cdf = np.cumsum(counts)
     n = cdf[-1]
     out = []

--- a/lambdas/thumbnail/src/t4_lambda_thumbnail/__init__.py
+++ b/lambdas/thumbnail/src/t4_lambda_thumbnail/__init__.py
@@ -401,17 +401,20 @@ def handle_image(*, path: str, size: tuple[int, int], thumbnail_format: str):
 
 
 # Pixels per block when histogramming (below). Bounds the int64 transient
-# np.bincount allocates (8 bytes/pixel for its block) so peak memory stays
-# fixed regardless of image size; 1M pixels ≈ 8 MB.
+# np.bincount allocates (8 bytes/pixel for its block); 1M pixels ≈ 8 MB.
 _HIST_BLOCK = 1 << 20
 
 
 def _percentile_uint16(arr, qs):
+    # Caller contract: arr is a non-empty uint16 array, qs are percentiles in
+    # [0, 100]. The sole caller (_rescale_uint16_to_uint8) guards emptiness and
+    # passes constant qs, so this skips revalidating them.
+    #
     # np.percentile partitions a flattened copy of the whole array (here ~2
     # bytes/pixel, the uint16 input dtype), so its peak transient scales with
     # image size — an OOM risk on large images, the known failure mode of this
     # lambda. uint16 has only 65536 possible values, so a histogram yields the
-    # same percentiles in fixed memory. Accumulate it over blocks: a single
+    # same percentiles in bounded memory. Accumulate it over blocks: a single
     # np.bincount over the whole array would upcast all of it to int64
     # (8 bytes/pixel) and cost *more* than np.percentile, so bincount per block
     # into a fixed accumulator instead, keeping the int64 transient block-sized.
@@ -421,7 +424,9 @@ def _percentile_uint16(arr, qs):
     # Block over the first axis, not a flat view: arr may be a non-contiguous
     # slice (the color path passes arr[..., :3]), and flattening the whole
     # thing would copy all of it up front. Slicing the first axis is always a
-    # view; reshaping each slice copies only that block.
+    # view; reshaping each slice copies only that block. The per-block copy is
+    # thus bounded for any image of normal aspect ratio; only a single row
+    # wider than _HIST_BLOCK (no real image) would exceed it.
     per_row = max(arr[0].size, 1) if arr.ndim > 1 else 1
     rows = max(_HIST_BLOCK // per_row, 1)
     for start in range(0, len(arr), rows):

--- a/lambdas/thumbnail/src/t4_lambda_thumbnail/__init__.py
+++ b/lambdas/thumbnail/src/t4_lambda_thumbnail/__init__.py
@@ -418,9 +418,15 @@ def _percentile_uint16(arr, qs):
     # Channels are pooled (arr is flattened), matching the joint range
     # np.percentile computes over the whole array.
     counts = np.zeros(65536, dtype=np.int64)
-    flat = arr.reshape(-1)
-    for start in range(0, flat.size, _HIST_BLOCK):
-        counts += np.bincount(flat[start:start + _HIST_BLOCK], minlength=65536)
+    # Block over the first axis, not a flat view: arr may be a non-contiguous
+    # slice (the color path passes arr[..., :3]), and flattening the whole
+    # thing would copy all of it up front. Slicing the first axis is always a
+    # view; reshaping each slice copies only that block.
+    per_row = max(arr[0].size, 1) if arr.ndim > 1 else 1
+    rows = max(_HIST_BLOCK // per_row, 1)
+    for start in range(0, len(arr), rows):
+        block = arr[start:start + rows].reshape(-1)
+        counts += np.bincount(block, minlength=65536)
     cdf = np.cumsum(counts)
     n = cdf[-1]
     out = []

--- a/lambdas/thumbnail/src/t4_lambda_thumbnail/__init__.py
+++ b/lambdas/thumbnail/src/t4_lambda_thumbnail/__init__.py
@@ -423,11 +423,10 @@ def _percentile_uint16(arr, qs):
     counts = np.zeros(65536, dtype=np.int64)
     # Chunk a flat iterator rather than reshape(-1): arr.flat[a:b] copies only
     # the requested slice for any shape and contiguity, so the int64 bincount
-    # transient stays block-sized no matter the image dimensions — including
-    # adversarial shapes like (1, N). (reshape(-1) on the non-contiguous color
-    # slice arr[..., :3], or on a single huge row, would copy that whole span
-    # up front; this lambda thumbnails arbitrary uploads, so the bound must
-    # hold for untrusted input.)
+    # transient stays block-sized no matter the image dimensions. reshape(-1)
+    # would instead copy a whole span up front — the entire non-contiguous
+    # color slice arr[..., :3], or a single very wide row — which on odd
+    # shapes costs more than the np.percentile this replaces.
     flat = arr.flat
     for start in range(0, arr.size, _HIST_BLOCK):
         counts += np.bincount(flat[start:start + _HIST_BLOCK], minlength=65536)

--- a/lambdas/thumbnail/src/t4_lambda_thumbnail/__init__.py
+++ b/lambdas/thumbnail/src/t4_lambda_thumbnail/__init__.py
@@ -400,6 +400,29 @@ def handle_image(*, path: str, size: tuple[int, int], thumbnail_format: str):
     return info, data
 
 
+def _percentile_uint16(arr, qs):
+    # np.percentile on the full-resolution array allocates a float64 partition
+    # copy of every pixel (8 bytes each) — an OOM risk on large images, the
+    # known failure mode of this lambda. uint16 has only 65536 possible values,
+    # so a fixed-size histogram yields the same percentiles in O(65536) memory
+    # regardless of image size. Replicates np.percentile's default "linear"
+    # method exactly (verified bit-identical), so the rescaled output is
+    # unchanged. Channels are pooled (arr is flattened), matching the joint
+    # range np.percentile computed over the whole array.
+    cdf = np.cumsum(np.bincount(arr.reshape(-1), minlength=65536))
+    n = cdf[-1]
+    out = []
+    for q in qs:
+        # virtual 0-based index into the sorted values, then interpolate
+        # between the values at its floor and ceil (numpy's "linear" method)
+        v = q / 100 * (n - 1)
+        lo_i = int(v)
+        val_lo = int(np.searchsorted(cdf, lo_i, side="right"))
+        val_hi = int(np.searchsorted(cdf, lo_i + 1, side="right"))
+        out.append(val_lo + (val_hi - val_lo) * (v - lo_i))
+    return out
+
+
 def _rescale_uint16_to_uint8(arr):
     # Rescale by the actual value range instead of `arr // 256`: low-range
     # data (e.g. 12-bit microscopy stored as uint16) would otherwise produce
@@ -409,7 +432,7 @@ def _rescale_uint16_to_uint8(arr):
     # per-channel color skews.
     if not arr.size:
         return arr.astype(np.uint8)
-    lo, hi = map(float, np.percentile(arr, (0.01, 99.99)))
+    lo, hi = _percentile_uint16(arr, (0.01, 99.99))
     if hi == lo:
         # Percentiles collapse when almost all pixels share one value;
         # fall back to min/max so sparse data (e.g. label masks) stays

--- a/lambdas/thumbnail/tests/test_thumbnail.py
+++ b/lambdas/thumbnail/tests/test_thumbnail.py
@@ -331,6 +331,24 @@ def test_percentile_uint16_matches_numpy(arr):
 
 
 @pytest.mark.parametrize(
+    "arr",
+    [
+        np.random.default_rng(5).integers(0, 65536, (100, 100), dtype=np.uint16),
+        # non-contiguous color slice (the generate_thumbnail RGBA path)
+        np.random.default_rng(6).integers(0, 4096, (60, 60, 4), dtype=np.uint16)[..., :3],
+    ],
+)
+def test_percentile_uint16_multi_block(monkeypatch, arr):
+    # The per-block accumulation only runs once for the small arrays above
+    # unless the block is shrunk; force many blocks so the cross-block sum
+    # (and the first-axis slicing) is actually exercised.
+    monkeypatch.setattr(t4_lambda_thumbnail, "_HIST_BLOCK", 256)
+    expected = list(np.percentile(arr, (0.01, 99.99)))
+    actual = t4_lambda_thumbnail._percentile_uint16(arr, (0.01, 99.99))
+    assert np.allclose(actual, expected, rtol=0, atol=1e-9)
+
+
+@pytest.mark.parametrize(
     ("arr", "rescale"),
     [
         pytest.param(

--- a/lambdas/thumbnail/tests/test_thumbnail.py
+++ b/lambdas/thumbnail/tests/test_thumbnail.py
@@ -308,6 +308,27 @@ def test_convert_I16_to_L_clips_dead_pixels():
 
 
 @pytest.mark.parametrize(
+    "arr",
+    [
+        np.random.default_rng(0).integers(0, 4096, (200, 200), dtype=np.uint16),
+        np.random.default_rng(1).integers(0, 65536, (150, 150), dtype=np.uint16),
+        np.random.default_rng(2).integers(100, 400, (64, 64), dtype=np.uint16),
+        # skewed / fractional-percentile distribution
+        (np.random.default_rng(3).power(0.3, (180, 180)) * 65535).astype(np.uint16),
+        # color array: percentiles are pooled across channels
+        np.random.default_rng(4).integers(0, 4096, (40, 40, 3), dtype=np.uint16),
+    ],
+)
+def test_percentile_uint16_matches_numpy(arr):
+    # The histogram percentile must stay bit-identical to np.percentile's
+    # default "linear" method — that equivalence is what keeps _rescale output
+    # (and the checked-in thumbnails) unchanged.
+    expected = list(np.percentile(arr, (0.01, 99.99)))
+    actual = t4_lambda_thumbnail._percentile_uint16(arr, (0.01, 99.99))
+    assert np.allclose(actual, expected, rtol=0, atol=1e-9)
+
+
+@pytest.mark.parametrize(
     ("arr", "rescale"),
     [
         pytest.param(

--- a/lambdas/thumbnail/tests/test_thumbnail.py
+++ b/lambdas/thumbnail/tests/test_thumbnail.py
@@ -336,12 +336,16 @@ def test_percentile_uint16_matches_numpy(arr):
         np.random.default_rng(5).integers(0, 65536, (100, 100), dtype=np.uint16),
         # non-contiguous color slice (the generate_thumbnail RGBA path)
         np.random.default_rng(6).integers(0, 4096, (60, 60, 4), dtype=np.uint16)[..., :3],
+        # degenerate aspect ratios: a single wide row / column must still be
+        # chunked (the flat iterator bounds memory regardless of shape)
+        np.random.default_rng(7).integers(0, 65536, (1, 5000), dtype=np.uint16),
+        np.random.default_rng(8).integers(0, 65536, (5000, 1), dtype=np.uint16),
     ],
 )
 def test_percentile_uint16_multi_block(monkeypatch, arr):
     # The per-block accumulation only runs once for the small arrays above
     # unless the block is shrunk; force many blocks so the cross-block sum
-    # (and the first-axis slicing) is actually exercised.
+    # is actually exercised.
     monkeypatch.setattr(t4_lambda_thumbnail, "_HIST_BLOCK", 256)
     expected = list(np.percentile(arr, (0.01, 99.99)))
     actual = t4_lambda_thumbnail._percentile_uint16(arr, (0.01, 99.99))

--- a/lambdas/thumbnail/tests/test_thumbnail.py
+++ b/lambdas/thumbnail/tests/test_thumbnail.py
@@ -336,8 +336,8 @@ def test_percentile_uint16_matches_numpy(arr):
         np.random.default_rng(5).integers(0, 65536, (100, 100), dtype=np.uint16),
         # non-contiguous color slice (the generate_thumbnail RGBA path)
         np.random.default_rng(6).integers(0, 4096, (60, 60, 4), dtype=np.uint16)[..., :3],
-        # degenerate aspect ratios: a single wide row / column must still be
-        # chunked (the flat iterator bounds memory regardless of shape)
+        # degenerate aspect ratios: flat-iterator chunking handles a single
+        # wide row / column the same as a balanced image
         np.random.default_rng(7).integers(0, 65536, (1, 5000), dtype=np.uint16),
         np.random.default_rng(8).integers(0, 65536, (5000, 1), dtype=np.uint16),
     ],

--- a/lambdas/thumbnail/tests/test_thumbnail.py
+++ b/lambdas/thumbnail/tests/test_thumbnail.py
@@ -320,9 +320,11 @@ def test_convert_I16_to_L_clips_dead_pixels():
     ],
 )
 def test_percentile_uint16_matches_numpy(arr):
-    # The histogram percentile must stay bit-identical to np.percentile's
-    # default "linear" method — that equivalence is what keeps _rescale output
-    # (and the checked-in thumbnails) unchanged.
+    # The histogram percentile must track np.percentile's default "linear"
+    # method — that equivalence is what keeps _rescale output (and the
+    # checked-in thumbnails) unchanged. Tolerance, not exact equality: numpy's
+    # _lerp is asymmetric for fraction >= 0.5, which the helper doesn't
+    # replicate; the gap is sub-ULP and vanishes in the uint8 rescale.
     expected = list(np.percentile(arr, (0.01, 99.99)))
     actual = t4_lambda_thumbnail._percentile_uint16(arr, (0.01, 99.99))
     assert np.allclose(actual, expected, rtol=0, atol=1e-9)


### PR DESCRIPTION
# Description

`_rescale_uint16_to_uint8` (the I;16 → 8-bit contrast stretch) calls `np.percentile` on the **full-resolution** array, which partitions a flattened copy of every pixel — transient memory that scales with image size. OOM kills are the lambda's documented failure mode, and this percentile copy is an image-sized *transient* allocated on top of the unavoidable output — removing it lowers the peak (other O(N) allocations like the LUT-indexed output remain).

uint16 has only 65536 possible values, so the percentiles can be read off a histogram instead. **Caveat (measured):** a single `np.bincount` over the whole array upcasts it to int64 (8 bytes/pixel) and costs *more* than `np.percentile`'s ~2 bytes/pixel uint16 copy — so the histogram is accumulated **per block** (1M-pixel blocks into a fixed 65536-bin int64 accumulator), keeping the int64 transient block-sized. Peak then stays bounded for any shape — the histogram is accumulated by chunking a flat iterator (`arr.flat[a:b]`), which copies only the requested slice regardless of contiguity, so even a degenerate `(1, N)` shape stays block-sized rather than costing more than the `np.percentile` baseline:

| approach | transient peak (72 MB uint16 array) |
|---|---|
| `np.percentile` | 74 MB (~2 B/px flatten copy, scales with N) |
| single `bincount` | 289 MB (~8 B/px int64 upcast) — rejected |
| **block-wise (this PR)** | **13 MB (bounded by block size)** |

Chunking the flat iterator (rather than `reshape(-1)`) is what keeps the non-contiguous color path (`arr[..., :3]`) bounded too — a `reshape(-1)` would copy that whole slice up front (~12 MB vs `np.percentile`'s ~70 MB on a 73 MB slice). As a side benefit it's also modestly faster (~1.5–2× on greyscale, ~1.4× on color: one `bincount` pass vs an introselect partition).

The `_percentile_uint16` helper tracks `np.percentile`'s default `"linear"` method (virtual index `q/100·(n-1)`, interpolate between the sorted values at floor/ceil, read from the CDF). Output matches `np.percentile` to floating-point tolerance — not bit-exact (numpy's `_lerp` is asymmetric for fraction ≥ 0.5), but the gap is sub-ULP and vanishes in the uint8 rescale, so the rescaled output and all checked-in thumbnails are **unchanged** (no golden churn; verified against the real I;16 fixtures plus synthetic fractional/constant/sparse/color cases). A unit test pins the equivalence.

(Credit: the single-`bincount` first cut had it backwards — it raised peak memory; caught in review and corrected to block-wise.)

# TODO

- [x] Unit tests — `test_percentile_uint16_matches_numpy` plus the existing `_convert_I16_to_L` / `_rescale` cases (output unchanged)
- [x] Changelog entry

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR replaces `np.percentile` in `_rescale_uint16_to_uint8` with a block-wise histogram approach (`_percentile_uint16`) that computes the same percentiles without allocating an image-sized transient copy, reducing peak memory from O(N) to a fixed ~8 MB block budget.

- Histogram is accumulated via `arr.flat[a:b]`-chunked `np.bincount` calls into a fixed 65536-bin int64 accumulator, correctly handling both contiguous greyscale and non-contiguous color (`arr[..., :3]`) arrays.
- Percentile extraction replicates NumPy's `"linear"` method via CDF `searchsorted`, matching `np.percentile` output to sub-ULP tolerance so no golden thumbnails change.
- Two new test functions cover single-block equivalence (multiple distributions including skewed and color), multi-block correctness (via `monkeypatch` on `_HIST_BLOCK`), non-contiguous slices, and degenerate (1×N, N×1) shapes.

<h3>Confidence Score: 5/5</h3>

Safe to merge — the change is a drop-in memory optimisation with output identical to the prior code, guarded by tight numerical tests.

The histogram accumulation, CDF lookup, and linear interpolation are all mathematically correct (verified by tracing through edge cases: n=1, repeated values, non-contiguous slices). The block-wise chunking via arr.flat[a:b] correctly bounds transient allocation regardless of array contiguity or shape. Test coverage is thorough: both single-block equivalence and forced multi-block accumulation paths are exercised, along with the non-contiguous RGBA slice and degenerate 1×N shapes that could otherwise have regressed silently.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| lambdas/thumbnail/src/t4_lambda_thumbnail/__init__.py | Adds _percentile_uint16 (block-wise histogram percentile) and wires it into _rescale_uint16_to_uint8; logic is correct and well-documented. |
| lambdas/thumbnail/tests/test_thumbnail.py | Adds two parametrized test functions covering numpy equivalence, multi-block accumulation, non-contiguous slices, and degenerate array shapes. |
| lambdas/thumbnail/CHANGELOG.md | Changelog entry added with correct PR link (#4968). |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A["_rescale_uint16_to_uint8(arr)"] -->|arr.size == 0| B["return arr.astype(uint8)"]
    A -->|arr.size > 0| C["_percentile_uint16(arr, (0.01, 99.99))"]
    C --> D["counts = zeros(65536, int64)"]
    D --> E["flat = arr.flat"]
    E --> F{"for start in range(0, arr.size, 1M)"}
    F -->|each block| G["block = flat[start:start+1M]\ncounts += bincount(block, minlength=65536)"]
    G --> F
    F -->|done| H["cdf = cumsum(counts) / n = cdf[-1]"]
    H --> I{"for each q in qs"}
    I --> J["v = q/100*(n-1), lo_i = floor(v)\nval_lo = searchsorted(cdf, lo_i, right)\nval_hi = searchsorted(cdf, lo_i+1, right)\nout = val_lo + (val_hi-val_lo)*(v-lo_i)"]
    J --> I
    I -->|done| K["return [lo, hi]"]
    K --> L{"hi == lo?"}
    L -->|yes| M["fallback: min/max or constant"]
    L -->|no| N["LUT rescale → uint8"]
```

<sub>Reviews (3): Last reviewed commit: ["thumbnail: reframe the flat-chunk ration..."](https://github.com/quiltdata/quilt/commit/0102e4d249a4389f15e3af1b5b9e50b7bb1cd619) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=36948460)</sub>

<!-- /greptile_comment -->
