### PR TITLE
build: update pytest to 9.1.1 across all Python components

### DIFF
--- a/api/python/pyproject.toml
+++ b/api/python/pyproject.toml
@@ -72,7 +72,7 @@ dev = [
     "pytest-cov",
     "pytest-env",
     "pytest-subtests",
-    "pytest~=8.4",
+    "pytest~=9.1",
     "responses",
     "ruff>=0.12.11",
     "quilt3[pyarrow,anndata]",

--- a/api/python/uv.lock
+++ b/api/python/uv.lock
@@ -2753,7 +2753,7 @@ wheels = [
 
 [[package]]
 name = "pytest"
-version = "8.4.2"
+version = "9.1.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "colorama", marker = "sys_platform == 'win32'" },
@@ -2764,9 +2764,9 @@ dependencies = [
     { name = "pygments" },
     { name = "tomli", marker = "python_full_version < '3.11'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/a3/5c/00a0e072241553e1a7496d638deababa67c5058571567b92a7eaa258397c/pytest-8.4.2.tar.gz", hash = "sha256:86c0d0b93306b961d58d62a4db4879f27fe25513d4b969df351abdddb3c30e01", size = 1519618, upload-time = "2025-09-04T14:34:22.711Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/e4/47/b9efed96c114afcfa3c9d3fe98a76a1d14c74a9e266d397cf6eb64be5e01/pytest-9.1.1.tar.gz", hash = "sha256:1088fbde8f2b49d95a549a195707afa7a76a3ce9bcadc26b6d71f0ffda5fe313", size = 1636369, upload-time = "2026-06-19T10:58:32.857Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/a8/a4/20da314d277121d6534b3a980b29035dcd51e6744bd79075a6ce8fa4eb8d/pytest-8.4.2-py3-none-any.whl", hash = "sha256:872f880de3fc3a5bdc88a11b39c9710c3497a547cfa9320bc3c5e62fbf272e79", size = 365750, upload-time = "2025-09-04T14:34:20.226Z" },
+    { url = "https://files.pythonhosted.org/packages/24/25/1de2678b631f5a49215c6c96fff41ba892b0a34df68d6d80292b1b48aa7f/pytest-9.1.1-py3-none-any.whl", hash = "sha256:37a86b45efb9a47a61a36449063e8e18d0cab3161329fc099eb21783169c4f0c", size = 386536, upload-time = "2026-06-19T10:58:31.347Z" },
 ]
 
 [[package]]
@@ -3045,7 +3045,7 @@ provides-extras = ["pyarrow", "anndata", "catalog"]
 [package.metadata.requires-dev]
 dev = [
     { name = "poethepoet", specifier = ">=0.37.0" },
-    { name = "pytest", specifier = "~=8.4" },
+    { name = "pytest", specifier = "~=9.1" },
     { name = "pytest-cov" },
     { name = "pytest-env" },
     { name = "pytest-subtests" },

--- a/docs/CrossAccount.md
+++ b/docs/CrossAccount.md
@@ -71,7 +71,7 @@ When Quilt (running in Control Account) writes objects to buckets in Data Accoun
 3. **Edit Object Ownership** and select **"Bucket owner enforced"**
 
 **Using AWS CLI:**
-<!-- pytest-codeblocks:skip -->
+<!-- pytest.mark.skip -->
 ```bash
 # Set object ownership to bucket owner enforced
 aws s3api put-bucket-ownership-controls \
@@ -136,7 +136,7 @@ Grant Quilt infrastructure in Control Account the necessary permissions to manag
 3. Click **Save changes**
 
 **CLI Method:**
-<!-- pytest-codeblocks:skip -->
+<!-- pytest.mark.skip -->
 ```bash
 # Save policy to file
 cat > bucket-policy.json << 'EOF'
@@ -211,7 +211,7 @@ Add this statement to your SNS topic's resource policy in the Data Account:
 
 **Apply SNS Policy:**
 
-<!-- pytest-codeblocks:skip -->
+<!-- pytest.mark.skip -->
 ```bash
 # Get current policy
 aws sns get-topic-attributes \
@@ -255,7 +255,7 @@ If Quilt manages CloudTrail in the Control Account:
 If you have existing CloudTrail in either account:
 
 1. **Identify the Trail:**
-   <!-- pytest-codeblocks:skip -->
+   <!-- pytest.mark.skip -->
    ```bash
    # List trails in Data Account
    aws cloudtrail describe-trails --profile data-account
@@ -265,7 +265,7 @@ If you have existing CloudTrail in either account:
    ```
 
 2. **Add S3 Data Events:**
-   <!-- pytest-codeblocks:skip -->
+   <!-- pytest.mark.skip -->
    ```bash
    # Add data events for your bucket
    aws cloudtrail put-event-selectors \
@@ -343,7 +343,7 @@ If CloudTrail is in Data Account but Quilt needs access:
 ### Verification Steps
 
 #### 1. Test Basic Access
-<!-- pytest-codeblocks:skip -->
+<!-- pytest.mark.skip -->
 ```bash
 # From Control Account, test bucket access
 aws s3 ls s3://your-data-bucket --profile control-account
@@ -360,7 +360,7 @@ aws s3 cp test.txt s3://your-data-bucket/ --profile control-account
 4. **Test search functionality** in Quilt
 
 #### 3. Check CloudTrail Logging
-<!-- pytest-codeblocks:skip -->
+<!-- pytest.mark.skip -->
 ```bash
 # Verify CloudTrail is capturing events
 aws logs filter-log-events \
@@ -478,7 +478,7 @@ Instead of granting access to the entire Control Account root, consider restrict
 **CloudWatch Alarms:**
 Set up monitoring for cross-account access:
 
-<!-- pytest-codeblocks:skip -->
+<!-- pytest.mark.skip -->
 ```bash
 # Create alarm for failed S3 access attempts
 aws cloudwatch put-metric-alarm \
@@ -535,7 +535,7 @@ Monitor specific cross-account activities:
 
 For multi-region deployments:
 
-<!-- pytest-codeblocks:skip -->
+<!-- pytest.mark.skip -->
 ```bash
 # Replicate bucket policy across regions
 for region in us-east-1 us-west-2 eu-west-1; do

--- a/docs/EventBridge.md
+++ b/docs/EventBridge.md
@@ -74,7 +74,7 @@ Before starting, ensure you have:
 
 Create an SNS topic in the **same region** as your S3 bucket:
 
-<!-- pytest-codeblocks:skip -->
+<!-- pytest.mark.skip -->
 ```bash
 # Using AWS CLI
 aws sns create-topic \
@@ -243,7 +243,7 @@ Perform initial bucket indexing:
 
 Test that events are flowing correctly:
 
-<!-- pytest-codeblocks:skip -->
+<!-- pytest.mark.skip -->
 ```bash
 # Upload a test file
 aws s3 cp test.txt s3://your-bucket-name/test.txt
@@ -274,7 +274,7 @@ aws sns get-topic-attributes --topic-arn YOUR_SNS_TOPIC_ARN
 
 **Troubleshooting Steps:**
 1. **Check EventBridge Rule Status**
-   <!-- pytest-codeblocks:skip -->
+   <!-- pytest.mark.skip -->
 ```bash
 aws events describe-rule --name quilt-s3-events-rule
 ```
@@ -336,7 +336,7 @@ Ensure EventBridge has permission to publish to SNS:
 - **Batch Processing**: Consider batching for high-volume buckets
 
 #### Cost Optimization
-<!-- pytest-codeblocks:skip -->
+<!-- pytest.mark.skip -->
 ```bash
 # Monitor EventBridge usage
 aws events describe-rule --name quilt-s3-events-rule --query 'EventPattern'

--- a/docs/MentalModel.md
+++ b/docs/MentalModel.md
@@ -178,7 +178,7 @@ graph LR
 
 ### Package Promotion Workflow
 
-<!-- pytest-codeblocks:skip -->
+<!-- pytest.mark.skip -->
 ```python
 # Promote a package through environments
 import quilt3

--- a/docs/Quickstart.md
+++ b/docs/Quickstart.md
@@ -32,7 +32,7 @@ pip install quilt3
 
 For public datasets like `s3://quilt-example`, no authentication is needed. For private buckets or catalogs, choose your authentication method:
 
-<!-- pytest-codeblocks:skip -->
+<!-- pytest.mark.skip -->
 ```python
 import quilt3
 

--- a/docs/api-reference/authentication.md
+++ b/docs/api-reference/authentication.md
@@ -14,7 +14,7 @@ Interactive authentication uses OAuth or SSO to authenticate through your web br
 
 ### Login
 
-<!-- pytest-codeblocks:skip -->
+<!-- pytest.mark.skip -->
 ```python
 import quilt3
 
@@ -31,7 +31,7 @@ This command will:
 
 ### Check Authentication Status
 
-<!-- pytest-codeblocks:skip -->
+<!-- pytest.mark.skip -->
 ```python
 # Returns catalog URL if authenticated, None otherwise
 catalog_url = quilt3.logged_in()
@@ -44,7 +44,7 @@ else:
 
 ### Logout
 
-<!-- pytest-codeblocks:skip -->
+<!-- pytest.mark.skip -->
 ```python
 # Clear all credentials (both interactive and API keys)
 quilt3.logout()
@@ -73,7 +73,7 @@ API keys provide programmatic access to Quilt without requiring browser-based au
 
 First, log in using the interactive method:
 
-<!-- pytest-codeblocks:skip -->
+<!-- pytest.mark.skip -->
 ```python
 import quilt3
 quilt3.login()
@@ -81,7 +81,7 @@ quilt3.login()
 
 #### Step 2: Create an API Key
 
-<!-- pytest-codeblocks:skip -->
+<!-- pytest.mark.skip -->
 ```python
 # Create a key that expires in 90 days (default)
 key, secret = quilt3.api_keys.create("my-automation-key")
@@ -117,7 +117,7 @@ QUILT_API_KEY=qk_your_secret_here
 
 Load it in your Python code:
 
-<!-- pytest-codeblocks:skip -->
+<!-- pytest.mark.skip -->
 ```python
 from dotenv import load_dotenv
 import os
@@ -132,7 +132,7 @@ For production deployments, embed it in environment variables or AWS secrets man
 
 #### Step 4: Use the API Key
 
-<!-- pytest-codeblocks:skip -->
+<!-- pytest.mark.skip -->
 ```python
 import os
 import quilt3
@@ -152,7 +152,7 @@ You must explicitly login with it.
 
 #### List All Your Keys
 
-<!-- pytest-codeblocks:skip -->
+<!-- pytest.mark.skip -->
 ```python
 import quilt3
 
@@ -171,7 +171,7 @@ for key in keys:
 
 #### Filter Keys
 
-<!-- pytest-codeblocks:skip -->
+<!-- pytest.mark.skip -->
 ```python
 # Find keys by name
 production_keys = quilt3.api_keys.list(name="production-pipeline")
@@ -188,7 +188,7 @@ expired_keys = quilt3.api_keys.list(status="EXPIRED")
 
 #### Get a Specific Key
 
-<!-- pytest-codeblocks:skip -->
+<!-- pytest.mark.skip -->
 ```python
 # Get details about a specific key
 key = quilt3.api_keys.get("key-id-here")
@@ -205,7 +205,7 @@ else:
 
 #### Revoke a Key
 
-<!-- pytest-codeblocks:skip -->
+<!-- pytest.mark.skip -->
 ```python
 # Revoke by ID (if you know it)
 quilt3.api_keys.revoke(id="key-id-here")
@@ -256,7 +256,7 @@ import quilt3.admin
 
 ### List All API Keys
 
-<!-- pytest-codeblocks:skip -->
+<!-- pytest.mark.skip -->
 ```python
 # List all keys in the system
 all_keys = quilt3.admin.api_keys.list()
@@ -279,7 +279,7 @@ print(f"Expired keys: {len(expired_keys)}")
 
 ### Get Key Details
 
-<!-- pytest-codeblocks:skip -->
+<!-- pytest.mark.skip -->
 ```python
 # Get details about a specific key
 key = quilt3.admin.api_keys.get("key-id-here")
@@ -296,7 +296,7 @@ if key:
 
 ### Revoke a User's Key
 
-<!-- pytest-codeblocks:skip -->
+<!-- pytest.mark.skip -->
 ```python
 # Revoke a specific key by ID
 key_id = "key-id-here"
@@ -306,7 +306,7 @@ print(f"Revoked key: {key_id}")
 
 ### Audit Key Usage
 
-<!-- pytest-codeblocks:skip -->
+<!-- pytest.mark.skip -->
 ```python
 from datetime import datetime, timedelta
 
@@ -328,7 +328,7 @@ print(f"\nFound {len(unused_keys)} unused keys")
 
 ### Generate Usage Reports
 
-<!-- pytest-codeblocks:skip -->
+<!-- pytest.mark.skip -->
 ```python
 # Get summary statistics
 all_keys = quilt3.admin.api_keys.list()
@@ -383,7 +383,7 @@ LIMIT 100;
 
 ##### Verify the Key Format
 
-<!-- pytest-codeblocks:skip -->
+<!-- pytest.mark.skip -->
 ```python
 api_key = "qk_..."  # Must start with qk_
 if not api_key.startswith("qk_"):
@@ -392,7 +392,7 @@ if not api_key.startswith("qk_"):
 
 ##### Check if Key is Expired
 
-<!-- pytest-codeblocks:skip -->
+<!-- pytest.mark.skip -->
 ```python
 import quilt3
 quilt3.login()  # Use interactive login first
@@ -404,7 +404,7 @@ for key in keys:
 
 ##### Clear Old Sessions
 
-<!-- pytest-codeblocks:skip -->
+<!-- pytest.mark.skip -->
 ```python
 import quilt3
 quilt3.logout()  # Clear all credentials
@@ -429,7 +429,7 @@ quilt3.login_with_api_key(api_key)  # Try again
 
 Create a new key:
 
-<!-- pytest-codeblocks:skip -->
+<!-- pytest.mark.skip -->
 ```python
 import quilt3
 
@@ -484,7 +484,7 @@ echo 'QUILT_API_KEY="qk_..."' >> .env
 
 Then load it in Python:
 
-<!-- pytest-codeblocks:skip -->
+<!-- pytest.mark.skip -->
 ```python
 from dotenv import load_dotenv
 load_dotenv()
@@ -496,7 +496,7 @@ If you have existing scripts using `quilt3.login()`, here's how to migrate:
 
 ### Before (Interactive Login)
 
-<!-- pytest-codeblocks:skip -->
+<!-- pytest.mark.skip -->
 ```python
 import quilt3
 
@@ -508,7 +508,7 @@ pkg = quilt3.Package.browse("data/latest", "s3://mybucket")
 
 ### After (API Key)
 
-<!-- pytest-codeblocks:skip -->
+<!-- pytest.mark.skip -->
 ```python
 import os
 import quilt3

--- a/gendocs/uv.lock
+++ b/gendocs/uv.lock
@@ -659,7 +659,7 @@ provides-extras = ["pyarrow", "anndata", "catalog"]
 [package.metadata.requires-dev]
 dev = [
     { name = "poethepoet", specifier = ">=0.37.0" },
-    { name = "pytest", specifier = "~=8.4" },
+    { name = "pytest", specifier = "~=9.1" },
     { name = "pytest-cov" },
     { name = "pytest-env" },
     { name = "pytest-subtests" },

--- a/lambdas/access_counts/pyproject.toml
+++ b/lambdas/access_counts/pyproject.toml
@@ -13,7 +13,7 @@ build-backend = "uv_build"
 
 [dependency-groups]
 test = [
-    "pytest~=8.4",
+    "pytest~=9.1",
     "pytest-cov~=7.0",
     "pytest-env~=1.1",
     "pytest-mock~=3.15",

--- a/lambdas/access_counts/uv.lock
+++ b/lambdas/access_counts/uv.lock
@@ -189,7 +189,7 @@ wheels = [
 
 [[package]]
 name = "pytest"
-version = "8.4.2"
+version = "9.1.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "colorama", marker = "sys_platform == 'win32'" },
@@ -198,9 +198,9 @@ dependencies = [
     { name = "pluggy" },
     { name = "pygments" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/a3/5c/00a0e072241553e1a7496d638deababa67c5058571567b92a7eaa258397c/pytest-8.4.2.tar.gz", hash = "sha256:86c0d0b93306b961d58d62a4db4879f27fe25513d4b969df351abdddb3c30e01", size = 1519618, upload-time = "2025-09-04T14:34:22.711Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/e4/47/b9efed96c114afcfa3c9d3fe98a76a1d14c74a9e266d397cf6eb64be5e01/pytest-9.1.1.tar.gz", hash = "sha256:1088fbde8f2b49d95a549a195707afa7a76a3ce9bcadc26b6d71f0ffda5fe313", size = 1636369, upload-time = "2026-06-19T10:58:32.857Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/a8/a4/20da314d277121d6534b3a980b29035dcd51e6744bd79075a6ce8fa4eb8d/pytest-8.4.2-py3-none-any.whl", hash = "sha256:872f880de3fc3a5bdc88a11b39c9710c3497a547cfa9320bc3c5e62fbf272e79", size = 365750, upload-time = "2025-09-04T14:34:20.226Z" },
+    { url = "https://files.pythonhosted.org/packages/24/25/1de2678b631f5a49215c6c96fff41ba892b0a34df68d6d80292b1b48aa7f/pytest-9.1.1-py3-none-any.whl", hash = "sha256:37a86b45efb9a47a61a36449063e8e18d0cab3161329fc099eb21783169c4f0c", size = 386536, upload-time = "2026-06-19T10:58:31.347Z" },
 ]
 
 [[package]]
@@ -349,7 +349,7 @@ requires-dist = [
 
 [package.metadata.requires-dev]
 test = [
-    { name = "pytest", specifier = "~=8.4" },
+    { name = "pytest", specifier = "~=9.1" },
     { name = "pytest-cov", specifier = "~=7.0" },
     { name = "pytest-env", specifier = "~=1.1" },
     { name = "pytest-mock", specifier = "~=3.15" },

--- a/lambdas/es_ingest/pyproject.toml
+++ b/lambdas/es_ingest/pyproject.toml
@@ -20,7 +20,7 @@ quilt-shared = { url = "https://github.com/quiltdata/quilt/archive/df53c9ce125ea
 
 [dependency-groups]
 test = [
-    "pytest~=9.0",
+    "pytest~=9.1",
     "pytest-cov~=6.2",
     "pytest-env~=1.1",
     "pytest-mock~=3.14",

--- a/lambdas/es_ingest/uv.lock
+++ b/lambdas/es_ingest/uv.lock
@@ -291,7 +291,7 @@ wheels = [
 
 [[package]]
 name = "pytest"
-version = "9.0.3"
+version = "9.1.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "colorama", marker = "sys_platform == 'win32'" },
@@ -300,9 +300,9 @@ dependencies = [
     { name = "pluggy" },
     { name = "pygments" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/7d/0d/549bd94f1a0a402dc8cf64563a117c0f3765662e2e668477624baeec44d5/pytest-9.0.3.tar.gz", hash = "sha256:b86ada508af81d19edeb213c681b1d48246c1a91d304c6c81a427674c17eb91c", size = 1572165, upload-time = "2026-04-07T17:16:18.027Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/e4/47/b9efed96c114afcfa3c9d3fe98a76a1d14c74a9e266d397cf6eb64be5e01/pytest-9.1.1.tar.gz", hash = "sha256:1088fbde8f2b49d95a549a195707afa7a76a3ce9bcadc26b6d71f0ffda5fe313", size = 1636369, upload-time = "2026-06-19T10:58:32.857Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/d4/24/a372aaf5c9b7208e7112038812994107bc65a84cd00e0354a88c2c77a617/pytest-9.0.3-py3-none-any.whl", hash = "sha256:2c5efc453d45394fdd706ade797c0a81091eccd1d6e4bccfcd476e2b8e0ab5d9", size = 375249, upload-time = "2026-04-07T17:16:16.13Z" },
+    { url = "https://files.pythonhosted.org/packages/24/25/1de2678b631f5a49215c6c96fff41ba892b0a34df68d6d80292b1b48aa7f/pytest-9.1.1-py3-none-any.whl", hash = "sha256:37a86b45efb9a47a61a36449063e8e18d0cab3161329fc099eb21783169c4f0c", size = 386536, upload-time = "2026-06-19T10:58:31.347Z" },
 ]
 
 [[package]]
@@ -497,7 +497,7 @@ requires-dist = [
 
 [package.metadata.requires-dev]
 test = [
-    { name = "pytest", specifier = "~=9.0" },
+    { name = "pytest", specifier = "~=9.1" },
     { name = "pytest-cov", specifier = "~=6.2" },
     { name = "pytest-env", specifier = "~=1.1" },
     { name = "pytest-mock", specifier = "~=3.14" },

--- a/lambdas/iceberg/pyproject.toml
+++ b/lambdas/iceberg/pyproject.toml
@@ -17,7 +17,7 @@ build-backend = "uv_build"
 
 [dependency-groups]
 test = [
-    "pytest~=9.0",
+    "pytest~=9.1",
     "pytest-cov~=7.0",
     "pytest-env~=1.1",
     "pytest-mock~=3.15",

--- a/lambdas/iceberg/uv.lock
+++ b/lambdas/iceberg/uv.lock
@@ -133,7 +133,7 @@ wheels = [
 
 [[package]]
 name = "pytest"
-version = "9.0.3"
+version = "9.1.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "colorama", marker = "sys_platform == 'win32'" },
@@ -142,9 +142,9 @@ dependencies = [
     { name = "pluggy" },
     { name = "pygments" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/7d/0d/549bd94f1a0a402dc8cf64563a117c0f3765662e2e668477624baeec44d5/pytest-9.0.3.tar.gz", hash = "sha256:b86ada508af81d19edeb213c681b1d48246c1a91d304c6c81a427674c17eb91c", size = 1572165, upload-time = "2026-04-07T17:16:18.027Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/e4/47/b9efed96c114afcfa3c9d3fe98a76a1d14c74a9e266d397cf6eb64be5e01/pytest-9.1.1.tar.gz", hash = "sha256:1088fbde8f2b49d95a549a195707afa7a76a3ce9bcadc26b6d71f0ffda5fe313", size = 1636369, upload-time = "2026-06-19T10:58:32.857Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/d4/24/a372aaf5c9b7208e7112038812994107bc65a84cd00e0354a88c2c77a617/pytest-9.0.3-py3-none-any.whl", hash = "sha256:2c5efc453d45394fdd706ade797c0a81091eccd1d6e4bccfcd476e2b8e0ab5d9", size = 375249, upload-time = "2026-04-07T17:16:16.13Z" },
+    { url = "https://files.pythonhosted.org/packages/24/25/1de2678b631f5a49215c6c96fff41ba892b0a34df68d6d80292b1b48aa7f/pytest-9.1.1-py3-none-any.whl", hash = "sha256:37a86b45efb9a47a61a36449063e8e18d0cab3161329fc099eb21783169c4f0c", size = 386536, upload-time = "2026-06-19T10:58:31.347Z" },
 ]
 
 [[package]]
@@ -270,7 +270,7 @@ requires-dist = [
 
 [package.metadata.requires-dev]
 test = [
-    { name = "pytest", specifier = "~=9.0" },
+    { name = "pytest", specifier = "~=9.1" },
     { name = "pytest-cov", specifier = "~=7.0" },
     { name = "pytest-env", specifier = "~=1.1" },
     { name = "pytest-mock", specifier = "~=3.15" },

--- a/lambdas/indexer/pyproject.toml
+++ b/lambdas/indexer/pyproject.toml
@@ -27,7 +27,7 @@ quilt-shared = { url = "https://github.com/quiltdata/quilt/archive/df53c9ce125ea
 
 [dependency-groups]
 test = [
-    "pytest~=9.0",
+    "pytest~=9.1",
     "pytest-cov~=7.0",
     "pytest-env~=1.1",
     "pytest-mock~=3.15",

--- a/lambdas/indexer/uv.lock
+++ b/lambdas/indexer/uv.lock
@@ -578,7 +578,7 @@ wheels = [
 
 [[package]]
 name = "pytest"
-version = "9.0.3"
+version = "9.1.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "colorama", marker = "sys_platform == 'win32'" },
@@ -587,9 +587,9 @@ dependencies = [
     { name = "pluggy" },
     { name = "pygments" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/7d/0d/549bd94f1a0a402dc8cf64563a117c0f3765662e2e668477624baeec44d5/pytest-9.0.3.tar.gz", hash = "sha256:b86ada508af81d19edeb213c681b1d48246c1a91d304c6c81a427674c17eb91c", size = 1572165, upload-time = "2026-04-07T17:16:18.027Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/e4/47/b9efed96c114afcfa3c9d3fe98a76a1d14c74a9e266d397cf6eb64be5e01/pytest-9.1.1.tar.gz", hash = "sha256:1088fbde8f2b49d95a549a195707afa7a76a3ce9bcadc26b6d71f0ffda5fe313", size = 1636369, upload-time = "2026-06-19T10:58:32.857Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/d4/24/a372aaf5c9b7208e7112038812994107bc65a84cd00e0354a88c2c77a617/pytest-9.0.3-py3-none-any.whl", hash = "sha256:2c5efc453d45394fdd706ade797c0a81091eccd1d6e4bccfcd476e2b8e0ab5d9", size = 375249, upload-time = "2026-04-07T17:16:16.13Z" },
+    { url = "https://files.pythonhosted.org/packages/24/25/1de2678b631f5a49215c6c96fff41ba892b0a34df68d6d80292b1b48aa7f/pytest-9.1.1-py3-none-any.whl", hash = "sha256:37a86b45efb9a47a61a36449063e8e18d0cab3161329fc099eb21783169c4f0c", size = 386536, upload-time = "2026-06-19T10:58:31.347Z" },
 ]
 
 [[package]]
@@ -856,7 +856,7 @@ requires-dist = [
 [package.metadata.requires-dev]
 prod = [{ name = "awslambdaric", specifier = "~=3.1" }]
 test = [
-    { name = "pytest", specifier = "~=9.0" },
+    { name = "pytest", specifier = "~=9.1" },
     { name = "pytest-cov", specifier = "~=7.0" },
     { name = "pytest-env", specifier = "~=1.1" },
     { name = "pytest-mock", specifier = "~=3.15" },

--- a/lambdas/manifest_indexer/pyproject.toml
+++ b/lambdas/manifest_indexer/pyproject.toml
@@ -22,7 +22,7 @@ quilt-shared = { url = "https://github.com/quiltdata/quilt/archive/df53c9ce125ea
 
 [dependency-groups]
 test = [
-    "pytest~=9.0",
+    "pytest~=9.1",
     "pytest-cov~=6.2",
     "pytest-env~=1.1",
 ]

--- a/lambdas/manifest_indexer/uv.lock
+++ b/lambdas/manifest_indexer/uv.lock
@@ -300,7 +300,7 @@ wheels = [
 
 [[package]]
 name = "pytest"
-version = "9.0.3"
+version = "9.1.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "colorama", marker = "sys_platform == 'win32'" },
@@ -309,9 +309,9 @@ dependencies = [
     { name = "pluggy" },
     { name = "pygments" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/7d/0d/549bd94f1a0a402dc8cf64563a117c0f3765662e2e668477624baeec44d5/pytest-9.0.3.tar.gz", hash = "sha256:b86ada508af81d19edeb213c681b1d48246c1a91d304c6c81a427674c17eb91c", size = 1572165, upload-time = "2026-04-07T17:16:18.027Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/e4/47/b9efed96c114afcfa3c9d3fe98a76a1d14c74a9e266d397cf6eb64be5e01/pytest-9.1.1.tar.gz", hash = "sha256:1088fbde8f2b49d95a549a195707afa7a76a3ce9bcadc26b6d71f0ffda5fe313", size = 1636369, upload-time = "2026-06-19T10:58:32.857Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/d4/24/a372aaf5c9b7208e7112038812994107bc65a84cd00e0354a88c2c77a617/pytest-9.0.3-py3-none-any.whl", hash = "sha256:2c5efc453d45394fdd706ade797c0a81091eccd1d6e4bccfcd476e2b8e0ab5d9", size = 375249, upload-time = "2026-04-07T17:16:16.13Z" },
+    { url = "https://files.pythonhosted.org/packages/24/25/1de2678b631f5a49215c6c96fff41ba892b0a34df68d6d80292b1b48aa7f/pytest-9.1.1-py3-none-any.whl", hash = "sha256:37a86b45efb9a47a61a36449063e8e18d0cab3161329fc099eb21783169c4f0c", size = 386536, upload-time = "2026-06-19T10:58:31.347Z" },
 ]
 
 [[package]]
@@ -497,7 +497,7 @@ requires-dist = [
 
 [package.metadata.requires-dev]
 test = [
-    { name = "pytest", specifier = "~=9.0" },
+    { name = "pytest", specifier = "~=9.1" },
     { name = "pytest-cov", specifier = "~=6.2" },
     { name = "pytest-env", specifier = "~=1.1" },
 ]

--- a/lambdas/pkgevents/pyproject.toml
+++ b/lambdas/pkgevents/pyproject.toml
@@ -13,7 +13,7 @@ build-backend = "uv_build"
 
 [dependency-groups]
 test = [
-    "pytest~=9.0",
+    "pytest~=9.1",
     "pytest-cov~=7.0",
     "pytest-env~=1.1",
     "pytest-mock~=3.15",

--- a/lambdas/pkgevents/uv.lock
+++ b/lambdas/pkgevents/uv.lock
@@ -157,7 +157,7 @@ wheels = [
 
 [[package]]
 name = "pytest"
-version = "9.0.3"
+version = "9.1.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "colorama", marker = "sys_platform == 'win32'" },
@@ -166,9 +166,9 @@ dependencies = [
     { name = "pluggy" },
     { name = "pygments" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/7d/0d/549bd94f1a0a402dc8cf64563a117c0f3765662e2e668477624baeec44d5/pytest-9.0.3.tar.gz", hash = "sha256:b86ada508af81d19edeb213c681b1d48246c1a91d304c6c81a427674c17eb91c", size = 1572165, upload-time = "2026-04-07T17:16:18.027Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/e4/47/b9efed96c114afcfa3c9d3fe98a76a1d14c74a9e266d397cf6eb64be5e01/pytest-9.1.1.tar.gz", hash = "sha256:1088fbde8f2b49d95a549a195707afa7a76a3ce9bcadc26b6d71f0ffda5fe313", size = 1636369, upload-time = "2026-06-19T10:58:32.857Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/d4/24/a372aaf5c9b7208e7112038812994107bc65a84cd00e0354a88c2c77a617/pytest-9.0.3-py3-none-any.whl", hash = "sha256:2c5efc453d45394fdd706ade797c0a81091eccd1d6e4bccfcd476e2b8e0ab5d9", size = 375249, upload-time = "2026-04-07T17:16:16.13Z" },
+    { url = "https://files.pythonhosted.org/packages/24/25/1de2678b631f5a49215c6c96fff41ba892b0a34df68d6d80292b1b48aa7f/pytest-9.1.1-py3-none-any.whl", hash = "sha256:37a86b45efb9a47a61a36449063e8e18d0cab3161329fc099eb21783169c4f0c", size = 386536, upload-time = "2026-06-19T10:58:31.347Z" },
 ]
 
 [[package]]
@@ -317,7 +317,7 @@ requires-dist = [
 
 [package.metadata.requires-dev]
 test = [
-    { name = "pytest", specifier = "~=9.0" },
+    { name = "pytest", specifier = "~=9.1" },
     { name = "pytest-cov", specifier = "~=7.0" },
     { name = "pytest-env", specifier = "~=1.1" },
     { name = "pytest-mock", specifier = "~=3.15" },

--- a/lambdas/pkgpush/pyproject.toml
+++ b/lambdas/pkgpush/pyproject.toml
@@ -17,7 +17,7 @@ build-backend = "uv_build"
 
 [dependency-groups]
 test = [
-    "pytest~=9.0",
+    "pytest~=9.1",
     "pytest-cov~=7.0",
     "pytest-env~=1.1",
     "pytest-mock~=3.15",

--- a/lambdas/pkgpush/uv.lock
+++ b/lambdas/pkgpush/uv.lock
@@ -309,7 +309,7 @@ wheels = [
 
 [[package]]
 name = "pytest"
-version = "9.0.3"
+version = "9.1.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "colorama", marker = "sys_platform == 'win32'" },
@@ -318,9 +318,9 @@ dependencies = [
     { name = "pluggy" },
     { name = "pygments" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/7d/0d/549bd94f1a0a402dc8cf64563a117c0f3765662e2e668477624baeec44d5/pytest-9.0.3.tar.gz", hash = "sha256:b86ada508af81d19edeb213c681b1d48246c1a91d304c6c81a427674c17eb91c", size = 1572165, upload-time = "2026-04-07T17:16:18.027Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/e4/47/b9efed96c114afcfa3c9d3fe98a76a1d14c74a9e266d397cf6eb64be5e01/pytest-9.1.1.tar.gz", hash = "sha256:1088fbde8f2b49d95a549a195707afa7a76a3ce9bcadc26b6d71f0ffda5fe313", size = 1636369, upload-time = "2026-06-19T10:58:32.857Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/d4/24/a372aaf5c9b7208e7112038812994107bc65a84cd00e0354a88c2c77a617/pytest-9.0.3-py3-none-any.whl", hash = "sha256:2c5efc453d45394fdd706ade797c0a81091eccd1d6e4bccfcd476e2b8e0ab5d9", size = 375249, upload-time = "2026-04-07T17:16:16.13Z" },
+    { url = "https://files.pythonhosted.org/packages/24/25/1de2678b631f5a49215c6c96fff41ba892b0a34df68d6d80292b1b48aa7f/pytest-9.1.1-py3-none-any.whl", hash = "sha256:37a86b45efb9a47a61a36449063e8e18d0cab3161329fc099eb21783169c4f0c", size = 386536, upload-time = "2026-06-19T10:58:31.347Z" },
 ]
 
 [[package]]
@@ -586,7 +586,7 @@ requires-dist = [
 
 [package.metadata.requires-dev]
 test = [
-    { name = "pytest", specifier = "~=9.0" },
+    { name = "pytest", specifier = "~=9.1" },
     { name = "pytest-cov", specifier = "~=7.0" },
     { name = "pytest-env", specifier = "~=1.1" },
     { name = "pytest-mock", specifier = "~=3.15" },

--- a/lambdas/preview/pyproject.toml
+++ b/lambdas/preview/pyproject.toml
@@ -16,7 +16,7 @@ build-backend = "uv_build"
 
 [dependency-groups]
 test = [
-    "pytest~=9.0",
+    "pytest~=9.1",
     "pytest-cov~=7.0",
     "pytest-env~=1.1",
     "pytest-mock~=3.15",

--- a/lambdas/preview/uv.lock
+++ b/lambdas/preview/uv.lock
@@ -506,7 +506,7 @@ wheels = [
 
 [[package]]
 name = "pytest"
-version = "9.0.3"
+version = "9.1.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "colorama", marker = "sys_platform == 'win32'" },
@@ -515,9 +515,9 @@ dependencies = [
     { name = "pluggy" },
     { name = "pygments" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/7d/0d/549bd94f1a0a402dc8cf64563a117c0f3765662e2e668477624baeec44d5/pytest-9.0.3.tar.gz", hash = "sha256:b86ada508af81d19edeb213c681b1d48246c1a91d304c6c81a427674c17eb91c", size = 1572165, upload-time = "2026-04-07T17:16:18.027Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/e4/47/b9efed96c114afcfa3c9d3fe98a76a1d14c74a9e266d397cf6eb64be5e01/pytest-9.1.1.tar.gz", hash = "sha256:1088fbde8f2b49d95a549a195707afa7a76a3ce9bcadc26b6d71f0ffda5fe313", size = 1636369, upload-time = "2026-06-19T10:58:32.857Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/d4/24/a372aaf5c9b7208e7112038812994107bc65a84cd00e0354a88c2c77a617/pytest-9.0.3-py3-none-any.whl", hash = "sha256:2c5efc453d45394fdd706ade797c0a81091eccd1d6e4bccfcd476e2b8e0ab5d9", size = 375249, upload-time = "2026-04-07T17:16:16.13Z" },
+    { url = "https://files.pythonhosted.org/packages/24/25/1de2678b631f5a49215c6c96fff41ba892b0a34df68d6d80292b1b48aa7f/pytest-9.1.1-py3-none-any.whl", hash = "sha256:37a86b45efb9a47a61a36449063e8e18d0cab3161329fc099eb21783169c4f0c", size = 386536, upload-time = "2026-06-19T10:58:31.347Z" },
 ]
 
 [[package]]
@@ -752,7 +752,7 @@ requires-dist = [
 
 [package.metadata.requires-dev]
 test = [
-    { name = "pytest", specifier = "~=9.0" },
+    { name = "pytest", specifier = "~=9.1" },
     { name = "pytest-cov", specifier = "~=7.0" },
     { name = "pytest-env", specifier = "~=1.1" },
     { name = "pytest-mock", specifier = "~=3.15" },

--- a/lambdas/s3hash/pyproject.toml
+++ b/lambdas/s3hash/pyproject.toml
@@ -17,7 +17,7 @@ build-backend = "uv_build"
 
 [dependency-groups]
 test = [
-    "pytest~=9.0",
+    "pytest~=9.1",
     "pytest-asyncio ~= 1.3",
     "pytest-cov~=7.0",
     "pytest-env~=1.1",

--- a/lambdas/s3hash/uv.lock
+++ b/lambdas/s3hash/uv.lock
@@ -495,7 +495,7 @@ wheels = [
 
 [[package]]
 name = "pytest"
-version = "9.0.3"
+version = "9.1.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "colorama", marker = "sys_platform == 'win32'" },
@@ -504,9 +504,9 @@ dependencies = [
     { name = "pluggy" },
     { name = "pygments" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/7d/0d/549bd94f1a0a402dc8cf64563a117c0f3765662e2e668477624baeec44d5/pytest-9.0.3.tar.gz", hash = "sha256:b86ada508af81d19edeb213c681b1d48246c1a91d304c6c81a427674c17eb91c", size = 1572165, upload-time = "2026-04-07T17:16:18.027Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/e4/47/b9efed96c114afcfa3c9d3fe98a76a1d14c74a9e266d397cf6eb64be5e01/pytest-9.1.1.tar.gz", hash = "sha256:1088fbde8f2b49d95a549a195707afa7a76a3ce9bcadc26b6d71f0ffda5fe313", size = 1636369, upload-time = "2026-06-19T10:58:32.857Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/d4/24/a372aaf5c9b7208e7112038812994107bc65a84cd00e0354a88c2c77a617/pytest-9.0.3-py3-none-any.whl", hash = "sha256:2c5efc453d45394fdd706ade797c0a81091eccd1d6e4bccfcd476e2b8e0ab5d9", size = 375249, upload-time = "2026-04-07T17:16:16.13Z" },
+    { url = "https://files.pythonhosted.org/packages/24/25/1de2678b631f5a49215c6c96fff41ba892b0a34df68d6d80292b1b48aa7f/pytest-9.1.1-py3-none-any.whl", hash = "sha256:37a86b45efb9a47a61a36449063e8e18d0cab3161329fc099eb21783169c4f0c", size = 386536, upload-time = "2026-06-19T10:58:31.347Z" },
 ]
 
 [[package]]
@@ -776,7 +776,7 @@ requires-dist = [
 
 [package.metadata.requires-dev]
 test = [
-    { name = "pytest", specifier = "~=9.0" },
+    { name = "pytest", specifier = "~=9.1" },
     { name = "pytest-asyncio", specifier = "~=1.3" },
     { name = "pytest-cov", specifier = "~=7.0" },
     { name = "pytest-env", specifier = "~=1.1" },

--- a/lambdas/shared/pyproject.toml
+++ b/lambdas/shared/pyproject.toml
@@ -28,7 +28,7 @@ build-backend = "uv_build"
 
 [dependency-groups]
 test = [
-    "pytest~=8.4",
+    "pytest~=9.1",
     "pytest-cov~=7.0",
     "pytest-env~=1.1",
     "pytest-mock~=3.15",

--- a/lambdas/shared/uv.lock
+++ b/lambdas/shared/uv.lock
@@ -292,7 +292,7 @@ wheels = [
 
 [[package]]
 name = "pytest"
-version = "8.4.2"
+version = "9.1.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "colorama", marker = "sys_platform == 'win32'" },
@@ -301,9 +301,9 @@ dependencies = [
     { name = "pluggy" },
     { name = "pygments" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/a3/5c/00a0e072241553e1a7496d638deababa67c5058571567b92a7eaa258397c/pytest-8.4.2.tar.gz", hash = "sha256:86c0d0b93306b961d58d62a4db4879f27fe25513d4b969df351abdddb3c30e01", size = 1519618, upload-time = "2025-09-04T14:34:22.711Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/e4/47/b9efed96c114afcfa3c9d3fe98a76a1d14c74a9e266d397cf6eb64be5e01/pytest-9.1.1.tar.gz", hash = "sha256:1088fbde8f2b49d95a549a195707afa7a76a3ce9bcadc26b6d71f0ffda5fe313", size = 1636369, upload-time = "2026-06-19T10:58:32.857Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/a8/a4/20da314d277121d6534b3a980b29035dcd51e6744bd79075a6ce8fa4eb8d/pytest-8.4.2-py3-none-any.whl", hash = "sha256:872f880de3fc3a5bdc88a11b39c9710c3497a547cfa9320bc3c5e62fbf272e79", size = 365750, upload-time = "2025-09-04T14:34:20.226Z" },
+    { url = "https://files.pythonhosted.org/packages/24/25/1de2678b631f5a49215c6c96fff41ba892b0a34df68d6d80292b1b48aa7f/pytest-9.1.1-py3-none-any.whl", hash = "sha256:37a86b45efb9a47a61a36449063e8e18d0cab3161329fc099eb21783169c4f0c", size = 386536, upload-time = "2026-06-19T10:58:31.347Z" },
 ]
 
 [[package]]
@@ -527,7 +527,7 @@ provides-extras = ["mem", "preview", "lambda"]
 [package.metadata.requires-dev]
 test = [
     { name = "py-w3c", specifier = "~=0.3.1" },
-    { name = "pytest", specifier = "~=8.4" },
+    { name = "pytest", specifier = "~=9.1" },
     { name = "pytest-cov", specifier = "~=7.0" },
     { name = "pytest-env", specifier = "~=1.1" },
     { name = "pytest-mock", specifier = "~=3.15" },

--- a/lambdas/status_reports/pyproject.toml
+++ b/lambdas/status_reports/pyproject.toml
@@ -13,7 +13,7 @@ build-backend = "uv_build"
 
 [dependency-groups]
 test = [
-    "pytest~=9.0",
+    "pytest~=9.1",
     "pytest-cov~=7.0",
     "pytest-env~=1.1",
     "pytest-mock~=3.15",

--- a/lambdas/status_reports/uv.lock
+++ b/lambdas/status_reports/uv.lock
@@ -380,7 +380,7 @@ wheels = [
 
 [[package]]
 name = "pytest"
-version = "9.0.3"
+version = "9.1.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "colorama", marker = "sys_platform == 'win32'" },
@@ -389,9 +389,9 @@ dependencies = [
     { name = "pluggy" },
     { name = "pygments" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/7d/0d/549bd94f1a0a402dc8cf64563a117c0f3765662e2e668477624baeec44d5/pytest-9.0.3.tar.gz", hash = "sha256:b86ada508af81d19edeb213c681b1d48246c1a91d304c6c81a427674c17eb91c", size = 1572165, upload-time = "2026-04-07T17:16:18.027Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/e4/47/b9efed96c114afcfa3c9d3fe98a76a1d14c74a9e266d397cf6eb64be5e01/pytest-9.1.1.tar.gz", hash = "sha256:1088fbde8f2b49d95a549a195707afa7a76a3ce9bcadc26b6d71f0ffda5fe313", size = 1636369, upload-time = "2026-06-19T10:58:32.857Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/d4/24/a372aaf5c9b7208e7112038812994107bc65a84cd00e0354a88c2c77a617/pytest-9.0.3-py3-none-any.whl", hash = "sha256:2c5efc453d45394fdd706ade797c0a81091eccd1d6e4bccfcd476e2b8e0ab5d9", size = 375249, upload-time = "2026-04-07T17:16:16.13Z" },
+    { url = "https://files.pythonhosted.org/packages/24/25/1de2678b631f5a49215c6c96fff41ba892b0a34df68d6d80292b1b48aa7f/pytest-9.1.1-py3-none-any.whl", hash = "sha256:37a86b45efb9a47a61a36449063e8e18d0cab3161329fc099eb21783169c4f0c", size = 386536, upload-time = "2026-06-19T10:58:31.347Z" },
 ]
 
 [[package]]
@@ -478,7 +478,7 @@ requires-dist = [
 
 [package.metadata.requires-dev]
 test = [
-    { name = "pytest", specifier = "~=9.0" },
+    { name = "pytest", specifier = "~=9.1" },
     { name = "pytest-cov", specifier = "~=7.0" },
     { name = "pytest-env", specifier = "~=1.1" },
     { name = "pytest-mock", specifier = "~=3.15" },

--- a/lambdas/tabular_preview/pyproject.toml
+++ b/lambdas/tabular_preview/pyproject.toml
@@ -20,7 +20,7 @@ build-backend = "uv_build"
 
 [dependency-groups]
 test = [
-    "pytest~=9.0",
+    "pytest~=9.1",
     "pytest-cov~=7.0",
     "pytest-env~=1.1",
     "pytest-mock~=3.15",

--- a/lambdas/tabular_preview/uv.lock
+++ b/lambdas/tabular_preview/uv.lock
@@ -904,7 +904,7 @@ wheels = [
 
 [[package]]
 name = "pytest"
-version = "9.0.3"
+version = "9.1.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "colorama", marker = "sys_platform == 'win32'" },
@@ -913,9 +913,9 @@ dependencies = [
     { name = "pluggy" },
     { name = "pygments" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/7d/0d/549bd94f1a0a402dc8cf64563a117c0f3765662e2e668477624baeec44d5/pytest-9.0.3.tar.gz", hash = "sha256:b86ada508af81d19edeb213c681b1d48246c1a91d304c6c81a427674c17eb91c", size = 1572165, upload-time = "2026-04-07T17:16:18.027Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/e4/47/b9efed96c114afcfa3c9d3fe98a76a1d14c74a9e266d397cf6eb64be5e01/pytest-9.1.1.tar.gz", hash = "sha256:1088fbde8f2b49d95a549a195707afa7a76a3ce9bcadc26b6d71f0ffda5fe313", size = 1636369, upload-time = "2026-06-19T10:58:32.857Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/d4/24/a372aaf5c9b7208e7112038812994107bc65a84cd00e0354a88c2c77a617/pytest-9.0.3-py3-none-any.whl", hash = "sha256:2c5efc453d45394fdd706ade797c0a81091eccd1d6e4bccfcd476e2b8e0ab5d9", size = 375249, upload-time = "2026-04-07T17:16:16.13Z" },
+    { url = "https://files.pythonhosted.org/packages/24/25/1de2678b631f5a49215c6c96fff41ba892b0a34df68d6d80292b1b48aa7f/pytest-9.1.1-py3-none-any.whl", hash = "sha256:37a86b45efb9a47a61a36449063e8e18d0cab3161329fc099eb21783169c4f0c", size = 386536, upload-time = "2026-06-19T10:58:31.347Z" },
 ]
 
 [[package]]
@@ -1298,7 +1298,7 @@ requires-dist = [
 [package.metadata.requires-dev]
 prod = [{ name = "awslambdaric", specifier = "~=3.1" }]
 test = [
-    { name = "pytest", specifier = "~=9.0" },
+    { name = "pytest", specifier = "~=9.1" },
     { name = "pytest-cov", specifier = "~=7.0" },
     { name = "pytest-env", specifier = "~=1.1" },
     { name = "pytest-mock", specifier = "~=3.15" },

--- a/lambdas/thumbnail/pyproject.toml
+++ b/lambdas/thumbnail/pyproject.toml
@@ -25,7 +25,7 @@ build-backend = "uv_build"
 
 [dependency-groups]
 test = [
-    "pytest~=9.0",
+    "pytest~=9.1",
     "pytest-cov~=7.0",
     "pytest-mock~=3.15",
     "responses~=0.25",

--- a/lambdas/thumbnail/uv.lock
+++ b/lambdas/thumbnail/uv.lock
@@ -1175,7 +1175,7 @@ wheels = [
 
 [[package]]
 name = "pytest"
-version = "9.0.3"
+version = "9.1.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "colorama", marker = "sys_platform == 'win32'" },
@@ -1184,9 +1184,9 @@ dependencies = [
     { name = "pluggy" },
     { name = "pygments" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/7d/0d/549bd94f1a0a402dc8cf64563a117c0f3765662e2e668477624baeec44d5/pytest-9.0.3.tar.gz", hash = "sha256:b86ada508af81d19edeb213c681b1d48246c1a91d304c6c81a427674c17eb91c", size = 1572165, upload-time = "2026-04-07T17:16:18.027Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/e4/47/b9efed96c114afcfa3c9d3fe98a76a1d14c74a9e266d397cf6eb64be5e01/pytest-9.1.1.tar.gz", hash = "sha256:1088fbde8f2b49d95a549a195707afa7a76a3ce9bcadc26b6d71f0ffda5fe313", size = 1636369, upload-time = "2026-06-19T10:58:32.857Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/d4/24/a372aaf5c9b7208e7112038812994107bc65a84cd00e0354a88c2c77a617/pytest-9.0.3-py3-none-any.whl", hash = "sha256:2c5efc453d45394fdd706ade797c0a81091eccd1d6e4bccfcd476e2b8e0ab5d9", size = 375249, upload-time = "2026-04-07T17:16:16.13Z" },
+    { url = "https://files.pythonhosted.org/packages/24/25/1de2678b631f5a49215c6c96fff41ba892b0a34df68d6d80292b1b48aa7f/pytest-9.1.1-py3-none-any.whl", hash = "sha256:37a86b45efb9a47a61a36449063e8e18d0cab3161329fc099eb21783169c4f0c", size = 386536, upload-time = "2026-06-19T10:58:31.347Z" },
 ]
 
 [[package]]
@@ -1528,7 +1528,7 @@ requires-dist = [
 [package.metadata.requires-dev]
 prod = [{ name = "awslambdaric", specifier = "~=3.1" }]
 test = [
-    { name = "pytest", specifier = "~=9.0" },
+    { name = "pytest", specifier = "~=9.1" },
     { name = "pytest-cov", specifier = "~=7.0" },
     { name = "pytest-mock", specifier = "~=3.15" },
     { name = "quilt3", specifier = "~=7.0" },

--- a/lambdas/transcode/pyproject.toml
+++ b/lambdas/transcode/pyproject.toml
@@ -12,7 +12,7 @@ build-backend = "uv_build"
 
 [dependency-groups]
 test = [
-    "pytest~=9.0",
+    "pytest~=9.1",
     "pytest-cov~=7.0",
     "pytest-env~=1.1",
     "pytest-mock~=3.15",

--- a/lambdas/transcode/uv.lock
+++ b/lambdas/transcode/uv.lock
@@ -120,7 +120,7 @@ wheels = [
 
 [[package]]
 name = "pytest"
-version = "9.0.3"
+version = "9.1.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "colorama", marker = "sys_platform == 'win32'" },
@@ -129,9 +129,9 @@ dependencies = [
     { name = "pluggy" },
     { name = "pygments" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/7d/0d/549bd94f1a0a402dc8cf64563a117c0f3765662e2e668477624baeec44d5/pytest-9.0.3.tar.gz", hash = "sha256:b86ada508af81d19edeb213c681b1d48246c1a91d304c6c81a427674c17eb91c", size = 1572165, upload-time = "2026-04-07T17:16:18.027Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/e4/47/b9efed96c114afcfa3c9d3fe98a76a1d14c74a9e266d397cf6eb64be5e01/pytest-9.1.1.tar.gz", hash = "sha256:1088fbde8f2b49d95a549a195707afa7a76a3ce9bcadc26b6d71f0ffda5fe313", size = 1636369, upload-time = "2026-06-19T10:58:32.857Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/d4/24/a372aaf5c9b7208e7112038812994107bc65a84cd00e0354a88c2c77a617/pytest-9.0.3-py3-none-any.whl", hash = "sha256:2c5efc453d45394fdd706ade797c0a81091eccd1d6e4bccfcd476e2b8e0ab5d9", size = 375249, upload-time = "2026-04-07T17:16:16.13Z" },
+    { url = "https://files.pythonhosted.org/packages/24/25/1de2678b631f5a49215c6c96fff41ba892b0a34df68d6d80292b1b48aa7f/pytest-9.1.1-py3-none-any.whl", hash = "sha256:37a86b45efb9a47a61a36449063e8e18d0cab3161329fc099eb21783169c4f0c", size = 386536, upload-time = "2026-06-19T10:58:31.347Z" },
 ]
 
 [[package]]
@@ -268,7 +268,7 @@ requires-dist = [{ name = "t4-lambda-shared", url = "https://github.com/quiltdat
 
 [package.metadata.requires-dev]
 test = [
-    { name = "pytest", specifier = "~=9.0" },
+    { name = "pytest", specifier = "~=9.1" },
     { name = "pytest-cov", specifier = "~=7.0" },
     { name = "pytest-env", specifier = "~=1.1" },
     { name = "pytest-mock", specifier = "~=3.15" },

--- a/py-shared/pyproject.toml
+++ b/py-shared/pyproject.toml
@@ -31,7 +31,7 @@ es = [
 
 [dependency-groups]
 test = [
-    "pytest~=8.4",
+    "pytest~=9.1",
     "pytest-cov~=6.2",
     "pytest-env~=1.1",
     "pytest-mock~=3.15",

--- a/py-shared/uv.lock
+++ b/py-shared/uv.lock
@@ -432,7 +432,7 @@ wheels = [
 
 [[package]]
 name = "pytest"
-version = "8.4.2"
+version = "9.1.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "colorama", marker = "sys_platform == 'win32'" },
@@ -441,9 +441,9 @@ dependencies = [
     { name = "pluggy" },
     { name = "pygments" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/a3/5c/00a0e072241553e1a7496d638deababa67c5058571567b92a7eaa258397c/pytest-8.4.2.tar.gz", hash = "sha256:86c0d0b93306b961d58d62a4db4879f27fe25513d4b969df351abdddb3c30e01", size = 1519618, upload-time = "2025-09-04T14:34:22.711Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/e4/47/b9efed96c114afcfa3c9d3fe98a76a1d14c74a9e266d397cf6eb64be5e01/pytest-9.1.1.tar.gz", hash = "sha256:1088fbde8f2b49d95a549a195707afa7a76a3ce9bcadc26b6d71f0ffda5fe313", size = 1636369, upload-time = "2026-06-19T10:58:32.857Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/a8/a4/20da314d277121d6534b3a980b29035dcd51e6744bd79075a6ce8fa4eb8d/pytest-8.4.2-py3-none-any.whl", hash = "sha256:872f880de3fc3a5bdc88a11b39c9710c3497a547cfa9320bc3c5e62fbf272e79", size = 365750, upload-time = "2025-09-04T14:34:20.226Z" },
+    { url = "https://files.pythonhosted.org/packages/24/25/1de2678b631f5a49215c6c96fff41ba892b0a34df68d6d80292b1b48aa7f/pytest-9.1.1-py3-none-any.whl", hash = "sha256:37a86b45efb9a47a61a36449063e8e18d0cab3161329fc099eb21783169c4f0c", size = 386536, upload-time = "2026-06-19T10:58:31.347Z" },
 ]
 
 [[package]]
@@ -591,7 +591,7 @@ provides-extras = ["pydantic", "boto", "quilt", "es"]
 
 [package.metadata.requires-dev]
 test = [
-    { name = "pytest", specifier = "~=8.4" },
+    { name = "pytest", specifier = "~=9.1" },
     { name = "pytest-cov", specifier = "~=6.2" },
     { name = "pytest-env", specifier = "~=1.1" },
     { name = "pytest-mock", specifier = "~=3.15" },

--- a/testdocs/pyproject.toml
+++ b/testdocs/pyproject.toml
@@ -6,10 +6,10 @@ readme = "README.md"
 requires-python = "==3.10.*"
 dependencies = [
     "quilt3",
-    "pytest-codeblocks~=0.16.1",
+    "pytest-codeblocks~=0.18.0",
     "altair~=4.2",
     "pandas~=2.0",
-    "pytest~=7.1",
+    "pytest~=9.1",
 ]
 
 [tool.uv.sources]

--- a/testdocs/uv.lock
+++ b/testdocs/uv.lock
@@ -364,8 +364,17 @@ wheels = [
 ]
 
 [[package]]
+name = "pygments"
+version = "2.20.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/c3/b2/bc9c9196916376152d655522fdcebac55e66de6603a76a02bca1b6414f6c/pygments-2.20.0.tar.gz", hash = "sha256:6757cd03768053ff99f3039c1a36d6c0aa0b263438fcab17520b30a303a82b5f", size = 4955991, upload-time = "2026-03-29T13:29:33.898Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f4/7e/a72dd26f3b0f4f2bf1dd8923c85f7ceb43172af56d63c7383eb62b332364/pygments-2.20.0-py3-none-any.whl", hash = "sha256:81a9e26dd42fd28a23a2d169d86d7ac03b46e2f8b59ed4698fb4785f946d0176", size = 1231151, upload-time = "2026-03-29T13:29:30.038Z" },
+]
+
+[[package]]
 name = "pytest"
-version = "7.4.4"
+version = "9.1.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "colorama", marker = "sys_platform == 'win32'" },
@@ -373,23 +382,23 @@ dependencies = [
     { name = "iniconfig" },
     { name = "packaging" },
     { name = "pluggy" },
+    { name = "pygments" },
     { name = "tomli" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/80/1f/9d8e98e4133ffb16c90f3b405c43e38d3abb715bb5d7a63a5a684f7e46a3/pytest-7.4.4.tar.gz", hash = "sha256:2cf0005922c6ace4a3e2ec8b4080eb0d9753fdc93107415332f50ce9e7994280", size = 1357116, upload-time = "2023-12-31T12:00:18.035Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/e4/47/b9efed96c114afcfa3c9d3fe98a76a1d14c74a9e266d397cf6eb64be5e01/pytest-9.1.1.tar.gz", hash = "sha256:1088fbde8f2b49d95a549a195707afa7a76a3ce9bcadc26b6d71f0ffda5fe313", size = 1636369, upload-time = "2026-06-19T10:58:32.857Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/51/ff/f6e8b8f39e08547faece4bd80f89d5a8de68a38b2d179cc1c4490ffa3286/pytest-7.4.4-py3-none-any.whl", hash = "sha256:b090cdf5ed60bf4c45261be03239c2c1c22df034fbffe691abe93cd80cea01d8", size = 325287, upload-time = "2023-12-31T12:00:13.963Z" },
+    { url = "https://files.pythonhosted.org/packages/24/25/1de2678b631f5a49215c6c96fff41ba892b0a34df68d6d80292b1b48aa7f/pytest-9.1.1-py3-none-any.whl", hash = "sha256:37a86b45efb9a47a61a36449063e8e18d0cab3161329fc099eb21783169c4f0c", size = 386536, upload-time = "2026-06-19T10:58:31.347Z" },
 ]
 
 [[package]]
 name = "pytest-codeblocks"
-version = "0.16.2"
+version = "0.18.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "pytest" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/ba/f5/847eb4a320600d917b38832eaa287a872abc96681cb0cb91282f536bc077/pytest_codeblocks-0.16.2.tar.gz", hash = "sha256:fd4c1c913a49df4c8f107728418e7ffb454be0f2676ea6e972eb77ae03c6c373", size = 11155, upload-time = "2023-09-17T19:04:57.584Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/05/2d/715bece123dcd0424305633a67acca192f6adb71e4a7c0b332e3ed32187d/pytest_codeblocks-0.16.2-py3-none-any.whl", hash = "sha256:488726753a34583b5263a1518ae57d87543b8384e5e46c652e2779d9bd0e40bf", size = 7739, upload-time = "2023-09-17T19:04:55.925Z" },
+    { url = "https://files.pythonhosted.org/packages/3a/cb/5f40df7db75c0ac2555009287bb97b322f8d79f9f2bfdfb0bdb560834c28/pytest_codeblocks-0.18.0-py3-none-any.whl", hash = "sha256:3fe944dc505107421204c83e9232e0155eea1279b9425a10bee327079b272efb", size = 8009, upload-time = "2026-06-15T20:48:02.608Z" },
 ]
 
 [[package]]
@@ -474,7 +483,7 @@ provides-extras = ["pyarrow", "anndata", "catalog"]
 [package.metadata.requires-dev]
 dev = [
     { name = "poethepoet", specifier = ">=0.37.0" },
-    { name = "pytest", specifier = "~=8.4" },
+    { name = "pytest", specifier = "~=9.1" },
     { name = "pytest-cov" },
     { name = "pytest-env" },
     { name = "pytest-subtests" },
@@ -605,8 +614,8 @@ dependencies = [
 requires-dist = [
     { name = "altair", specifier = "~=4.2" },
     { name = "pandas", specifier = "~=2.0" },
-    { name = "pytest", specifier = "~=7.1" },
-    { name = "pytest-codeblocks", specifier = "~=0.16.1" },
+    { name = "pytest", specifier = "~=9.1" },
+    { name = "pytest-codeblocks", specifier = "~=0.18.0" },
     { name = "quilt3", editable = "../api/python" },
 ]
 


### PR DESCRIPTION
# Description

Update pytest to the latest release (**9.1.1**) across all Python components.

- Bump the pytest floor to `~=9.1` in all 17 components (previously a mix of `~=9.0`, `~=8.4`, `~=7.1`) and refresh every `uv.lock` to pytest 9.1.1.
- Bump `pytest-codeblocks` to `~=0.18.0` in `testdocs`: the previously pinned 0.16.x uses the `path` argument in the `pytest_collect_file` hook, which pytest 9 removed — without this, doc collection crashes with a `PluginValidationError`.
- Migrate the remaining deprecated `<!-- pytest-codeblocks:skip -->` doc comments to `<!-- pytest.mark.skip -->` (the rest of the docs already use the new form, so this finishes an in-progress migration). `:skipfile`, `:cont`, and `:importorskip` are not deprecated and are left as-is.

Verified pytest 9.1.1 against the suites that crossed a major version: `api/python` (547 passed), `py-shared` (32), `lambdas/shared` (22), `lambdas/access_counts` (1); `testdocs` collects 107 code blocks with no deprecation warnings.

# TODO

- [x] Unit tests — existing suites pass on pytest 9.1.1
- [ ] Changelog entry — N/A (dev/test dependency bump + docs-comment migration; not significant to end users)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR standardizes pytest to 9.1.1 across all 17 Python components in the monorepo and applies two compatibility fixes needed to use pytest 9 with the documentation test suite.

- **pytest version alignment**: All components (`api/python`, `py-shared`, all lambda packages) move from a mix of `~=7.1`, `~=8.4`, and `~=9.0` floor versions to a uniform `~=9.1`, with `uv.lock` files refreshed to resolve 9.1.1.
- **testdocs compatibility**: `pytest-codeblocks` is bumped from `~=0.16.1` to `~=0.18.0` to fix a `PluginValidationError` caused by the removal of the `path` argument in pytest 9's `pytest_collect_file` hook; `pytest` itself jumps from `~=7.1` to `~=9.1`.
- **Doc comment migration**: `<!-- pytest-codeblocks:skip -->` directives (the deprecated per-block form) are updated to `<!-- pytest.mark.skip -->` across five documentation files; the non-deprecated `skipfile`, `cont`, and `importorskip` variants are correctly left unchanged.

<h3>Confidence Score: 5/5</h3>

Safe to merge — all changes are dev/test dependency bumps and doc-comment syntax updates with no effect on production runtime behaviour.

Every changed file is either a pyproject.toml/uv.lock updating a test-only dependency, or a Markdown doc migrating a deprecated pytest-codeblocks comment directive. The pytest-codeblocks upgrade from 0.16.x to 0.18.0 directly fixes the collection crash the PR describes. The testdocs lock file confirms pytest 9.1.1 and pytest-codeblocks 0.18.0 resolved correctly. All remaining pytest-codeblocks:skip occurrences in the docs are the non-deprecated skipfile variant and are intentionally left unchanged. No production code paths are touched.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| testdocs/pyproject.toml | Bumps pytest from ~=7.1 to ~=9.1 and pytest-codeblocks from ~=0.16.1 to ~=0.18.0; both changes are required together to fix the PluginValidationError from the removed path argument in pytest 9's collect hook. |
| api/python/pyproject.toml | Bumps pytest floor from ~=8.4 to ~=9.1; straightforward minor-version bump, no other changes. |
| py-shared/pyproject.toml | Bumps pytest from ~=8.4 to ~=9.1; no other changes. |
| lambdas/shared/pyproject.toml | Bumps pytest from ~=8.4 to ~=9.1; no other changes. |
| docs/api-reference/authentication.md | Migrates 20 occurrences of the deprecated pytest-codeblocks:skip directive to pytest.mark.skip; no content changes. |
| docs/CrossAccount.md | Migrates 9 pytest-codeblocks:skip directives to pytest.mark.skip; no content changes. |
| docs/EventBridge.md | Migrates 4 pytest-codeblocks:skip directives to pytest.mark.skip; no content changes. |
| docs/MentalModel.md | Migrates 1 pytest-codeblocks:skip directive to pytest.mark.skip; no content changes. |
| docs/Quickstart.md | Migrates 1 pytest-codeblocks:skip directive to pytest.mark.skip; no content changes. |

</details>

<h3>Flowchart</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[pytest 9.1.1 invoked] --> B{pytest-codeblocks plugin}
    B -->|0.16.x — uses removed 'path' arg| C[PluginValidationError\ncollection crash]
    B -->|0.18.0 — uses new 'fspath_or_path' API| D[Plugin loads successfully]
    D --> E[Collect .md files]
    E --> F{Code block directive}
    F -->|pytest-codeblocks:skip DEPRECATED| G[DeprecationWarning / future break]
    F -->|pytest.mark.skip NEW FORM| H[Block skipped cleanly]
    F -->|pytest-codeblocks:skipfile\npytest-codeblocks:cont\npytest-codeblocks:importorskip| I[Not deprecated — left as-is]
    H --> J[107 blocks collected, 0 warnings]
    I --> J
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A[pytest 9.1.1 invoked] --> B{pytest-codeblocks plugin}
    B -->|0.16.x — uses removed 'path' arg| C[PluginValidationError\ncollection crash]
    B -->|0.18.0 — uses new 'fspath_or_path' API| D[Plugin loads successfully]
    D --> E[Collect .md files]
    E --> F{Code block directive}
    F -->|pytest-codeblocks:skip DEPRECATED| G[DeprecationWarning / future break]
    F -->|pytest.mark.skip NEW FORM| H[Block skipped cleanly]
    F -->|pytest-codeblocks:skipfile\npytest-codeblocks:cont\npytest-codeblocks:importorskip| I[Not deprecated — left as-is]
    H --> J[107 blocks collected, 0 warnings]
    I --> J
```

</a>

<sub>Reviews (1): Last reviewed commit: ["build: update pytest to 9.1.1 across all..."](https://github.com/quiltdata/quilt/commit/b6b8a9d310bc1f55404f939962d3a4a43fb36244) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=39225367)</sub>

<!-- /greptile_comment -->