### PR TITLE
Catalog: bump dompurify 3.2.5 → 3.4.11

### DIFF
--- a/catalog/app/components/Markdown/Markdown.spec.ts
+++ b/catalog/app/components/Markdown/Markdown.spec.ts
@@ -38,10 +38,10 @@ describe('components/Markdown', () => {
 <img src="anything"/>`
       expect(await resolved(render, input)).toMatchInlineSnapshot(`
         "<p>Something</p>
-        <p><a rel="nofollow" href="https://link/anything">link</a>
-        <img alt="" src="https://image/anything"></p>
-        <p><span src="anything" href="anything">don’t touch</span>
-        <a rel="nofollow" href="https://link/anything">link</a>
+        <p><a href="https://link/anything" rel="nofollow">link</a>
+        <img src="https://image/anything" alt=""></p>
+        <p><span href="anything" src="anything">don’t touch</span>
+        <a href="https://link/anything" rel="nofollow">link</a>
         <img src="https://image/anything"></p>
         "
       `)
@@ -58,11 +58,11 @@ describe('components/Markdown', () => {
 <img alt="Alternative text" src="anything"/>`
       expect(await resolved(render, input)).toMatchInlineSnapshot(`
         "<p>Something</p>
-        <p><a rel="nofollow" href="https://link/anything">link</a>
-        <img alt="Alternative text" src="https://image/anything"></p>
-        <p><span data-dont-touch="" src="anything" href="anything">don’t touch</span>
-        <a href="https://link/anything" title="Link title" rel="nofollow base nofollow">link</a>
+        <p><a href="https://link/anything" rel="nofollow">link</a>
         <img src="https://image/anything" alt="Alternative text"></p>
+        <p><span href="anything" src="anything" data-dont-touch="">don’t touch</span>
+        <a rel="nofollow base nofollow" title="Link title" href="https://link/anything">link</a>
+        <img alt="Alternative text" src="https://image/anything"></p>
         "
       `)
     })
@@ -129,7 +129,7 @@ describe('components/Markdown', () => {
     it('Autolinks bare URLs', async () => {
       const input = 'see https://example.com'
       expect(await resolved(render, input)).toMatchInlineSnapshot(`
-        "<p>see <a rel="nofollow" href="https://link/https://example.com">https://example.com</a></p>
+        "<p>see <a href="https://link/https://example.com" rel="nofollow">https://example.com</a></p>
         "
       `)
     })
@@ -137,7 +137,7 @@ describe('components/Markdown', () => {
     it('Adds nofollow rel to links', async () => {
       const input = '[x](https://example.com)'
       expect(await resolved(render, input)).toMatchInlineSnapshot(`
-        "<p><a rel="nofollow" href="https://link/https://example.com">x</a></p>
+        "<p><a href="https://link/https://example.com" rel="nofollow">x</a></p>
         "
       `)
     })
@@ -189,7 +189,7 @@ describe('components/Markdown', () => {
     it('Renders tasklist nested inside image label', async () => {
       const input = '![ [x] image](url)'
       expect(await resolved(render, input)).toMatchInlineSnapshot(`
-        "<p><img alt="image" src="https://image/url"></p>
+        "<p><img src="https://image/url" alt="image"></p>
         "
       `)
     })

--- a/catalog/package-lock.json
+++ b/catalog/package-lock.json
@@ -35,7 +35,7 @@
         "date-fns": "^2.30.0",
         "dedent": "^1.5.1",
         "diff": "^8.0.2",
-        "dompurify": "^3.2.5",
+        "dompurify": "^3.4.11",
         "echarts": "^5.5.0",
         "effect": "^3.21.4",
         "final-form": "^4.20.9",
@@ -8770,9 +8770,9 @@
       }
     },
     "node_modules/dompurify": {
-      "version": "3.2.5",
-      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.2.5.tgz",
-      "integrity": "sha512-mLPd29uoRe9HpvwP2TxClGQBzGXeEC/we/q+bFlmPPmj2p2Ugl3r6ATu/UU1v77DXNcehiBg9zsr1dREyA/dJQ==",
+      "version": "3.4.11",
+      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.11.tgz",
+      "integrity": "sha512-zhlUV12GsaRzMsf9q5M254YhA4+VuF0fG+QFqu6aYpoGlKtz+w8//jBcGVYBgQkR5GHjUomejY84AV+/uPbWdw==",
       "license": "(MPL-2.0 OR Apache-2.0)",
       "optionalDependencies": {
         "@types/trusted-types": "^2.0.7"

--- a/catalog/package.json
+++ b/catalog/package.json
@@ -72,7 +72,7 @@
     "date-fns": "^2.30.0",
     "dedent": "^1.5.1",
     "diff": "^8.0.2",
-    "dompurify": "^3.2.5",
+    "dompurify": "^3.4.11",
     "echarts": "^5.5.0",
     "effect": "^3.21.4",
     "final-form": "^4.20.9",


### PR DESCRIPTION
Bumps `dompurify` **3.2.5 → 3.4.11** (latest) in `/catalog`. This is a security update — it covers the mXSS-via-re-contextualization and closing-tag mXSS fixes landed across the 3.3.x / 3.4.0 line (the dependency Renovate flagged as vulnerable), plus several prototype-pollution and config-bypass fixes.

### Scope
- `dompurify` is dependency-free, so the lockfile change is the **single package entry** — no transitive churn.
- One **test-only** adjustment: dompurify 3.4 serializes element attributes in source-insertion order (e.g. `<a href=… rel=…>`) where 3.2.5 reordered them (`<a rel=… href=…>`). Updated 5 inline snapshots in `Markdown.spec.ts` to match. **Same attributes and values in every case — nothing added or dropped** (`rel="nofollow base nofollow"`, `data-dont-touch=""`, the dual `src`+`href` span all preserved). All sanitization assertions (`Avoids XSS`, `Strips invalid attributes`, `Strips <script>`) pass unchanged.

Diff: 3 files, +16/−16.

### Verification (Node 26 / npm 11)
- `npm ci` clean (lockfile in sync — CI gate)
- `tsc --noEmit --skipLibCheck` clean
- `Markdown.spec.ts` 15/15 green
- prettier + eslint clean on the changed spec
- `npm run build` (webpack prod) green (2 pre-existing asset-size warnings only)

### Supersedes
- #5004 — Dependabot 3.4.11 (lockfile/package.json-only; would **fail CI** on the snapshot drift this PR fixes)
- #4887 — Renovate 3.4.0 `[security]`

(Earlier #4831 → 3.4.0 already closed.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR updates the catalog Markdown sanitizer dependency.

- `dompurify` moves from 3.2.5 to 3.4.11 in `catalog/package.json`.
- The lockfile updates the single resolved `dompurify` entry.
- Markdown inline snapshots are refreshed for the new attribute serialization order.

<h3>Confidence Score: 5/5</h3>

This looks safe to merge.

- No blocking issues found in the changed code.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| catalog/package.json | Updates the direct `dompurify` dependency to `^3.4.11`. |
| catalog/package-lock.json | Updates the resolved `dompurify` package entry without transitive churn. |
| catalog/app/components/Markdown/Markdown.spec.ts | Refreshes Markdown snapshots for attribute order changes while preserving the same expected attributes. |

<sub>Reviews (1): Last reviewed commit: ["Catalog: bump dompurify 3.2.5 → 3.4.11"](https://github.com/quiltdata/quilt/commit/314a30e5338c9902af7a1e31953e3cff04b9e475) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=40157727)</sub>

<!-- /greptile_comment -->