### PR TITLE
catalog: adopt oxlint correctness category, de-opinionate config

### DIFF
--- a/catalog/.oxlintrc.json
+++ b/catalog/.oxlintrc.json
@@ -1,62 +1,13 @@
 {
   "$schema": "./node_modules/oxlint/configuration_schema.json",
-  "plugins": [
-    "typescript",
-    "import",
-    "jsx-a11y",
-    "react"
-  ],
+  "plugins": ["typescript", "import", "jsx-a11y", "react"],
   "categories": {
-    "correctness": "off"
+    "correctness": "error"
   },
   "env": {
     "builtin": true
   },
   "rules": {
-    "arrow-body-style": [
-      "error",
-      "as-needed"
-    ],
-    "import/newline-after-import": "error",
-    "import/no-duplicates": "error",
-    "jsx-a11y/aria-props": "error",
-    "jsx-a11y/label-has-associated-control": [
-      "error",
-      {
-        "controlComponents": [
-          "Input"
-        ]
-      }
-    ],
-    "jsx-a11y/mouse-events-have-key-events": "error",
-    "jsx-a11y/role-has-required-aria-props": "error",
-    "jsx-a11y/role-supports-aria-props": "error",
-    "no-alert": "error",
-    "no-console": "error",
-    "no-debugger": "error",
-    "no-nested-ternary": "warn",
-    "no-restricted-globals": "off",
-    "no-underscore-dangle": [
-      "error",
-      {
-        "allow": [
-          "_",
-          "__",
-          "__typename",
-          "_tag"
-        ]
-      }
-    ],
-    "prefer-arrow-callback": [
-      "error",
-      {
-        "allowNamedFunctions": true
-      }
-    ],
-    "prefer-template": "error",
-    "react/jsx-key": "error",
-    "react/exhaustive-deps": "error",
-    "react/rules-of-hooks": "error",
     "no-unused-vars": [
       "error",
       {
@@ -67,14 +18,34 @@
       }
     ],
     "no-shadow": "error",
-    "no-redeclare": "error"
+    "no-redeclare": "error",
+    "no-console": "error",
+    "no-alert": "error",
+    "no-underscore-dangle": ["error", { "allow": ["_", "__", "__typename", "_tag"] }],
+    "react/rules-of-hooks": "error",
+    "import/no-duplicates": "error",
+    "no-restricted-globals": "off",
+    "react/no-children-prop": "off",
+    "jsx-a11y/label-has-associated-control": [
+      "error",
+      { "controlComponents": ["Input"] }
+    ],
+    "jsx-a11y/no-autofocus": "off",
+    "jsx-a11y/click-events-have-key-events": "off",
+    "jsx-a11y/no-static-element-interactions": "off",
+    "jsx-a11y/prefer-tag-over-role": "off",
+    "jsx-a11y/no-redundant-roles": "off",
+    "jsx-a11y/media-has-caption": "off",
+    "jsx-a11y/control-has-associated-label": "off",
+    "jsx-a11y/interactive-supports-focus": "off",
+    "jsx-a11y/anchor-is-valid": "off",
+    "jsx-a11y/anchor-has-content": "off",
+    "jsx-a11y/alt-text": "off"
   },
   "settings": {
     "react": {
       "version": "17.0.2"
     }
   },
-  "ignorePatterns": [
-    "**/*.generated.ts"
-  ]
+  "ignorePatterns": ["**/*.generated.ts"]
 }

--- a/catalog/app/components/Assistant/Model/GlobalContext/preview.ts
+++ b/catalog/app/components/Assistant/Model/GlobalContext/preview.ts
@@ -82,7 +82,7 @@ export const fromS3Signer = (
 // The name can't contain more than one consecutive whitespace character
 const normalizeDocumentName = (name: string) =>
   name
-    .replace(/[^a-zA-Z0-9\s\-\(\)\[\]]/g, ' ') // Remove invalid characters
+    .replace(/[^a-zA-Z0-9\s\-()[\]]/g, ' ') // Remove invalid characters
     .replace(/\s+/g, ' ') // Replace multiple whitespace characters with a single space
     .trim() // Remove leading and trailing whitespace
 

--- a/catalog/app/components/Form/Checkbox.tsx
+++ b/catalog/app/components/Form/Checkbox.tsx
@@ -15,7 +15,7 @@ interface CheckboxProps {
   errors?: Record<string, React.ReactNode>
   input?: RF.FieldInputProps<boolean>
   label?: string
-  meta: RF.FieldMetaState<string | Symbol>
+  meta: RF.FieldMetaState<string | symbol>
 }
 
 export default function Checkbox({

--- a/catalog/app/components/JsonEditor/constants.ts
+++ b/catalog/app/components/JsonEditor/constants.ts
@@ -12,8 +12,8 @@ export type ValidationErrors = (Error | ErrorObject)[]
 export type RowData = JsonDictItem
 
 // TODO: use enum, when conversion to typescript will be done
-const KEY: 'key' = 'key'
-const VALUE: 'value' = 'value'
+const KEY = 'key' as const
+const VALUE = 'value' as const
 
 export const COLUMN_IDS = {
   KEY,

--- a/catalog/app/components/Logo/index.tsx
+++ b/catalog/app/components/Logo/index.tsx
@@ -16,7 +16,7 @@ interface LogoProps {
   width: string
 }
 
-const useStyles = M.makeStyles(({}) => ({
+const useStyles = M.makeStyles(() => ({
   custom: ({ height }: { height: string }) => ({
     height,
   }),

--- a/catalog/app/containers/Admin/Form.tsx
+++ b/catalog/app/containers/Admin/Form.tsx
@@ -43,7 +43,7 @@ const useCheckboxStyles = M.makeStyles({
 export interface CheckboxProps {
   errors?: ErrorMessageMap
   input?: RF.FieldInputProps<boolean>
-  meta: RF.FieldMetaState<string | Symbol>
+  meta: RF.FieldMetaState<string | symbol>
   label?: React.ReactNode
   FormControlLabelProps?: M.FormControlLabelProps
 }

--- a/catalog/app/containers/Admin/Settings/ThemeEditor.tsx
+++ b/catalog/app/containers/Admin/Settings/ThemeEditor.tsx
@@ -232,9 +232,7 @@ const useThemePreviewStyles = M.makeStyles((t) => ({
   },
 }))
 
-interface ThemePreviewProps {}
-
-function ThemePreview({}: ThemePreviewProps) {
+function ThemePreview() {
   const settings = CatalogSettings.use()
   const classes = useThemePreviewStyles({
     backgroundColor: settings?.theme?.palette?.primary?.main,

--- a/catalog/app/containers/Bucket/PackageCompare/Diff/Metadata.tsx
+++ b/catalog/app/containers/Bucket/PackageCompare/Diff/Metadata.tsx
@@ -37,7 +37,7 @@ interface MetadataDiffProps {
 
 function MetadataDiff({
   revisions: [base, other],
-  changesOnly: changesOnly = false,
+  changesOnly = false,
 }: MetadataDiffProps) {
   const colors = useColors()
   const classes = useStyles()

--- a/catalog/app/containers/Search/model.ts
+++ b/catalog/app/containers/Search/model.ts
@@ -705,7 +705,7 @@ function addMagicWildcardsQS(s: string | null): string | null {
   // - grouping: ( ) [ ] { }
   // - fuzzy search: ~
   // - negaion: -
-  if (/:|\*|\?|"|'|\bAND\b|\bOR\b|\+|\||\(|\)|\[|\]|\{|\}|\~|-/.test(s)) return s
+  if (/:|\*|\?|"|'|\bAND\b|\bOR\b|\+|\||\(|\)|\[|\]|\{|\}|~|-/.test(s)) return s
   // Append trailing wildcard for substring matching
   return `${s}*`
 }

--- a/catalog/app/utils/spreadsheets/spreadsheets.spec.ts
+++ b/catalog/app/utils/spreadsheets/spreadsheets.spec.ts
@@ -2,7 +2,7 @@ import path from 'path'
 import { describe, expect, it } from 'vitest'
 
 import dedent from 'dedent'
-import xlsx from 'xlsx'
+import * as xlsx from 'xlsx'
 
 import * as spreadsheets from './spreadsheets'
 

--- a/catalog/app/utils/types.ts
+++ b/catalog/app/utils/types.ts
@@ -48,7 +48,7 @@ export const nullable = <C extends IO.Mixed>(
 enum Enum {}
 
 export class EnumType<E extends typeof Enum> extends IO.Type<E[keyof E]> {
-  readonly _tag: 'EnumType' = 'EnumType'
+  readonly _tag = 'EnumType' as const
 
   private readonly enum: E
 


### PR DESCRIPTION
**Stacked on #5040** (now merged). **Replayed onto current master** and rebased to just this tighten commit.

Replaces #5040's hand-enumerated rule allowlist with oxlint's curated **`correctness`** category + a small keep/override set — the config expresses intent (categories) rather than a bespoke list.

### Config
- `categories.correctness: error` (oxlint's recommended baseline; catches real bugs the allowlist missed: no-empty-pattern, no-useless-escape, prefer-as-const, …). Verified to include `no-debugger`, `react/jsx-key`, `react-hooks/exhaustive-deps`, and the jsx-a11y core set.
- Dropped purely-stylistic rules now handled by the formatter or low value: `arrow-body-style`, `prefer-template`, `prefer-arrow-callback`, `no-nested-ternary`, `import/newline-after-import`.
- **Kept deliberately** (verified *not* in `correctness`, so set explicitly): `no-shadow`, `no-redeclare`, `no-console`, `no-alert`, `no-underscore-dangle` (allowlist `_`/`__typename`/`_tag`), **`react/rules-of-hooks`** (hook-order safety), **`import/no-duplicates`**; overrides: `no-unused-vars` (tseslint v6 opts), `label-has-associated-control`.
- Disabled: `no-restricted-globals` (oxlint scope FP), `react/no-children-prop` (deliberate render-prop-via-createElement pattern).
- **Deferred jsx-a11y backlog**: correctness pulls in ~10 a11y rules the catalog never enforced (real accessibility debt) — off here, tracked separately, so this stays a config change not a UI project.

### Findings fixed (after `oxlint --fix`)
- Auto-fixed: Symbol→symbol, prefer-as-const, no-useless-rename/escape.
- Logo / ThemeEditor: drop empty-pattern args. spreadsheets.spec: `import * as xlsx`. preview.ts: drop unnecessary `\)` regex escape.

### Review
Greptile flagged that `react/rules-of-hooks` and `import/no-duplicates` are not in `correctness` — both verified correct and restored as explicit keeps (they were enforced pre-migration). Re-adding both is clean (0 findings).

### Verification (Node 26)
oxlint clean (0), oxfmt --check clean, `tsc --noEmit` clean, webpack build green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)