### PR TITLE
thumbnail: replace choose_min_grid with a direct most_square_grid helper

### DIFF
--- a/lambdas/thumbnail/src/t4_lambda_thumbnail/__init__.py
+++ b/lambdas/thumbnail/src/t4_lambda_thumbnail/__init__.py
@@ -17,8 +17,8 @@ import sys
 import tempfile
 import urllib.parse
 from io import BytesIO
-from math import sqrt
-from typing import List, Tuple
+from math import isqrt
+from typing import Tuple
 
 import bioio_base.exceptions
 import bioio_czi
@@ -116,35 +116,18 @@ def clean_tmp_dir():
             print(f'Failed to delete {file_path}. Reason: {e}', file=sys.stderr)
 
 
-def generate_factor_pairs(x: int) -> List[Tuple[int, int]]:
-    """
-    Generate tuples of integer pairs that are factors for the provided x integer value.
-    """
-    # Generate all factor pairs for an integer x.
-    step = 2 if x % 2 else 1
-    pairs = []
-
-    for i in range(1, int(sqrt(x) + 1), step):
-        if x % i == 0:
-            pairs.append((i, x//i))
-
-    return pairs
-
-
 def choose_min_grid(x: int) -> Tuple[int, int]:
     """
-    Choose a minimum grid size based off the distance between two values that form
-    a factor pair of the provided x amount of objects to create a grid off.
-    """
-    # Chose a minimum grid size. (The smallest distance between a factor pair.)
-    factor_pairs = generate_factor_pairs(x)
-    min_grid_shape = None
-    min_distance = sys.maxsize
-    for pair in factor_pairs:
-        if pair[1] - pair[0] < min_distance:
-            min_grid_shape = pair
+    Return the most-square grid (rows, cols) for laying out `x` cells: the factor
+    pair of `x` whose two factors are closest together. The gap shrinks as the
+    smaller factor grows, so the largest divisor of `x` that is <= sqrt(x) is the
+    number of rows and its cofactor the number of columns.
 
-    return min_grid_shape
+    `x` must be >= 1 (the only caller guards on >1 channels, so x >= 2); for x == 0
+    there is no such divisor and this raises ValueError.
+    """
+    rows = max(i for i in range(1, isqrt(x) + 1) if x % i == 0)
+    return rows, x // rows
 
 
 def _finite_clip_range(arr: np.ndarray) -> tuple[float, float] | None:

--- a/lambdas/thumbnail/src/t4_lambda_thumbnail/__init__.py
+++ b/lambdas/thumbnail/src/t4_lambda_thumbnail/__init__.py
@@ -18,7 +18,6 @@ import tempfile
 import urllib.parse
 from io import BytesIO
 from math import isqrt
-from typing import Tuple
 
 import bioio_base.exceptions
 import bioio_czi
@@ -116,15 +115,14 @@ def clean_tmp_dir():
             print(f'Failed to delete {file_path}. Reason: {e}', file=sys.stderr)
 
 
-def choose_min_grid(x: int) -> Tuple[int, int]:
+def most_square_grid(x: int) -> tuple[int, int]:
     """
     Return the most-square grid (rows, cols) for laying out `x` cells: the factor
     pair of `x` whose two factors are closest together. The gap shrinks as the
     smaller factor grows, so the largest divisor of `x` that is <= sqrt(x) is the
     number of rows and its cofactor the number of columns.
 
-    `x` must be >= 1 (the only caller guards on >1 channels, so x >= 2); for x == 0
-    there is no such divisor and this raises ValueError.
+    Requires x >= 1; x == 0 has no factor pair and raises ValueError.
     """
     rows = max(i for i in range(1, isqrt(x) + 1) if x % i == 0)
     return rows, x // rows
@@ -350,17 +348,16 @@ def _format_n_dim_ndarray(img: BioImage) -> da.Array:
                 )
                 projections.append(padded)
 
-        # Get min grid shape
-        # For 6 channels this returns (2, 3)
-        min_grid_shape = choose_min_grid(len(projections))
+        # Lay the channels out in the most-square grid (6 channels -> (2, 3))
+        grid_shape = most_square_grid(len(projections))
 
         # Make rows of images
         # Use a counter so that we don't have to use `projections.pop` which is O(N)
         rows = []
         proj_counter = 0
-        for y_i in range(min_grid_shape[0]):
+        for y_i in range(grid_shape[0]):
             row = []
-            for x_i in range(min_grid_shape[1]):
+            for x_i in range(grid_shape[1]):
                 row.append(projections[proj_counter])
                 proj_counter += 1
 

--- a/lambdas/thumbnail/tests/test_thumbnail.py
+++ b/lambdas/thumbnail/tests/test_thumbnail.py
@@ -990,6 +990,35 @@ def test_handle_image_multichannel_bgr_czi_channel_order(data_dir):
     assert right[2] > right[0] + 10, f"channel 1 should render blue (B>R), got {right}"
 
 
+@pytest.mark.parametrize(
+    "x, expected",
+    [
+        (1, (1, 1)),
+        (2, (1, 2)),
+        (3, (1, 3)),  # prime -> single row
+        (4, (2, 2)),  # perfect square -> square grid
+        (6, (2, 3)),  # the montage layout exercised by the docstring
+        (7, (1, 7)),
+        (12, (3, 4)),
+        (16, (4, 4)),
+    ],
+)
+def test_most_square_grid(x, expected):
+    # The most-square grid is the factor pair with the smallest gap, and it
+    # always tiles exactly (rows * cols == x) so the montage has no empty cells.
+    rows, cols = t4_lambda_thumbnail.most_square_grid(x)
+    assert (rows, cols) == expected
+    assert rows * cols == x
+    assert rows <= cols
+
+
+def test_most_square_grid_zero_raises():
+    # x == 0 has no factor pair; the montage caller guards against it (channel
+    # count > 1), so this only pins the documented contract.
+    with pytest.raises(ValueError):
+        t4_lambda_thumbnail.most_square_grid(0)
+
+
 def test_http():
     """
     Smoke test for image with HTTP URL.


### PR DESCRIPTION
# Description

`most_square_grid` (was `choose_min_grid`) lays out a multi-channel image as the most-square montage grid. The old implementation was **correct-by-accident**: `min_distance = sys.maxsize` was never reassigned inside the loop, so the `pair[1] - pair[0] < min_distance` comparison was always true and the function simply returned the *last* factor pair from `generate_factor_pairs`. That happened to be the most-square grid only because `generate_factor_pairs` emits pairs in non-increasing-gap order. The min-tracking was vestigial and the comment described logic that did nothing — a latent trap, since a linter or a well-meaning fix of the always-true comparison could silently break the (currently correct) behavior.

This collapses the two functions into one that computes the result directly: the most-square grid's row count is the largest divisor of `x` that is `<= sqrt(x)` (the factor gap shrinks as the smaller factor grows). `math.isqrt` gives an exact integer bound, dropping the float-`sqrt` edge case along with the now-unused `generate_factor_pairs` (its only caller). The function is renamed `choose_min_grid` → `most_square_grid` (the "min" name belonged to the deleted minimum-distance loop), and the return annotation is modernized to the builtin `tuple[int, int]`, dropping the `typing` import.

**Output is unchanged** — verified bit-identical to the old result against an independent brute-force most-square oracle across all realistic channel counts. A new parametrized unit test pins the most-square contract (`rows * cols == x`, `rows <= cols`, the `6 → (2, 3)` montage case, and the `x == 0 → ValueError` edge); the previous suite only routed `x ∈ {2, 3}` through the montage path, both `rows == 1`, so the layout had no CI coverage. No CHANGELOG entry: behavior-neutral internal cleanup, not significant to end users.

# TODO

- [x] Unit tests — added a parametrized test for the most-square grid contract + the `x == 0` edge
- [x] Security: no security-relevant surface touched
- [x] Open and Embed: unaffected (pure server-side lambda refactor)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Replaces the vestigial two-function pattern (`generate_factor_pairs` + `choose_min_grid`) with a single, correct `most_square_grid` that directly computes the largest divisor of `x` that is `<= isqrt(x)`. The old minimum-distance tracking loop was dead code — `min_distance` was never updated inside it — so output is unchanged, but the new implementation is explicit about what it computes.

- **Algorithm simplification**: `rows = max(i for i in range(1, isqrt(x) + 1) if x % i == 0)` is a direct derivation of the most-square-grid property; removes the now-unused `from math import sqrt` and `from typing import List, Tuple` imports.
- **Rename**: `choose_min_grid` → `most_square_grid` better reflects the function's purpose; the single call site in `_format_n_dim_ndarray` is updated accordingly.
- **New tests**: Parametrized over 8 representative values (primes, composites, perfect squares) and a `ValueError` edge case for `x == 0`, giving meaningful layout coverage where the previous suite had none.

<h3>Confidence Score: 5/5</h3>

Safe to merge — behavior-neutral algorithmic cleanup with verified-identical output and new parametrized tests.

The refactor eliminates dead code and makes the most-square-grid property explicit. The new one-liner is mathematically correct (largest divisor ≤ sqrt gives the smallest factor gap), `isqrt` avoids the float edge case of the old `sqrt`-based bound, `sys` is still used for `sys.stderr` so no stale import remains, and all former callers are updated. The test suite now exercises the layout path across primes, composites, and perfect squares — coverage that did not exist before.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| lambdas/thumbnail/src/t4_lambda_thumbnail/__init__.py | Replaces two-function vestigial `generate_factor_pairs` + `choose_min_grid` with a single correct `most_square_grid`; algorithm and all callers are sound. |
| lambdas/thumbnail/tests/test_thumbnail.py | Adds parametrized `test_most_square_grid` covering prime, composite, and perfect-square inputs plus a `ValueError` contract test for `x == 0`. |

</details>

<h3>Flowchart</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A["most_square_grid(x)"] --> B{"range(1, isqrt(x)+1)\nnon-empty?"}
    B -- "No (x == 0)" --> C["max() on empty →\nValueError"]
    B -- "Yes" --> D["collect all i where\nx % i == 0"]
    D --> E["rows = max(collected divisors)"]
    E --> F["cols = x // rows"]
    F --> G["return (rows, cols)\nrows ≤ cols, rows × cols == x"]
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A["most_square_grid(x)"] --> B{"range(1, isqrt(x)+1)\nnon-empty?"}
    B -- "No (x == 0)" --> C["max() on empty →\nValueError"]
    B -- "Yes" --> D["collect all i where\nx % i == 0"]
    D --> E["rows = max(collected divisors)"]
    E --> F["cols = x // rows"]
    F --> G["return (rows, cols)\nrows ≤ cols, rows × cols == x"]
```

</a>

<sub>Reviews (3): Last reviewed commit: ["thumbnail: rename to most\_square\_grid, a..."](https://github.com/quiltdata/quilt/commit/715f79709f408df2985770d641eb4e828eb4a61a) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=37921268)</sub>

<!-- /greptile_comment -->