### PR TITLE
Catalog: prune orphaned package-lock.json entries

### DIFF
--- a/catalog/package-lock.json
+++ b/catalog/package-lock.json
@@ -194,8 +194,8 @@
         "webpack-dev-server": "^5.2.4"
       },
       "engines": {
-        "node": "22",
-        "npm": "10"
+        "node": "26",
+        "npm": "11"
       }
     },
     "node_modules/@aashutoshrathi/word-wrap": {
@@ -3905,15 +3905,6 @@
         "node": ">=20.0.0"
       }
     },
-    "node_modules/@polka/url": {
-      "version": "1.0.0-next.29",
-      "resolved": "https://registry.npmjs.org/@polka/url/-/url-1.0.0-next.29.tgz",
-      "integrity": "sha512-wwQAWhWSuHaag8c4q/KN/vCoeOJYshAIvMQwD4GpSb3OiZklFfvAgmj0VCBBImRpuF/aFgIRzllXlVX93Jevww==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true
-    },
     "node_modules/@redux-saga/core": {
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/@redux-saga/core/-/core-1.2.3.tgz",
@@ -5481,39 +5472,6 @@
         "url": "https://opencollective.com/vitest"
       }
     },
-    "node_modules/@vitest/ui": {
-      "version": "4.0.15",
-      "resolved": "https://registry.npmjs.org/@vitest/ui/-/ui-4.0.15.tgz",
-      "integrity": "sha512-sxSyJMaKp45zI0u+lHrPuZM1ZJQ8FaVD35k+UxVrha1yyvQ+TZuUYllUixwvQXlB7ixoDc7skf3lQPopZIvaQw==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "@vitest/utils": "4.0.15",
-        "fflate": "^0.8.2",
-        "flatted": "^3.3.3",
-        "pathe": "^2.0.3",
-        "sirv": "^3.0.2",
-        "tinyglobby": "^0.2.15",
-        "tinyrainbow": "^3.0.3"
-      },
-      "funding": {
-        "url": "https://opencollective.com/vitest"
-      },
-      "peerDependencies": {
-        "vitest": "4.0.15"
-      }
-    },
-    "node_modules/@vitest/ui/node_modules/fflate": {
-      "version": "0.8.2",
-      "resolved": "https://registry.npmjs.org/fflate/-/fflate-0.8.2.tgz",
-      "integrity": "sha512-cPJU47OaAoCbg0pBvzsgpTPhmhqI5eJjh/JIu8tPj5q+T7iLvW/JAYUqmE7KOB4R1ZyEhzBaIQpQpardBF5z8A==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true
-    },
     "node_modules/@vitest/utils": {
       "version": "4.0.15",
       "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.0.15.tgz",
@@ -6400,23 +6358,6 @@
       "dev": true,
       "dependencies": {
         "dequal": "^2.0.3"
-      }
-    },
-    "node_modules/babel-plugin-macros": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/babel-plugin-macros/-/babel-plugin-macros-3.1.0.tgz",
-      "integrity": "sha512-Cg7TFGpIr01vOQNODXOOaGz2NpCU5gl8x1qJFbb6hbZxR7XrcE2vtbAsTAbJ7/xwJtUuJEw8K8Zr/AE0LHlesg==",
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "@babel/runtime": "^7.12.5",
-        "cosmiconfig": "^7.0.0",
-        "resolve": "^1.19.0"
-      },
-      "engines": {
-        "node": ">=10",
-        "npm": ">=6"
       }
     },
     "node_modules/balanced-match": {
@@ -13470,18 +13411,6 @@
         "fp-ts": "^2.5.0"
       }
     },
-    "node_modules/mrmime": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/mrmime/-/mrmime-2.0.1.tgz",
-      "integrity": "sha512-Y3wQdFg2Va6etvQ5I82yUhGdsKrcYox6p7FfL1LbK2J4V01F9TGlepTIhnK24t7koZibmg82KGglhA1XK5IsLQ==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "engines": {
-        "node": ">=10"
-      }
-    },
     "node_modules/ms": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
@@ -14986,21 +14915,6 @@
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
       "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ=="
     },
-    "node_modules/react-shallow-renderer": {
-      "version": "16.14.1",
-      "resolved": "https://registry.npmjs.org/react-shallow-renderer/-/react-shallow-renderer-16.14.1.tgz",
-      "integrity": "sha512-rkIMcQi01/+kxiTE9D3fdS959U1g7gs+/rborw++42m1O9FAQiNI/UNRZExVUoAOprn4umcXf+pFRou8i4zuBg==",
-      "dev": true,
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "object-assign": "^4.1.1",
-        "react-is": "^16.12.0 || ^17.0.0"
-      },
-      "peerDependencies": {
-        "react": "^16.0.0 || ^17.0.0"
-      }
-    },
     "node_modules/react-side-effect": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/react-side-effect/-/react-side-effect-2.1.1.tgz",
@@ -15147,23 +15061,6 @@
       },
       "peerDependencies": {
         "react": "^16.8.3 || ^17.0.0-0 || ^18.0.0"
-      }
-    },
-    "node_modules/react-test-renderer": {
-      "version": "17.0.2",
-      "resolved": "https://registry.npmjs.org/react-test-renderer/-/react-test-renderer-17.0.2.tgz",
-      "integrity": "sha512-yaQ9cB89c17PUb0x6UfWRs7kQCorVdHlutU1boVPEsB8IDZH6n9tHxMacc3y0JoXOJUsZb/t/Mb8FUWMKaM7iQ==",
-      "dev": true,
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "object-assign": "^4.1.1",
-        "react-is": "^17.0.2",
-        "react-shallow-renderer": "^16.13.1",
-        "scheduler": "^0.20.2"
-      },
-      "peerDependencies": {
-        "react": "17.0.2"
       }
     },
     "node_modules/react-transition-group": {
@@ -16156,23 +16053,6 @@
       "resolved": "https://registry.npmjs.org/signals/-/signals-1.0.0.tgz",
       "integrity": "sha1-ZfDBWZNSs1Ny7KrlolDmEHN27Wk="
     },
-    "node_modules/sirv": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/sirv/-/sirv-3.0.2.tgz",
-      "integrity": "sha512-2wcC/oGxHis/BoHkkPwldgiPSYcpZK3JU28WoMVv55yHJgcZ8rlXvuG9iZggz+sU1d4bRgIGASwyWqjxu3FM0g==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "@polka/url": "^1.0.0-next.24",
-        "mrmime": "^2.0.0",
-        "totalist": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=18"
-      }
-    },
     "node_modules/slash": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/slash/-/slash-3.0.0.tgz",
@@ -17031,18 +16911,6 @@
       "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
       "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
       "license": "MIT"
-    },
-    "node_modules/totalist": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/totalist/-/totalist-3.0.1.tgz",
-      "integrity": "sha512-sf4i37nQ2LBx4m3wB74y+ubopq6W/dIzXg0FDGjsYnZHVa1Da8FH853wlL2gtUhg+xJXjfk3kUZS3BRoQeoQBQ==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "engines": {
-        "node": ">=6"
-      }
     },
     "node_modules/tough-cookie": {
       "version": "4.1.2",
@@ -18399,24 +18267,6 @@
         "yaml": {
           "optional": true
         }
-      }
-    },
-    "node_modules/vitest/node_modules/yaml": {
-      "version": "2.8.2",
-      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.2.tgz",
-      "integrity": "sha512-mplynKqc1C2hTVYxd0PU2xQAc22TI1vShAYGksCCfxbn/dFwnHTNi1bvYsBTkhdUNtGIf5xNOg938rrSSYvS9A==",
-      "dev": true,
-      "license": "ISC",
-      "optional": true,
-      "peer": true,
-      "bin": {
-        "yaml": "bin.mjs"
-      },
-      "engines": {
-        "node": ">= 14.6"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/eemeli"
       }
     },
     "node_modules/w3c-xmlserializer": {


### PR DESCRIPTION
## What

Prunes orphaned npm package entries from `catalog/package-lock.json` that npm removes on a plain `npm install --package-lock-only` re-resolve (no `package.json` change). These are leftovers from the vitest migration / node24 upgrade / effect dependency removals.

## What was pruned (10 entries, ~152 lines)

All were `optional: true` / `peer: true` lockfile nodes — unreachable from the actual dependency graph:

- `@polka/url`, `mrmime`, `totalist`, `sirv` — the `sirv` static-server chain
- `@vitest/ui` (+ its nested `fflate`) — optional vitest peer, not installed
- `vitest/node_modules/yaml` — optional vitest peer
- `babel-plugin-macros` — optional peer, unused
- `react-test-renderer` (+ `react-shallow-renderer`) — optional peers of `@testing-library/react-hooks`

**Note on `react-test-renderer`/`react-shallow-renderer`:** `@testing-library/react-hooks` is still a declared dependency and is still imported by many spec files (via the main and `/pure` entry points). Those entry points use the DOM renderer (`react-dom`, already a real dep); only the unused `/native` entry point needs `react-test-renderer`. npm therefore marks these two as optional and prunes them as extraneous. Verified: no source imports `@testing-library/react-hooks/native`.

## Scope guarantee

- **Lockfile-only.** `catalog/package.json` is unchanged.
- **No real-dependency version/`resolved`/`integrity` change.** The only non-deletion edit is syncing the lockfile's embedded root-package `engines` (`node` 22→26, `npm` 10→11) to match the already-committed `package.json`, which the node26 commit (#5037) left stale in the lockfile.
- Diff: `1 file changed, 2 insertions(+), 152 deletions(-)`.

## Verification (Node 26.3.0 / npm 11.16.0 — the CI runtime)

- `npm ci` — succeeds (exit 0); orphans confirmed absent from `node_modules`, `@testing-library/react-hooks` confirmed present
- `npx tsc --noEmit --skipLibCheck` — exit 0
- `npx vitest run` — **117 test files passed, 1075 tests passed, 1 skipped** (exit 0). One unhandled teardown error ("window is not defined" in `react-dom` during `Preview/loaders/utils.spec.ts` teardown) — originates in `react-dom`/`scheduler` (untouched real deps), not in any pruned package, and does not fail the run.
- `npm run build` (webpack prod) — exit 0, compiled with 2 warnings (pre-existing entrypoint asset-size limits only)

Tracking: qhq-7roh.1

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR updates the catalog lockfile metadata and prunes stale package entries.

- Root lockfile engines now match Node 26 and npm 11.
- Optional peer-only package nodes were removed.
- No `package.json` dependency changes were made.

<h3>Confidence Score: 5/5</h3>

This looks safe to merge.

- No blocking issues found in the changed code.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| catalog/package-lock.json | Updates embedded engine metadata and removes stale optional peer lockfile entries. |

<sub>Reviews (1): Last reviewed commit: ["Merge branch &#39;master&#39; into lockfile-prun..."](https://github.com/quiltdata/quilt/commit/9ce1e36418d90462506b35bf7fc1e8ed35d7d37d) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=40203407)</sub>

<!-- /greptile_comment -->