### PR TITLE
thumbnail: deduplicate the n-dim montage assembly

### DIFF
--- a/lambdas/thumbnail/src/t4_lambda_thumbnail/__init__.py
+++ b/lambdas/thumbnail/src/t4_lambda_thumbnail/__init__.py
@@ -296,7 +296,8 @@ def _project_channel(img: BioImage, c: int) -> da.Array:
     Reduce channel `c` to a 2D (Y, X) plane — or (Y, X, S) for color — by
     max-projecting over Z when the reader has a Z axis, else taking its single Z
     slice. Shared by the multi-channel montage and the single-channel return
-    below so they slice identically.
+    below so they slice identically. (Max projection is a deliberate simple
+    default — no strong opinion over mean/median.)
     """
     if "Z" in img.reader.dims.order:
         return img.dask_data[0, c, :, :, :].max(axis=0)

--- a/lambdas/thumbnail/src/t4_lambda_thumbnail/__init__.py
+++ b/lambdas/thumbnail/src/t4_lambda_thumbnail/__init__.py
@@ -291,6 +291,19 @@ def norm_img(img: da.Array) -> da.Array:
     )
 
 
+def _project_channel(img: BioImage, c: int) -> da.Array:
+    """
+    Reduce channel `c` to a 2D (Y, X) plane — or (Y, X, S) for color — by
+    max-projecting over Z when the reader has a Z axis, else taking its single Z
+    slice. (Without a war over which projection is best, max is the simple choice
+    that gets a 2D image out of a Z stack.) Shared by the multi-channel montage
+    and the single-channel return below so they slice identically.
+    """
+    if "Z" in img.reader.dims.order:
+        return img.dask_data[0, c, :, :, :].max(axis=0)
+    return img.dask_data[0, c, 0, :, :]
+
+
 def _format_n_dim_ndarray(img: BioImage) -> tuple[da.Array, bool]:
     # Returns (array, normalized): normalized is True only when norm_img
     # contrast-stretched the data to uint8 (a greyscale montage / Z-projection,
@@ -326,40 +339,17 @@ def _format_n_dim_ndarray(img: BioImage) -> tuple[da.Array, bool]:
         # planes lazy lets dask release each once it has been copied into the
         # montage, so they don't stay resident through the downstream resize (see
         # norm_img); a concrete-array assembly would hold all N until then.
-        projections = []
         s_pad = ((0, 0),) if has_samples else ()
-        for i in range(img.dask_data.shape[1]):
-            if "Z" in img.reader.dims.order:
-                # Add padding to the top and left of the projection
-                padded = da.pad(
-                    norm_img(img.dask_data[0, i, :, :, :].max(axis=0)),
-                    ((5, 0), (5, 0)) + s_pad,
-                    mode="constant"
-                )
-                projections.append(padded)
-            else:
-                # Add padding to the top and the left of the projection
-                padded = da.pad(
-                    norm_img(img.dask_data[0, i, 0, :, :]),
-                    ((5, 0), (5, 0)) + s_pad,
-                    mode="constant"
-                )
-                projections.append(padded)
+        projections = [
+            da.pad(norm_img(_project_channel(img, c)), ((5, 0), (5, 0)) + s_pad, mode="constant")
+            for c in range(img.dask_data.shape[1])
+        ]
 
-        # Lay the channels out in the most-square grid (6 channels -> (2, 3))
-        grid_shape = most_square_grid(len(projections))
-
-        # Make rows of images
-        # Use a counter so that we don't have to use `projections.pop` which is O(N)
-        rows = []
-        proj_counter = 0
-        for y_i in range(grid_shape[0]):
-            row = []
-            for x_i in range(grid_shape[1]):
-                row.append(projections[proj_counter])
-                proj_counter += 1
-
-            rows.append(row)
+        # Lay the channels out in the most-square grid (6 channels -> (2, 3)).
+        # most_square_grid returns exact factors, so the projections slice evenly
+        # into rows_n rows of cols_n.
+        rows_n, cols_n = most_square_grid(len(projections))
+        rows = [projections[r * cols_n:(r + 1) * cols_n] for r in range(rows_n)]
 
         # Concatenate each row then concatenate all rows together into a single 2D image
         merged = [da.concatenate(row, axis=1) for row in rows]
@@ -368,13 +358,7 @@ def _format_n_dim_ndarray(img: BioImage) -> tuple[da.Array, bool]:
         montage = da.pad(da.concatenate(merged, axis=0), ((0, 5), (0, 5)) + s_pad, mode="constant")
         return montage, not has_samples
 
-    # If there is a Z dimension we need to do _something_ the get a 2D out.
-    # Without causing a war about which projection method is best
-    # we will simply use a max projection on files that contain a Z dimension
-    if "Z" in img.reader.dims.order:
-        return norm_img(img.dask_data[0, 0, :, :, :].max(axis=0)), not has_samples
-
-    return norm_img(img.dask_data[0, 0, 0, :, :]), not has_samples
+    return norm_img(_project_channel(img, 0)), not has_samples
 
 
 def format_aicsimage_to_prepped(img: BioImage) -> tuple[da.Array, bool]:
@@ -753,22 +737,10 @@ def lambda_handler(request):
             elif input_ == "pptx":
                 info, data = handle_pptx(path=src_file.name, page=page, size=size[0], count_pages=count_pages)
             else:
-                # XXX: This never seemed to work, because imageio.get_reader() returns an instance,
-                #      not a class/type. imageio 2.28+ stopped return instances of these classes altogether.
-                #      So for now, always use PNG.
-                # If the image is one of these formats, retain the format after formatting
-                # SUPPORTED_BROWSER_FORMATS = {
-                #     imageio.plugins.pillow_legacy.JPEGFormat.Reader: "JPG",
-                #     imageio.plugins.pillow_legacy.PNGFormat.Reader: "PNG",
-                #     imageio.plugins.pillow_legacy.GIFFormat.Reader: "GIF"
-                # }
-                # try:
-                #     thumbnail_format = SUPPORTED_BROWSER_FORMATS.get(
-                #         imageio.get_reader(url),
-                #         "PNG"
-                #     )
-                # except ValueError:
-                #     thumbnail_format = "PNG"
+                # Always PNG: we once tried to retain the source's browser format
+                # (JPG/PNG/GIF) via imageio.get_reader(), but it returns a reader
+                # instance, not a class to key on — and imageio 2.28+ stopped
+                # returning these instances at all — so format detection never worked.
                 thumbnail_format = "PNG"
                 info, data = handle_image(
                     path=src_file.name,

--- a/lambdas/thumbnail/src/t4_lambda_thumbnail/__init__.py
+++ b/lambdas/thumbnail/src/t4_lambda_thumbnail/__init__.py
@@ -295,9 +295,8 @@ def _project_channel(img: BioImage, c: int) -> da.Array:
     """
     Reduce channel `c` to a 2D (Y, X) plane — or (Y, X, S) for color — by
     max-projecting over Z when the reader has a Z axis, else taking its single Z
-    slice. (Without a war over which projection is best, max is the simple choice
-    that gets a 2D image out of a Z stack.) Shared by the multi-channel montage
-    and the single-channel return below so they slice identically.
+    slice. Shared by the multi-channel montage and the single-channel return
+    below so they slice identically.
     """
     if "Z" in img.reader.dims.order:
         return img.dask_data[0, c, :, :, :].max(axis=0)
@@ -737,10 +736,10 @@ def lambda_handler(request):
             elif input_ == "pptx":
                 info, data = handle_pptx(path=src_file.name, page=page, size=size[0], count_pages=count_pages)
             else:
-                # Always PNG: we once tried to retain the source's browser format
-                # (JPG/PNG/GIF) via imageio.get_reader(), but it returns a reader
-                # instance, not a class to key on — and imageio 2.28+ stopped
-                # returning these instances at all — so format detection never worked.
+                # Always PNG: imageio can't report the source's browser format
+                # (JPG/PNG/GIF) — get_reader() returns a reader instance, not a
+                # class to key on, and 2.28+ returns no instance at all — so there's
+                # nothing to preserve it from.
                 thumbnail_format = "PNG"
                 info, data = handle_image(
                     path=src_file.name,

--- a/lambdas/thumbnail/src/t4_lambda_thumbnail/__init__.py
+++ b/lambdas/thumbnail/src/t4_lambda_thumbnail/__init__.py
@@ -738,8 +738,8 @@ def lambda_handler(request):
             else:
                 # Always PNG: imageio can't report the source's browser format
                 # (JPG/PNG/GIF) — get_reader() returns a reader instance, not a
-                # class to key on, and 2.28+ returns no instance at all — so there's
-                # nothing to preserve it from.
+                # class to key on, and 2.28+ no longer returns instances of those
+                # reader classes — so there's nothing to preserve it from.
                 thumbnail_format = "PNG"
                 info, data = handle_image(
                     path=src_file.name,

--- a/lambdas/thumbnail/src/t4_lambda_thumbnail/__init__.py
+++ b/lambdas/thumbnail/src/t4_lambda_thumbnail/__init__.py
@@ -736,10 +736,9 @@ def lambda_handler(request):
             elif input_ == "pptx":
                 info, data = handle_pptx(path=src_file.name, page=page, size=size[0], count_pages=count_pages)
             else:
-                # Always PNG: imageio can't report the source's browser format
-                # (JPG/PNG/GIF) — get_reader() returns a reader instance, not a
-                # class to key on, and 2.28+ no longer returns instances of those
-                # reader classes — so there's nothing to preserve it from.
+                # Always PNG: imageio can't recover the source's browser format
+                # (JPG/PNG/GIF) — get_reader() returns a reader instance, not the
+                # format class a lookup would need — so there's nothing to preserve.
                 thumbnail_format = "PNG"
                 info, data = handle_image(
                     path=src_file.name,


### PR DESCRIPTION
# Description

Pure refactor of the thumbnail lambda's n-dimensional image handling — no behavior change. Generated thumbnails are unchanged and the full test suite passes (143 passed).

`_format_n_dim_ndarray` had the same "reduce one channel to a 2D plane" slicing (max-project over Z when present, else take the single Z slice) inlined at four sites, and assembled the channel montage grid with a manual `proj_counter` double loop. This PR:

- Extracts `_project_channel(img, c)` for that shared slice, used by both the multi-channel montage and the single-channel path so the two can't diverge.
- Replaces the per-channel append-loop with a comprehension, and the `proj_counter` grid-fill with list slicing keyed on `most_square_grid`'s exact factors (a tested invariant: `rows * cols == n`).
- Drops a ~15-line commented-out `imageio` format-detection block in `lambda_handler`, keeping a short note on why the output format is always PNG.

Net −28 lines.

# TODO

- [x] Unit tests — existing suite already covers the montage / Z-projection paths; unchanged and passing
- [x] Security: no security-relevant change
- [x] Changelog: skipped — internal refactor, no behavior change (not significant to end users)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR is a pure refactor of the n-dimensional thumbnail assembly in the thumbnail Lambda — no behavior change to generated thumbnails. The full existing test suite (143 tests) validates the equivalence.

- Extracts `_project_channel(img, c)` to unify the four previously-inlined Z-projection / single-Z-slice sites; both the multi-channel montage and the single-channel fallback now call it so they can never diverge.
- Replaces the manual `proj_counter` double-loop with a list comprehension and a single list-slice keyed on `most_square_grid`'s exact factor pair, producing the same grid layout more concisely.
- Drops ~15 lines of commented-out, never-functional `imageio` format-detection code, replacing it with a concise comment that explains why PNG is always used.

<h3>Confidence Score: 5/5</h3>

Safe to merge — the refactored paths are mechanically equivalent to what they replaced and the existing test suite validates the output.

Every changed code path is a straightforward mechanical equivalence: `_project_channel` reproduces the inlined slicing exactly, the list-comprehension produces the same ordered projections, and the slice-based grid rows produce the same row lists as the old double-loop. No edge case is introduced because `most_square_grid` always returns exact factors of its input, keeping the final slice `projections[r*cols_n:(r+1)*cols_n]` well-defined for all rows. The dropped commented-out block was already dead code.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| lambdas/thumbnail/src/t4_lambda_thumbnail/__init__.py | Pure refactor: extracts `_project_channel` helper, replaces manual proj_counter double-loop with list-comprehension + slice, and drops a dead commented-out imageio block. Behavior is identical to the original code. |

</details>

<h3>Flowchart</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A["_format_n_dim_ndarray(img)"] --> B{2D data?}
    B -- yes --> C[return raw array, False]
    B -- no --> D{3-channel YXC?}
    D -- yes --> E[return raw array, False]
    D -- no --> F{T in dims?}
    F -- yes --> G[slice to middle timepoint]
    G --> H
    F -- no --> H{C in dims and shape_C > 1?}
    H -- yes --> I["for c in range(C):\n_project_channel(img, c)\n→ norm_img → da.pad"]
    I --> J["most_square_grid(len(projections))\n→ rows_n, cols_n"]
    J --> K["rows = [projections[r*cols_n:(r+1)*cols_n]\nfor r in range(rows_n)]"]
    K --> L["da.concatenate rows & cols → montage"]
    L --> M["return montage, not has_samples"]
    H -- no --> N["_project_channel(img, 0)\n→ norm_img"]
    N --> O["return result, not has_samples"]

    subgraph _project_channel["_project_channel(img, c)"]
        P{Z in dims?}
        P -- yes --> Q["img.dask_data[0,c,:,:,:].max(axis=0)"]
        P -- no --> R["img.dask_data[0,c,0,:,:]"]
    end

    I -.calls.-> P
    N -.calls.-> P
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A["_format_n_dim_ndarray(img)"] --> B{2D data?}
    B -- yes --> C[return raw array, False]
    B -- no --> D{3-channel YXC?}
    D -- yes --> E[return raw array, False]
    D -- no --> F{T in dims?}
    F -- yes --> G[slice to middle timepoint]
    G --> H
    F -- no --> H{C in dims and shape_C > 1?}
    H -- yes --> I["for c in range(C):\n_project_channel(img, c)\n→ norm_img → da.pad"]
    I --> J["most_square_grid(len(projections))\n→ rows_n, cols_n"]
    J --> K["rows = [projections[r*cols_n:(r+1)*cols_n]\nfor r in range(rows_n)]"]
    K --> L["da.concatenate rows & cols → montage"]
    L --> M["return montage, not has_samples"]
    H -- no --> N["_project_channel(img, 0)\n→ norm_img"]
    N --> O["return result, not has_samples"]

    subgraph _project_channel["_project_channel(img, c)"]
        P{Z in dims?}
        P -- yes --> Q["img.dask_data[0,c,:,:,:].max(axis=0)"]
        P -- no --> R["img.dask_data[0,c,0,:,:]"]
    end

    I -.calls.-> P
    N -.calls.-> P
```

</a>

<sub>Reviews (2): Last reviewed commit: ["thumbnail: restore the max-projection ra..."](https://github.com/quiltdata/quilt/commit/abda876fd798714ccf2782d4fd0d8d6f75763568) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=38298393)</sub>

<!-- /greptile_comment -->