### PR TITLE
thumbnail tests: add mosaic CZI fixture and gate large files before download

### DIFF
--- a/lambdas/thumbnail/tests/test_thumbnail.py
+++ b/lambdas/thumbnail/tests/test_thumbnail.py
@@ -946,7 +946,7 @@ def test_handle_image(pytestconfig, pkg_ref, lk):
         top_hash=top_hash,
     )
     src_entry = src_pkg[lk]
-    # Gate on size before install() downloads the file (browse() read only the manifest).
+    # Gate on size before install() downloads the file (browse() reads only the manifest).
     if not pytestconfig.getoption("large_files") and src_entry.size > 20 * 1024 * 1024:
         pytest.skip("Skipping large file test; use --large-files to enable")
     quilt3.Package.install(

--- a/lambdas/thumbnail/tests/test_thumbnail.py
+++ b/lambdas/thumbnail/tests/test_thumbnail.py
@@ -787,8 +787,8 @@ def test_norm_img_leaves_color_planes_unchanged():
 TEST_DATA_REGISTRY = "s3://quilt-test-public-data"
 TIFF_PKG = "images/bioio-tifffile", "5fa99558a167d6430defbfa4033808c7e7004b847e94a213292c2c776ef43ac5"
 OME_TIFF_PKG = "images/bioio-ome-tiff", "6dbddd093e0a92cfc1cc5957ad7a7177ba98a0fee5d99ffaea58e30b7c46e182"
-CZI_PKG = "images/pylibczirw", "552c9290ffa24738a578c494b7fc9f95cc03e3d12d701bc0bd944f5c1c558b2c"
-THUMBS_PKG = "images/thumbs", "5ae720b35c5abc296ad5e708d3dea402bc4269c6e6f1920aa48cbc4be21ba443"
+CZI_PKG = "images/pylibczirw", "617551541881add8011f55de0c3936a90fc2188a40b6ef47c7e6ab20c3d2c8bf"
+THUMBS_PKG = "images/thumbs", "6244534f2034cf1166107a8da3915cb469761cf342d85eb653623d9f92390474"
 SIZE = (1024, 768)
 
 
@@ -906,6 +906,15 @@ SIZE = (1024, 768)
         (CZI_PKG, "c1_gray8_s2_overlapping_bounding_boxes.czi"),
         (CZI_PKG, "c2_gray8_gray16.czi"),
         (CZI_PKG, "c2_gray8_t3_z5_s2.czi"),
+        # A real mosaic (whole-slide) acquisition. bioio-czi's pylibCZIrw backend
+        # stitches the tiles in C++ and exposes a single pre-stitched greyscale
+        # plane with no M dimension, so this takes the same single-plane path as
+        # the c1_gray* fixtures rather than a distinct mosaic code path. It exists
+        # to pin the stitched thumbnail as a golden: it guards against an upstream
+        # mosaic-stitching regression and against a future bioio that re-exposes
+        # mosaic tiles (which _format_n_dim_ndarray's 5-D TCZYX assumption would
+        # not handle). --large-files-gated (82 MB).
+        (CZI_PKG, "OverViewScan.czi"),
         #   File "site-packages/bioio_base/reader.py", line 613, in dims
         #     self._dims = Dimensions(dims=self.xarray_dask_data.dims, shape=self.shape)
         #                                  ^^^^^^^^^^^^^^^^^^^^^

--- a/lambdas/thumbnail/tests/test_thumbnail.py
+++ b/lambdas/thumbnail/tests/test_thumbnail.py
@@ -906,15 +906,7 @@ SIZE = (1024, 768)
         (CZI_PKG, "c1_gray8_s2_overlapping_bounding_boxes.czi"),
         (CZI_PKG, "c2_gray8_gray16.czi"),
         (CZI_PKG, "c2_gray8_t3_z5_s2.czi"),
-        # A real mosaic (whole-slide) acquisition. bioio-czi's pylibCZIrw backend
-        # stitches the tiles in C++ and exposes a single pre-stitched greyscale
-        # plane with no M dimension, so this takes the same single-plane path as
-        # the c1_gray* fixtures rather than a distinct mosaic code path. It exists
-        # to pin the stitched thumbnail as a golden: it guards against an upstream
-        # mosaic-stitching regression and against a future bioio that re-exposes
-        # mosaic tiles, which _format_n_dim_ndarray would silently mis-slice under
-        # its 5-D TCZYX assumption (the dims/pixel assertions here catch it). Gated
-        # behind --large-files (82 MB).
+        # A real mosaic (whole-slide) acquisition that decodes to a single greyscale plane.
         (CZI_PKG, "OverViewScan.czi"),
         #   File "site-packages/bioio_base/reader.py", line 613, in dims
         #     self._dims = Dimensions(dims=self.xarray_dask_data.dims, shape=self.shape)

--- a/lambdas/thumbnail/tests/test_thumbnail.py
+++ b/lambdas/thumbnail/tests/test_thumbnail.py
@@ -790,8 +790,6 @@ OME_TIFF_PKG = "images/bioio-ome-tiff", "6dbddd093e0a92cfc1cc5957ad7a7177ba98a0f
 CZI_PKG = "images/pylibczirw", "617551541881add8011f55de0c3936a90fc2188a40b6ef47c7e6ab20c3d2c8bf"
 THUMBS_PKG = "images/thumbs", "6244534f2034cf1166107a8da3915cb469761cf342d85eb653623d9f92390474"
 SIZE = (1024, 768)
-# Fixtures larger than this are downloaded and tested only under --large-files.
-LARGE_FILE_THRESHOLD_BYTES = 20 * 1024 * 1024
 
 
 @pytest.mark.parametrize(
@@ -959,7 +957,7 @@ def test_handle_image(pytestconfig, pkg_ref, lk):
     # Gate on the manifest size before installing: install() downloads the file,
     # so checking size only afterwards would still fetch large fixtures (e.g. the
     # 82 MB OverViewScan.czi) just to skip them.
-    if not pytestconfig.getoption("large_files") and src_entry.size > LARGE_FILE_THRESHOLD_BYTES:
+    if not pytestconfig.getoption("large_files") and src_entry.size > 20 * 1024 * 1024:
         pytest.skip("Skipping large file test; use --large-files to enable")
     quilt3.Package.install(
         pkg_name,

--- a/lambdas/thumbnail/tests/test_thumbnail.py
+++ b/lambdas/thumbnail/tests/test_thumbnail.py
@@ -954,9 +954,7 @@ def test_handle_image(pytestconfig, pkg_ref, lk):
         top_hash=top_hash,
     )
     src_entry = src_pkg[lk]
-    # Gate on the manifest size before installing: install() downloads the file,
-    # so checking size only afterwards would still fetch large fixtures (e.g. the
-    # 82 MB OverViewScan.czi) just to skip them.
+    # Gate on size before install() downloads the file (browse() read only the manifest).
     if not pytestconfig.getoption("large_files") and src_entry.size > 20 * 1024 * 1024:
         pytest.skip("Skipping large file test; use --large-files to enable")
     quilt3.Package.install(

--- a/lambdas/thumbnail/tests/test_thumbnail.py
+++ b/lambdas/thumbnail/tests/test_thumbnail.py
@@ -790,6 +790,8 @@ OME_TIFF_PKG = "images/bioio-ome-tiff", "6dbddd093e0a92cfc1cc5957ad7a7177ba98a0f
 CZI_PKG = "images/pylibczirw", "617551541881add8011f55de0c3936a90fc2188a40b6ef47c7e6ab20c3d2c8bf"
 THUMBS_PKG = "images/thumbs", "6244534f2034cf1166107a8da3915cb469761cf342d85eb653623d9f92390474"
 SIZE = (1024, 768)
+# Fixtures larger than this are downloaded and tested only under --large-files.
+LARGE_FILE_THRESHOLD_BYTES = 20 * 1024 * 1024
 
 
 @pytest.mark.parametrize(
@@ -957,7 +959,7 @@ def test_handle_image(pytestconfig, pkg_ref, lk):
     # Gate on the manifest size before installing: install() downloads the file,
     # so checking size only afterwards would still fetch large fixtures (e.g. the
     # 82 MB OverViewScan.czi) just to skip them.
-    if not pytestconfig.getoption("large_files") and src_entry.size > 20 * 1024 * 1024:
+    if not pytestconfig.getoption("large_files") and src_entry.size > LARGE_FILE_THRESHOLD_BYTES:
         pytest.skip("Skipping large file test; use --large-files to enable")
     quilt3.Package.install(
         pkg_name,

--- a/lambdas/thumbnail/tests/test_thumbnail.py
+++ b/lambdas/thumbnail/tests/test_thumbnail.py
@@ -912,8 +912,9 @@ SIZE = (1024, 768)
         # the c1_gray* fixtures rather than a distinct mosaic code path. It exists
         # to pin the stitched thumbnail as a golden: it guards against an upstream
         # mosaic-stitching regression and against a future bioio that re-exposes
-        # mosaic tiles (which _format_n_dim_ndarray's 5-D TCZYX assumption would
-        # not handle). --large-files-gated (82 MB).
+        # mosaic tiles, which _format_n_dim_ndarray would silently mis-slice under
+        # its 5-D TCZYX assumption (the dims/pixel assertions here catch it). Gated
+        # behind --large-files (82 MB).
         (CZI_PKG, "OverViewScan.czi"),
         #   File "site-packages/bioio_base/reader.py", line 613, in dims
         #     self._dims = Dimensions(dims=self.xarray_dask_data.dims, shape=self.shape)
@@ -947,20 +948,23 @@ SIZE = (1024, 768)
 )
 def test_handle_image(pytestconfig, pkg_ref, lk):
     pkg_name, top_hash = pkg_ref
-    quilt3.Package.install(
-        pkg_name,
-        registry=TEST_DATA_REGISTRY,
-        top_hash=top_hash,
-        path=lk,
-    )
     src_pkg = quilt3.Package.browse(
         pkg_name,
         registry=TEST_DATA_REGISTRY,
         top_hash=top_hash,
     )
     src_entry = src_pkg[lk]
+    # Gate on the manifest size before installing: install() downloads the file,
+    # so checking size only afterwards would still fetch large fixtures (e.g. the
+    # 82 MB OverViewScan.czi) just to skip them.
     if not pytestconfig.getoption("large_files") and src_entry.size > 20 * 1024 * 1024:
         pytest.skip("Skipping large file test; use --large-files to enable")
+    quilt3.Package.install(
+        pkg_name,
+        registry=TEST_DATA_REGISTRY,
+        top_hash=top_hash,
+        path=lk,
+    )
 
     print(f"Testing {pkg_name}/{lk}...")
     _info, data = t4_lambda_thumbnail.handle_image(path=src_entry.get_cached_path(), size=SIZE, thumbnail_format="PNG")


### PR DESCRIPTION
# Description

Adds a real mosaic (whole-slide) acquisition to the thumbnail test set so the multi-tile-origin image category is covered end-to-end. `OverViewScan.czi` — the canonical mosaic from the AICS test resources — is added to the `images/pylibczirw` test-data package, and its golden thumbnail to `images/thumbs`; both package top-hashes in `test_thumbnail.py` are bumped to the new revisions.

**What this actually covers.** bioio-czi's pylibCZIrw backend stitches mosaic tiles in C++ and exposes a single pre-stitched greyscale plane with no `M` dimension (`mosaic_tile_dims → None`; `_get_stitched_dask_mosaic` is a passthrough to `xarray_dask_data`). So the lambda takes the same single-plane path as the existing `c1_gray*` fixtures — not a distinct mosaic code path. The fixture's value is the **pinned golden**:

- guards against an upstream mosaic-stitching regression that would silently break thumbnails for the whole whole-slide/tiled-acquisition category, and
- guards against a future bioio that re-exposes mosaic tiles — `_format_n_dim_ndarray` would silently mis-slice such an array under its 5-D TCZYX assumption, and the golden's dims/pixel assertions would catch the divergence.

`OverViewScan.czi` is 82 MB, so it runs only under `pytest --large-files`.

**Opportunistic fix (surfaced in review).** Adding a fixture over the size gate exposed that `test_handle_image` called `Package.install` (which downloads the file) *before* checking `src_entry.size`, so large fixtures were downloaded and then skipped. This was already happening for 8 pre-existing fixtures — the gate dates to #4612; `OverViewScan.czi` just made it visible. Reordered to `browse` (manifest only) → size-gate → `install`, so the 9 currently-gated large files are no longer fetched on a normal `pytest` run.

Spun off from #4974.

# TODO

- [x] Unit tests

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds an `OverViewScan.czi` mosaic fixture to the CZI thumbnail test suite and fixes a pre-existing bug where large files were downloaded before the size gate was checked.

- **Gate-ordering fix**: `browse()` (manifest only) is now called before the size check, so the 9 currently-gated large fixtures are no longer fetched on a normal `pytest` run; `install()` only fires when the file passes the gate.
- **New mosaic fixture**: `OverViewScan.czi` (82 MB) is added behind the `--large-files` flag with a clear comment explaining that bioio-czi exposes this as a single pre-stitched greyscale plane; package top-hashes for `CZI_PKG` and `THUMBS_PKG` are bumped accordingly.

<h3>Confidence Score: 5/5</h3>

Safe to merge — the gate reorder is a straightforward correctness fix with no logic changes to the thumbnail path itself, and the new fixture is properly guarded behind --large-files.

The only functional change is moving browse() + size-check before install(), which closes a gap where large files were downloaded and then immediately skipped. The new OverViewScan.czi fixture exercises a well-understood code path and is gated so it does not slow normal runs. No production code is touched.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| lambdas/thumbnail/tests/test_thumbnail.py | Gate reordered to browse→size-check→install so large files are no longer downloaded unnecessarily; new OverViewScan.czi mosaic fixture added and both package hashes bumped. |

</details>

<sub>Reviews (3): Last reviewed commit: ["thumbnail tests: trim the OverViewScan f..."](https://github.com/quiltdata/quilt/commit/b577949e01a2fa03f20232f7c643d8f139c9d579) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=37649016)</sub>

<!-- /greptile_comment -->