### PR TITLE
es_ingest: log Elasticsearch bulk indexing errors

### DIFF
--- a/lambdas/es_ingest/CHANGELOG.md
+++ b/lambdas/es_ingest/CHANGELOG.md
@@ -17,7 +17,7 @@ where verb is one of
 
 ## Changes
 
-- [Added] Log Elasticsearch bulk indexing errors ([#PR](https://github.com/quiltdata/quilt/pull/PR))
+- [Added] Log Elasticsearch bulk indexing errors ([#4975](https://github.com/quiltdata/quilt/pull/4975))
 - [Changed] Upgrade to Python 3.13 ([#4656](https://github.com/quiltdata/quilt/pull/4656))
 - [Changed] Switch to EventBridge S3 events ([#4471](https://github.com/quiltdata/quilt/pull/4471))
 - [Added] Bootstrap the change log ([#4422](https://github.com/quiltdata/quilt/pull/4422))

--- a/lambdas/es_ingest/CHANGELOG.md
+++ b/lambdas/es_ingest/CHANGELOG.md
@@ -17,6 +17,7 @@ where verb is one of
 
 ## Changes
 
+- [Added] Log Elasticsearch bulk indexing errors ([#PR](https://github.com/quiltdata/quilt/pull/PR))
 - [Changed] Upgrade to Python 3.13 ([#4656](https://github.com/quiltdata/quilt/pull/4656))
 - [Changed] Switch to EventBridge S3 events ([#4471](https://github.com/quiltdata/quilt/pull/4471))
 - [Added] Bootstrap the change log ([#4422](https://github.com/quiltdata/quilt/pull/4422))

--- a/lambdas/es_ingest/src/t4_lambda_es_ingest/__init__.py
+++ b/lambdas/es_ingest/src/t4_lambda_es_ingest/__init__.py
@@ -112,5 +112,11 @@ def handler(event, context):
         params["VersionId"] = version_id
 
     data = s3_client.get_object(**params)["Body"].read()
-    bulk(context, es, data)
+    try:
+        bulk(context, es, data)
+    except BulkDocumentError:
+        # Surface which batch failed. The object isn't deleted (below), so it
+        # stays in S3 for retry/DLQ and can be fetched for inspection.
+        logger.error("Bulk indexing failed for s3://%s/%s", bucket, key)
+        raise
     s3_client.delete_object(**params)

--- a/lambdas/es_ingest/src/t4_lambda_es_ingest/__init__.py
+++ b/lambdas/es_ingest/src/t4_lambda_es_ingest/__init__.py
@@ -1,3 +1,4 @@
+import collections
 import json
 import os
 import random
@@ -38,7 +39,10 @@ def bulk(context, es, data: bytes):
     try:
         resp = es.bulk(
             data,
-            filter_path="errors",
+            # Return per-item errors so failures can be diagnosed. Successful
+            # items have no `error` field, so they're pruned from the response,
+            # keeping the (common) no-error case compact.
+            filter_path="errors,items.*.error",
             # wait as much as possible because it's better die trying than just die
             # leave a second to avoid lambda timeout
             request_timeout=context.get_remaining_time_in_millis() / 1000 - 1,
@@ -65,9 +69,21 @@ def bulk(context, es, data: bytes):
         logger.warning("Sleeping for %s seconds to avoid ES overload", time_to_sleep)
         time.sleep(time_to_sleep)
     if resp["errors"]:
-        # TODO: log errors from items.*.error?
+        # Failures are usually systematic (e.g. a single bad mapping affecting
+        # many documents), so aggregate by error to bound the log/message size.
+        failures = collections.Counter(
+            (op, error.get("type"), error.get("reason"))
+            for item in resp.get("items", [])
+            for op, details in item.items()
+            if (error := details.get("error"))
+        )
+        for (op, error_type, reason), count in failures.items():
+            logger.error("Bulk %s failed (x%s): %s: %s", op, count, error_type, reason)
         # TODO: ignore index_not_found_exception for delete operations?
-        raise BulkDocumentError
+        raise BulkDocumentError(
+            f"{sum(failures.values())} document(s) failed to index "
+            f"({len(failures)} distinct error(s))"
+        )
 
 
 def handler(event, context):

--- a/lambdas/es_ingest/src/t4_lambda_es_ingest/__init__.py
+++ b/lambdas/es_ingest/src/t4_lambda_es_ingest/__init__.py
@@ -80,9 +80,11 @@ def bulk(context, es, data: bytes):
         )
         if failures:
             for (op, error_type, reason), count in failures.items():
-                logger.error("Bulk %s failed (x%s): %s: %s", op, count, error_type, reason)
+                # %r so a user-controlled `reason` (ES echoes field names/values)
+                # can't forge log lines via embedded newlines.
+                logger.error("Bulk %s failed (x%s): %r: %r", op, count, error_type, reason)
             detail = (
-                f"{failures.total()} document(s) failed to index "
+                f"{failures.total()} document(s) failed in bulk request "
                 f"({len(failures)} distinct error(s))"
             )
         else:

--- a/lambdas/es_ingest/src/t4_lambda_es_ingest/__init__.py
+++ b/lambdas/es_ingest/src/t4_lambda_es_ingest/__init__.py
@@ -78,13 +78,22 @@ def bulk(context, es, data: bytes):
             for op, details in item.items()
             if (error := details.get("error"))
         )
-        for (op, error_type, reason), count in failures.items():
-            logger.error("Bulk %s failed (x%s): %s: %s", op, count, error_type, reason)
+        if failures:
+            for (op, error_type, reason), count in failures.items():
+                logger.error("Bulk %s failed (x%s): %s: %s", op, count, error_type, reason)
+            detail = (
+                f"{failures.total()} document(s) failed to index "
+                f"({len(failures)} distinct error(s))"
+            )
+        else:
+            # `errors` is set but no per-item error details came back. This
+            # shouldn't happen for ES 6.8 (failed items always carry an `error`),
+            # but log the raw response so the failure stays diagnosable instead
+            # of raising with no detail.
+            logger.error("Bulk reported errors but no per-item error details were found: %s", resp)
+            detail = "bulk reported errors but no per-item error details were found"
         # TODO: ignore index_not_found_exception for delete operations?
-        raise BulkDocumentError(
-            f"{failures.total()} document(s) failed to index "
-            f"({len(failures)} distinct error(s))"
-        )
+        raise BulkDocumentError(detail)
 
 
 def handler(event, context):

--- a/lambdas/es_ingest/src/t4_lambda_es_ingest/__init__.py
+++ b/lambdas/es_ingest/src/t4_lambda_es_ingest/__init__.py
@@ -69,8 +69,9 @@ def bulk(context, es, data: bytes):
         logger.warning("Sleeping for %s seconds to avoid ES overload", time_to_sleep)
         time.sleep(time_to_sleep)
     if resp["errors"]:
-        # Failures are usually systematic (e.g. a single bad mapping affecting
-        # many documents), so aggregate by error to bound the log/message size.
+        # Aggregate by error: failures are usually systematic (e.g. one bad
+        # mapping affecting many documents), so this keeps the logs and message
+        # compact in the common case.
         failures = collections.Counter(
             (op, error.get("type"), error.get("reason"))
             for item in resp.get("items", [])
@@ -81,7 +82,7 @@ def bulk(context, es, data: bytes):
             logger.error("Bulk %s failed (x%s): %s: %s", op, count, error_type, reason)
         # TODO: ignore index_not_found_exception for delete operations?
         raise BulkDocumentError(
-            f"{sum(failures.values())} document(s) failed to index "
+            f"{failures.total()} document(s) failed to index "
             f"({len(failures)} distinct error(s))"
         )
 

--- a/lambdas/es_ingest/tests/test_main.py
+++ b/lambdas/es_ingest/tests/test_main.py
@@ -22,12 +22,15 @@ def test_bulk_ok(mocker):
 
 
 def test_bulk_error(mocker, caplog):
+    mapper_error = {"index": {"error": {"type": "mapper_parsing_exception", "reason": "failed to parse field [x]"}}}
     mock_bulk = mocker.patch(
         "elasticsearch.Elasticsearch.bulk",
         return_value={
             "errors": True,
             "items": [
-                {"index": {"error": {"type": "mapper_parsing_exception", "reason": "failed to parse field [x]"}}},
+                mapper_error,
+                # Identical to the first: must collapse into a single (x2) group.
+                mapper_error,
                 {"delete": {"error": {"type": "index_not_found_exception", "reason": "no such index [y]"}}},
             ],
         },
@@ -41,10 +44,10 @@ def test_bulk_error(mocker, caplog):
         filter_path="errors,items.*.error",
         request_timeout=mocker.ANY,
     )
-    assert "mapper_parsing_exception" in caplog.text
-    assert "failed to parse field [x]" in caplog.text
-    assert "index_not_found_exception" in caplog.text
-    assert "2 document(s) failed to index" in str(exc_info.value)
+    # The two identical errors collapse into one (x2) group; the delete stays separate.
+    assert "Bulk index failed (x2): mapper_parsing_exception: failed to parse field [x]" in caplog.text
+    assert "Bulk delete failed (x1): index_not_found_exception: no such index [y]" in caplog.text
+    assert "3 document(s) failed to index (2 distinct error(s))" in str(exc_info.value)
 
 
 def test_bulk_too_many_requests(mocker):

--- a/lambdas/es_ingest/tests/test_main.py
+++ b/lambdas/es_ingest/tests/test_main.py
@@ -45,9 +45,10 @@ def test_bulk_error(mocker, caplog):
         request_timeout=mocker.ANY,
     )
     # The two identical errors collapse into one (x2) group; the delete stays separate.
-    assert "Bulk index failed (x2): mapper_parsing_exception: failed to parse field [x]" in caplog.text
-    assert "Bulk delete failed (x1): index_not_found_exception: no such index [y]" in caplog.text
-    assert "3 document(s) failed to index (2 distinct error(s))" in str(exc_info.value)
+    # %r-quoted so log-line forgery via a crafted reason is escaped.
+    assert "Bulk index failed (x2): 'mapper_parsing_exception': 'failed to parse field [x]'" in caplog.text
+    assert "Bulk delete failed (x1): 'index_not_found_exception': 'no such index [y]'" in caplog.text
+    assert "3 document(s) failed in bulk request (2 distinct error(s))" in str(exc_info.value)
 
 
 def test_bulk_error_without_details(mocker, caplog):

--- a/lambdas/es_ingest/tests/test_main.py
+++ b/lambdas/es_ingest/tests/test_main.py
@@ -135,3 +135,28 @@ def test_handler(mocker, version_id):
 
         stubber.assert_no_pending_responses()
         mock_bulk.assert_called_once_with(mock_context, t4_lambda_es_ingest.es, b"test data")
+
+
+def test_handler_logs_source_on_bulk_error(mocker, caplog):
+    mock_context = mocker.MagicMock()
+    mock_event = {
+        "Records": [
+            {"body": json.dumps({"detail": {"bucket": {"name": "test-bucket"}, "object": {"key": "test-key"}}})},
+        ]
+    }
+
+    with Stubber(t4_lambda_es_ingest.s3_client) as stubber:
+        mocker.patch("t4_lambda_es_ingest.bulk", side_effect=t4_lambda_es_ingest.BulkDocumentError("boom"))
+        stubber.add_response(
+            "get_object",
+            {"Body": mocker.MagicMock(read=lambda: b"test data"), "LastModified": "2023-10-01T00:00:00Z"},
+            {"Bucket": "test-bucket", "Key": "test-key"},
+        )
+        # No delete_object response is queued: the object must NOT be deleted on
+        # failure (so it stays for retry/DLQ); a delete call would error here.
+        with caplog.at_level(logging.ERROR), pytest.raises(t4_lambda_es_ingest.BulkDocumentError):
+            t4_lambda_es_ingest.handler(mock_event, mock_context)
+
+        stubber.assert_no_pending_responses()
+
+    assert "s3://test-bucket/test-key" in caplog.text

--- a/lambdas/es_ingest/tests/test_main.py
+++ b/lambdas/es_ingest/tests/test_main.py
@@ -50,6 +50,23 @@ def test_bulk_error(mocker, caplog):
     assert "3 document(s) failed to index (2 distinct error(s))" in str(exc_info.value)
 
 
+def test_bulk_error_without_details(mocker, caplog):
+    # `errors` set but no per-item error details: still raise, and log the raw
+    # response so the failure isn't silently undiagnosable.
+    mock_bulk = mocker.patch("elasticsearch.Elasticsearch.bulk", return_value={"errors": True})
+    mock_context = mocker.MagicMock()
+    with caplog.at_level(logging.ERROR), pytest.raises(t4_lambda_es_ingest.BulkDocumentError) as exc_info:
+        t4_lambda_es_ingest.bulk(mock_context, t4_lambda_es_ingest.es, b"data")
+
+    mock_bulk.assert_called_once_with(
+        b"data",
+        filter_path="errors,items.*.error",
+        request_timeout=mocker.ANY,
+    )
+    assert "no per-item error details" in caplog.text
+    assert "no per-item error details" in str(exc_info.value)
+
+
 def test_bulk_too_many_requests(mocker):
     mocker.patch("elasticsearch.exceptions.TransportError.status_code", 429)
     mock_bulk = mocker.patch("elasticsearch.Elasticsearch.bulk", side_effect=elasticsearch.exceptions.TransportError)

--- a/lambdas/es_ingest/tests/test_main.py
+++ b/lambdas/es_ingest/tests/test_main.py
@@ -1,4 +1,5 @@
 import json
+import logging
 
 import elasticsearch
 import pytest
@@ -7,17 +8,43 @@ from botocore.stub import Stubber
 import t4_lambda_es_ingest
 
 
-def test_bulk_error(mocker):
-    mock_bulk = mocker.patch("elasticsearch.Elasticsearch.bulk", return_value={"errors": True})
+def test_bulk_ok(mocker):
+    mock_bulk = mocker.patch("elasticsearch.Elasticsearch.bulk", return_value={"errors": False})
     mock_context = mocker.MagicMock()
-    with pytest.raises(t4_lambda_es_ingest.BulkDocumentError):
+
+    t4_lambda_es_ingest.bulk(mock_context, t4_lambda_es_ingest.es, b"data")
+
+    mock_bulk.assert_called_once_with(
+        b"data",
+        filter_path="errors,items.*.error",
+        request_timeout=mocker.ANY,
+    )
+
+
+def test_bulk_error(mocker, caplog):
+    mock_bulk = mocker.patch(
+        "elasticsearch.Elasticsearch.bulk",
+        return_value={
+            "errors": True,
+            "items": [
+                {"index": {"error": {"type": "mapper_parsing_exception", "reason": "failed to parse field [x]"}}},
+                {"delete": {"error": {"type": "index_not_found_exception", "reason": "no such index [y]"}}},
+            ],
+        },
+    )
+    mock_context = mocker.MagicMock()
+    with caplog.at_level(logging.ERROR), pytest.raises(t4_lambda_es_ingest.BulkDocumentError) as exc_info:
         t4_lambda_es_ingest.bulk(mock_context, t4_lambda_es_ingest.es, b"data")
 
     mock_bulk.assert_called_once_with(
         b"data",
-        filter_path=mocker.ANY,
+        filter_path="errors,items.*.error",
         request_timeout=mocker.ANY,
     )
+    assert "mapper_parsing_exception" in caplog.text
+    assert "failed to parse field [x]" in caplog.text
+    assert "index_not_found_exception" in caplog.text
+    assert "2 document(s) failed to index" in str(exc_info.value)
 
 
 def test_bulk_too_many_requests(mocker):


### PR DESCRIPTION
# Description

When the `es_ingest` lambda got a bulk Elasticsearch response with item-level errors, it raised a bare `BulkDocumentError` with no detail — operators had no way to tell which documents failed or why (the long-standing TODO at `bulk()`).

This widens the bulk `filter_path` from `errors` to `errors,items.*.error` so per-item error info comes back. On failure the items are aggregated by `(operation, error type, reason)` — failures are usually systematic (one bad mapping affecting many docs), so this bounds the log/message size — each distinct error is logged via `logger.error`, and a summary (`N document(s) failed in bulk request (M distinct error(s))`) is attached to `BulkDocumentError`.

Successful items carry no `error` field and so are pruned from the response, keeping the common no-error case compact. `BulkDocumentError` is still raised, so SQS retry/DLQ behavior is unchanged.

## Design decision: don't log per-document `_id`

Failure logs carry the error **type, reason, and count**, but not the document `_id`. `_id` exists on successful items too, so adding it to `filter_path` would un-prune every success and echo full item metadata back on *every* healthy bulk call. Given the deployed load, that's the wrong trade-off:

- es_ingest runs on a **160 MB** lambda (Lambda CPU scales with memory) and processes **one S3 object per invocation of up to 10,000 docs / 8 MB** (`BATCH_MAX_DOCS` / `BATCH_MAX_BYTES`), at up to 20× concurrency — the minimal `filter_path` is what keeps the common no-error response tiny (`{"errors": false}`).
- A fully-successful 10k-doc batch would echo back **~1.5 MB** of `_id`s to receive and JSON-parse on that 160 MB lambda, on every successful invocation; the compact response is ~17 bytes.
- The entry `_id` is `entry:{manifest_hash}:sha256(logical_key)` — opaque and non-reversible, so it wouldn't even identify the offending file. `error.reason` (which names the field/value) is the actionable signal.

So failures log as `Bulk <op> failed (xN): <type>: <reason>` plus the exception summary, and the handler logs the failing batch's `s3://bucket/key` — an O(1) correlator that (unlike `_id`) names the object to fetch and inspect, and which stays in S3 on failure for retry/DLQ. That's enough to diagnose the systematic failures that dominate, without taxing the hot path.

# TODO

- [x] Unit tests
- [x] Security: Confirm that this change meets security best practices and does not violate the security model
- [x] [Changelog](../tree/master/docs/CHANGELOG.md) entry

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR resolves a long-standing TODO by widening the Elasticsearch bulk `filter_path` from `"errors"` to `"errors,items.*.error"`, enabling per-item error details to be captured and logged on failure. Errors are aggregated by `(operation, type, reason)` before logging, keeping output compact for the common case of systematic failures.

- **Error aggregation and logging**: on bulk failure, a `Counter` collapses identical `(op, type, reason)` tuples into a single `logger.error` line with a repeat count, then attaches a human-readable summary (`N document(s) failed, M distinct error(s)`) to the raised `BulkDocumentError`.
- **Fallback path**: when `errors: true` but no per-item error details are returned (unexpected for ES 6.8), the raw response is logged and a descriptive detail string is attached to the exception so the failure remains diagnosable.
- **Tests**: three focused new/updated tests cover the happy path, the aggregation path, and the no-details fallback; `filter_path` is now asserted exactly (not `mocker.ANY`) in the error and ok tests.

<h3>Confidence Score: 4/5</h3>

Safe to merge; the change is additive (broader filter_path + aggregated logging) with no impact on the existing retry/DLQ path or SQS behavior.

The logic is correct, the fallback for unexpected ES responses is handled, and BulkDocumentError is still raised so downstream retry behavior is unchanged. The one observation is that the log loop iterating failures.items() has no explicit upper bound — ES reason strings can carry per-field or per-value detail, making it possible for a large batch to produce many distinct tuples and a corresponding burst of logger.error calls. This is unlikely in practice for the systematic failures that dominate, but it could matter in edge cases with diverse per-document reasons.

lambdas/es_ingest/src/t4_lambda_es_ingest/__init__.py — specifically the for … in failures.items() loop

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| lambdas/es_ingest/src/t4_lambda_es_ingest/__init__.py | Core change: widens filter_path to "errors,items.*.error", aggregates per-item errors via Counter, and attaches a detail string to BulkDocumentError. Logic is correct; one minor note on unbounded logger.error loop for highly-distinct failures. |
| lambdas/es_ingest/tests/test_main.py | Good new test coverage: test_bulk_ok verifies the updated filter_path, test_bulk_error checks Counter aggregation and exception message, test_bulk_error_without_details covers the fallback path. All assertions are specific and meaningful. |
| lambdas/es_ingest/CHANGELOG.md | Changelog entry added correctly at the top of the Changes section. |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[es.bulk called\nfilter_path: errors,items.*.error] --> B{TransportError?}
    B -- 429 --> C[sleep_until_timeout\nraise TooManyRequestsError]
    B -- other --> D[re-raise]
    B -- no --> E{resp errors == True?}
    E -- no --> F[Return normally\ncompact response ~17 bytes]
    E -- yes --> G[Build Counter\ngroup by op + type + reason]
    G --> H{any failures in Counter?}
    H -- yes --> I[logger.error per\ndistinct group\nop, count, type, reason]
    I --> J[detail = N doc\nfailed M distinct errors]
    H -- no --> K[logger.error raw resp\ndetail = no per-item details]
    J --> L[raise BulkDocumentError with detail]
    K --> L
```

<sub>Reviews (1): Last reviewed commit: ["es\_ingest: guard against errors flag wit..."](https://github.com/quiltdata/quilt/commit/b947156e2a75011fb98e5419c64b11ac044328d1) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=37615128)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->

