### PR TITLE
thumbnail tests: golden-regeneration-proof channel-order oracle for the non-CZI color path

### DIFF
--- a/lambdas/thumbnail/tests/test_thumbnail.py
+++ b/lambdas/thumbnail/tests/test_thumbnail.py
@@ -12,6 +12,7 @@ import dask.array as da
 import numpy as np
 import pytest
 import responses
+import tifffile
 from bioio import BioImage
 from PIL import Image
 
@@ -228,6 +229,64 @@ def test_generate_thumbnail(
             expected = BioImage(data_dir / expected_thumb)
             assert actual.dims.items() == expected.dims.items()
             assert np.array_equal(actual.reader.data, expected.reader.data)
+
+
+# Local color fixtures, each with an independent decoder, covering the three
+# distinct non-CZI color reader paths exercised by the oracle below.
+_COLOR_ORACLE_FIXTURES = [
+    # bioio-imageio path: 8-bit RGB JPEG (a penguin with an orange beak/feet).
+    # PIL here is a genuinely different decoder than bioio-imageio's.
+    ("penguin.jpg", lambda p: np.asarray(Image.open(p).convert("RGB"))),
+    # bioio-tifffile YXC path: 8-bit RGBA aerial photo.
+    ("sat_rgb.tiff", lambda p: tifffile.imread(p)[..., :3]),
+    # bioio-tifffile float path through _rescale_float_to_uint8: float16 RGB.
+    ("float-rgb.tiff", lambda p: tifffile.imread(p).astype(np.float64)),
+]
+
+
+def _coarse_means(rgb, grid=12):
+    # Average a HxWxC image into a grid x grid x C array of block means so the
+    # oracle compares coarse regional color, not exact pixels: the thumbnail is
+    # resized (and, for floats, contrast-stretched), so it never matches an
+    # independent decode pixel-for-pixel — but its regional hue must still line up.
+    rgb = np.asarray(rgb, np.float64)
+    h, w, c = rgb.shape
+    ys = np.linspace(0, h, grid + 1, dtype=int)
+    xs = np.linspace(0, w, grid + 1, dtype=int)
+    return np.array([[rgb[ys[i]:ys[i + 1], xs[j]:xs[j + 1]].reshape(-1, c).mean(0)
+                      for j in range(grid)] for i in range(grid)])
+
+
+@pytest.mark.parametrize(
+    "fixture, decode", _COLOR_ORACLE_FIXTURES, ids=[f for f, _ in _COLOR_ORACLE_FIXTURES]
+)
+def test_color_path_channel_order(data_dir, fixture, decode):
+    # Channel-order oracle for the non-CZI color path, complementing the
+    # byte-exact goldens in test_generate_thumbnail. Those goldens are generated
+    # by the lambda itself: a swap does make them fail, but the tempting fix —
+    # regenerating the golden — would then enshrine the swap silently. (That is
+    # how the BGR R/B swap nearly shipped; see the CZI sibling of this test,
+    # test_handle_image_bgr_czi_channel_order.) Comparing the thumbnail's
+    # regional R-vs-B lean against an independent decode asserts ground truth a
+    # regeneration can't fake; the synthetic-array rescale unit tests can't —
+    # their min/max checks are invariant under a channel swap.
+    #
+    # For penguin.jpg the decoder (PIL) genuinely differs from bioio-imageio's;
+    # for the TIFFs tifffile is what bioio-tifffile wraps, so there this guards
+    # the lambda's own channel handling rather than the decode.
+    ref = decode(data_dir / fixture)
+    _info, png = t4_lambda_thumbnail.handle_image(
+        path=str(data_dir / fixture), size=(256, 256), thumbnail_format="PNG")
+    out = np.asarray(Image.open(BytesIO(png)).convert("RGB"), np.float64)
+
+    cr, co = _coarse_means(ref), _coarse_means(out)
+    # On blocks the source decodes as clearly red- or blue-leaning, the thumbnail
+    # must lean the same way. An R/B swap flips every sign -> agreement near 0.
+    rb_ref, rb_out = cr[..., 0] - cr[..., 2], co[..., 0] - co[..., 2]
+    colored = np.abs(rb_ref) > 0.05 * (cr.max() - cr.min())
+    assert colored.sum() >= 5, f"{fixture}: too few colored blocks to test ({colored.sum()})"
+    agree = (np.sign(rb_ref[colored]) == np.sign(rb_out[colored])).mean()
+    assert agree > 0.9, f"{fixture}: R/B channel order agreement only {agree * 100:.0f}%"
 
 
 def test_rescale_uint16_to_uint8_rescales_by_range():

--- a/lambdas/thumbnail/tests/test_thumbnail.py
+++ b/lambdas/thumbnail/tests/test_thumbnail.py
@@ -231,10 +231,8 @@ def test_generate_thumbnail(
             assert np.array_equal(actual.reader.data, expected.reader.data)
 
 
-# The three distinct non-CZI color reader paths, each with an independent decoder
-# returning an H×W×3 array. Keep in sync with the color rows in
-# test_generate_thumbnail — a color reader with a byte golden but no entry here
-# silently skips the channel-order check.
+# The three non-CZI color reader paths, each with an independent decoder; keep in
+# sync with test_generate_thumbnail's color rows.
 _COLOR_ORACLE_FIXTURES = [
     ("penguin.jpg", lambda p: np.asarray(Image.open(p).convert("RGB"))),    # bioio-imageio 8-bit RGB
     ("sat_rgb.tiff", lambda p: tifffile.imread(p)[..., :3]),                # bioio-tifffile 8-bit RGBA
@@ -243,11 +241,8 @@ _COLOR_ORACLE_FIXTURES = [
 
 
 def _coarse_means(rgb, grid=12):
-    # Reduce an H×W×C image to a grid×grid×C array of block means (float64: np.mean
-    # promotes per block, so no full-image upcast): the thumbnail is resized (and
-    # floats contrast-stretched), so it never matches an independent decode
-    # pixel-for-pixel, but regional hue must still line up. The assert pins the
-    # contract — a 2-D/4-D array unpacks opaquely, a sub-grid one gives NaN blocks.
+    # Reduce an image to grid×grid×C block means (np.mean → float64, no full-image
+    # upcast), coarse enough to survive the thumbnail's resize/stretch.
     rgb = np.asarray(rgb)
     assert rgb.ndim == 3 and min(rgb.shape[:2]) >= grid, f"expected an H×W×C image, H,W >= {grid}; got {rgb.shape}"
     h, w, c = rgb.shape
@@ -261,24 +256,21 @@ def _coarse_means(rgb, grid=12):
     "fixture, decode", _COLOR_ORACLE_FIXTURES, ids=[f for f, _ in _COLOR_ORACLE_FIXTURES]
 )
 def test_handle_image_color_channel_order(data_dir, fixture, decode):
-    # Channel-order oracle for the non-CZI color path, complementing the byte
-    # goldens in test_generate_thumbnail. Those are self-generated, so a swap that
-    # is "fixed" by regenerating the golden gets enshrined silently — how the BGR
-    # R/B swap nearly shipped (see the CZI sibling test_handle_image_bgr_czi_channel_order).
-    # Comparing the thumbnail's regional R-vs-B lean to an independent decode can't
-    # be faked by a regeneration; the synthetic rescale unit tests can't catch a
-    # swap at all (their min/max checks are swap-invariant). Only R/B is checked —
-    # the axis BGR reverses; for penguin PIL is a genuinely independent decoder,
-    # while for the TIFFs tifffile is what bioio-tifffile wraps (guarding the
-    # lambda's channel handling, not the decode).
+    # Independent channel-order oracle for the non-CZI color path. The byte goldens
+    # in test_generate_thumbnail are self-generated, so a swap "fixed" by
+    # regenerating them is enshrined silently — how the BGR R/B swap nearly shipped
+    # (CZI sibling: test_handle_image_bgr_czi_channel_order). Checking regional
+    # R-vs-B lean against an independent decode can't be faked that way. Only R/B
+    # (the axis BGR reverses) is checked; for the TIFFs tifffile is shared with
+    # bioio-tifffile, so there it guards the lambda's handling, not the decode.
     ref = decode(data_dir / fixture)
     _info, png = t4_lambda_thumbnail.handle_image(
         path=str(data_dir / fixture), size=(256, 256), thumbnail_format="PNG")
     out = np.asarray(Image.open(BytesIO(png)).convert("RGB"), np.float64)
 
     cr, co = _coarse_means(ref), _coarse_means(out)
-    # On blocks the source decodes as clearly red- or blue-leaning, the thumbnail
-    # must lean the same way. An R/B swap flips every sign -> agreement near 0.
+    # On clearly red/blue-leaning blocks the thumbnail must lean the same way; an
+    # R/B swap flips every sign -> ~0 agreement.
     rb_ref, rb_out = cr[..., 0] - cr[..., 2], co[..., 0] - co[..., 2]
     colored = np.abs(rb_ref) > 0.05 * (cr.max() - cr.min())
     assert colored.sum() >= 5, f"{fixture}: too few colored blocks to test ({colored.sum()})"

--- a/lambdas/thumbnail/tests/test_thumbnail.py
+++ b/lambdas/thumbnail/tests/test_thumbnail.py
@@ -231,25 +231,24 @@ def test_generate_thumbnail(
             assert np.array_equal(actual.reader.data, expected.reader.data)
 
 
-# Local color fixtures, each with an independent decoder, covering the three
-# distinct non-CZI color reader paths exercised by the oracle below.
+# The three distinct non-CZI color reader paths, each with an independent decoder
+# returning an H×W×3 array. Keep in sync with the color rows in
+# test_generate_thumbnail — a color reader with a byte golden but no entry here
+# silently skips the channel-order check.
 _COLOR_ORACLE_FIXTURES = [
-    # bioio-imageio path: 8-bit RGB JPEG (a penguin with an orange beak/feet).
-    # PIL here is a genuinely different decoder than bioio-imageio's.
-    ("penguin.jpg", lambda p: np.asarray(Image.open(p).convert("RGB"))),
-    # bioio-tifffile YXC path: 8-bit RGBA aerial photo.
-    ("sat_rgb.tiff", lambda p: tifffile.imread(p)[..., :3]),
-    # bioio-tifffile float path through _rescale_float_to_uint8: float16 RGB.
-    ("float-rgb.tiff", lambda p: tifffile.imread(p).astype(np.float64)),
+    ("penguin.jpg", lambda p: np.asarray(Image.open(p).convert("RGB"))),    # bioio-imageio 8-bit RGB
+    ("sat_rgb.tiff", lambda p: tifffile.imread(p)[..., :3]),                # bioio-tifffile 8-bit RGBA
+    ("float-rgb.tiff", lambda p: tifffile.imread(p).astype(np.float64)),    # bioio-tifffile float16
 ]
 
 
 def _coarse_means(rgb, grid=12):
-    # Average a HxWxC image into a grid x grid x C array of block means so the
-    # oracle compares coarse regional color, not exact pixels: the thumbnail is
-    # resized (and, for floats, contrast-stretched), so it never matches an
-    # independent decode pixel-for-pixel — but its regional hue must still line up.
+    # Reduce an H×W×C image to a grid×grid×C array of block means: the thumbnail is
+    # resized (and floats contrast-stretched), so it never matches an independent
+    # decode pixel-for-pixel, but regional hue must still line up. The assert pins
+    # the contract — a 2-D/4-D array unpacks opaquely, a sub-grid one gives NaN blocks.
     rgb = np.asarray(rgb, np.float64)
+    assert rgb.ndim == 3 and min(rgb.shape[:2]) >= grid, f"expected an H×W×C image, H,W >= {grid}; got {rgb.shape}"
     h, w, c = rgb.shape
     ys = np.linspace(0, h, grid + 1, dtype=int)
     xs = np.linspace(0, w, grid + 1, dtype=int)
@@ -260,20 +259,17 @@ def _coarse_means(rgb, grid=12):
 @pytest.mark.parametrize(
     "fixture, decode", _COLOR_ORACLE_FIXTURES, ids=[f for f, _ in _COLOR_ORACLE_FIXTURES]
 )
-def test_color_path_channel_order(data_dir, fixture, decode):
-    # Channel-order oracle for the non-CZI color path, complementing the
-    # byte-exact goldens in test_generate_thumbnail. Those goldens are generated
-    # by the lambda itself: a swap does make them fail, but the tempting fix —
-    # regenerating the golden — would then enshrine the swap silently. (That is
-    # how the BGR R/B swap nearly shipped; see the CZI sibling of this test,
-    # test_handle_image_bgr_czi_channel_order.) Comparing the thumbnail's
-    # regional R-vs-B lean against an independent decode asserts ground truth a
-    # regeneration can't fake; the synthetic-array rescale unit tests can't —
-    # their min/max checks are invariant under a channel swap.
-    #
-    # For penguin.jpg the decoder (PIL) genuinely differs from bioio-imageio's;
-    # for the TIFFs tifffile is what bioio-tifffile wraps, so there this guards
-    # the lambda's own channel handling rather than the decode.
+def test_handle_image_color_channel_order(data_dir, fixture, decode):
+    # Channel-order oracle for the non-CZI color path, complementing the byte
+    # goldens in test_generate_thumbnail. Those are self-generated, so a swap that
+    # is "fixed" by regenerating the golden gets enshrined silently — how the BGR
+    # R/B swap nearly shipped (see the CZI sibling test_handle_image_bgr_czi_channel_order).
+    # Comparing the thumbnail's regional R-vs-B lean to an independent decode can't
+    # be faked by a regeneration; the synthetic rescale unit tests can't catch a
+    # swap at all (their min/max checks are swap-invariant). Only R/B is checked —
+    # the axis BGR reverses; for penguin PIL is a genuinely independent decoder,
+    # while for the TIFFs tifffile is what bioio-tifffile wraps (guarding the
+    # lambda's channel handling, not the decode).
     ref = decode(data_dir / fixture)
     _info, png = t4_lambda_thumbnail.handle_image(
         path=str(data_dir / fixture), size=(256, 256), thumbnail_format="PNG")

--- a/lambdas/thumbnail/tests/test_thumbnail.py
+++ b/lambdas/thumbnail/tests/test_thumbnail.py
@@ -243,11 +243,12 @@ _COLOR_ORACLE_FIXTURES = [
 
 
 def _coarse_means(rgb, grid=12):
-    # Reduce an H×W×C image to a grid×grid×C array of block means: the thumbnail is
-    # resized (and floats contrast-stretched), so it never matches an independent
-    # decode pixel-for-pixel, but regional hue must still line up. The assert pins
-    # the contract — a 2-D/4-D array unpacks opaquely, a sub-grid one gives NaN blocks.
-    rgb = np.asarray(rgb, np.float64)
+    # Reduce an H×W×C image to a grid×grid×C array of block means (float64: np.mean
+    # promotes per block, so no full-image upcast): the thumbnail is resized (and
+    # floats contrast-stretched), so it never matches an independent decode
+    # pixel-for-pixel, but regional hue must still line up. The assert pins the
+    # contract — a 2-D/4-D array unpacks opaquely, a sub-grid one gives NaN blocks.
+    rgb = np.asarray(rgb)
     assert rgb.ndim == 3 and min(rgb.shape[:2]) >= grid, f"expected an H×W×C image, H,W >= {grid}; got {rgb.shape}"
     h, w, c = rgb.shape
     ys = np.linspace(0, h, grid + 1, dtype=int)


### PR DESCRIPTION
# Description

The thumbnail lambda's color goldens (`test_generate_thumbnail`, `test_handle_image`) are generated by the lambda itself and committed as the expected output. A byte-golden does catch a channel-swap as a *failure*, but the tempting fix — regenerating the golden — would then enshrine the swap silently. That is the exact path by which the BGR R/B swap nearly shipped (#4992): the relevant color goldens didn't exist (they were `xfail`), and the bug was caught only by a human eyeballing the output.

#4992 closed that gap for the **CZI** path with an independent channel-order oracle (`test_handle_image_bgr_czi_channel_order`). This PR adds the equivalent guard for the **non-CZI** color path, which had none:

- `penguin.jpg` — bioio-imageio 8-bit RGB (PIL is a genuinely different decoder here)
- `sat_rgb.tiff` — bioio-tifffile 8-bit RGBA
- `float-rgb.tiff` — bioio-tifffile float16, through `_rescale_float_to_uint8`

`test_color_path_channel_order` renders each fixture through `handle_image`, independently decodes the source, coarsens both into a grid of block means, and asserts that on clearly-colored blocks the thumbnail's regional R-vs-B lean matches the source. An R/B swap flips every sign → agreement collapses to ~0% (validated by mutation). Because the assertion is against an independent decode, not a stored golden, a golden regeneration can't fake it; the synthetic-array rescale unit tests can't catch a swap at all (their min/max checks are invariant under channel permutation).

Scope notes:
- Test-only; no behavior change. No CHANGELOG entry (not end-user-significant).
- Orientation was deliberately left out: the single-plane color path has no transposition logic, so an orientation regression there is implausible and would be caught by the byte goldens anyway; the montage layout path is covered separately (`test_handle_image_multichannel_bgr_czi_channel_order`).
- For the TIFF fixtures, tifffile is what bioio-tifffile wraps, so there the oracle guards the lambda's own channel handling rather than the decode; `penguin.jpg` (PIL vs bioio-imageio) is the genuinely cross-library case.

I also independently audited every existing color golden (local + the S3 `images/thumbs` package) against an independent decode — all render with correct channel order and orientation; no enshrined bug was found. This test makes that conclusion durable against future regenerations.

# TODO

- [x] Unit tests

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds `test_color_path_channel_order`, a parametrized channel-order oracle for the three non-CZI color paths in the thumbnail lambda (JPEG via bioio-imageio, 8-bit RGBA TIFF, and float16 TIFF). It is the non-CZI sibling of the existing `test_handle_image_bgr_czi_channel_order`, closing the gap that nearly let a BGR R/B swap ship undetected (#4992).

- Each fixture is independently decoded (PIL for JPEG, raw `tifffile` for TIFFs), coarsened into a 12×12 grid of block means, and compared against the lambda's own thumbnail output by sign of the R−B difference. Because the comparison is against an independent decode rather than a stored golden, golden regeneration cannot silently enshrine a swap.
- Test-only change; all three fixture files already exist on disk; no production code is modified.

<h3>Confidence Score: 5/5</h3>

Pure test addition with no changes to production code; all fixture files are pre-existing and already covered by the byte-golden suite.

The new test logic is sound: the coarse-grid approach tolerates resize and scale differences between decoder outputs, the sign-only comparison is invariant to the float-vs-uint8 scale mismatch in the float fixture, the `colored.sum() >= 5` pre-condition provides a clear sanity guard, and the 90% agreement threshold definitively distinguishes correct channel order from a full R/B swap. All three fixture files exist in the data directory and are independently verified by the existing golden tests. No production paths are touched.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| lambdas/thumbnail/tests/test_thumbnail.py | Adds `test_color_path_channel_order` (parametrized over 3 local fixtures), helper `_coarse_means`, and a module-level `_COLOR_ORACLE_FIXTURES` list. Test-only; no production code changed. |

</details>

<h3>Flowchart</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A["fixture file on disk\n(penguin.jpg / sat_rgb.tiff / float-rgb.tiff)"] --> B["Independent reference decode\n(PIL / tifffile / tifffile.astype float64)"]
    A --> C["handle_image()\n→ PNG bytes"]
    C --> D["Image.open().convert('RGB')\n→ uint8 HxWx3"]
    B --> E["_coarse_means(ref)\n12×12×3 block means"]
    D --> F["_coarse_means(out)\n12×12×3 block means"]
    E --> G["rb_ref = R_mean − B_mean\ncolored = |rb_ref| > 5% dynamic range"]
    F --> H["rb_out = R_mean − B_mean"]
    G --> I["assert colored.sum() ≥ 5"]
    G --> J["agree = sign(rb_ref) == sign(rb_out)\nover colored blocks"]
    H --> J
    J --> K["assert agree > 0.90\n(R/B swap → agree ≈ 0%)"]
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A["fixture file on disk\n(penguin.jpg / sat_rgb.tiff / float-rgb.tiff)"] --> B["Independent reference decode\n(PIL / tifffile / tifffile.astype float64)"]
    A --> C["handle_image()\n→ PNG bytes"]
    C --> D["Image.open().convert('RGB')\n→ uint8 HxWx3"]
    B --> E["_coarse_means(ref)\n12×12×3 block means"]
    D --> F["_coarse_means(out)\n12×12×3 block means"]
    E --> G["rb_ref = R_mean − B_mean\ncolored = |rb_ref| > 5% dynamic range"]
    F --> H["rb_out = R_mean − B_mean"]
    G --> I["assert colored.sum() ≥ 5"]
    G --> J["agree = sign(rb_ref) == sign(rb_out)\nover colored blocks"]
    H --> J
    J --> K["assert agree > 0.90\n(R/B swap → agree ≈ 0%)"]
```

</a>

<sub>Reviews (2): Last reviewed commit: ["thumbnail tests: add golden-regeneration..."](https://github.com/quiltdata/quilt/commit/12ede8b3427fb233b069f6895467c903afdd1ff1) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=37925091)</sub>

<!-- /greptile_comment -->