### PR TITLE
Catalog: bump effect 3.14.13 → 3.21.4

### DIFF
--- a/catalog/app/components/Assistant/Model/Conversation.spec.ts
+++ b/catalog/app/components/Assistant/Model/Conversation.spec.ts
@@ -52,21 +52,20 @@ const makeContextStub = (): {
 })
 
 /**
- * LLM stub — `converse` returns the provided response. The deferred
- * lets tests notice when the LLM was actually invoked. The only stable
- * shape we need from the response is `content: Option.Option<[]>` and
- * the BedrockRuntime envelope — we minimally satisfy both with `[]`.
+ * LLM stub — `converse` signals via the deferred that it was invoked, then
+ * suspends. A real `converse` is an async round-trip, so the conversation
+ * stays in `WaitingForAssistant` (an observable state) for the duration. If
+ * the stub returned synchronously instead, the actor would fall straight back
+ * to Idle and effect's scheduler would coalesce the transient
+ * `WaitingForAssistant` out of `state.changes` before any observer saw it.
+ * Tests that need the response delivered gate their own stub (see below).
  */
-const makeLLMStub = (next: Eff.Deferred.Deferred<unknown>): LLM.LLM['Type'] => ({
+const makeLLMStub = (called: Eff.Deferred.Deferred<unknown>): LLM.LLM['Type'] => ({
   converse: () =>
     Eff.Effect.gen(function* () {
-      yield* Eff.Deferred.succeed(next, undefined)
-      return {
-        // Force at least one content block so the actor doesn't error;
-        // empty content array is the simplest valid shape.
-        content: Eff.Option.some([]),
-        backendResponse: {} as never,
-      }
+      yield* Eff.Deferred.succeed(called, undefined)
+      yield* Eff.Effect.never
+      return { content: Eff.Option.some([]), backendResponse: {} as never }
     }),
 })
 
@@ -302,6 +301,7 @@ describe('Conversation actor — connector gating', () => {
         Eff.Effect.gen(function* () {
           const isBlockedRef = yield* Eff.SubscriptionRef.make(false)
           const executorRan = yield* Eff.Deferred.make<void>()
+          const responded = yield* Eff.Ref.make(false)
 
           const connectorTool: Tool.Descriptor<Record<string, unknown>> = {
             schema: {} as Eff.JSONSchema.JsonSchema7Root,
@@ -324,15 +324,24 @@ describe('Conversation actor — connector gating', () => {
           }
           const llm: LLM.LLM['Type'] = {
             converse: () =>
-              Eff.Effect.succeed({
-                content: Eff.Option.some([
-                  Content.ResponseMessageContentBlock.ToolUse({
-                    toolUseId: 'tu1',
-                    name: 'c1__t1',
-                    input: {},
-                  }),
-                ]),
-                backendResponse: {} as never,
+              Eff.Effect.gen(function* () {
+                // Issue the tool-use once. On the follow-up round (after the
+                // ToolResult) respond with no tools so the conversation
+                // settles, instead of looping converse → ToolUse → converse
+                // forever.
+                if (yield* Eff.Ref.getAndSet(responded, true)) {
+                  return { content: Eff.Option.some([]), backendResponse: {} as never }
+                }
+                return {
+                  content: Eff.Option.some([
+                    Content.ResponseMessageContentBlock.ToolUse({
+                      toolUseId: 'tu1',
+                      name: 'c1__t1',
+                      input: {},
+                    }),
+                  ]),
+                  backendResponse: {} as never,
+                }
               }),
           }
           const layer = Eff.Layer.mergeAll(

--- a/catalog/app/components/Assistant/Model/Tool.ts
+++ b/catalog/app/components/Assistant/Model/Tool.ts
@@ -46,8 +46,10 @@ function convertSchema(schema: any) {
   // Process object properties recursively
   Object.values(schema).forEach(convertSchema)
 
-  // Replace empty schema IDs produced by Effect, which are not valid according to draft-2020
-  if (schema.$id === '/schemas/{}') schema.$id = '/schemas/empty'
+  // Replace empty schema IDs produced by Effect, which are not valid according to draft-2020.
+  // Effect <3.18 emitted the raw `/schemas/{}`; >=3.18 percent-encodes it as `/schemas/%7B%7D`.
+  if (schema.$id === '/schemas/{}' || schema.$id === '/schemas/%7B%7D')
+    schema.$id = '/schemas/empty'
 
   // Handle items and additionalItems conversion for draft-2020
   if (Array.isArray(schema.items)) {

--- a/catalog/app/containers/Bucket/Routes.spec.ts
+++ b/catalog/app/containers/Bucket/Routes.spec.ts
@@ -3,17 +3,8 @@ import { describe, it, expect } from 'vitest'
 
 import { s3Object, s3Prefix } from './Routes'
 
-/**
- * Round-trip guard for the S3 object/prefix routes: a `path` param decoded out
- * of a URL must encode back to the same URL (and vice-versa). This pins the
- * effect-Schema <-> path-to-regexp encoding seam that the effect 3.21 bump
- * touched (branded `S3Path`, non-strict `fromPathParams`).
- *
- * Scope: the byte classes that real S3 keys hit — spaces, URI-significant
- * characters (`#`, `?`), non-ASCII, and nested/trailing slashes. The point is
- * to cover what the catalog actually needs, not every theoretically-valid key;
- * the known boundary is encoded explicitly at the bottom of this file.
- */
+// Round-trip guard for the S3 routes: a `path` decoded out of a URL must encode
+// back to the same URL, across the byte classes real S3 keys hit.
 
 const roundTrip =
   (route: { paramsSchema: S.Schema<any, any> }) =>
@@ -54,19 +45,15 @@ describe('Bucket S3 routes: path encoding', () => {
     })
   })
 
-  // BOUNDARY (known, pre-existing — not introduced by the effect 3.21 bump):
-  // a literal `%` in a key is not round-trip-safe, because the URL->params path
-  // decodes twice (path-to-regexp's matcher, then `S3PathFromString.decode`)
-  // against a single encode. `%`+hex silently corrupts (`a%41b` -> `aAb`) and
-  // `%`+non-hex throws. Tracked in qhq-yoxv. These are written as expected
-  // failures asserting the *desired* round-trip: they pass today (the body
-  // fails) and flip RED the day the seam is fixed, prompting their removal —
-  // rather than pinning the corrupt output as a green contract.
-  it.fails('round-trips a literal "%" + hex key (xfail until qhq-yoxv)', () => {
+  // Known limitation: a literal `%` in a key is not round-trip-safe — the
+  // URL->params path decodes twice (path-to-regexp's matcher, then
+  // `S3PathFromString`) against a single encode. Asserted as the desired
+  // round-trip via `it.fails`, so it flips red if the seam is ever fixed.
+  it.fails('round-trips a literal "%" + hex key', () => {
     expect(objectRoundTrip('a%41b.txt')).toBe('a%41b.txt')
   })
 
-  it.fails('round-trips a literal "%" + non-hex key (xfail until qhq-yoxv)', () => {
+  it.fails('round-trips a literal "%" + non-hex key', () => {
     expect(objectRoundTrip('a%zz.txt')).toBe('a%zz.txt')
   })
 })

--- a/catalog/app/containers/Bucket/Routes.spec.ts
+++ b/catalog/app/containers/Bucket/Routes.spec.ts
@@ -1,0 +1,72 @@
+import { Schema as S } from 'effect'
+import { describe, it, expect } from 'vitest'
+
+import { s3Object, s3Prefix } from './Routes'
+
+/**
+ * Round-trip guard for the S3 object/prefix routes: a `path` param decoded out
+ * of a URL must encode back to the same URL (and vice-versa). This pins the
+ * effect-Schema <-> path-to-regexp encoding seam that the effect 3.21 bump
+ * touched (branded `S3Path`, non-strict `fromPathParams`).
+ *
+ * Scope: the byte classes that real S3 keys hit — spaces, URI-significant
+ * characters (`#`, `?`), non-ASCII, and nested/trailing slashes. The point is
+ * to cover what the catalog actually needs, not every theoretically-valid key;
+ * the known boundary is encoded explicitly at the bottom of this file.
+ */
+
+const roundTrip =
+  (route: { paramsSchema: S.Schema<any, any> }) =>
+  (path: string): string => {
+    const loc = S.encodeSync(route.paramsSchema)({ bucket: 'b', path } as any)
+    return (S.decodeSync(route.paramsSchema)(loc) as { path: string }).path
+  }
+
+const objectRoundTrip = roundTrip(s3Object)
+const prefixRoundTrip = roundTrip(s3Prefix)
+
+describe('Bucket S3 routes: path encoding', () => {
+  // Encoding is per-segment: URI-significant bytes are percent-encoded, but the
+  // `/` separators are preserved so multi-segment keys still match `:path`.
+  it('percent-encodes per segment and preserves separators', () => {
+    const { pathname } = S.encodeSync(s3Object.paramsSchema)({
+      bucket: 'b',
+      path: 'with space/and#hash/q?uery.txt',
+    } as any) as { pathname: string }
+    expect(pathname).toBe('/b/b/tree/with%20space/and%23hash/q%3Fuery.txt')
+  })
+
+  describe('object keys round-trip', () => {
+    it.each([
+      'plain/key.txt',
+      'a/b/c/deep.csv',
+      'with space/and#hash/q?uery.txt',
+      'unicode/имя/файл.txt',
+      'has+plus and&amp.txt',
+    ])('%s', (path) => {
+      expect(objectRoundTrip(path)).toBe(path)
+    })
+  })
+
+  describe('prefix keys round-trip', () => {
+    it.each(['some dir/sub dir/', 'q?#/x/'])('%s', (path) => {
+      expect(prefixRoundTrip(path)).toBe(path)
+    })
+  })
+
+  // BOUNDARY (known, pre-existing — not introduced by the effect 3.21 bump):
+  // a literal `%` in a key is not round-trip-safe, because the URL->params path
+  // decodes twice (path-to-regexp's matcher, then `S3PathFromString.decode`)
+  // against a single encode. `%`+hex silently corrupts (`a%41b` -> `aAb`) and
+  // `%`+non-hex throws. Tracked in qhq-yoxv. These are written as expected
+  // failures asserting the *desired* round-trip: they pass today (the body
+  // fails) and flip RED the day the seam is fixed, prompting their removal —
+  // rather than pinning the corrupt output as a green contract.
+  it.fails('round-trips a literal "%" + hex key (xfail until qhq-yoxv)', () => {
+    expect(objectRoundTrip('a%41b.txt')).toBe('a%41b.txt')
+  })
+
+  it.fails('round-trips a literal "%" + non-hex key (xfail until qhq-yoxv)', () => {
+    expect(objectRoundTrip('a%zz.txt')).toBe('a%zz.txt')
+  })
+})

--- a/catalog/app/containers/Bucket/Routes.ts
+++ b/catalog/app/containers/Bucket/Routes.ts
@@ -50,7 +50,9 @@ const PATH_SEP = '/'
 const mapSegments = (separator: string, map: (s: string) => string) =>
   Eff.flow(Eff.String.split(separator), Eff.Array.map(map), Eff.Array.join(separator))
 
-const S3Path = S.brand('S3Path')(S.String)
+// NB: use the piped form; effect >=3.18 infers a non-`never` schema Context
+// for the curried `S.brand('S3Path')(S.String)`, which breaks `fromPathParams`.
+const S3Path = S.String.pipe(S.brand('S3Path'))
 
 const S3PathFromString = (S3PathSchema: typeof S3Path) =>
   S.transform(S.String, S3PathSchema, {

--- a/catalog/app/utils/Navigation.ts
+++ b/catalog/app/utils/Navigation.ts
@@ -45,8 +45,16 @@ export const PathParams = S.Record({
 // eslint-disable-next-line @typescript-eslint/no-redeclare
 export type PathParams = typeof PathParams.Type
 
-export const fromPathParams = <T extends typeof PathParams.Type>(schema: S.Schema<T>) =>
+export const fromPathParams = <
+  A extends typeof PathParams.Type,
+  I extends typeof PathParams.Type,
+>(
+  schema: S.Schema<A, I>,
+) =>
   S.transformOrFail(PathParams, schema, {
+    // non-strict: decoded params may be branded/refined subtypes of the raw
+    // string-record encoding (e.g. S3Path), so the identity encode widens.
+    strict: false,
     encode: (toI) => Eff.Effect.succeed(toI),
     decode: (fromA, _parseOptions, ast) =>
       Eff.pipe(

--- a/catalog/package-lock.json
+++ b/catalog/package-lock.json
@@ -37,7 +37,7 @@
         "diff": "^8.0.2",
         "dompurify": "^3.2.5",
         "echarts": "^5.5.0",
-        "effect": "^3.14.13",
+        "effect": "^3.21.4",
         "final-form": "^4.20.9",
         "fontfaceobserver": "^2.3.0",
         "fp-ts": "^2.16.1",
@@ -8849,9 +8849,9 @@
       "dev": true
     },
     "node_modules/effect": {
-      "version": "3.14.13",
-      "resolved": "https://registry.npmjs.org/effect/-/effect-3.14.13.tgz",
-      "integrity": "sha512-mQgZx8xgzHK86J5O0J5pmMs23U5ylkX/+JkfzTkRjCK0kK4L0PSYTaNAqlJZV6IA5uUIvysK5D+pCqqoXbAQnQ==",
+      "version": "3.21.4",
+      "resolved": "https://registry.npmjs.org/effect/-/effect-3.21.4.tgz",
+      "integrity": "sha512-B89v/xSgPbl1J2Ai2u18jxq3odpFauU1rC6/eSs4FeNHi72kwKdJp12VGigvRV2lK+kRnx+OOz41XV8guZd4gQ==",
       "license": "MIT",
       "dependencies": {
         "@standard-schema/spec": "^1.0.0",

--- a/catalog/package.json
+++ b/catalog/package.json
@@ -74,7 +74,7 @@
     "diff": "^8.0.2",
     "dompurify": "^3.2.5",
     "echarts": "^5.5.0",
-    "effect": "^3.14.13",
+    "effect": "^3.21.4",
     "final-form": "^4.20.9",
     "fontfaceobserver": "^2.3.0",
     "fp-ts": "^2.16.1",


### PR DESCRIPTION
Bumps `effect` from 3.14.13 to **3.21.4** (latest), covering the security advisory behind Renovate #4928.

**This is not a lockfile-only bump.** effect ≥3.18 changed JSON-Schema emission, Schema type inference, and fiber scheduling, so the bot PRs (#4779 @3.21.0, #4928 @3.20.0) — which touch only `package.json`/`package-lock.json` — would fail CI. This PR includes the required source + test fixes.

### Source fixes

| File | Change in effect ≥3.18 | Fix |
|------|------------------------|-----|
| `app/components/Assistant/Model/Tool.ts` | Empty-schema `$id` is now percent-encoded `/schemas/%7B%7D` (was the raw, draft-2020-invalid `/schemas/{}`), slipping past the sanitizer | Extend the condition to normalize both forms to `/schemas/empty` — restores the existing `navigation.spec` snapshot, no `-u` needed |
| `app/containers/Bucket/Routes.ts` | Curried `S.brand('S3Path')(S.String)` now infers a non-`never` schema `Context`, breaking `fromPathParams` | Switch to the idiomatic piped form `S.String.pipe(S.brand('S3Path'))` |
| `app/utils/Navigation.ts` | With the brand correctly propagating, a route's decoded params (branded) no longer match their string-record encoding | Widen `fromPathParams` to `<A, I>` and mark the identity `transformOrFail` non-strict (runtime-identical — brands are type-only) |

### Test fixes

- **`app/containers/Bucket/Routes.spec.ts` (new)** — round-trip guard for the real `s3Object`/`s3Prefix` routes over realistic S3 keys (spaces, `#`, `?`, non-ASCII, nested/trailing slashes), pinning the effect-Schema ↔ path-to-regexp encoding seam. Encoding is **per-segment** and `/` separators are preserved, so multi-segment keys still match `:path`.
- **`app/components/Assistant/Model/Conversation.spec.ts`** — effect 3.21's fiber scheduling change made two pre-existing specs hang, which ran the CI `test-catalog` job ~33 min before an out-of-memory crash. Both fixes are **test-only** (the Conversation actor and all product code are unchanged):
  - The LLM stub now signals it was invoked, then suspends instead of resolving synchronously — a real `converse` is an async round-trip, so the conversation stays in the observable `WaitingForAssistant` state. A synchronous resolve collapsed `Idle → WaitingForAssistant → Idle` so fast that `SubscriptionRef.changes` coalesced the transient state before any observer saw it.
  - A stub that re-issued the *same* `ToolUse` every round (an infinite `converse → ToolUse → ToolResult → converse` loop, previously cut short only by teardown) now returns the tool-use once, then settles. Under 3.21 the tight synchronous loop starved the observer and grew `events` without bound → the OOM.

### Verification

- `tsc --noEmit --skipLibCheck` clean (matches CI's `ForkTsCheckerWebpackPlugin` typecheck during `npm run build`).
- CI `test-catalog` green (~5 min; previously hung ~33 min → OOM before the Conversation fix). Full local suite passes apart from pre-existing Node-26-only `@testing-library/react-hooks` flakes in Athena Queries (unrelated; green on CI's Node 20).
- Routing round-trip baselined **byte-identical** against master + effect 3.14.13, confirming `strict: false` changes no runtime behavior and all three source fixes address genuine 3.21 regressions.

**Known boundary (pre-existing, unchanged by this PR):** a literal `%` in an S3 key isn't round-trip-safe — the URL→params path decodes twice (`path-to-regexp`'s matcher, then `S3PathFromString.decode`) against a single encode. Pinned as `it.fails` xfail tests so it surfaces the day the seam is fixed; tracked separately. This is the edge case Greptile originally flagged — see the resolved inline thread for the full analysis.

Supersedes #4779 and #4928.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR bumps `effect` and updates the affected catalog code paths.

- Upgrades `effect` from 3.14.13 to 3.21.4.
- Normalizes both old and new empty-schema `$id` formats.
- Updates branded S3 route schemas for newer Effect inference.
- Adds S3 object and prefix route round-trip tests.
- Adjusts assistant conversation tests for the newer scheduler behavior.

<h3>Confidence Score: 5/5</h3>

This looks safe to merge.

- No blocking issues found in the changed code.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| catalog/app/utils/Navigation.ts | Widens route param schema typing and keeps runtime path param encoding behavior aligned with the existing route flow. |
| catalog/app/containers/Bucket/Routes.ts | Switches the S3 path brand to the piped Effect Schema form used by the upgraded dependency. |
| catalog/app/containers/Bucket/Routes.spec.ts | Adds focused route round-trip coverage for S3 object and prefix paths. |
| catalog/app/components/Assistant/Model/Tool.ts | Extends empty-schema `$id` cleanup to handle the percent-encoded format emitted by newer Effect versions. |
| catalog/app/components/Assistant/Model/Conversation.spec.ts | Updates the test LLM stubs so observable conversation states are preserved under the newer scheduler. |
| catalog/package.json | Updates the direct `effect` dependency version. |
| catalog/package-lock.json | Locks the upgraded `effect` package version and integrity metadata. |

<sub>Reviews (2): Last reviewed commit: ["test(catalog): fix Conversation actor sp..."](https://github.com/quiltdata/quilt/commit/d10d66da8ac77aed5524c77b26a5e8957d4fba3f) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=40064961)</sub>

<!-- /greptile_comment -->
