### PR TITLE
docs: refresh stale image preview limitations in Preview.md

### DIFF
--- a/docs/Catalog/Preview.md
+++ b/docs/Catalog/Preview.md
@@ -62,7 +62,8 @@ files) are already display-ready and are shown without this adjustment.
 
 ### Limitations
 
-* 32-bit integer images may render incorrectly or fail to preview.
+* Integer images deeper than 16 bits may render incorrectly or fail to
+  preview.
 * Very large images may fail to preview if they exceed memory or pixel
   limits.
 

--- a/docs/Catalog/Preview.md
+++ b/docs/Catalog/Preview.md
@@ -58,7 +58,7 @@ way, jointly across their channels so the colors aren't skewed.
 Because every image and channel is stretched on its own, displayed
 brightness does **not** represent absolute pixel intensity: it is not
 comparable between thumbnails, nor between the channels of a multi-channel
-montage. Standard 8-bit images (such as .jpg and .png files) are already
+montage. Standard 8-bit images (such as .jpg files) are already
 display-ready and are shown without this adjustment.
 
 ## Binary and special file format previews

--- a/docs/Catalog/Preview.md
+++ b/docs/Catalog/Preview.md
@@ -62,8 +62,7 @@ files) are already display-ready and are shown without this adjustment.
 
 ### Limitations
 
-* 32-bit integer images may render incorrectly or fail to preview;
-  32-bit floating-point images are unaffected.
+* 32-bit integer images may render incorrectly or fail to preview.
 * Very large images may fail to preview if they exceed memory or pixel
   limits.
 

--- a/docs/Catalog/Preview.md
+++ b/docs/Catalog/Preview.md
@@ -55,10 +55,11 @@ after clipping the most extreme values so a few hot or dead pixels don't
 flatten the rest. High-bit-depth color previews are stretched the same
 way, jointly across their channels so the colors aren't skewed.
 
-Because the stretch is computed independently for each image, displayed
-brightness does **not** represent absolute pixel intensity and is **not
-comparable between thumbnails**. Ordinary 8-bit photos (such as .jpg and
-.png files) display as-is.
+Because every image and channel is stretched on its own, displayed
+brightness does **not** represent absolute pixel intensity: it is not
+comparable between thumbnails, nor between the channels of a multi-channel
+montage. Standard 8-bit images (such as .jpg and .png files) are already
+display-ready and are shown without this adjustment.
 
 ## Binary and special file format previews
 

--- a/docs/Catalog/Preview.md
+++ b/docs/Catalog/Preview.md
@@ -37,10 +37,27 @@ to automatically generate thumbnail previews of common image formats
 and select microscopy image formats such as .bmp, .gif, .jpg, .jpeg,
 .png, .webp, .tif, .tiff (including `OME-TIFF`), and .czi.
 
-### Known limitations
+8-bit, 16-bit, and floating-point pixel data are all supported, as are
+multi-channel and Z-stack images. Multi-channel images are rendered as a
+grid of per-channel previews, Z-stacks are flattened with a
+maximum-intensity projection, and time-series show their middle timepoint.
 
-Automated previews of 8-bit depth and higher image files are not
-currently supported.
+### Display normalization
+
+> Thumbnails are a visual aid, not a faithful reproduction of the original
+> pixel values.
+
+To keep high-bit-depth and low-contrast images visible, greyscale previews
+are **contrast-stretched per image**: each image — and each channel of a
+multi-channel image — is rescaled from its own range of pixel values, after
+clipping the most extreme values so a few hot or dead pixels don't flatten
+the rest. High-bit-depth color previews are normalized the same way,
+jointly across their channels.
+
+Because this stretch is computed independently for every image, the
+displayed brightness does **not** represent absolute intensity and is
+**not comparable between thumbnails**. Plain 8-bit images (such as typical
+.jpg/.png photos) are displayed as-is.
 
 ## Binary and special file format previews
 

--- a/docs/Catalog/Preview.md
+++ b/docs/Catalog/Preview.md
@@ -60,6 +60,13 @@ intensity: it is not comparable between thumbnails, nor between the
 channels of a multi-channel montage. Standard 8-bit images (such as .jpg
 files) are already display-ready and are shown without this adjustment.
 
+### Limitations
+
+* 32-bit integer images may render incorrectly or fail to preview;
+  32-bit and 64-bit floating-point images are fully supported.
+* Very large images may fail to preview if they exceed the preview
+  service's memory or pixel limits.
+
 ## Binary and special file format previews
 
 * AnnData (.h5ad) — annotated matrix metadata, with QC metrics for small files

--- a/docs/Catalog/Preview.md
+++ b/docs/Catalog/Preview.md
@@ -63,9 +63,9 @@ files) are already display-ready and are shown without this adjustment.
 ### Limitations
 
 * 32-bit integer images may render incorrectly or fail to preview;
-  32-bit and 64-bit floating-point images are fully supported.
-* Very large images may fail to preview if they exceed the preview
-  service's memory or pixel limits.
+  32-bit floating-point images are unaffected.
+* Very large images may fail to preview if they exceed memory or pixel
+  limits.
 
 ## Binary and special file format previews
 

--- a/docs/Catalog/Preview.md
+++ b/docs/Catalog/Preview.md
@@ -48,18 +48,17 @@ middle timepoint.
 > Thumbnails are a visual aid, not a faithful reproduction of the original
 > pixel values.
 
-To keep high-bit-depth and low-contrast data visible, greyscale previews
+To keep high-bit-depth and low-contrast data visible, grayscale previews
 are **contrast-stretched per image**: each image — and each channel of a
 multi-channel image — is rescaled from its own range of pixel values,
 after clipping the most extreme values so a few hot or dead pixels don't
 flatten the rest. High-bit-depth color previews are stretched the same
 way, jointly across their channels so the colors aren't skewed.
 
-Because every image and channel is stretched on its own, displayed
-brightness does **not** represent absolute pixel intensity: it is not
-comparable between thumbnails, nor between the channels of a multi-channel
-montage. Standard 8-bit images (such as .jpg files) are already
-display-ready and are shown without this adjustment.
+As a result, displayed brightness does **not** represent absolute pixel
+intensity: it is not comparable between thumbnails, nor between the
+channels of a multi-channel montage. Standard 8-bit images (such as .jpg
+files) are already display-ready and are shown without this adjustment.
 
 ## Binary and special file format previews
 

--- a/docs/Catalog/Preview.md
+++ b/docs/Catalog/Preview.md
@@ -48,17 +48,17 @@ middle timepoint.
 > Thumbnails are a visual aid, not a faithful reproduction of the original
 > pixel values.
 
-To keep high-bit-depth and low-contrast data visible, grayscale previews
-are **contrast-stretched per image**: each image — and each channel of a
-multi-channel image — is rescaled from its own range of pixel values,
-after clipping the most extreme values so a few hot or dead pixels don't
-flatten the rest. High-bit-depth color previews are stretched the same
-way, jointly across their channels so the colors aren't skewed.
+Previews of high-bit-depth and microscopy images are **contrast-stretched
+per image** to keep faint, low-contrast detail visible: each grayscale
+image — and each channel of a multi-channel image — is rescaled from its
+own range of pixel values, after clipping the most extreme values so a few
+hot or dead pixels don't flatten the rest. Color previews are stretched the
+same way, jointly across their channels so the colors aren't skewed.
 
 As a result, displayed brightness does **not** represent absolute pixel
 intensity: it is not comparable between thumbnails, nor between the
-channels of a multi-channel montage. Standard 8-bit images (such as .jpg
-files) are already display-ready and are shown without this adjustment.
+channels of a multi-channel montage. Ordinary 8-bit images (such as .jpg
+files) are already display-ready and are shown unchanged.
 
 ### Limitations
 

--- a/docs/Catalog/Preview.md
+++ b/docs/Catalog/Preview.md
@@ -37,27 +37,28 @@ to automatically generate thumbnail previews of common image formats
 and select microscopy image formats such as .bmp, .gif, .jpg, .jpeg,
 .png, .webp, .tif, .tiff (including `OME-TIFF`), and .czi.
 
-8-bit, 16-bit, and floating-point pixel data are all supported, as are
-multi-channel and Z-stack images. Multi-channel images are rendered as a
-grid of per-channel previews, Z-stacks are flattened with a
-maximum-intensity projection, and time-series show their middle timepoint.
+8-bit, 16-bit, and floating-point pixel data are all supported. Quilt
+reduces multi-dimensional microscopy images to a single 2D preview:
+channels are laid out as a grid of per-channel previews, Z-stacks are
+flattened with a maximum-intensity projection, and time-series show their
+middle timepoint.
 
 ### Display normalization
 
 > Thumbnails are a visual aid, not a faithful reproduction of the original
 > pixel values.
 
-To keep high-bit-depth and low-contrast images visible, greyscale previews
+To keep high-bit-depth and low-contrast data visible, greyscale previews
 are **contrast-stretched per image**: each image — and each channel of a
-multi-channel image — is rescaled from its own range of pixel values, after
-clipping the most extreme values so a few hot or dead pixels don't flatten
-the rest. High-bit-depth color previews are normalized the same way,
-jointly across their channels.
+multi-channel image — is rescaled from its own range of pixel values,
+after clipping the most extreme values so a few hot or dead pixels don't
+flatten the rest. High-bit-depth color previews are stretched the same
+way, jointly across their channels so the colors aren't skewed.
 
-Because this stretch is computed independently for every image, the
-displayed brightness does **not** represent absolute intensity and is
-**not comparable between thumbnails**. Plain 8-bit images (such as typical
-.jpg/.png photos) are displayed as-is.
+Because the stretch is computed independently for each image, displayed
+brightness does **not** represent absolute pixel intensity and is **not
+comparable between thumbnails**. Ordinary 8-bit photos (such as .jpg and
+.png files) display as-is.
 
 ## Binary and special file format previews
 


### PR DESCRIPTION
# Description

`docs/Catalog/Preview.md`'s "Known limitations" claimed that "Automated previews of 8-bit depth and higher image files are not currently supported." That contradicts current behavior: the [thumbnail lambda](https://github.com/quiltdata/quilt/tree/master/lambdas/thumbnail) now previews 8-bit, 16-bit, and floating-point images, including multi-channel and Z-stack microscopy (czi, OME-TIFF, tiff), after a series of fixes (#4960, #4961, #4967, #4968, #4971, #4974, #4976).

It also never documented that greyscale previews are contrast-stretched per image — a display aid that makes high-bit-depth / low-contrast data visible but is not photometric.

This PR replaces the stale limitation with:

- a note that 8/16-bit and float pixel data are supported, and how multi-channel (grid of per-channel previews), Z-stack (max-intensity projection), and time-series (middle timepoint) images are rendered;
- a "Display normalization" section explaining the per-image contrast stretch, with the caveat that displayed brightness does not represent absolute intensity and is not comparable between thumbnails.

Surfaced in https://github.com/quiltdata/quilt/pull/4960#pullrequestreview-4468523808.

# TODO

- [x] Documentation
    - [x] Markdown somewhere in docs/**/*.md that explains the feature to end users (said .md files should be linked from SUMMARY.md so they appear on https://docs.quilt.bio)
- [ ] Changelog entry (skipped — docs only)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Refreshes the image-preview documentation to reflect current thumbnail-lambda capability: the old stale claim that "8-bit depth and higher" previews are unsupported is removed and replaced with an accurate support statement covering 8-bit, 16-bit, and floating-point pixel data, along with multi-channel, Z-stack, and time-series rendering strategies. A new "Display normalization" subsection (rescoped to high-bit-depth and microscopy images) explains per-image contrast-stretching and its implications for interpretability.

- **Removed stale limitation**: The previous claim that 8-bit-and-higher images are unsupported directly contradicted the live behavior introduced by PRs #4960–#4976; the replacement copy accurately describes the current rendering path.
- **New normalization section**: Explains per-image contrast-stretching, the independent-per-channel behaviour for microscopy montages, and the joint-channel stretch for standard color images, with an explicit caveat that displayed brightness is not photometrically comparable.
- **Updated limitations block**: Two remaining caveats (>16-bit integer depth, very large images) replace the old blanket limitation.

<h3>Confidence Score: 5/5</h3>

Documentation-only change that removes an inaccurate limitation and replaces it with correct, well-scoped prose — no code paths are affected.

The change is confined to a single Markdown file. The rescoped normalization paragraph now correctly targets 'high-bit-depth and microscopy images' while explicitly noting that ordinary 8-bit images are shown unchanged, which is consistent with the thumbnail-lambda implementation referenced in the PR. The new limitations bullets are appropriately hedged. No functional code is touched.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| docs/Catalog/Preview.md | Removes stale 8-bit limitation, adds accurate support matrix for 8/16-bit and float images, adds a rescoped "Display normalization" section, and replaces the old limitations block with two current caveats. |

</details>

<h3>Flowchart</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Image file uploaded] --> B{Image type?}
    B -->|Standard 8-bit .jpg etc.| C[Shown unchanged — display-ready]
    B -->|High-bit-depth / microscopy| D{Dimensionality?}
    D -->|2D single-channel| E[Contrast-stretch per image]
    D -->|Multi-channel| F[Grid of per-channel previews\neach channel stretched independently]
    D -->|Z-stack| G[Max-intensity projection → 2D\nthen contrast-stretched]
    D -->|Time-series| H[Middle timepoint selected\nthen contrast-stretched]
    D -->|Standard color RGB| I[Contrast-stretch jointly\nacross channels]
    E --> J[Thumbnail served]
    F --> J
    G --> J
    H --> J
    I --> J
    C --> J
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A[Image file uploaded] --> B{Image type?}
    B -->|Standard 8-bit .jpg etc.| C[Shown unchanged — display-ready]
    B -->|High-bit-depth / microscopy| D{Dimensionality?}
    D -->|2D single-channel| E[Contrast-stretch per image]
    D -->|Multi-channel| F[Grid of per-channel previews\neach channel stretched independently]
    D -->|Z-stack| G[Max-intensity projection → 2D\nthen contrast-stretched]
    D -->|Time-series| H[Middle timepoint selected\nthen contrast-stretched]
    D -->|Standard color RGB| I[Contrast-stretch jointly\nacross channels]
    E --> J[Thumbnail served]
    F --> J
    G --> J
    H --> J
    I --> J
    C --> J
```

</a>

<sub>Reviews (3): Last reviewed commit: ["docs: scope normalization to high-bit-de..."](https://github.com/quiltdata/quilt/commit/d8f608be7edc8664143d35f39530806f5b7ca987) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=37840626)</sub>

<!-- /greptile_comment -->