### PR TITLE
thumbnail: stream the source download to disk instead of buffering in memory

### DIFF
--- a/.github/workflows/deploy-lambdas.yaml
+++ b/.github/workflows/deploy-lambdas.yaml
@@ -4,12 +4,14 @@ on:
   push:
     branches:
       - master
+      - thumbnail-stream-download  # TEMP(#5000): build dev image for memory A/B; revert before merge
     paths:
       - '.github/workflows/deploy-lambdas.yaml'
       - 'lambdas/**'
 
 jobs:
   deploy-lambda-s3:
+    if: github.ref_name == 'master'  # TEMP(#5000): skip zip lambdas on feature branch; revert before merge
     strategy:
       fail-fast: false
       matrix:
@@ -67,9 +69,8 @@ jobs:
       fail-fast: false
       matrix:
         path:
-          - indexer
+          # TEMP(#5000): narrowed to thumbnail for the dev-image build; revert before merge
           - thumbnail
-          - tabular_preview
     runs-on: ubuntu-latest
     # These permissions are needed to interact with GitHub's OIDC Token endpoint.
     permissions:

--- a/.github/workflows/deploy-lambdas.yaml
+++ b/.github/workflows/deploy-lambdas.yaml
@@ -4,14 +4,12 @@ on:
   push:
     branches:
       - master
-      - thumbnail-stream-download  # TEMP(#5000): build dev image for memory A/B; revert before merge
     paths:
       - '.github/workflows/deploy-lambdas.yaml'
       - 'lambdas/**'
 
 jobs:
   deploy-lambda-s3:
-    if: github.ref_name == 'master'  # TEMP(#5000): skip zip lambdas on feature branch; revert before merge
     strategy:
       fail-fast: false
       matrix:
@@ -69,8 +67,9 @@ jobs:
       fail-fast: false
       matrix:
         path:
-          # TEMP(#5000): narrowed to thumbnail for the dev-image build; revert before merge
+          - indexer
           - thumbnail
+          - tabular_preview
     runs-on: ubuntu-latest
     # These permissions are needed to interact with GitHub's OIDC Token endpoint.
     permissions:

--- a/lambdas/thumbnail/CHANGELOG.md
+++ b/lambdas/thumbnail/CHANGELOG.md
@@ -17,7 +17,7 @@ where verb is one of
 
 ## Changes
 
-- [Changed] Stream the source download straight to the temp file instead of buffering the whole object in memory, so the compressed file no longer stays resident through decoding — lowering peak memory; generated thumbnails unchanged ([#5000](https://github.com/quiltdata/quilt/pull/5000))
+- [Changed] Stream the source download to disk instead of into memory, lowering peak memory on large images (output unchanged) ([#5000](https://github.com/quiltdata/quilt/pull/5000))
 - [Changed] Thumbnails are now 8-bit everywhere: normalized greyscale montages and Z-projections (multi-channel microscopy stacks, greyscale CZIs) are emitted as 8-bit PNGs (mode `L`) instead of 16-bit (`I;16`). These previews are already contrast-stretched per image, so the extra depth carried no recoverable pixel meaning; output is smaller and the affected thumbnails now resize at 8-bit like every other path (slightly coarser tonal steps) ([#4999](https://github.com/quiltdata/quilt/pull/4999))
 - [Fixed] Signed and wider-than-16-bit integer images (`uint32`/`uint64`, `int8`/`int16`/`int64`, and 32-bit-integer color) now preview — contrast-stretched to 8-bit — instead of failing with HTTP 500 (color and 64-bit integers) or rendering as a clamped/dark 16-bit image ([#4998](https://github.com/quiltdata/quilt/pull/4998))
 - [Fixed] Color CZI images stored as BGR pixel types (e.g. `Bgr24`/`Bgr48`) now preview with correct colors instead of failing; bumps bioio-czi to 2.7 ([#4992](https://github.com/quiltdata/quilt/pull/4992))

--- a/lambdas/thumbnail/CHANGELOG.md
+++ b/lambdas/thumbnail/CHANGELOG.md
@@ -17,7 +17,7 @@ where verb is one of
 
 ## Changes
 
-- [Changed] Stream the source download to disk instead of into memory, lowering peak memory on large images (output unchanged) ([#5000](https://github.com/quiltdata/quilt/pull/5000))
+- [Changed] Stream the source download to disk instead of into memory, lowering peak memory on large images ([#5000](https://github.com/quiltdata/quilt/pull/5000))
 - [Changed] Thumbnails are now 8-bit everywhere: normalized greyscale montages and Z-projections (multi-channel microscopy stacks, greyscale CZIs) are emitted as 8-bit PNGs (mode `L`) instead of 16-bit (`I;16`). These previews are already contrast-stretched per image, so the extra depth carried no recoverable pixel meaning; output is smaller and the affected thumbnails now resize at 8-bit like every other path (slightly coarser tonal steps) ([#4999](https://github.com/quiltdata/quilt/pull/4999))
 - [Fixed] Signed and wider-than-16-bit integer images (`uint32`/`uint64`, `int8`/`int16`/`int64`, and 32-bit-integer color) now preview — contrast-stretched to 8-bit — instead of failing with HTTP 500 (color and 64-bit integers) or rendering as a clamped/dark 16-bit image ([#4998](https://github.com/quiltdata/quilt/pull/4998))
 - [Fixed] Color CZI images stored as BGR pixel types (e.g. `Bgr24`/`Bgr48`) now preview with correct colors instead of failing; bumps bioio-czi to 2.7 ([#4992](https://github.com/quiltdata/quilt/pull/4992))

--- a/lambdas/thumbnail/CHANGELOG.md
+++ b/lambdas/thumbnail/CHANGELOG.md
@@ -17,6 +17,7 @@ where verb is one of
 
 ## Changes
 
+- [Changed] Stream the source download straight to the temp file instead of buffering the whole object in memory, so the compressed file no longer stays resident through decoding — lowering peak memory; generated thumbnails unchanged ([#5000](https://github.com/quiltdata/quilt/pull/5000))
 - [Changed] Thumbnails are now 8-bit everywhere: normalized greyscale montages and Z-projections (multi-channel microscopy stacks, greyscale CZIs) are emitted as 8-bit PNGs (mode `L`) instead of 16-bit (`I;16`). These previews are already contrast-stretched per image, so the extra depth carried no recoverable pixel meaning; output is smaller and the affected thumbnails now resize at 8-bit like every other path (slightly coarser tonal steps) ([#4999](https://github.com/quiltdata/quilt/pull/4999))
 - [Fixed] Signed and wider-than-16-bit integer images (`uint32`/`uint64`, `int8`/`int16`/`int64`, and 32-bit-integer color) now preview — contrast-stretched to 8-bit — instead of failing with HTTP 500 (color and 64-bit integers) or rendering as a clamped/dark 16-bit image ([#4998](https://github.com/quiltdata/quilt/pull/4998))
 - [Fixed] Color CZI images stored as BGR pixel types (e.g. `Bgr24`/`Bgr48`) now preview with correct colors instead of failing; bumps bioio-czi to 2.7 ([#4992](https://github.com/quiltdata/quilt/pull/4992))

--- a/lambdas/thumbnail/src/t4_lambda_thumbnail/__init__.py
+++ b/lambdas/thumbnail/src/t4_lambda_thumbnail/__init__.py
@@ -710,52 +710,6 @@ def generate_thumbnail(arr, size, *, normalized=False):
     return img
 
 
-class UpstreamError(Exception):
-    """
-    A non-ok response while fetching the source URL. Carries the JSON error
-    response to return so the upstream status (not 500) is surfaced; caught
-    locally in lambda_handler, not by @handle_exceptions.
-    """
-
-    def __init__(self, resp):
-        super().__init__(resp.reason)
-        self.response = make_json_response(
-            resp.status_code, {'error': resp.reason, 'text': resp.text}
-        )
-
-
-@contextlib.contextmanager
-def download_to_tempfile(url):
-    """
-    Stream `url` to a NamedTemporaryFile and yield its local path.
-
-    Streams the body straight to disk rather than buffering the whole object in
-    memory via resp.content (this lambda's OOM-prone peak), on top of
-    resp.content's transient ~2x during its b"".join. decode_content=True makes
-    the streamed bytes match what resp.content would yield: it decodes a response
-    Content-Encoding when present (e.g. a gzip-stored S3 object) and passes
-    through when absent — not a no-op to drop.
-
-    Raises UpstreamError (before touching /tmp) on a non-ok response. The
-    connection and the temp file are both released on exit, including on a
-    mid-stream exception.
-    """
-    with requests.get(url, stream=True) as resp:
-        if not resp.ok:
-            raise UpstreamError(resp)
-
-        clean_tmp_dir()
-        # XXX: BioImage can read from s3/http(s) URLs directly, but in practice it's at least 2x slower
-        #      than downloading the file first and reading from local FS even with cache_type='all' which
-        #      downloads the file in one shot.
-        filename_suffix = urllib.parse.unquote(urllib.parse.urlparse(url).path.split('/')[-1])
-        with tempfile.NamedTemporaryFile(suffix=filename_suffix) as src_file:
-            resp.raw.decode_content = True
-            shutil.copyfileobj(resp.raw, src_file)
-            src_file.flush()
-            yield src_file.name
-
-
 @api(cors_origins=get_default_origins())
 @validate(SCHEMA)
 @handle_exceptions(PDFThumbError)
@@ -770,14 +724,37 @@ def lambda_handler(request):
     page = int(request.args.get('page', '1'))
     count_pages = request.args.get('countPages') == 'true'
 
-    # Download the source to a temp file, then thumbnail it.
-    try:
-        with download_to_tempfile(url) as src_path:
+    # Handle request
+    with requests.get(url, stream=True) as resp:
+        if not resp.ok:
+            # Errored, return error code
+            ret_val = {
+                'error': resp.reason,
+                'text': resp.text,
+            }
+            return make_json_response(resp.status_code, ret_val)
+
+        clean_tmp_dir()
+        # XXX: BioImage can read from s3/http(s) URLs directly, but in practice it's at least 2x slower
+        #      than downloading the file first and reading from local FS even with cache_type='all' which
+        #      downloads the file in one shot.
+        filename_suffix = urllib.parse.unquote(urllib.parse.urlparse(url).path.split('/')[-1])
+        with tempfile.NamedTemporaryFile(suffix=filename_suffix) as src_file:
+            # Stream the body straight to the temp file instead of buffering the
+            # whole object in memory via resp.content: the full compressed file
+            # would otherwise stay resident through the decode (this lambda's
+            # OOM-prone peak), on top of resp.content's transient ~2x during its
+            # b"".join. decode_content applies any transfer Content-Encoding
+            # (presigned S3 GETs carry none, so this matches resp.content's bytes).
+            resp.raw.decode_content = True
+            shutil.copyfileobj(resp.raw, src_file)
+            src_file.flush()
+
             thumbnail_format = "JPEG"
             if input_ == "pdf":
-                info, data = handle_pdf(path=src_path, page=page, size=size[0], count_pages=count_pages)
+                info, data = handle_pdf(path=src_file.name, page=page, size=size[0], count_pages=count_pages)
             elif input_ == "pptx":
-                info, data = handle_pptx(path=src_path, page=page, size=size[0], count_pages=count_pages)
+                info, data = handle_pptx(path=src_file.name, page=page, size=size[0], count_pages=count_pages)
             else:
                 # XXX: This never seemed to work, because imageio.get_reader() returns an instance,
                 #      not a class/type. imageio 2.28+ stopped return instances of these classes altogether.
@@ -797,12 +774,10 @@ def lambda_handler(request):
                 #     thumbnail_format = "PNG"
                 thumbnail_format = "PNG"
                 info, data = handle_image(
-                    path=src_path,
+                    path=src_file.name,
                     size=size,
                     thumbnail_format=thumbnail_format,
                 )
-    except UpstreamError as e:
-        return e.response
 
     headers = {
         'Content-Type': Image.MIME[thumbnail_format],

--- a/lambdas/thumbnail/src/t4_lambda_thumbnail/__init__.py
+++ b/lambdas/thumbnail/src/t4_lambda_thumbnail/__init__.py
@@ -710,6 +710,52 @@ def generate_thumbnail(arr, size, *, normalized=False):
     return img
 
 
+class UpstreamError(Exception):
+    """
+    A non-ok response while fetching the source URL. Carries the JSON error
+    response to return so the upstream status (not 500) is surfaced; caught
+    locally in lambda_handler, not by @handle_exceptions.
+    """
+
+    def __init__(self, resp):
+        super().__init__(resp.reason)
+        self.response = make_json_response(
+            resp.status_code, {'error': resp.reason, 'text': resp.text}
+        )
+
+
+@contextlib.contextmanager
+def download_to_tempfile(url):
+    """
+    Stream `url` to a NamedTemporaryFile and yield its local path.
+
+    Streams the body straight to disk rather than buffering the whole object in
+    memory via resp.content (this lambda's OOM-prone peak), on top of
+    resp.content's transient ~2x during its b"".join. decode_content=True makes
+    the streamed bytes match what resp.content would yield: it decodes a response
+    Content-Encoding when present (e.g. a gzip-stored S3 object) and passes
+    through when absent — not a no-op to drop.
+
+    Raises UpstreamError (before touching /tmp) on a non-ok response. The
+    connection and the temp file are both released on exit, including on a
+    mid-stream exception.
+    """
+    with requests.get(url, stream=True) as resp:
+        if not resp.ok:
+            raise UpstreamError(resp)
+
+        clean_tmp_dir()
+        # XXX: BioImage can read from s3/http(s) URLs directly, but in practice it's at least 2x slower
+        #      than downloading the file first and reading from local FS even with cache_type='all' which
+        #      downloads the file in one shot.
+        filename_suffix = urllib.parse.unquote(urllib.parse.urlparse(url).path.split('/')[-1])
+        with tempfile.NamedTemporaryFile(suffix=filename_suffix) as src_file:
+            resp.raw.decode_content = True
+            shutil.copyfileobj(resp.raw, src_file)
+            src_file.flush()
+            yield src_file.name
+
+
 @api(cors_origins=get_default_origins())
 @validate(SCHEMA)
 @handle_exceptions(PDFThumbError)
@@ -724,37 +770,14 @@ def lambda_handler(request):
     page = int(request.args.get('page', '1'))
     count_pages = request.args.get('countPages') == 'true'
 
-    # Handle request
-    with requests.get(url, stream=True) as resp:
-        if not resp.ok:
-            # Errored, return error code
-            ret_val = {
-                'error': resp.reason,
-                'text': resp.text,
-            }
-            return make_json_response(resp.status_code, ret_val)
-
-        clean_tmp_dir()
-        # XXX: BioImage can read from s3/http(s) URLs directly, but in practice it's at least 2x slower
-        #      than downloading the file first and reading from local FS even with cache_type='all' which
-        #      downloads the file in one shot.
-        filename_suffix = urllib.parse.unquote(urllib.parse.urlparse(url).path.split('/')[-1])
-        with tempfile.NamedTemporaryFile(suffix=filename_suffix) as src_file:
-            # Stream the body straight to the temp file instead of buffering the
-            # whole object in memory via resp.content: the full compressed file
-            # would otherwise stay resident through the decode (this lambda's
-            # OOM-prone peak), on top of resp.content's transient ~2x during its
-            # b"".join. decode_content applies any transfer Content-Encoding
-            # (presigned S3 GETs carry none, so this matches resp.content's bytes).
-            resp.raw.decode_content = True
-            shutil.copyfileobj(resp.raw, src_file)
-            src_file.flush()
-
+    # Download the source to a temp file, then thumbnail it.
+    try:
+        with download_to_tempfile(url) as src_path:
             thumbnail_format = "JPEG"
             if input_ == "pdf":
-                info, data = handle_pdf(path=src_file.name, page=page, size=size[0], count_pages=count_pages)
+                info, data = handle_pdf(path=src_path, page=page, size=size[0], count_pages=count_pages)
             elif input_ == "pptx":
-                info, data = handle_pptx(path=src_file.name, page=page, size=size[0], count_pages=count_pages)
+                info, data = handle_pptx(path=src_path, page=page, size=size[0], count_pages=count_pages)
             else:
                 # XXX: This never seemed to work, because imageio.get_reader() returns an instance,
                 #      not a class/type. imageio 2.28+ stopped return instances of these classes altogether.
@@ -774,10 +797,12 @@ def lambda_handler(request):
                 #     thumbnail_format = "PNG"
                 thumbnail_format = "PNG"
                 info, data = handle_image(
-                    path=src_file.name,
+                    path=src_path,
                     size=size,
                     thumbnail_format=thumbnail_format,
                 )
+    except UpstreamError as e:
+        return e.response
 
     headers = {
         'Content-Type': Image.MIME[thumbnail_format],

--- a/lambdas/thumbnail/src/t4_lambda_thumbnail/__init__.py
+++ b/lambdas/thumbnail/src/t4_lambda_thumbnail/__init__.py
@@ -740,12 +740,9 @@ def lambda_handler(request):
         #      downloads the file in one shot.
         filename_suffix = urllib.parse.unquote(urllib.parse.urlparse(url).path.split('/')[-1])
         with tempfile.NamedTemporaryFile(suffix=filename_suffix) as src_file:
-            # Stream the body straight to the temp file instead of buffering the
-            # whole object in memory via resp.content: the full compressed file
-            # would otherwise stay resident through the decode (this lambda's
-            # OOM-prone peak), on top of resp.content's transient ~2x during its
-            # b"".join. decode_content applies any transfer Content-Encoding
-            # (presigned S3 GETs carry none, so this matches resp.content's bytes).
+            # Stream straight to disk, not into memory via resp.content (OOM-prone here).
+            # decode_content makes the bytes match resp.content (decodes a gzip-stored
+            # object, else passthrough) — load-bearing, not a no-op.
             resp.raw.decode_content = True
             shutil.copyfileobj(resp.raw, src_file)
             src_file.flush()

--- a/lambdas/thumbnail/src/t4_lambda_thumbnail/__init__.py
+++ b/lambdas/thumbnail/src/t4_lambda_thumbnail/__init__.py
@@ -725,52 +725,59 @@ def lambda_handler(request):
     count_pages = request.args.get('countPages') == 'true'
 
     # Handle request
-    resp = requests.get(url)
-    if not resp.ok:
-        # Errored, return error code
-        ret_val = {
-            'error': resp.reason,
-            'text': resp.text,
-        }
-        return make_json_response(resp.status_code, ret_val)
+    with requests.get(url, stream=True) as resp:
+        if not resp.ok:
+            # Errored, return error code
+            ret_val = {
+                'error': resp.reason,
+                'text': resp.text,
+            }
+            return make_json_response(resp.status_code, ret_val)
 
-    clean_tmp_dir()
-    # XXX: BioImage can read from s3/http(s) URLs directly, but in practice it's at least 2x slower
-    #      than downloading the file first and reading from local FS even with cache_type='all' which
-    #      downloads the file in one shot.
-    filename_suffix = urllib.parse.unquote(urllib.parse.urlparse(url).path.split('/')[-1])
-    with tempfile.NamedTemporaryFile(suffix=filename_suffix) as src_file:
-        src_file.write(resp.content)
-        src_file.flush()
+        clean_tmp_dir()
+        # XXX: BioImage can read from s3/http(s) URLs directly, but in practice it's at least 2x slower
+        #      than downloading the file first and reading from local FS even with cache_type='all' which
+        #      downloads the file in one shot.
+        filename_suffix = urllib.parse.unquote(urllib.parse.urlparse(url).path.split('/')[-1])
+        with tempfile.NamedTemporaryFile(suffix=filename_suffix) as src_file:
+            # Stream the body straight to the temp file instead of buffering the
+            # whole object in memory via resp.content: the full compressed file
+            # would otherwise stay resident through the decode (this lambda's
+            # OOM-prone peak), on top of resp.content's transient ~2x during its
+            # b"".join. decode_content applies any transfer Content-Encoding
+            # (presigned S3 GETs carry none, so this matches resp.content's bytes).
+            resp.raw.decode_content = True
+            shutil.copyfileobj(resp.raw, src_file)
+            src_file.flush()
 
-        thumbnail_format = "JPEG"
-        if input_ == "pdf":
-            info, data = handle_pdf(path=src_file.name, page=page, size=size[0], count_pages=count_pages)
-        elif input_ == "pptx":
-            info, data = handle_pptx(path=src_file.name, page=page, size=size[0], count_pages=count_pages)
-        else:
-            # XXX: This never seemed to work, because imageio.get_reader() returns an instance,
-            #      not a class/type. imageio 2.28+ stopped return instances of these classes altogether.
-            #      So for now, always use PNG.
-            # If the image is one of these formats, retain the format after formatting
-            # SUPPORTED_BROWSER_FORMATS = {
-            #     imageio.plugins.pillow_legacy.JPEGFormat.Reader: "JPG",
-            #     imageio.plugins.pillow_legacy.PNGFormat.Reader: "PNG",
-            #     imageio.plugins.pillow_legacy.GIFFormat.Reader: "GIF"
-            # }
-            # try:
-            #     thumbnail_format = SUPPORTED_BROWSER_FORMATS.get(
-            #         imageio.get_reader(url),
-            #         "PNG"
-            #     )
-            # except ValueError:
-            #     thumbnail_format = "PNG"
-            thumbnail_format = "PNG"
-            info, data = handle_image(
-                path=src_file.name,
-                size=size,
-                thumbnail_format=thumbnail_format,
-            )
+            thumbnail_format = "JPEG"
+            if input_ == "pdf":
+                info, data = handle_pdf(path=src_file.name, page=page, size=size[0], count_pages=count_pages)
+            elif input_ == "pptx":
+                info, data = handle_pptx(path=src_file.name, page=page, size=size[0], count_pages=count_pages)
+            else:
+                # XXX: This never seemed to work, because imageio.get_reader() returns an instance,
+                #      not a class/type. imageio 2.28+ stopped return instances of these classes altogether.
+                #      So for now, always use PNG.
+                # If the image is one of these formats, retain the format after formatting
+                # SUPPORTED_BROWSER_FORMATS = {
+                #     imageio.plugins.pillow_legacy.JPEGFormat.Reader: "JPG",
+                #     imageio.plugins.pillow_legacy.PNGFormat.Reader: "PNG",
+                #     imageio.plugins.pillow_legacy.GIFFormat.Reader: "GIF"
+                # }
+                # try:
+                #     thumbnail_format = SUPPORTED_BROWSER_FORMATS.get(
+                #         imageio.get_reader(url),
+                #         "PNG"
+                #     )
+                # except ValueError:
+                #     thumbnail_format = "PNG"
+                thumbnail_format = "PNG"
+                info, data = handle_image(
+                    path=src_file.name,
+                    size=size,
+                    thumbnail_format=thumbnail_format,
+                )
 
     headers = {
         'Content-Type': Image.MIME[thumbnail_format],


### PR DESCRIPTION
# Description

The thumbnail lambda's known failure mode is OOM. `requests.get(url)` (the default `stream=False`) reads the **entire compressed object into RAM** inside `send()` — built via `b"".join(iter_content(...))`, which is a transient ~2× peak during the join, settling to one full copy cached on the response. Because `resp` stays bound for the rest of the handler, that copy stays resident through `arr.compute()` — the decode, which is the actual memory peak.

This switches the download to `stream=True` + `shutil.copyfileobj(resp.raw, src_file)`: the body goes straight to the temp file in `COPY_BUFSIZE` chunks, so nothing compressed is held during the decode and the join transient is gone. `resp.raw.decode_content = True` preserves `resp.content`'s decode semantics (presigned S3 GETs carry no transfer `Content-Encoding`, so the bytes are identical).

Bounded by the 512 MB `/tmp` cap either way (a larger source can't be written regardless) — this just stops the download copy from stacking on top of the decode peak. The sibling `preview` lambda already streams this way.

Generated thumbnails are unchanged (the golden-image `test_generate_thumbnail` cases pass through the new path).

# TODO

- [x] Unit tests (existing `test_generate_thumbnail` golden cases exercise the streamed download path; output unchanged)
- [x] Security: Confirm that this change meets security best practices and does not violate the security model
- [x] Open and Embed: Confirm that this change doesn't break Open variant and Embed widget (lambda-only change)
- [ ] Documentation
- [x] [Changelog](../tree/master/docs/CHANGELOG.md) entry

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR addresses the thumbnail lambda's primary OOM failure mode by switching the source-file download from `requests.get(url)` (full buffered `resp.content`) to `stream=True` + `shutil.copyfileobj(resp.raw, src_file)`, so the compressed bytes stream straight to the temp file and are not held in memory during the subsequent decode peak.

- **Memory improvement**: eliminates the transient ~2× allocation from `b\"\".join(iter_content(...))` and the full compressed-object copy that previously stayed resident through `arr.compute()` / the image decode.
- **Correctness**: `resp.raw.decode_content = True` is set before the copy, matching `resp.content`'s transfer-encoding decode semantics; `requests.get(...) as resp:` (context-manager form) replaces the bare call, ensuring proper connection cleanup.
- **Alignment with sibling**: the `preview` lambda already streams this way (though without the context-manager form), making this the consistent pattern across both lambdas.

<h3>Confidence Score: 5/5</h3>

Safe to merge — a well-scoped memory optimisation with no change to generated output.

The change is mechanically straightforward: swap buffered `resp.content` for `stream=True` + `shutil.copyfileobj`, wrap the call in a context manager for clean connection teardown, and set `decode_content = True` to preserve byte-for-byte equivalence. Error handling, temp-file flush, and cleanup are all intact. The existing golden-image tests exercise the new path and pass, confirming output is unchanged.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| lambdas/thumbnail/src/t4_lambda_thumbnail/__init__.py | Core handler switch from buffered `resp.content` to `stream=True` + `shutil.copyfileobj`; error path, flush, and context-manager cleanup all handled correctly. |
| lambdas/thumbnail/CHANGELOG.md | Changelog entry added at the top of the Changes section; correctly describes the memory improvement and links to the PR. |

</details>

<h3>Sequence Diagram</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant Client
    participant Handler as lambda_handler
    participant S3 as Presigned S3 URL
    participant TmpFile as NamedTemporaryFile
    participant Decoder as handle_image/pdf/pptx

    Client->>Handler: "GET /thumbnail?url=..."
    Handler->>S3: "requests.get(url, stream=True)"
    S3-->>Handler: HTTP headers (status)
    alt response not OK
        Handler-->>Client: JSON error (resp.reason, resp.text)
    else response OK
        Handler->>Handler: clean_tmp_dir()
        Handler->>TmpFile: open temp file
        Note over Handler,S3: resp.raw.decode_content = True
        S3-->>TmpFile: shutil.copyfileobj (chunked stream)
        Handler->>TmpFile: flush()
        Handler->>S3: close connection (context manager exit)
        Handler->>Decoder: "handle_*(path=src_file.name)"
        Decoder-->>Handler: (info, data)
        Handler-->>Client: 200 + thumbnail bytes
    end
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant Client
    participant Handler as lambda_handler
    participant S3 as Presigned S3 URL
    participant TmpFile as NamedTemporaryFile
    participant Decoder as handle_image/pdf/pptx

    Client->>Handler: "GET /thumbnail?url=..."
    Handler->>S3: "requests.get(url, stream=True)"
    S3-->>Handler: HTTP headers (status)
    alt response not OK
        Handler-->>Client: JSON error (resp.reason, resp.text)
    else response OK
        Handler->>Handler: clean_tmp_dir()
        Handler->>TmpFile: open temp file
        Note over Handler,S3: resp.raw.decode_content = True
        S3-->>TmpFile: shutil.copyfileobj (chunked stream)
        Handler->>TmpFile: flush()
        Handler->>S3: close connection (context manager exit)
        Handler->>Decoder: "handle_*(path=src_file.name)"
        Decoder-->>Handler: (info, data)
        Handler-->>Client: 200 + thumbnail bytes
    end
```

</a>

<sub>Reviews (2): Last reviewed commit: ["Revert &quot;TEMP(#5000): build thumbnail dev..."](https://github.com/quiltdata/quilt/commit/8b9ca52a166c19832c8eadd73a551f339f6a805b) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=38159448)</sub>

<!-- /greptile_comment -->