### PR TITLE
catalog: move JS toolchain to Node 26 + npm 11

### DIFF
--- a/catalog/app/containers/Bucket/Queries/Athena/model/requests.spec.ts
+++ b/catalog/app/containers/Bucket/Queries/Athena/model/requests.spec.ts
@@ -1093,10 +1093,8 @@ describe('containers/Bucket/Queries/Athena/model/requests', () => {
         }),
       )
       try {
-        // database is not ready, so the mount effect leaves value `undefined`
-        // (undefined -> undefined: no re-render). Flush effects, then assert —
-        // there is no "next update" to wait for.
-        await act(async () => {})
+        // database is not ready, so the hook stays at `undefined` (not ready to
+        // run); there is no state transition to wait for.
         expect(result.current[0]).toBeUndefined()
       } finally {
         unmount()
@@ -1117,14 +1115,14 @@ describe('containers/Bucket/Queries/Athena/model/requests', () => {
       )
       try {
         // database is "" (empty, not loading) -> ready to run; mount effect
-        // settles value to null. Poll the condition rather than a single update.
+        // settles the value to null. Poll the condition rather than a single
+        // update, then drive run() inside act and assert on its result.
         await waitFor(() => expect(result.current[0]).toBeNull())
-        let run: unknown
         await act(async () => {
-          run = await result.current[1](false)
+          const run = await result.current[1](false)
+          expect(run).toBeInstanceOf(Error)
+          expect(run).toBe(requests.NO_DATABASE)
         })
-        expect(run!).toBeInstanceOf(Error)
-        expect(run!).toBe(requests.NO_DATABASE)
       } finally {
         unmount()
       }

--- a/catalog/app/containers/Bucket/Queries/Athena/model/requests.spec.ts
+++ b/catalog/app/containers/Bucket/Queries/Athena/model/requests.spec.ts
@@ -1084,42 +1084,50 @@ describe('containers/Bucket/Queries/Athena/model/requests', () => {
       startQueryExecution.mockImplementation(
         reqThen<A.StartQueryExecutionInput, A.StartQueryExecutionOutput>(() => ({})),
       )
-      await act(async () => {
-        const { result, unmount, waitForNextUpdate } = renderHook(() =>
-          requests.useQueryRun({
-            workgroup: 'a',
-            catalogName: 'b',
-            database: Model.Loading,
-            queryBody: 'd',
-          }),
-        )
-        await waitForNextUpdate()
+      const { result, unmount } = renderHook(() =>
+        requests.useQueryRun({
+          workgroup: 'a',
+          catalogName: 'b',
+          database: Model.Loading,
+          queryBody: 'd',
+        }),
+      )
+      try {
+        // database is not ready, so the mount effect leaves value `undefined`
+        // (undefined -> undefined: no re-render). Flush effects, then assert —
+        // there is no "next update" to wait for.
+        await act(async () => {})
         expect(result.current[0]).toBeUndefined()
+      } finally {
         unmount()
-      })
+      }
     })
 
     it('mark as ready to run but return error for confirmation if database is empty', async () => {
       startQueryExecution.mockImplementation(
         reqThen<A.StartQueryExecutionInput, A.StartQueryExecutionOutput>(() => ({})),
       )
-      await act(async () => {
-        const { result, unmount, waitForValueToChange } = renderHook(() =>
-          requests.useQueryRun({
-            workgroup: 'a',
-            catalogName: 'b',
-            database: '',
-            queryBody: 'd',
-          }),
-        )
-        await waitForValueToChange(() => result.current, { timeout: 5000 })
-        await waitForValueToChange(() => result.current[0])
-        expect(result.current[0]).toBeNull()
-        const run = await result.current[1](false)
-        expect(run).toBeInstanceOf(Error)
-        expect(run).toBe(requests.NO_DATABASE)
+      const { result, unmount, waitFor } = renderHook(() =>
+        requests.useQueryRun({
+          workgroup: 'a',
+          catalogName: 'b',
+          database: '',
+          queryBody: 'd',
+        }),
+      )
+      try {
+        // database is "" (empty, not loading) -> ready to run; mount effect
+        // settles value to null. Poll the condition rather than a single update.
+        await waitFor(() => expect(result.current[0]).toBeNull())
+        let run: unknown
+        await act(async () => {
+          run = await result.current[1](false)
+        })
+        expect(run!).toBeInstanceOf(Error)
+        expect(run!).toBe(requests.NO_DATABASE)
+      } finally {
         unmount()
-      })
+      }
     })
   })
 

--- a/catalog/package.json
+++ b/catalog/package.json
@@ -7,8 +7,8 @@
     "url": "git://github.com/quiltdata/quilt.git"
   },
   "engines": {
-    "npm": "10",
-    "node": "22"
+    "npm": "11",
+    "node": "26"
   },
   "author": "Quilt Data, Inc. <support@quilt.bio> (https://quilt.bio)",
   "license": "MIT",
@@ -31,10 +31,10 @@
     "lint:prettier": "prettier --check",
     "lint:app": "npm run lint:prettier -- \"./app\" && npm run lint:eslint -- \"./app/**/*.[jt]s?(x)\"",
     "pretest": "npm run test:clean",
-    "test": "vitest run --coverage",
+    "test": "cross-env NODE_OPTIONS=--no-webstorage vitest run --coverage",
     "test:clean": "rimraf ./coverage",
-    "test:only": "vitest run",
-    "test:watch": "vitest",
+    "test:only": "cross-env NODE_OPTIONS=--no-webstorage vitest run",
+    "test:watch": "cross-env NODE_OPTIONS=--no-webstorage vitest",
     "prettify": "prettier --write",
     "gql:generate": "graphql-codegen",
     "prepare": "cd .. && husky install catalog/.husky"

--- a/catalog/package.json
+++ b/catalog/package.json
@@ -31,10 +31,10 @@
     "lint:prettier": "prettier --check",
     "lint:app": "npm run lint:prettier -- \"./app\" && npm run lint:eslint -- \"./app/**/*.[jt]s?(x)\"",
     "pretest": "npm run test:clean",
-    "test": "cross-env NODE_OPTIONS=--no-webstorage vitest run --coverage",
+    "test": "vitest run --coverage",
     "test:clean": "rimraf ./coverage",
-    "test:only": "cross-env NODE_OPTIONS=--no-webstorage vitest run",
-    "test:watch": "cross-env NODE_OPTIONS=--no-webstorage vitest",
+    "test:only": "vitest run",
+    "test:watch": "vitest",
     "prettify": "prettier --write",
     "gql:generate": "graphql-codegen",
     "prepare": "cd .. && husky install catalog/.husky"

--- a/catalog/vitest.config.ts
+++ b/catalog/vitest.config.ts
@@ -11,6 +11,16 @@ export default defineConfig({
       },
     },
 
+    // Node 25+ enables the Web Storage API by default; its built-in
+    // `localStorage` global reads as undefined without --localstorage-file and
+    // shadows jsdom's, so app code using the bare `localStorage` global sees
+    // undefined. Disable Node's webstorage (the forks pool reads NODE_OPTIONS
+    // at spawn) so jsdom owns localStorage again — no test-side storage mock.
+    // See https://github.com/vitest-dev/vitest/issues/8757.
+    env: {
+      NODE_OPTIONS: '--no-webstorage',
+    },
+
     setupFiles: ['./setup-vitest.ts'],
 
     include: ['app/**/*.spec.{js,ts,tsx}'],


### PR DESCRIPTION
## What

Pin the catalog JS toolchain to **Node 26 / npm 11** (`engines.node` `"22"`→`"26"`, `engines.npm` `10`→`11`) and fix the two test-toolchain breakages that surface on newer Node so the suite is green. CI reads `engines.node` via `setup-node`'s `node-version-file`; `fnm` resolves it locally.

## Fixes

1. **jsdom `localStorage`** — Node 25+ enables the Web Storage API by default; its built-in `localStorage` global reads as `undefined` without `--localstorage-file` and **shadows jsdom's**, so app code using the bare `localStorage` global (`utils/storage.js`) got `undefined` → *"Cannot read properties of undefined (reading getItem)"*. Per the upstream guidance ([vitest-dev/vitest#8757](https://github.com/vitest-dev/vitest/issues/8757)), disable Node's webstorage so jsdom owns `localStorage` again. Done with a single `test.env: { NODE_OPTIONS: '--no-webstorage' }` in `vitest.config.ts` (the forks pool reads `NODE_OPTIONS` at spawn). **No test-side storage mock** — app code runs against jsdom's real `Storage`. (`poolOptions.forks.execArgv`, the documented flag-passing option, is silently dropped in vitest 4.0.15, hence `test.env`.) Fixes Athena `state.spec.tsx`.

2. **`@testing-library/react-hooks` `waitForNextUpdate`/`waitForValueToChange`** — two `useQueryRun` tests polled for a render tick that no longer occurs under Node ≥24 fiber scheduling (one waited on a no-op `undefined→undefined` setState; the other on an already-settled value changing again). Rewritten to `act`-flush / `waitFor(condition)`, matching the idiom of the passing tests in the same file. **Product code unchanged.**

## Verification (Node 26)

- `npm test` (CI-identical, with coverage): **1060 passed / 1 skipped / 0 failed**.
- `tsc --noEmit --skipLibCheck`, prettier, eslint clean.
- **Production webpack build green**: `webpack 5.104.1 compiled` (exit 0; only pre-existing bundle-size perf warnings). Full `build/` emitted.

## npm 11 install-scripts — verified, no impact

npm 11 prints a new advisory at `npm ci` (*"N packages have install scripts not yet covered by allowScripts"*). It's **informational, not a block**: with `ignore-scripts=false` all install/postinstall scripts still run (confirmed via `npm ci --foreground-scripts`). It just surfaces npm 11's *opt-in* `npm approve-scripts` allowlist, which this PR doesn't adopt. Net effect: extra advisory lines in install logs, no behavioral change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR moves the catalog test toolchain to newer Node and npm versions. The main changes are:

- Pins catalog engines to Node 26 and npm 11.
- Disables Node web storage for Vitest so jsdom owns `localStorage`.
- Rewrites two Athena hook tests to wait for settled hook state.

<h3>Confidence Score: 5/5</h3>

This looks safe to merge.

- No blocking issues found in the changed code.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| catalog/package.json | Updates catalog engine pins from Node 22/npm 10 to Node 26/npm 11. |
| catalog/vitest.config.ts | Adds Vitest `NODE_OPTIONS` to disable Node web storage during tests. |
| catalog/app/containers/Bucket/Queries/Athena/model/requests.spec.ts | Updates Athena `useQueryRun` tests to flush or wait for explicit settled state. |

<sub>Reviews (1): Last reviewed commit: ["catalog: move --no-webstorage to vitest ..."](https://github.com/quiltdata/quilt/commit/6cc9b81fcd3e33c328272f42a073f68065ec522b) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=40127292)</sub>

<!-- /greptile_comment -->