### PR TITLE
thumbnail: stream montage normalization to bound multi-channel memory

### DIFF
--- a/.github/workflows/deploy-lambdas.yaml
+++ b/.github/workflows/deploy-lambdas.yaml
@@ -4,14 +4,12 @@ on:
   push:
     branches:
       - master
-      - thumbnail-montage-bounded-memory  # TEMP: build branch image for dev-stack benchmark; revert before merge
     paths:
       - '.github/workflows/deploy-lambdas.yaml'
       - 'lambdas/**'
 
 jobs:
   deploy-lambda-s3:
-    if: github.ref == 'refs/heads/master'  # TEMP: skip on the benchmark branch; revert before merge
     strategy:
       fail-fast: false
       matrix:
@@ -69,9 +67,9 @@ jobs:
       fail-fast: false
       matrix:
         path:
-          # TEMP: thumbnail only for the dev-stack benchmark; restore indexer +
-          # tabular_preview before merge
+          - indexer
           - thumbnail
+          - tabular_preview
     runs-on: ubuntu-latest
     # These permissions are needed to interact with GitHub's OIDC Token endpoint.
     permissions:
@@ -89,5 +87,10 @@ jobs:
           aws-region: us-east-1
       - name: Push Docker image to Prod ECR
         run: ./lambdas/scripts/upload_ecr.sh 730278974607 "quiltdata/lambdas/${{ matrix.path }}:${{ github.sha }}"
-      # TEMP: GovCloud push removed for the branch build (dev-stack pulls from
-      # Prod only); restore before merge.
+      - name: Configure AWS credentials from GovCloud account
+        uses: aws-actions/configure-aws-credentials@v6
+        with:
+          role-to-assume: arn:aws-us-gov:iam::313325871032:role/github/GitHub-Quilt
+          aws-region: us-gov-east-1
+      - name: Push Docker image to GovCloud ECR
+        run: ./lambdas/scripts/upload_ecr.sh 313325871032 "quiltdata/lambdas/${{ matrix.path }}:${{ github.sha }}"

--- a/.github/workflows/deploy-lambdas.yaml
+++ b/.github/workflows/deploy-lambdas.yaml
@@ -4,12 +4,14 @@ on:
   push:
     branches:
       - master
+      - thumbnail-montage-bounded-memory  # TEMP: build branch image for dev-stack benchmark; revert before merge
     paths:
       - '.github/workflows/deploy-lambdas.yaml'
       - 'lambdas/**'
 
 jobs:
   deploy-lambda-s3:
+    if: github.ref == 'refs/heads/master'  # TEMP: skip on the benchmark branch; revert before merge
     strategy:
       fail-fast: false
       matrix:
@@ -67,9 +69,9 @@ jobs:
       fail-fast: false
       matrix:
         path:
-          - indexer
+          # TEMP: thumbnail only for the dev-stack benchmark; restore indexer +
+          # tabular_preview before merge
           - thumbnail
-          - tabular_preview
     runs-on: ubuntu-latest
     # These permissions are needed to interact with GitHub's OIDC Token endpoint.
     permissions:
@@ -87,10 +89,5 @@ jobs:
           aws-region: us-east-1
       - name: Push Docker image to Prod ECR
         run: ./lambdas/scripts/upload_ecr.sh 730278974607 "quiltdata/lambdas/${{ matrix.path }}:${{ github.sha }}"
-      - name: Configure AWS credentials from GovCloud account
-        uses: aws-actions/configure-aws-credentials@v6
-        with:
-          role-to-assume: arn:aws-us-gov:iam::313325871032:role/github/GitHub-Quilt
-          aws-region: us-gov-east-1
-      - name: Push Docker image to GovCloud ECR
-        run: ./lambdas/scripts/upload_ecr.sh 313325871032 "quiltdata/lambdas/${{ matrix.path }}:${{ github.sha }}"
+      # TEMP: GovCloud push removed for the branch build (dev-stack pulls from
+      # Prod only); restore before merge.

--- a/lambdas/thumbnail/CHANGELOG.md
+++ b/lambdas/thumbnail/CHANGELOG.md
@@ -17,6 +17,7 @@ where verb is one of
 
 ## Changes
 
+- [Changed] Lower peak memory of the normalized greyscale montage/projection path for unsigned 16-bit images via a histogram percentile and lookup-table rescale, instead of a float64 copy of the whole plane (generated thumbnails unchanged) ([#4976](https://github.com/quiltdata/quilt/pull/4976))
 - [Fixed] Normalized greyscale thumbnails (multi-channel montages, Z-projections) with a constant channel or NaN pixels now render deterministically instead of coming out blank or garbled; other thumbnails are unchanged ([#4974](https://github.com/quiltdata/quilt/pull/4974))
 - [Changed] Simplify 16-bit greyscale handling: rescale to 8-bit by array dtype before resizing and drop the now-unreachable resampler fallback (generated thumbnails unchanged) ([#4971](https://github.com/quiltdata/quilt/pull/4971))
 - [Changed] Compute the 16-bit rescale percentiles via a histogram instead of `np.percentile`, lowering peak memory on large images (output unchanged) ([#4968](https://github.com/quiltdata/quilt/pull/4968))

--- a/lambdas/thumbnail/CHANGELOG.md
+++ b/lambdas/thumbnail/CHANGELOG.md
@@ -17,7 +17,7 @@ where verb is one of
 
 ## Changes
 
-- [Changed] Lower peak memory of the normalized greyscale montage/projection path for unsigned 16-bit images via a histogram percentile and lookup-table rescale, instead of a float64 copy of the whole plane (generated thumbnails unchanged) ([#4976](https://github.com/quiltdata/quilt/pull/4976))
+- [Changed] Normalize greyscale montage/projection planes lazily so the montage streams — dask computes and frees one channel at a time instead of holding all of them at once — keeping peak memory bounded on large multi-channel images and running faster; generated thumbnails unchanged ([#4976](https://github.com/quiltdata/quilt/pull/4976))
 - [Fixed] Normalized greyscale thumbnails (multi-channel montages, Z-projections) with a constant channel or NaN pixels now render deterministically instead of coming out blank or garbled; other thumbnails are unchanged ([#4974](https://github.com/quiltdata/quilt/pull/4974))
 - [Changed] Simplify 16-bit greyscale handling: rescale to 8-bit by array dtype before resizing and drop the now-unreachable resampler fallback (generated thumbnails unchanged) ([#4971](https://github.com/quiltdata/quilt/pull/4971))
 - [Changed] Compute the 16-bit rescale percentiles via a histogram instead of `np.percentile`, lowering peak memory on large images (output unchanged) ([#4968](https://github.com/quiltdata/quilt/pull/4968))

--- a/lambdas/thumbnail/CHANGELOG.md
+++ b/lambdas/thumbnail/CHANGELOG.md
@@ -17,7 +17,7 @@ where verb is one of
 
 ## Changes
 
-- [Changed] Normalize greyscale montage/projection planes lazily so the montage streams — dask computes and frees one channel at a time instead of holding all of them at once — keeping peak memory bounded on large multi-channel images and running faster; generated thumbnails unchanged ([#4976](https://github.com/quiltdata/quilt/pull/4976))
+- [Changed] Normalize greyscale montage/projection planes lazily so dask releases each plane once it is copied into the montage instead of keeping every channel resident through the downstream resize — lowering peak memory on large multi-channel images and running faster; generated thumbnails unchanged ([#4976](https://github.com/quiltdata/quilt/pull/4976))
 - [Fixed] Normalized greyscale thumbnails (multi-channel montages, Z-projections) with a constant channel or NaN pixels now render deterministically instead of coming out blank or garbled; other thumbnails are unchanged ([#4974](https://github.com/quiltdata/quilt/pull/4974))
 - [Changed] Simplify 16-bit greyscale handling: rescale to 8-bit by array dtype before resizing and drop the now-unreachable resampler fallback (generated thumbnails unchanged) ([#4971](https://github.com/quiltdata/quilt/pull/4971))
 - [Changed] Compute the 16-bit rescale percentiles via a histogram instead of `np.percentile`, lowering peak memory on large images (output unchanged) ([#4968](https://github.com/quiltdata/quilt/pull/4968))

--- a/lambdas/thumbnail/src/t4_lambda_thumbnail/__init__.py
+++ b/lambdas/thumbnail/src/t4_lambda_thumbnail/__init__.py
@@ -211,7 +211,7 @@ def _norm_uint_to_int32(arr: np.ndarray, lo: float, hi: float) -> np.ndarray:
     images). Caller guarantees hi != lo.
     """
     imax = np.iinfo(np.uint16).max + 1  # 65536; the I;16 range is [0, imax)
-    lut = np.arange(65536, dtype=np.float64)
+    lut = np.arange(imax, dtype=np.float64)  # one entry per possible uint16 value
     np.clip(lut, lo, hi, out=lut)
     lut -= lo
     lut /= hi - lo

--- a/lambdas/thumbnail/src/t4_lambda_thumbnail/__init__.py
+++ b/lambdas/thumbnail/src/t4_lambda_thumbnail/__init__.py
@@ -159,9 +159,9 @@ def _finite_clip_range(arr: np.ndarray) -> tuple[float, float] | None:
     finite plane collapses both the percentiles and the min/max fallback — so
     callers must re-check and handle the no-contrast case themselves.
 
-    Shared by norm_img (float planes) and _rescale_float_to_uint8 so their
-    clip/fallback and non-finite filtering can't diverge (the same pixels must
-    not render differently by reader path). The unsigned-integer paths use
+    Shared by _normalize_plane (float planes) and _rescale_float_to_uint8 so
+    their clip/fallback and non-finite filtering can't diverge (the same pixels
+    must not render differently by reader path). The unsigned-integer paths use
     _uint16_clip_range instead (histogram percentile, bounded memory).
     """
     # Compact to the finite values only when some are non-finite: the masked
@@ -185,13 +185,14 @@ def _finite_clip_range(arr: np.ndarray) -> tuple[float, float] | None:
 
 def _uint16_clip_range(arr: np.ndarray) -> tuple[float, float]:
     """
-    Percentile clip bounds (0.01, 99.99) for an unsigned <=16-bit plane via a
-    histogram (bounded memory, no float64 copy of the plane), with the same
-    min/max fallback as _finite_clip_range when the percentiles collapse. A
-    returned ``(lo, hi)`` can still have ``hi == lo`` (constant plane) — callers
-    re-check. Integer planes carry no non-finite values, so there is nothing to
-    filter. Shared by norm_img and _rescale_uint16_to_uint8 so their range
-    logic can't diverge.
+    Percentile clip bounds (0.01, 99.99) for an unsigned <=16-bit plane (uint16,
+    uint8, or byte-swapped >u2 — anything `_percentile_uint16`'s 65536-bin
+    histogram covers) via a histogram (bounded memory, no float64 copy of the
+    plane), with the same min/max fallback as _finite_clip_range when the
+    percentiles collapse. A returned ``(lo, hi)`` can still have ``hi == lo``
+    (constant plane) — callers re-check. Integer planes carry no non-finite
+    values, so there is nothing to filter. Shared by _normalize_plane and
+    _rescale_uint16_to_uint8 so their range logic can't diverge.
     """
     lo, hi = _percentile_uint16(arr, (0.01, 99.99))
     if hi == lo:
@@ -254,6 +255,11 @@ def _normalize_plane(plane) -> np.ndarray:
 
     # Float (and any other) planes: range in float64 with finite-aware
     # percentiles. float64 (not float32) matches the previous math bit-for-bit.
+    # copy=False skips the copy only when `arr` is already float64; the in-place
+    # math below then mutates it, so this assumes `arr` is private. It is here:
+    # np.asarray of the computed dask block (or of a non-float64 array, which
+    # astype copies) yields a fresh array. A future direct caller that hands in
+    # a float64 array it still needs would see it mutated.
     arr = arr.astype(np.float64, copy=False)
     imax = np.iinfo(np.uint16).max + 1  # 65536; the I;16 range is [0, imax)
 
@@ -288,13 +294,19 @@ def norm_img(img: da.Array) -> da.Array:
     Lazily normalize a greyscale plane for the n-dim montage / projection path;
     color planes (YXC / YXS) are returned unchanged.
 
-    The normalization (_normalize_plane) is eager NumPy, but wrapped in
-    dask.delayed so the montage stays a lazy graph: dask computes and frees one
-    plane at a time during the final .compute(), keeping peak memory to ~the
-    montage plus a single plane rather than all N planes at once. (Materializing
-    every plane up front, as a direct NumPy assembly would, raised peak memory
-    on large multi-channel images — OOM is this lambda's documented failure
-    mode.)
+    _normalize_plane is eager NumPy, but wrapped in dask.delayed so the plane is
+    a deferred task in the montage graph rather than a concrete array. dask
+    materializes each plane when the montage is computed and releases it once it
+    has been copied into the output, so the planes don't stay resident through
+    the downstream resize. Returning a concrete array instead (da.from_array)
+    bakes every plane into the graph, keeping all N resident as long as the
+    montage is referenced — and handle_image holds the montage through
+    generate_thumbnail's resize, so on large multi-channel images that OOMs (the
+    documented failure mode). The peak while the montage itself is assembled is
+    similar either way; the win is not carrying the planes into the resize.
+
+    da.from_delayed trusts _normalize_plane to return an array of this shape and
+    dtype — keep them in sync (a mismatch corrupts the graph rather than raising).
     """
     if len(img.shape) == 3:
         # leave color images alone
@@ -330,8 +342,9 @@ def _format_n_dim_ndarray(img: BioImage) -> da.Array:
         # Each channel is normalized lazily (norm_img returns a dask graph), then
         # laid out in the most-square grid: every cell padded 5px on its top and
         # left, the whole montage padded 5px on its bottom and right. Keeping the
-        # planes lazy lets dask compute and free them one at a time when the
-        # montage is finally computed, instead of holding all N at once.
+        # planes lazy lets dask release each once it has been copied into the
+        # montage, so they don't stay resident through the downstream resize (see
+        # norm_img); a concrete-array assembly would hold all N until then.
         projections = []
         s_pad = ((0, 0),) if "S" in img.reader.dims.order else ()
         for i in range(img.dask_data.shape[1]):
@@ -538,9 +551,10 @@ _HIST_BLOCK = 1 << 20
 
 
 def _percentile_uint16(arr, qs):
-    # Caller contract: arr is a non-empty uint16 array, qs are percentiles in
-    # [0, 100]. The sole caller (_rescale_uint16_to_uint8) guards emptiness and
-    # passes constant qs, so this skips revalidating them.
+    # Caller contract: arr is a non-empty unsigned <=16-bit array, qs are
+    # percentiles in [0, 100]. Reached only via _uint16_clip_range (from
+    # _rescale_uint16_to_uint8 and _normalize_plane); both guard emptiness and
+    # pass constant qs first, so this skips revalidating them.
     #
     # np.percentile partitions a flattened copy of the whole array (here ~2
     # bytes/pixel, the uint16 input dtype), so its peak transient scales with

--- a/lambdas/thumbnail/src/t4_lambda_thumbnail/__init__.py
+++ b/lambdas/thumbnail/src/t4_lambda_thumbnail/__init__.py
@@ -158,11 +158,10 @@ def _finite_clip_range(arr: np.ndarray) -> tuple[float, float] | None:
     finite plane collapses both the percentiles and the min/max fallback — so
     callers must re-check and handle the no-contrast case themselves.
 
-    Shared by norm_img and _rescale_float_to_uint8 so their clip/fallback and
-    non-finite filtering can't diverge (the same pixels must not render
-    differently by reader path). _rescale_uint16_to_uint8 deliberately keeps its
-    own copy of this logic (histogram percentile for bounded memory, no
-    non-finite values), so an edit to these constants must update it too.
+    Shared by norm_img (float planes) and _rescale_float_to_uint8 so their
+    clip/fallback and non-finite filtering can't diverge (the same pixels must
+    not render differently by reader path). The unsigned-integer paths use
+    _uint16_clip_range instead (histogram percentile, bounded memory).
     """
     # Compact to the finite values only when some are non-finite: the masked
     # copy would otherwise coexist with np.percentile's internal copy and double
@@ -183,6 +182,43 @@ def _finite_clip_range(arr: np.ndarray) -> tuple[float, float] | None:
     return lo, hi
 
 
+def _uint16_clip_range(arr: np.ndarray) -> tuple[float, float]:
+    """
+    Percentile clip bounds (0.01, 99.99) for an unsigned <=16-bit plane via a
+    histogram (bounded memory, no float64 copy of the plane), with the same
+    min/max fallback as _finite_clip_range when the percentiles collapse. A
+    returned ``(lo, hi)`` can still have ``hi == lo`` (constant plane) — callers
+    re-check. Integer planes carry no non-finite values, so there is nothing to
+    filter. Shared by norm_img and _rescale_uint16_to_uint8 so their range
+    logic can't diverge.
+    """
+    lo, hi = _percentile_uint16(arr, (0.01, 99.99))
+    if hi == lo:
+        lo, hi = float(arr.min()), float(arr.max())
+    return lo, hi
+
+
+def _norm_uint_to_int32(arr: np.ndarray, lo: float, hi: float) -> np.ndarray:
+    """
+    Rescale an unsigned <=16-bit plane to the full 16-bit range as int32 via a
+    lookup table over the 65536 possible values. The LUT applies the *same*
+    float64 arithmetic norm_img's float path applies per pixel — clip to
+    [lo, hi], shift, scale by 65536, clamp the top bin, truncate to int32 — so
+    for identical (lo, hi) the output is bit-identical to that path. The LUT
+    just memoizes it: peak memory is the plane plus its int32 output, with no
+    float64 copy of the full plane (OOM is this lambda's failure mode on large
+    images). Caller guarantees hi != lo.
+    """
+    imax = np.iinfo(np.uint16).max + 1  # 65536; the I;16 range is [0, imax)
+    lut = np.arange(65536, dtype=np.float64)
+    np.clip(lut, lo, hi, out=lut)
+    lut -= lo
+    lut /= hi - lo
+    lut *= imax
+    lut[lut == imax] = imax - 1
+    return lut.astype(np.int32)[arr]
+
+
 def norm_img(img: da.Array) -> da.Array:
     """
     Contrast-stretch a greyscale plane to the full 16-bit range for the n-dim
@@ -190,10 +226,14 @@ def norm_img(img: da.Array) -> da.Array:
     [0, 65535], and return int32 (PIL mode I, saved as a 16-bit I;16 PNG).
     Color planes (YXC / YXS) are returned unchanged.
 
-    Shares its clip/fallback and non-finite handling (_finite_clip_range) with
-    _rescale_float_to_uint8 so the same pixels can't render differently by
-    reader path; the only deliberate differences are the 16-bit output range
+    Shares its clip/fallback and non-finite handling with _rescale_float_to_uint8
+    (float planes, via _finite_clip_range) and _rescale_uint16_to_uint8 (unsigned
+    planes, via _uint16_clip_range) so the same pixels can't render differently
+    by reader path; the only deliberate differences are the 16-bit output range
     (vs uint8) and that a constant plane renders black.
+
+    da.from_array(..., name=False) skips hashing each plane's bytes to build a
+    graph key — pointless here (each plane is unique and computed once).
     """
     if len(img.shape) == 3:
         # leave color images alone
@@ -201,20 +241,33 @@ def norm_img(img: da.Array) -> da.Array:
         # XXX: do we need to cast to uint8?
         return img
 
-    # Normalize in NumPy on the computed plane. da.percentile supports only 1-D
-    # input on current dask — it raises NotImplementedError on a multi-chunk 2-D
-    # array — and finite-aware percentiles need concrete values anyway. The dask
-    # compute result is a freshly-owned buffer, so a float64 source can skip the
-    # astype copy and the in-place math below stays safe; non-float64 sources
-    # still copy. float64 (not float32) matches the previous math bit-for-bit.
-    # da.from_array(..., name=False) skips hashing each plane's bytes to build a
-    # graph key — pointless here (each plane is unique and computed once).
-    arr = np.asarray(img).astype(np.float64, copy=False)
+    arr = np.asarray(img)
+
+    # Unsigned <=16-bit planes (the common microscopy case): range via histogram
+    # and rescale via a 65536-entry LUT, so peak memory is the plane plus its
+    # int32 output, with no float64 copy of the full plane (OOM is this lambda's
+    # documented failure mode on large images). Bit-identical to the float path
+    # below for the same (lo, hi) — the LUT memoizes the same per-pixel math.
+    if arr.dtype.kind == "u" and arr.dtype.itemsize <= 2:
+        lo, hi = _uint16_clip_range(arr)
+        if hi == lo:
+            # Constant plane: no contrast to stretch; render black.
+            return da.from_array(np.zeros(arr.shape, np.int32), name=False)
+        return da.from_array(_norm_uint_to_int32(arr, lo, hi), name=False)
+
+    # Float (and any other) planes: range in float64 with finite-aware
+    # percentiles. da.percentile supports only 1-D input on current dask (it
+    # raises NotImplementedError on a multi-chunk 2-D array), and finite-aware
+    # percentiles need concrete values anyway. The dask compute result is a
+    # freshly-owned buffer, so a float64 source skips the astype copy and the
+    # in-place math stays safe; other dtypes copy. float64 (not float32) matches
+    # the previous math bit-for-bit.
+    arr = arr.astype(np.float64, copy=False)
     imax = np.iinfo(np.uint16).max + 1  # 65536; the I;16 range is [0, imax)
 
     rng = _finite_clip_range(arr)
     if rng is None:
-        # No finite values to range over; render black (as the float path does).
+        # No finite values to range over; render black (as the uint path does).
         return da.from_array(np.zeros(arr.shape, np.int32), name=False)
     lo, hi = rng
     if hi == lo:
@@ -516,14 +569,7 @@ def _rescale_uint16_to_uint8(arr):
     # per-channel color skews.
     if not arr.size:
         return arr.astype(np.uint8)
-    lo, hi = _percentile_uint16(arr, (0.01, 99.99))
-    if hi == lo:
-        # Percentiles collapse when almost all pixels share one value;
-        # fall back to min/max so sparse data (e.g. label masks) stays
-        # visible. (This path keeps its own clip/fallback rather than the
-        # shared _finite_clip_range: it uses the histogram percentile for
-        # bounded memory and has no non-finite values to filter.)
-        lo, hi = float(arr.min()), float(arr.max())
+    lo, hi = _uint16_clip_range(arr)
     if hi == lo:
         # Constant image: keep the brightness level.
         return (arr >> 8).astype(np.uint8)

--- a/lambdas/thumbnail/src/t4_lambda_thumbnail/__init__.py
+++ b/lambdas/thumbnail/src/t4_lambda_thumbnail/__init__.py
@@ -242,6 +242,12 @@ def norm_img(img: da.Array) -> da.Array:
         return img
 
     arr = np.asarray(img)
+    if not arr.size:
+        # Degenerate empty plane: nothing to range over; render black. (The
+        # float path's _finite_clip_range returns None for the same effect;
+        # _uint16_clip_range has no such guard, so handle emptiness here for
+        # both branches.)
+        return da.from_array(np.zeros(arr.shape, np.int32), name=False)
 
     # Unsigned <=16-bit planes (the common microscopy case): range via histogram
     # and rescale via a 65536-entry LUT, so peak memory is the plane plus its

--- a/lambdas/thumbnail/src/t4_lambda_thumbnail/__init__.py
+++ b/lambdas/thumbnail/src/t4_lambda_thumbnail/__init__.py
@@ -226,7 +226,8 @@ def _normalize_plane(plane) -> np.ndarray:
     Contrast-stretch one greyscale plane to the full 16-bit range and return
     int32 (PIL mode I, saved as a 16-bit I;16 PNG). The per-plane work is eager
     NumPy so finite-aware percentiles and the histogram/LUT rescale stay exact;
-    norm_img wraps this in dask.delayed so the montage assembly streams.
+    norm_img wraps this in dask.delayed so the montage releases each plane once
+    it's been copied in, rather than holding all N (see norm_img).
 
     Shares its clip/fallback and non-finite handling with _rescale_float_to_uint8
     (float planes, via _finite_clip_range) and _rescale_uint16_to_uint8 (unsigned
@@ -291,8 +292,9 @@ def _normalize_plane(plane) -> np.ndarray:
 
 def norm_img(img: da.Array) -> da.Array:
     """
-    Lazily normalize a greyscale plane for the n-dim montage / projection path;
-    color planes (YXC / YXS) are returned unchanged.
+    Lazily normalize a greyscale plane to the full 16-bit range (int32, PIL mode
+    I → 16-bit I;16 PNG) for the n-dim montage / projection path; color planes
+    (YXC / YXS) are returned unchanged.
 
     _normalize_plane is eager NumPy, but wrapped in dask.delayed so the plane is
     a deferred task in the montage graph rather than a concrete array. dask
@@ -584,8 +586,9 @@ def _percentile_uint16(arr, qs):
         # index into the sorted values, interpolated between the values at its
         # floor and ceil. Output matches np.percentile to within floating-point
         # tolerance — not bit-exact (numpy's _lerp is asymmetric for fraction
-        # >= 0.5), but the difference is sub-ULP and vanishes in the uint8
-        # rescale, so thumbnails are unchanged.
+        # >= 0.5), but the difference is sub-ULP and vanishes in both the uint8
+        # (_rescale_uint16_to_uint8) and 16-bit (_normalize_plane) rescales, so
+        # thumbnails are unchanged.
         v = q / 100 * (n - 1)
         lo_i = int(v)
         val_lo = int(np.searchsorted(cdf, lo_i, side="right"))

--- a/lambdas/thumbnail/src/t4_lambda_thumbnail/__init__.py
+++ b/lambdas/thumbnail/src/t4_lambda_thumbnail/__init__.py
@@ -318,47 +318,45 @@ def _format_n_dim_ndarray(img: BioImage) -> da.Array:
 
     # Keep Channel data, but max project when possible
     if "C" in img.reader.dims.order and img.dask_data.shape[1] > 1:
-        projections = []
-        s_pad = ((0, 0),) if "S" in img.reader.dims.order else ()
-        for i in range(img.dask_data.shape[1]):
-            if "Z" in img.reader.dims.order:
-                # Add padding to the top and left of the projection
-                padded = da.pad(
-                    norm_img(img.dask_data[0, i, :, :, :].max(axis=0)),
-                    ((5, 0), (5, 0)) + s_pad,
-                    mode="constant"
-                )
-                projections.append(padded)
-            else:
-                # Add padding to the top and the left of the projection
-                padded = da.pad(
-                    norm_img(img.dask_data[0, i, 0, :, :]),
-                    ((5, 0), (5, 0)) + s_pad,
-                    mode="constant"
-                )
-                projections.append(padded)
+        n_channels = img.dask_data.shape[1]
+        has_z = "Z" in img.reader.dims.order
 
-        # Get min grid shape
-        # For 6 channels this returns (2, 3)
-        min_grid_shape = choose_min_grid(len(projections))
+        def _channel_plane(i):
+            # Normalize channel i's 2D plane (max-projected over Z when present).
+            sl = (img.dask_data[0, i, :, :, :].max(axis=0) if has_z
+                  else img.dask_data[0, i, 0, :, :])
+            return np.asarray(norm_img(sl))
 
-        # Make rows of images
-        # Use a counter so that we don't have to use `projections.pop` which is O(N)
-        rows = []
-        proj_counter = 0
-        for y_i in range(min_grid_shape[0]):
-            row = []
-            for x_i in range(min_grid_shape[1]):
-                row.append(projections[proj_counter])
-                proj_counter += 1
+        # Lay the normalized channels out in the most-square grid (rows*cols ==
+        # n_channels), each cell padded 5px on its top and left and the whole
+        # montage padded 5px on its bottom and right. Fill a preallocated montage
+        # one channel at a time and free each plane, so peak memory is ~the
+        # montage plus a single plane -- not all N planes plus the concatenation
+        # copy the previous da.pad/da.concatenate held at once (OOM is this
+        # lambda's documented failure mode on large multi-channel images). The
+        # output is identical to that construction: cells are placed at the same
+        # offsets and the unwritten borders stay at the constant-pad value 0.
+        rows, cols = choose_min_grid(n_channels)
+        first = _channel_plane(0)
+        h, w = first.shape[0], first.shape[1]
+        cell_h, cell_w = h + 5, w + 5
+        montage = np.zeros(
+            (rows * cell_h + 5, cols * cell_w + 5) + first.shape[2:],
+            dtype=first.dtype,
+        )
 
-            rows.append(row)
+        def _place(i, plane):
+            r, c = divmod(i, cols)  # row-major, matching the old grid fill order
+            top, left = r * cell_h + 5, c * cell_w + 5
+            montage[top:top + h, left:left + w] = plane
 
-        # Concatenate each row then concatenate all rows together into a single 2D image
-        merged = [da.concatenate(row, axis=1) for row in rows]
-
-        # Add padding on the entire bottom and entire right side of the thumbnail
-        return da.pad(da.concatenate(merged, axis=0), ((0, 5), (0, 5)) + s_pad, mode="constant")
+        _place(0, first)
+        del first
+        for i in range(1, n_channels):
+            plane = _channel_plane(i)
+            _place(i, plane)
+            del plane
+        return da.from_array(montage, name=False)
 
     # If there is a Z dimension we need to do _something_ the get a 2D out.
     # Without causing a war about which projection method is best

--- a/lambdas/thumbnail/src/t4_lambda_thumbnail/__init__.py
+++ b/lambdas/thumbnail/src/t4_lambda_thumbnail/__init__.py
@@ -31,6 +31,7 @@ import pdf2image
 import pptx
 import requests
 from bioio import BioImage
+from dask import delayed
 from pdf2image.exceptions import (
     PDFInfoNotInstalledError,
     PDFPageCountError,
@@ -219,68 +220,53 @@ def _norm_uint_to_int32(arr: np.ndarray, lo: float, hi: float) -> np.ndarray:
     return lut.astype(np.int32)[arr]
 
 
-def norm_img(img: da.Array) -> da.Array:
+def _normalize_plane(plane) -> np.ndarray:
     """
-    Contrast-stretch a greyscale plane to the full 16-bit range for the n-dim
-    montage / projection path: clip the extreme percentiles, rescale to
-    [0, 65535], and return int32 (PIL mode I, saved as a 16-bit I;16 PNG).
-    Color planes (YXC / YXS) are returned unchanged.
+    Contrast-stretch one greyscale plane to the full 16-bit range and return
+    int32 (PIL mode I, saved as a 16-bit I;16 PNG). The per-plane work is eager
+    NumPy so finite-aware percentiles and the histogram/LUT rescale stay exact;
+    norm_img wraps this in dask.delayed so the montage assembly streams.
 
     Shares its clip/fallback and non-finite handling with _rescale_float_to_uint8
     (float planes, via _finite_clip_range) and _rescale_uint16_to_uint8 (unsigned
     planes, via _uint16_clip_range) so the same pixels can't render differently
     by reader path; the only deliberate differences are the 16-bit output range
     (vs uint8) and that a constant plane renders black.
-
-    da.from_array(..., name=False) skips hashing each plane's bytes to build a
-    graph key — pointless here (each plane is unique and computed once).
     """
-    if len(img.shape) == 3:
-        # leave color images alone
-        # XXX: is this correct?
-        # XXX: do we need to cast to uint8?
-        return img
-
-    arr = np.asarray(img)
+    arr = np.asarray(plane)
     if not arr.size:
         # Degenerate empty plane: nothing to range over; render black. (The
         # float path's _finite_clip_range returns None for the same effect;
         # _uint16_clip_range has no such guard, so handle emptiness here for
         # both branches.)
-        return da.from_array(np.zeros(arr.shape, np.int32), name=False)
+        return np.zeros(arr.shape, np.int32)
 
     # Unsigned <=16-bit planes (the common microscopy case): range via histogram
-    # and rescale via a 65536-entry LUT, so peak memory is the plane plus its
-    # int32 output, with no float64 copy of the full plane (OOM is this lambda's
-    # documented failure mode on large images). Bit-identical to the float path
-    # below for the same (lo, hi) — the LUT memoizes the same per-pixel math.
+    # and rescale via a 65536-entry LUT, with no float64 copy of the full plane.
+    # Bit-identical to the float path below for the same (lo, hi) — the LUT
+    # memoizes the same per-pixel math.
     if arr.dtype.kind == "u" and arr.dtype.itemsize <= 2:
         lo, hi = _uint16_clip_range(arr)
         if hi == lo:
             # Constant plane: no contrast to stretch; render black.
-            return da.from_array(np.zeros(arr.shape, np.int32), name=False)
-        return da.from_array(_norm_uint_to_int32(arr, lo, hi), name=False)
+            return np.zeros(arr.shape, np.int32)
+        return _norm_uint_to_int32(arr, lo, hi)
 
     # Float (and any other) planes: range in float64 with finite-aware
-    # percentiles. da.percentile supports only 1-D input on current dask (it
-    # raises NotImplementedError on a multi-chunk 2-D array), and finite-aware
-    # percentiles need concrete values anyway. The dask compute result is a
-    # freshly-owned buffer, so a float64 source skips the astype copy and the
-    # in-place math stays safe; other dtypes copy. float64 (not float32) matches
-    # the previous math bit-for-bit.
+    # percentiles. float64 (not float32) matches the previous math bit-for-bit.
     arr = arr.astype(np.float64, copy=False)
     imax = np.iinfo(np.uint16).max + 1  # 65536; the I;16 range is [0, imax)
 
     rng = _finite_clip_range(arr)
     if rng is None:
         # No finite values to range over; render black (as the uint path does).
-        return da.from_array(np.zeros(arr.shape, np.int32), name=False)
+        return np.zeros(arr.shape, np.int32)
     lo, hi = rng
     if hi == lo:
         # Constant plane: no contrast to stretch. Render black deterministically
         # rather than dividing 0/0 -> NaN -> an int32 cast whose result is
         # platform- and numpy-version-dependent (the bug this replaces).
-        return da.from_array(np.zeros(arr.shape, np.int32), name=False)
+        return np.zeros(arr.shape, np.int32)
 
     # (clip(arr, lo, hi) - lo) / (hi - lo) * imax, in this order, so the output
     # is bit-identical to the previous implementation on this branch (a finite
@@ -294,7 +280,30 @@ def norm_img(img: da.Array) -> da.Array:
     arr *= imax
     arr[arr == imax] = imax - 1
     arr[np.isnan(arr)] = 0
-    return da.from_array(arr.astype(np.int32), name=False)
+    return arr.astype(np.int32)
+
+
+def norm_img(img: da.Array) -> da.Array:
+    """
+    Lazily normalize a greyscale plane for the n-dim montage / projection path;
+    color planes (YXC / YXS) are returned unchanged.
+
+    The normalization (_normalize_plane) is eager NumPy, but wrapped in
+    dask.delayed so the montage stays a lazy graph: dask computes and frees one
+    plane at a time during the final .compute(), keeping peak memory to ~the
+    montage plus a single plane rather than all N planes at once. (Materializing
+    every plane up front, as a direct NumPy assembly would, raised peak memory
+    on large multi-channel images — OOM is this lambda's documented failure
+    mode.)
+    """
+    if len(img.shape) == 3:
+        # leave color images alone
+        # XXX: is this correct?
+        # XXX: do we need to cast to uint8?
+        return img
+    return da.from_delayed(
+        delayed(_normalize_plane)(img), shape=img.shape, dtype=np.int32,
+    )
 
 
 def _format_n_dim_ndarray(img: BioImage) -> da.Array:
@@ -318,45 +327,52 @@ def _format_n_dim_ndarray(img: BioImage) -> da.Array:
 
     # Keep Channel data, but max project when possible
     if "C" in img.reader.dims.order and img.dask_data.shape[1] > 1:
-        n_channels = img.dask_data.shape[1]
-        has_z = "Z" in img.reader.dims.order
+        # Each channel is normalized lazily (norm_img returns a dask graph), then
+        # laid out in the most-square grid: every cell padded 5px on its top and
+        # left, the whole montage padded 5px on its bottom and right. Keeping the
+        # planes lazy lets dask compute and free them one at a time when the
+        # montage is finally computed, instead of holding all N at once.
+        projections = []
+        s_pad = ((0, 0),) if "S" in img.reader.dims.order else ()
+        for i in range(img.dask_data.shape[1]):
+            if "Z" in img.reader.dims.order:
+                # Add padding to the top and left of the projection
+                padded = da.pad(
+                    norm_img(img.dask_data[0, i, :, :, :].max(axis=0)),
+                    ((5, 0), (5, 0)) + s_pad,
+                    mode="constant"
+                )
+                projections.append(padded)
+            else:
+                # Add padding to the top and the left of the projection
+                padded = da.pad(
+                    norm_img(img.dask_data[0, i, 0, :, :]),
+                    ((5, 0), (5, 0)) + s_pad,
+                    mode="constant"
+                )
+                projections.append(padded)
 
-        def _channel_plane(i):
-            # Normalize channel i's 2D plane (max-projected over Z when present).
-            sl = (img.dask_data[0, i, :, :, :].max(axis=0) if has_z
-                  else img.dask_data[0, i, 0, :, :])
-            return np.asarray(norm_img(sl))
+        # Get min grid shape
+        # For 6 channels this returns (2, 3)
+        min_grid_shape = choose_min_grid(len(projections))
 
-        # Lay the normalized channels out in the most-square grid (rows*cols ==
-        # n_channels), each cell padded 5px on its top and left and the whole
-        # montage padded 5px on its bottom and right. Fill a preallocated montage
-        # one channel at a time and free each plane, so peak memory is ~the
-        # montage plus a single plane -- not all N planes plus the concatenation
-        # copy the previous da.pad/da.concatenate held at once (OOM is this
-        # lambda's documented failure mode on large multi-channel images). The
-        # output is identical to that construction: cells are placed at the same
-        # offsets and the unwritten borders stay at the constant-pad value 0.
-        rows, cols = choose_min_grid(n_channels)
-        first = _channel_plane(0)
-        h, w = first.shape[0], first.shape[1]
-        cell_h, cell_w = h + 5, w + 5
-        montage = np.zeros(
-            (rows * cell_h + 5, cols * cell_w + 5) + first.shape[2:],
-            dtype=first.dtype,
-        )
+        # Make rows of images
+        # Use a counter so that we don't have to use `projections.pop` which is O(N)
+        rows = []
+        proj_counter = 0
+        for y_i in range(min_grid_shape[0]):
+            row = []
+            for x_i in range(min_grid_shape[1]):
+                row.append(projections[proj_counter])
+                proj_counter += 1
 
-        def _place(i, plane):
-            r, c = divmod(i, cols)  # row-major, matching the old grid fill order
-            top, left = r * cell_h + 5, c * cell_w + 5
-            montage[top:top + h, left:left + w] = plane
+            rows.append(row)
 
-        _place(0, first)
-        del first
-        for i in range(1, n_channels):
-            plane = _channel_plane(i)
-            _place(i, plane)
-            del plane
-        return da.from_array(montage, name=False)
+        # Concatenate each row then concatenate all rows together into a single 2D image
+        merged = [da.concatenate(row, axis=1) for row in rows]
+
+        # Add padding on the entire bottom and entire right side of the thumbnail
+        return da.pad(da.concatenate(merged, axis=0), ((0, 5), (0, 5)) + s_pad, mode="constant")
 
     # If there is a Z dimension we need to do _something_ the get a 2D out.
     # Without causing a war about which projection method is best

--- a/lambdas/thumbnail/tests/test_thumbnail.py
+++ b/lambdas/thumbnail/tests/test_thumbnail.py
@@ -605,6 +605,16 @@ def _norm_float_reference(arr):
     return a.astype(np.int32)
 
 
+@pytest.mark.parametrize("dtype", [np.uint8, np.uint16, np.float32])
+def test_norm_img_empty_plane_renders_black(dtype):
+    # A degenerate empty plane must render black (an empty int32 array) rather
+    # than raise — the unsigned path's _uint16_clip_range has no emptiness guard
+    # (unlike the float path's _finite_clip_range), so norm_img guards up front.
+    out = _norm(np.empty((0, 5), dtype=dtype))
+    assert out.dtype == np.int32
+    assert out.shape == (0, 5)
+
+
 @pytest.mark.parametrize("dtype", [np.uint8, np.uint16, np.dtype(">u2")])
 def test_norm_img_uint_path_bit_identical_to_float_reference(dtype):
     # The bounded unsigned path (histogram percentile + 65536-entry LUT) must

--- a/lambdas/thumbnail/tests/test_thumbnail.py
+++ b/lambdas/thumbnail/tests/test_thumbnail.py
@@ -586,6 +586,46 @@ def _norm(arr, chunks=-1):
     return np.asarray(t4_lambda_thumbnail.norm_img(da.from_array(arr, chunks=chunks)))
 
 
+def _norm_float_reference(arr):
+    # Independent float64 reference for norm_img's normalization, used to pin
+    # that the bounded unsigned-integer path (histogram percentile + LUT) stays
+    # bit-identical to it. Mirrors the float branch's exact arithmetic.
+    imax = np.iinfo(np.uint16).max + 1
+    a = np.asarray(arr).astype(np.float64)
+    lo, hi = map(float, np.percentile(a, (0.01, 99.99)))
+    if hi == lo:
+        lo, hi = float(a.min()), float(a.max())
+    if hi == lo:
+        return np.zeros(a.shape, np.int32)
+    np.clip(a, lo, hi, out=a)
+    a -= lo
+    a /= hi - lo
+    a *= imax
+    a[a == imax] = imax - 1
+    return a.astype(np.int32)
+
+
+@pytest.mark.parametrize("dtype", [np.uint8, np.uint16, np.dtype(">u2")])
+def test_norm_img_uint_path_bit_identical_to_float_reference(dtype):
+    # The bounded unsigned path (histogram percentile + 65536-entry LUT) must
+    # stay bit-identical to the float64 normalization — that equivalence is the
+    # whole reason it's a safe memory optimization rather than a visible change.
+    # Byte-swapped uint16 (>u2) takes the same path. Covers full-range, low-range
+    # (12-bit-style), sparse (min/max fallback), and constant (-> black).
+    top = np.iinfo(np.uint8 if np.dtype(dtype).itemsize == 1 else np.uint16).max
+    rng = np.random.default_rng(0)
+    sparse = np.full((100, 100), 5, dtype=dtype)
+    sparse[0, 0] = top
+    cases = [
+        rng.integers(0, top + 1, (120, 90)).astype(dtype),        # full range
+        rng.integers(0, top // 16 + 1, (100, 100)).astype(dtype),  # low range
+        sparse,                                                    # sparse
+        np.full((40, 40), 9, dtype=dtype),                         # constant -> black
+    ]
+    for arr in cases:
+        assert np.array_equal(_norm(arr), _norm_float_reference(arr))
+
+
 def test_handle_image_blank_and_nan_channels_through_public_path(data_dir):
     # End-to-end reachability: a real multi-channel image can carry a blank
     # (constant) channel and a region of masked/invalid float pixels (NaN).

--- a/lambdas/thumbnail/tests/test_thumbnail.py
+++ b/lambdas/thumbnail/tests/test_thumbnail.py
@@ -636,6 +636,33 @@ def test_norm_img_uint_path_bit_identical_to_float_reference(dtype):
         assert np.array_equal(_norm(arr), _norm_float_reference(arr))
 
 
+def test_norm_img_uint_path_bit_identical_sweep():
+    # Property-style guard for the same equivalence: many random unsigned planes
+    # across dtypes / sizes / value distributions must match the float64
+    # reference bit-for-bit. The histogram percentile differs from np.percentile
+    # only sub-ULP, and the *16-bit rescale must never let that flip an int32
+    # output bit. Seeded, so deterministic in CI (no flakiness).
+    rng = np.random.default_rng(1234)
+    for _ in range(60):
+        dtype = rng.choice([np.uint8, np.uint16, np.dtype(">u2")])
+        top = np.iinfo(np.uint8 if np.dtype(dtype).itemsize == 1 else np.uint16).max
+        h, w = int(rng.integers(8, 300)), int(rng.integers(8, 300))
+        kind = int(rng.integers(0, 4))
+        if kind == 0:        # uniform full range
+            arr = rng.integers(0, top + 1, (h, w))
+        elif kind == 1:      # narrow low-range band (12-bit-style)
+            lo = int(rng.integers(0, top // 2 + 1))
+            arr = rng.integers(lo, lo + top // 8 + 1, (h, w))
+        elif kind == 2:      # gaussian (hot/dead tails exercise the clip)
+            arr = rng.normal(top / 2, top / 8, (h, w)).clip(0, top)
+        else:                # sparse: a few bright pixels on a flat background
+            arr = np.full((h, w), int(rng.integers(0, top + 1)))
+            arr.flat[: max(1, arr.size // 500)] = top
+        arr = arr.astype(dtype)
+        assert np.array_equal(_norm(arr), _norm_float_reference(arr)), \
+            f"int32 flip: dtype={np.dtype(dtype).str} shape={(h, w)} kind={kind}"
+
+
 def test_handle_image_blank_and_nan_channels_through_public_path(data_dir):
     # End-to-end reachability: a real multi-channel image can carry a blank
     # (constant) channel and a region of masked/invalid float pixels (NaN).


### PR DESCRIPTION
# Description

The n-dim **montage / Z-projection** path normalizes each channel plane with `norm_img`. The recent eager rewrite (#4974) computes every plane up front, so the montage holds **all N normalized planes at once** before assembling them. Real-lambda benchmarking showed this raises peak memory on large multi-channel images and **OOMs a couple of channels sooner** than the previous lazy `da.percentile` path — a regression on exactly the OOM-prone case (OOM is this lambda's documented failure mode).

This restores the lazy path's memory behavior **without giving up the eager correctness/perf fixes**:
- The per-plane normalization stays **eager NumPy** (`_normalize_plane`) — finite-aware percentiles, constant/NaN handling, and the uint16 histogram+LUT rescale all stay exact and bit-identical.
- `norm_img` now wraps it in **`dask.delayed` / `da.from_delayed`**, and the montage goes back to `da.pad`/`da.concatenate`. The planes are deferred tasks in the montage graph rather than concrete arrays, so dask **releases each plane once it has been copied into the montage** and they don't stay resident through the downstream resize. (Returning a concrete array — `da.from_array` — instead bakes all N planes into the graph, and `handle_image` holds the montage through `generate_thumbnail`'s resize, so all N linger there.)

Net: eager's speed **+** the lazy path's OOM resistance + the correctness fixes.

## Output is unchanged

Bit-identical — verified against all montage goldens, including the `--large-files` ones (actk, 3d-cell-viewer, variance-cfe, pipeline-4, multi-scene CZIs) where the streaming actually engages. Ruff + pyflakes clean.

## Real-lambda benchmark (thumb.dev, final image, 2048 MB, 5 cold runs each)

Three normalization variants on the same images (uint16 and float32 montages, 4000×4000 channels): the original lazy `da.percentile` path, the eager rewrite #4974 merged to master, and this PR.

| montage | lazy `da.percentile` (pre-#4974) | eager (#4974, current master) | **this PR (lazy streaming)** |
|---|---|---|---|
| uint16 8ch | ok 5/5 · 15.9 s | ok 5/5 · 14.8 s | **ok 5/5 · 12.3 s** |
| uint16 10ch | ok 5/5 · 19.1 s | **OOM 5/5** | **ok 5/5 · 14.3 s** |
| float 6ch | ok 5/5 · 18.5 s | ok 5/5 · 17.6 s | **ok 5/5 · 16.2 s** |
| float 8ch | **OOM 2/5** | **OOM 5/5** | **ok 5/5 · 18.2 s** |

- **#4974's eager rewrite (current master) regressed multi-channel memory** — it OOMs at the cliffs (uint16 10ch, float 8ch) where the older lazy path coped. **This PR fixes both** and is the only variant that succeeds 5/5 everywhere (at float 8ch even more robustly than the old lazy path, which is flaky right at the 2048 MB edge).
- **~15-25% faster than the old lazy path** (eager NumPy beats per-plane `da.percentile`), and as fast as #4974's eager rewrite — `dask.delayed` changes only scheduling, not the math.

Method: `aws lambda invoke --log-type Tail` → `REPORT` line; cold start forced before every run (config bump + `wait function-updated`); same function, image swapped per version.

### What the win actually is (instrumented)

The instantaneous peak *while the montage is assembled* is similar lazy vs eager — the final `da.concatenate` holds all N planes momentarily either way. The difference is **afterward**: staged `tracemalloc` over the full `handle_image` shows eager keeps all N planes resident from `format` through the resize (254 MB → 493 MB held), while lazy drops to just the montage output after `.compute()` (242 MB) — so the planes don't coexist with the resize. The 5×-cold A/B above holds the histogram/LUT **constant** in both arms, so it isolates this lazy-release effect as the OOM-vs-ok difference at 10ch. (The uint16 histogram/LUT is kept and lowers the *per-plane* float64 transient, but it's not the lever that flips the OOM here.)

# TODO

- [x] Unit tests
- [x] Security: Confirm that this change meets security best practices and does not violate the security model
- [x] [Changelog](../tree/master/lambdas/thumbnail/CHANGELOG.md) entry

🤖 Generated with [Claude Code](https://claude.com/claude-code)



