### PR TITLE
build(deps): bump pyarrow from 18.1.0 to 23.0.1 in /lambdas/preview

### DIFF
--- a/lambdas/preview/pyproject.toml
+++ b/lambdas/preview/pyproject.toml
@@ -27,4 +27,4 @@ test = [
 default-groups = ["test"]
 
 [tool.uv.sources]
-t4-lambda-shared = { url = "https://github.com/quiltdata/quilt/archive/d496dffbfb4b7a2ae05f6c1f7f0cb7d5d43bc984.zip", subdirectory = "lambdas/shared" }
+t4-lambda-shared = { url = "https://github.com/quiltdata/quilt/archive/f9b6e0239aafb72145b670322daa971bc342f145.zip", subdirectory = "lambdas/shared" }

--- a/lambdas/preview/uv.lock
+++ b/lambdas/preview/uv.lock
@@ -466,23 +466,24 @@ wheels = [
 
 [[package]]
 name = "pyarrow"
-version = "18.1.0"
+version = "23.0.1"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/7f/7b/640785a9062bb00314caa8a387abce547d2a420cf09bd6c715fe659ccffb/pyarrow-18.1.0.tar.gz", hash = "sha256:9386d3ca9c145b5539a1cfc75df07757dff870168c959b473a0bccbc3abc8c73", size = 1118671, upload-time = "2024-11-26T02:01:48.62Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/88/22/134986a4cc224d593c1afde5494d18ff629393d74cc2eddb176669f234a4/pyarrow-23.0.1.tar.gz", hash = "sha256:b8c5873e33440b2bc2f4a79d2b47017a89c5a24116c055625e6f2ee50523f019", size = 1167336, upload-time = "2026-02-16T10:14:12.39Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/cb/87/aa4d249732edef6ad88899399047d7e49311a55749d3c373007d034ee471/pyarrow-18.1.0-cp313-cp313-macosx_12_0_arm64.whl", hash = "sha256:84e314d22231357d473eabec709d0ba285fa706a72377f9cc8e1cb3c8013813b", size = 29497406, upload-time = "2024-11-26T02:00:14.469Z" },
-    { url = "https://files.pythonhosted.org/packages/3c/c7/ed6adb46d93a3177540e228b5ca30d99fc8ea3b13bdb88b6f8b6467e2cb7/pyarrow-18.1.0-cp313-cp313-macosx_12_0_x86_64.whl", hash = "sha256:f591704ac05dfd0477bb8f8e0bd4b5dc52c1cadf50503858dce3a15db6e46ff2", size = 30835095, upload-time = "2024-11-26T02:00:19.347Z" },
-    { url = "https://files.pythonhosted.org/packages/41/d7/ed85001edfb96200ff606943cff71d64f91926ab42828676c0fc0db98963/pyarrow-18.1.0-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:acb7564204d3c40babf93a05624fc6a8ec1ab1def295c363afc40b0c9e66c191", size = 39194527, upload-time = "2024-11-26T02:00:24.085Z" },
-    { url = "https://files.pythonhosted.org/packages/59/16/35e28eab126342fa391593415d79477e89582de411bb95232f28b131a769/pyarrow-18.1.0-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:74de649d1d2ccb778f7c3afff6085bd5092aed4c23df9feeb45dd6b16f3811aa", size = 40131443, upload-time = "2024-11-26T02:00:29.483Z" },
-    { url = "https://files.pythonhosted.org/packages/0c/95/e855880614c8da20f4cd74fa85d7268c725cf0013dc754048593a38896a0/pyarrow-18.1.0-cp313-cp313-manylinux_2_28_aarch64.whl", hash = "sha256:f96bd502cb11abb08efea6dab09c003305161cb6c9eafd432e35e76e7fa9b90c", size = 38608750, upload-time = "2024-11-26T02:00:34.069Z" },
-    { url = "https://files.pythonhosted.org/packages/54/9d/f253554b1457d4fdb3831b7bd5f8f00f1795585a606eabf6fec0a58a9c38/pyarrow-18.1.0-cp313-cp313-manylinux_2_28_x86_64.whl", hash = "sha256:36ac22d7782554754a3b50201b607d553a8d71b78cdf03b33c1125be4b52397c", size = 40066690, upload-time = "2024-11-26T02:00:39.603Z" },
-    { url = "https://files.pythonhosted.org/packages/2f/58/8912a2563e6b8273e8aa7b605a345bba5a06204549826f6493065575ebc0/pyarrow-18.1.0-cp313-cp313-win_amd64.whl", hash = "sha256:25dbacab8c5952df0ca6ca0af28f50d45bd31c1ff6fcf79e2d120b4a65ee7181", size = 25081054, upload-time = "2024-11-26T02:00:43.611Z" },
-    { url = "https://files.pythonhosted.org/packages/82/f9/d06ddc06cab1ada0c2f2fd205ac8c25c2701182de1b9c4bf7a0a44844431/pyarrow-18.1.0-cp313-cp313t-macosx_12_0_arm64.whl", hash = "sha256:6a276190309aba7bc9d5bd2933230458b3521a4317acfefe69a354f2fe59f2bc", size = 29525542, upload-time = "2024-11-26T02:00:48.094Z" },
-    { url = "https://files.pythonhosted.org/packages/ab/94/8917e3b961810587ecbdaa417f8ebac0abb25105ae667b7aa11c05876976/pyarrow-18.1.0-cp313-cp313t-macosx_12_0_x86_64.whl", hash = "sha256:ad514dbfcffe30124ce655d72771ae070f30bf850b48bc4d9d3b25993ee0e386", size = 30829412, upload-time = "2024-11-26T02:00:52.458Z" },
-    { url = "https://files.pythonhosted.org/packages/5e/e3/3b16c3190f3d71d3b10f6758d2d5f7779ef008c4fd367cedab3ed178a9f7/pyarrow-18.1.0-cp313-cp313t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:aebc13a11ed3032d8dd6e7171eb6e86d40d67a5639d96c35142bd568b9299324", size = 39119106, upload-time = "2024-11-26T02:00:57.219Z" },
-    { url = "https://files.pythonhosted.org/packages/1d/d6/5d704b0d25c3c79532f8c0639f253ec2803b897100f64bcb3f53ced236e5/pyarrow-18.1.0-cp313-cp313t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:d6cf5c05f3cee251d80e98726b5c7cc9f21bab9e9783673bac58e6dfab57ecc8", size = 40090940, upload-time = "2024-11-26T02:01:02.31Z" },
-    { url = "https://files.pythonhosted.org/packages/37/29/366bc7e588220d74ec00e497ac6710c2833c9176f0372fe0286929b2d64c/pyarrow-18.1.0-cp313-cp313t-manylinux_2_28_aarch64.whl", hash = "sha256:11b676cd410cf162d3f6a70b43fb9e1e40affbc542a1e9ed3681895f2962d3d9", size = 38548177, upload-time = "2024-11-26T02:01:07.371Z" },
-    { url = "https://files.pythonhosted.org/packages/c8/11/fabf6ecabb1fe5b7d96889228ca2a9158c4c3bb732e3b8ee3f7f6d40b703/pyarrow-18.1.0-cp313-cp313t-manylinux_2_28_x86_64.whl", hash = "sha256:b76130d835261b38f14fc41fdfb39ad8d672afb84c447126b84d5472244cfaba", size = 40043567, upload-time = "2024-11-26T02:01:12.931Z" },
+    { url = "https://files.pythonhosted.org/packages/47/10/2cbe4c6f0fb83d2de37249567373d64327a5e4d8db72f486db42875b08f6/pyarrow-23.0.1-cp313-cp313-macosx_12_0_arm64.whl", hash = "sha256:6b8fda694640b00e8af3c824f99f789e836720aa8c9379fb435d4c4953a756b8", size = 34210066, upload-time = "2026-02-16T10:10:45.487Z" },
+    { url = "https://files.pythonhosted.org/packages/cb/4f/679fa7e84dadbaca7a65f7cdba8d6c83febbd93ca12fa4adf40ba3b6362b/pyarrow-23.0.1-cp313-cp313-macosx_12_0_x86_64.whl", hash = "sha256:8ff51b1addc469b9444b7c6f3548e19dc931b172ab234e995a60aea9f6e6025f", size = 35825526, upload-time = "2026-02-16T10:10:52.266Z" },
+    { url = "https://files.pythonhosted.org/packages/f9/63/d2747d930882c9d661e9398eefc54f15696547b8983aaaf11d4a2e8b5426/pyarrow-23.0.1-cp313-cp313-manylinux_2_28_aarch64.whl", hash = "sha256:71c5be5cbf1e1cb6169d2a0980850bccb558ddc9b747b6206435313c47c37677", size = 44473279, upload-time = "2026-02-16T10:11:01.557Z" },
+    { url = "https://files.pythonhosted.org/packages/b3/93/10a48b5e238de6d562a411af6467e71e7aedbc9b87f8d3a35f1560ae30fb/pyarrow-23.0.1-cp313-cp313-manylinux_2_28_x86_64.whl", hash = "sha256:9b6f4f17b43bc39d56fec96e53fe89d94bac3eb134137964371b45352d40d0c2", size = 47585798, upload-time = "2026-02-16T10:11:09.401Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/20/476943001c54ef078dbf9542280e22741219a184a0632862bca4feccd666/pyarrow-23.0.1-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:9fc13fc6c403d1337acab46a2c4346ca6c9dec5780c3c697cf8abfd5e19b6b37", size = 48179446, upload-time = "2026-02-16T10:11:17.781Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/b6/5dd0c47b335fcd8edba9bfab78ad961bd0fd55ebe53468cc393f45e0be60/pyarrow-23.0.1-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:5c16ed4f53247fa3ffb12a14d236de4213a4415d127fe9cebed33d51671113e2", size = 50623972, upload-time = "2026-02-16T10:11:26.185Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/09/a532297c9591a727d67760e2e756b83905dd89adb365a7f6e9c72578bcc1/pyarrow-23.0.1-cp313-cp313-win_amd64.whl", hash = "sha256:cecfb12ef629cf6be0b1887f9f86463b0dd3dc3195ae6224e74006be4736035a", size = 27540749, upload-time = "2026-02-16T10:12:23.297Z" },
+    { url = "https://files.pythonhosted.org/packages/a5/8e/38749c4b1303e6ae76b3c80618f84861ae0c55dd3c2273842ea6f8258233/pyarrow-23.0.1-cp313-cp313t-macosx_12_0_arm64.whl", hash = "sha256:29f7f7419a0e30264ea261fdc0e5fe63ce5a6095003db2945d7cd78df391a7e1", size = 34471544, upload-time = "2026-02-16T10:11:32.535Z" },
+    { url = "https://files.pythonhosted.org/packages/a3/73/f237b2bc8c669212f842bcfd842b04fc8d936bfc9d471630569132dc920d/pyarrow-23.0.1-cp313-cp313t-macosx_12_0_x86_64.whl", hash = "sha256:33d648dc25b51fd8055c19e4261e813dfc4d2427f068bcecc8b53d01b81b0500", size = 35949911, upload-time = "2026-02-16T10:11:39.813Z" },
+    { url = "https://files.pythonhosted.org/packages/0c/86/b912195eee0903b5611bf596833def7d146ab2d301afeb4b722c57ffc966/pyarrow-23.0.1-cp313-cp313t-manylinux_2_28_aarch64.whl", hash = "sha256:cd395abf8f91c673dd3589cadc8cc1ee4e8674fa61b2e923c8dd215d9c7d1f41", size = 44520337, upload-time = "2026-02-16T10:11:47.764Z" },
+    { url = "https://files.pythonhosted.org/packages/69/c2/f2a717fb824f62d0be952ea724b4f6f9372a17eed6f704b5c9526f12f2f1/pyarrow-23.0.1-cp313-cp313t-manylinux_2_28_x86_64.whl", hash = "sha256:00be9576d970c31defb5c32eb72ef585bf600ef6d0a82d5eccaae96639cf9d07", size = 47548944, upload-time = "2026-02-16T10:11:56.607Z" },
+    { url = "https://files.pythonhosted.org/packages/84/a7/90007d476b9f0dc308e3bc57b832d004f848fd6c0da601375d20d92d1519/pyarrow-23.0.1-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:c2139549494445609f35a5cda4eb94e2c9e4d704ce60a095b342f82460c73a83", size = 48236269, upload-time = "2026-02-16T10:12:04.47Z" },
+    { url = "https://files.pythonhosted.org/packages/b0/3f/b16fab3e77709856eb6ac328ce35f57a6d4a18462c7ca5186ef31b45e0e0/pyarrow-23.0.1-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:7044b442f184d84e2351e5084600f0d7343d6117aabcbc1ac78eb1ae11eb4125", size = 50604794, upload-time = "2026-02-16T10:12:11.797Z" },
+    { url = "https://files.pythonhosted.org/packages/e9/a1/22df0620a9fac31d68397a75465c344e83c3dfe521f7612aea33e27ab6c0/pyarrow-23.0.1-cp313-cp313t-win_amd64.whl", hash = "sha256:a35581e856a2fafa12f3f54fce4331862b1cfb0bef5758347a858a4aa9d6bae8", size = 27660642, upload-time = "2026-02-16T10:12:17.746Z" },
 ]
 
 [[package]]
@@ -746,7 +747,7 @@ requires-dist = [
     { name = "nbformat", specifier = "~=5.10" },
     { name = "pandas", specifier = "~=2.2" },
     { name = "requests", specifier = "~=2.32" },
-    { name = "t4-lambda-shared", extras = ["mem", "preview"], url = "https://github.com/quiltdata/quilt/archive/d496dffbfb4b7a2ae05f6c1f7f0cb7d5d43bc984.zip", subdirectory = "lambdas/shared" },
+    { name = "t4-lambda-shared", extras = ["mem", "preview"], url = "https://github.com/quiltdata/quilt/archive/f9b6e0239aafb72145b670322daa971bc342f145.zip", subdirectory = "lambdas/shared" },
 ]
 
 [package.metadata.requires-dev]
@@ -761,11 +762,11 @@ test = [
 [[package]]
 name = "t4-lambda-shared"
 version = "0.0.3"
-source = { url = "https://github.com/quiltdata/quilt/archive/d496dffbfb4b7a2ae05f6c1f7f0cb7d5d43bc984.zip", subdirectory = "lambdas/shared" }
+source = { url = "https://github.com/quiltdata/quilt/archive/f9b6e0239aafb72145b670322daa971bc342f145.zip", subdirectory = "lambdas/shared" }
 dependencies = [
     { name = "jsonschema" },
 ]
-sdist = { hash = "sha256:301e81a066f2f01f114bc94563d444f426501af4938e95c666b0ff3c329da439" }
+sdist = { hash = "sha256:8affdca5a2acaa981e1d6a13aad888b6d5b89630118262872fa33d0f1690cb0c" }
 
 [package.optional-dependencies]
 mem = [
@@ -788,13 +789,11 @@ requires-dist = [
     { name = "openpyxl", marker = "extra == 'preview'", specifier = "~=3.1" },
     { name = "pandas", marker = "extra == 'preview'", specifier = "~=2.2" },
     { name = "psutil", marker = "extra == 'mem'", specifier = "~=6.1" },
-    { name = "psutil", marker = "extra == 'preview'", specifier = "~=6.1" },
-    { name = "pyarrow", marker = "extra == 'preview'", specifier = "~=18.0" },
-    { name = "pytest", marker = "extra == 'tests'" },
-    { name = "pytest-cov", marker = "extra == 'tests'" },
+    { name = "pyarrow", marker = "extra == 'preview'", specifier = "~=23.0" },
+    { name = "t4-lambda-shared", extras = ["mem"], marker = "extra == 'preview'" },
     { name = "xlrd", marker = "extra == 'preview'", specifier = "~=2.0" },
 ]
-provides-extras = ["tests", "mem", "preview", "lambda"]
+provides-extras = ["mem", "preview", "lambda"]
 
 [[package]]
 name = "tinycss2"


### PR DESCRIPTION
# Description

Resolves Dependabot alert 988 — high-severity **CVE-2026-25087** (`GHSA-rgxp-2hwp-jwgg`), a use-after-free in the Apache Arrow IPC reader — by bumping **pyarrow 18.1.0 → 23.0.1** in the preview lambda.

`pyarrow` is a transitive dependency pulled in via the `t4-lambda-shared[preview]` extra, which capped it at `~=18.0`. Because that constraint lives in the pinned `t4-lambda-shared` archive (not an editable manifest), Dependabot could not bump it. This PR advances the `t4-lambda-shared` source pin to the commit that relaxed shared's constraint to `~=23.0` (#4951) and relocks.

**Net effect on the lock:** only `pyarrow` changes version (18.1.0 → 23.0.1) — no other dependency moves, and `pandas` stays at 2.2.3. The shared modules preview imports (`decorator`, `preview`, `utils`) are behaviorally unchanged across the pin; the in-between commits were a package restructure, a ruff autofix, and removal of unused constants.

**Compatibility check.** Preview's only pyarrow call site is `pyarrow.parquet.ParquetFile` → `iter_batches` → `to_pandas`. Across 18→23 that read API gained only additive, defaulted constructor kwargs. Running the real read path under both 18.1.0 and 23.0.1 (pandas held at 2.2.3) produced byte-identical metadata, dtypes, and rendered output on the parquet fixtures. The CVE itself is in the Arrow IPC reader with pre-buffering — a path preview never calls.

**Not in scope:** the sibling alert (same CVE in `lambdas/indexer`) is not fixed here. The indexer is Python 3.12, but current `t4-lambda-shared` requires ≥3.13, so it needs a Python 3.13 migration before it can take the same bump — to be handled separately.

# TODO

- [x] Unit tests — preview suite (including parquet/excel/fcs) passes on pyarrow 23.0.1
- [x] Security: Confirm that this change meets security best practices and does not violate the security model — resolves CVE-2026-25087; version bump of a transitive dep, no new attack surface

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Bumps `pyarrow` from 18.1.0 to 23.0.1 in the preview lambda to resolve the high-severity CVE-2026-25087 (use-after-free in the Arrow IPC reader). The change also advances the pinned `t4-lambda-shared` archive URL to the commit that already relaxed the `pyarrow` specifier from `~=18.0` to `~=23.0` (#4951, already in master).

- The lock file diff confirms exactly one package version change (`pyarrow` 18.1.0 → 23.0.1); `pandas` (2.2.3) and all other transitive deps are unchanged.
- The `t4-lambda-shared` dependency restructuring reflected in the lock (psutil moving from explicit `preview` extra into the transitively-pulled `mem` extra) is a side-effect of the shared-module commit and does not change the resolved set of installed packages.
- The CVE affects the Arrow IPC reader with pre-buffering, a path the preview lambda never exercises; its sole pyarrow call is `pyarrow.parquet.ParquetFile → iter_batches → to_pandas`.

<h3>Confidence Score: 5/5</h3>

Safe to merge — this is a tightly-scoped security dependency bump with no functional code changes and a verified-clean lock file.

The only runtime change is pyarrow moving from 18.1.0 to 23.0.1. The lock file was inspected and confirms no other package version moved. The t4-lambda-shared pin advances to a commit already present on master whose diff is a package restructure plus the pyarrow constraint relaxation. The preview lambda's single pyarrow call site (ParquetFile → iter_batches → to_pandas) is unaffected by the 18→23 range of additive API changes, and the vulnerable IPC reader path is not exercised at all.

No files require special attention. The two changed files (pyproject.toml and uv.lock) are straightforward dependency management artifacts.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| lambdas/preview/pyproject.toml | Single-line change advancing the t4-lambda-shared archive pin from commit d496dff to f9b6e02; the new commit is already merged to master and relaxes pyarrow from ~=18.0 to ~=23.0. |
| lambdas/preview/uv.lock | Lock file re-generated after the pin update; only pyarrow moves (18.1.0 → 23.0.1) and the t4-lambda-shared source hash updates. All other resolved versions are unchanged and pandas stays at 2.2.3. |

</details>

<h3>Flowchart</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A["lambdas/preview\nt4_lambda_preview"] -->|"depends on"| B["t4-lambda-shared\n@ f9b6e02 (master)"]
    B -->|"[preview] extra\npyarrow ~= 23.0"| C["pyarrow 23.0.1\n✅ CVE-2026-25087 fixed"]
    B -->|"[preview] → [mem] extra"| D["psutil ~= 6.1"]
    A -->|"calls"| E["t4_lambda_shared.preview\nextract_parquet()"]
    E -->|"uses"| F["pyarrow.parquet.ParquetFile\n→ iter_batches → to_pandas"]
    F -->|"IPC reader NOT used\n❌ CVE path never reached"| G["Arrow IPC Reader\n(CVE-2026-25087 sink)"]
    style C fill:#90EE90
    style G fill:#FFB6C1
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A["lambdas/preview\nt4_lambda_preview"] -->|"depends on"| B["t4-lambda-shared\n@ f9b6e02 (master)"]
    B -->|"[preview] extra\npyarrow ~= 23.0"| C["pyarrow 23.0.1\n✅ CVE-2026-25087 fixed"]
    B -->|"[preview] → [mem] extra"| D["psutil ~= 6.1"]
    A -->|"calls"| E["t4_lambda_shared.preview\nextract_parquet()"]
    E -->|"uses"| F["pyarrow.parquet.ParquetFile\n→ iter_batches → to_pandas"]
    F -->|"IPC reader NOT used\n❌ CVE path never reached"| G["Arrow IPC Reader\n(CVE-2026-25087 sink)"]
    style C fill:#90EE90
    style G fill:#FFB6C1
```

</a>

<sub>Reviews (1): Last reviewed commit: ["build(deps): bump pyarrow from 18.1.0 to..."](https://github.com/quiltdata/quilt/commit/21ea904399423cb39d8c58f3cbe42dc262f03692) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=39096126)</sub>

<!-- /greptile_comment -->