### PR TITLE
Qurator: fix DOM-nesting warning in chat connector helper

### DIFF
--- a/catalog/CHANGELOG.md
+++ b/catalog/CHANGELOG.md
@@ -18,6 +18,7 @@ where verb is one of
 
 ## Changes
 
+- [Fixed] Qurator chat: drop `<div>`-in-`<p>` DOM-nesting warning from the connector status helper text shown while connectors are still connecting ([#5003](https://github.com/quiltdata/quilt/pull/5003))
 - [Changed] Upgrade GraphQL code generator (`@graphql-codegen/*`) v1 → v7 and bump the toolchain to Node 22; eliminates the recurring duplicate-`lodash` transitive pin (the v1 codegen stack pinned `lodash@4.17.x` via `plugin-helpers` / `@graphql-tools/url-loader`, both of which drop `lodash` by v7). Codegen-only — `graphql` and the urql runtime are unchanged ([#4972](https://github.com/quiltdata/quilt/pull/4972))
 - [Fixed] Athena Queries tab: "Workgroup not found" on accounts with >50 workgroups in a region. The first `ListWorkGroups` page could be entirely access-denied for the caller's role, hiding the user's accessible workgroup on a later page. `fetchWorkgroups`, `fetchCatalogNames`, and `fetchDatabases` now drain all pages to exhaustion (with `MaxResults: 50` explicit, `isMounted` to bail on unmount, and a single sort at the boundary) so consumers see the complete list; the "Load more" affordance is removed from the workgroup / catalog / database pickers since pagination is no longer consumer-driven ([#4973](https://github.com/quiltdata/quilt/pull/4973))
 - [Added] Landing page: show bucket icons on the bucket cards, same as in the navbar bucket selector; custom icons are now circle-cropped everywhere ([#4970](https://github.com/quiltdata/quilt/pull/4970))

--- a/catalog/app/components/Assistant/UI/Chat/Chat.spec.tsx
+++ b/catalog/app/components/Assistant/UI/Chat/Chat.spec.tsx
@@ -1,0 +1,92 @@
+import * as React from 'react'
+import { render, cleanup } from '@testing-library/react'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+// The `Model` barrel transitively pulls AWS/Athena, which reads the catalog
+// config at module load; stub it so the import graph evaluates under jsdom.
+vi.mock('constants/config', () => ({ default: {} }))
+
+import * as Model from '../../Model'
+
+import { ConnectorHelperLine } from './Chat'
+
+// `ConnectorHelperLine` is rendered inside `Input`'s `FormHelperText`, which is
+// a <p>. Its output must therefore stay inline-only — a block element (<div>,
+// <p>, …) there triggers React's `validateDOMNesting` warning. These tests pin
+// that invariant for every state the connector helper can render.
+
+const error: Model.Connectors.BackendError = {
+  _tag: 'Transport',
+  message: 'down',
+  transient: true,
+  retryable: true,
+}
+
+// Only `config.title` is touched on render; `retry` / `acknowledge` fire on
+// click, never during render, so a bare config stub is enough.
+const fakeConnector = {
+  config: { title: 'Quilt Platform tools' },
+} as unknown as Model.Connectors.ConnectorRuntime
+
+const cases: ReadonlyArray<[string, Model.Connectors.ConnectorState, RegExp]> = [
+  ['Connecting', Model.Connectors.ConnectorState.Connecting(), /connecting/i],
+  [
+    'Disconnected',
+    Model.Connectors.ConnectorState.Disconnected({ retrying: true, error }),
+    /reconnecting/i,
+  ],
+  [
+    'Failed (acked)',
+    Model.Connectors.ConnectorState.Failed({ error, acked: true }),
+    /unavailable/i,
+  ],
+  [
+    'Failed (unacked)',
+    Model.Connectors.ConnectorState.Failed({ error, acked: false }),
+    /continue without/i,
+  ],
+]
+
+const BLOCK_SELECTOR = 'div, p, ul, ol, li, table, section, article, h1, h2, h3'
+
+describe('components/Assistant/UI/Chat/ConnectorHelperLine', () => {
+  afterEach(cleanup)
+
+  it.each(cases)('renders %s inline-only inside a <p>', (_name, state, expected) => {
+    const consoleError = vi.spyOn(console, 'error').mockImplementation(() => {})
+    const { container } = render(
+      <p>
+        <ConnectorHelperLine connector={fakeConnector} state={state} />
+      </p>,
+    )
+
+    // Sanity: it actually rendered the expected line (not a vacuous pass).
+    expect(container.textContent).toMatch(expected)
+
+    // The line must not introduce block-level elements under the <p>.
+    expect(container.querySelector('p')?.querySelector(BLOCK_SELECTOR)).toBeNull()
+
+    // And React must not have flagged invalid DOM nesting.
+    const nestingWarning = consoleError.mock.calls.some((args) =>
+      String(args[0]).includes('validateDOMNesting'),
+    )
+    expect(nestingWarning).toBe(false)
+
+    consoleError.mockRestore()
+  })
+
+  it('renders nothing for the Ready state', () => {
+    const { container } = render(
+      <p>
+        <ConnectorHelperLine
+          connector={fakeConnector}
+          state={Model.Connectors.ConnectorState.Ready({
+            tools: {},
+            resources: [],
+          })}
+        />
+      </p>,
+    )
+    expect(container.querySelector('p')?.textContent).toBe('')
+  })
+})

--- a/catalog/app/components/Assistant/UI/Chat/Chat.spec.tsx
+++ b/catalog/app/components/Assistant/UI/Chat/Chat.spec.tsx
@@ -1,89 +1,81 @@
 import * as React from 'react'
 import { render, cleanup } from '@testing-library/react'
-import { afterEach, describe, expect, it, vi } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
-// The `Model` barrel transitively pulls AWS/Athena, which reads the catalog
-// config at module load; stub it so the import graph evaluates under jsdom.
 vi.mock('constants/config', () => ({ default: {} }))
 
 import * as Model from '../../Model'
 
 import { ConnectorHelperLine } from './Chat'
 
-// `ConnectorHelperLine` is rendered inside `Input`'s `FormHelperText`, which is
-// a <p>. Its output must therefore stay inline-only — a block element (<div>,
-// <p>, …) there triggers React's `validateDOMNesting` warning. These tests pin
-// that invariant for every state the connector helper can render.
+// Rendered inside `FormHelperText` (a <p>), so the line must stay inline-only:
+// any block element there is invalid DOM nesting.
 
-// `ConnectorHelperLine` switches on the state tag only; the error payload is
-// never read, so the two required fields satisfy the Disconnected/Failed
-// constructors.
 const error: Model.Connectors.BackendError = { _tag: 'Transport', message: 'down' }
 
-// Only `config.title` is touched on render; `retry` / `acknowledge` fire on
-// click, never during render, so a bare config stub is enough.
 const fakeConnector = {
   config: { title: 'Quilt Platform tools' },
 } as unknown as Model.Connectors.ConnectorRuntime
 
-const cases: ReadonlyArray<[string, Model.Connectors.ConnectorState, RegExp]> = [
-  ['Connecting', Model.Connectors.ConnectorState.Connecting(), /connecting/i],
-  [
-    'Disconnected',
-    Model.Connectors.ConnectorState.Disconnected({ retrying: true, error }),
-    /reconnecting/i,
-  ],
-  [
-    'Failed (acked)',
-    Model.Connectors.ConnectorState.Failed({ error, acked: true }),
-    /unavailable/i,
-  ],
-  [
-    'Failed (unacked)',
-    Model.Connectors.ConnectorState.Failed({ error, acked: false }),
-    /continue without/i,
-  ],
-]
-
 const BLOCK_SELECTOR = 'div, p, ul, ol, li, table, section, article, h1, h2, h3'
 
+function renderLine(state: Model.Connectors.ConnectorState) {
+  return render(
+    <p>
+      <ConnectorHelperLine connector={fakeConnector} state={state} />
+    </p>,
+  )
+}
+
 describe('components/Assistant/UI/Chat/ConnectorHelperLine', () => {
-  afterEach(cleanup)
+  let consoleError: ReturnType<typeof vi.spyOn>
 
-  it.each(cases)('renders %s inline-only inside a <p>', (_name, state, expected) => {
-    const consoleError = vi.spyOn(console, 'error').mockImplementation(() => {})
-    const { container } = render(
-      <p>
-        <ConnectorHelperLine connector={fakeConnector} state={state} />
-      </p>,
-    )
+  beforeEach(() => {
+    consoleError = vi.spyOn(console, 'error').mockImplementation(() => {})
+  })
 
-    // Sanity: it actually rendered the expected line (not a vacuous pass).
-    expect(container.textContent).toMatch(expected)
-
-    // The line must not introduce block-level elements under the <p>.
-    expect(container.querySelector('p')?.querySelector(BLOCK_SELECTOR)).toBeNull()
-
-    // And React must not have flagged invalid DOM nesting.
-    const nestingWarning = consoleError.mock.calls.some((args) =>
-      String(args[0]).includes('validateDOMNesting'),
-    )
-    expect(nestingWarning).toBe(false)
-
+  afterEach(() => {
     consoleError.mockRestore()
+    cleanup()
+  })
+
+  it('renders the Connecting state inline-only inside a <p>', () => {
+    const { container } = renderLine(Model.Connectors.ConnectorState.Connecting())
+    expect(container.textContent).toMatch(/connecting/i)
+    expect(container.querySelector('p')?.querySelector(BLOCK_SELECTOR)).toBeNull()
+    expect(consoleError).not.toHaveBeenCalled()
+  })
+
+  it('renders the Disconnected state inline-only inside a <p>', () => {
+    const { container } = renderLine(
+      Model.Connectors.ConnectorState.Disconnected({ retrying: true, error }),
+    )
+    expect(container.textContent).toMatch(/reconnecting/i)
+    expect(container.querySelector('p')?.querySelector(BLOCK_SELECTOR)).toBeNull()
+    expect(consoleError).not.toHaveBeenCalled()
+  })
+
+  it('renders the acked Failed state inline-only inside a <p>', () => {
+    const { container } = renderLine(
+      Model.Connectors.ConnectorState.Failed({ error, acked: true }),
+    )
+    expect(container.textContent).toMatch(/unavailable/i)
+    expect(container.querySelector('p')?.querySelector(BLOCK_SELECTOR)).toBeNull()
+    expect(consoleError).not.toHaveBeenCalled()
+  })
+
+  it('renders the unacked Failed state inline-only inside a <p>', () => {
+    const { container } = renderLine(
+      Model.Connectors.ConnectorState.Failed({ error, acked: false }),
+    )
+    expect(container.textContent).toMatch(/continue without/i)
+    expect(container.querySelector('p')?.querySelector(BLOCK_SELECTOR)).toBeNull()
+    expect(consoleError).not.toHaveBeenCalled()
   })
 
   it('renders nothing for the Ready state', () => {
-    const { container } = render(
-      <p>
-        <ConnectorHelperLine
-          connector={fakeConnector}
-          state={Model.Connectors.ConnectorState.Ready({
-            tools: {},
-            resources: [],
-          })}
-        />
-      </p>,
+    const { container } = renderLine(
+      Model.Connectors.ConnectorState.Ready({ tools: {}, resources: [] }),
     )
     expect(container.querySelector('p')?.textContent).toBe('')
   })

--- a/catalog/app/components/Assistant/UI/Chat/Chat.spec.tsx
+++ b/catalog/app/components/Assistant/UI/Chat/Chat.spec.tsx
@@ -15,12 +15,10 @@ import { ConnectorHelperLine } from './Chat'
 // <p>, …) there triggers React's `validateDOMNesting` warning. These tests pin
 // that invariant for every state the connector helper can render.
 
-const error: Model.Connectors.BackendError = {
-  _tag: 'Transport',
-  message: 'down',
-  transient: true,
-  retryable: true,
-}
+// `ConnectorHelperLine` switches on the state tag only; the error payload is
+// never read, so the two required fields satisfy the Disconnected/Failed
+// constructors.
+const error: Model.Connectors.BackendError = { _tag: 'Transport', message: 'down' }
 
 // Only `config.title` is touched on render; `retry` / `acknowledge` fire on
 // click, never during render, so a bare config stub is enough.

--- a/catalog/app/components/Assistant/UI/Chat/Chat.tsx
+++ b/catalog/app/components/Assistant/UI/Chat/Chat.tsx
@@ -409,7 +409,7 @@ interface ConnectorHelperLineProps {
   state: Model.Connectors.ConnectorState
 }
 
-function ConnectorHelperLine({ connector, state }: ConnectorHelperLineProps) {
+export function ConnectorHelperLine({ connector, state }: ConnectorHelperLineProps) {
   const classes = useConnectorHelperStyles()
   const onRetry = React.useCallback(() => runtime.runFork(connector.retry), [connector])
   const onAck = React.useCallback(

--- a/catalog/app/components/Assistant/UI/Chat/Chat.tsx
+++ b/catalog/app/components/Assistant/UI/Chat/Chat.tsx
@@ -492,6 +492,11 @@ const useStyles = M.makeStyles((t) => ({
     paddingBottom: 0,
   },
   input: {},
+  // Stacks each connector on its own line; a <span> (not <div>) keeps this
+  // valid inside FormHelperText's <p>.
+  connectorLine: {
+    display: 'block',
+  },
 }))
 
 interface ChatProps {
@@ -518,9 +523,9 @@ export default function Chat({ state, dispatch, devTools, connectors }: ChatProp
   const helperLines = allConnectors.flatMap((c, i) =>
     Model.Connectors.stateIsUnready(connectorStates[i])
       ? [
-          <div key={c.id}>
+          <span key={c.id} className={classes.connectorLine}>
             <ConnectorHelperLine connector={c} state={connectorStates[i]} />
-          </div>,
+          </span>,
         ]
       : [],
   )

--- a/catalog/app/components/Assistant/UI/Chat/Chat.tsx
+++ b/catalog/app/components/Assistant/UI/Chat/Chat.tsx
@@ -492,8 +492,6 @@ const useStyles = M.makeStyles((t) => ({
     paddingBottom: 0,
   },
   input: {},
-  // Stacks each connector on its own line; a <span> (not <div>) keeps this
-  // valid inside FormHelperText's <p>.
   connectorLine: {
     display: 'block',
   },


### PR DESCRIPTION
While Qurator's MCP connectors are still connecting, the chat input renders one helper line per unready connector — each wrapped in a `<div>`. But `FormHelperText` renders a `<p>`, so React warned:

> validateDOMNesting(...): \<div\> cannot appear as a descendant of \<p\>.

Fix: wrap each line in a block-styled `<span>` instead. Valid inside `<p>`, and `display: block` keeps the one-line-per-connector layout.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes a React `validateDOMNesting` warning caused by `<div>` elements wrapped around each `ConnectorHelperLine` being placed inside the `<p>` rendered by MUI's `FormHelperText`. The wrapper is changed to a `<span>` with `display: block` to preserve the one-line-per-connector visual layout without violating HTML nesting rules.

- **`Chat.tsx`**: The `<div>` wrapper is replaced with `<span className={classes.connectorLine}>` and a `connectorLine: { display: 'block' }` style is added; `ConnectorHelperLine` is also exported for testability.
- **`Chat.spec.tsx`** (new): Parameterized tests render `ConnectorHelperLine` directly inside a `<p>` and assert no block-level descendants appear and no `validateDOMNesting` warning fires, for every possible connector state.
- **`CHANGELOG.md`**: Entry added for the fix.

<h3>Confidence Score: 5/5</h3>

Safe to merge — the change is a minimal, targeted swap of a single wrapper element confirmed correct by the new parameterised tests.

The production change is a two-line swap that has no logic implications, and MessageAction was already a span so the full render tree is inline-safe. The new tests exhaustively exercise every ConnectorState variant and check both DOM structure and the absence of React nesting warnings.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| catalog/app/components/Assistant/UI/Chat/Chat.tsx | Replaces div wrapper with span display:block to fix DOM-nesting violation; exports ConnectorHelperLine for testing. |
| catalog/app/components/Assistant/UI/Chat/Chat.spec.tsx | New test file verifying inline-only invariant for all connector states. The console.error spy is not restored in a try/finally, so a test failure could leave the spy active for subsequent cases. |
| catalog/CHANGELOG.md | Changelog entry added for the DOM-nesting fix; no issues. |

</details>

<h3>Flowchart</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[FormHelperText renders p] --> B{allConnectors.flatMap}
    B --> C{stateIsUnready?}
    C -- yes --> D[span className=connectorLine display:block]
    C -- no --> E[empty - filtered out]
    D --> F[ConnectorHelperLine]
    F --> G{ConnectorState.$match}
    G -- Connecting --> H[title: connecting]
    G -- Disconnected --> I[title: reconnecting]
    G -- Failed acked --> J[title: unavailable + reconnect]
    G -- Failed unacked --> K[title: could not connect + reconnect + continue without]
    G -- Ready --> L[null]
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A[FormHelperText renders p] --> B{allConnectors.flatMap}
    B --> C{stateIsUnready?}
    C -- yes --> D[span className=connectorLine display:block]
    C -- no --> E[empty - filtered out]
    D --> F[ConnectorHelperLine]
    F --> G{ConnectorState.$match}
    G -- Connecting --> H[title: connecting]
    G -- Disconnected --> I[title: reconnecting]
    G -- Failed acked --> J[title: unavailable + reconnect]
    G -- Failed unacked --> K[title: could not connect + reconnect + continue without]
    G -- Ready --> L[null]
```

</a>

<sub>Reviews (2): Last reviewed commit: ["test(qurator): restructure ConnectorHelp..."](https://github.com/quiltdata/quilt/commit/06ae13476169d72cfb0182ce4b0d72e91042ce46) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=38368881)</sub>

<!-- /greptile_comment -->