### PR TITLE
[PARKED] catalog: modernize module resolution to bundler

### DIFF
--- a/catalog/app/components/Markdown/markdownItTypes.ts
+++ b/catalog/app/components/Markdown/markdownItTypes.ts
@@ -1,0 +1,11 @@
+// markdown-it 14 ships no types of its own; they come from @types/markdown-it,
+// whose ESM entry (index.d.mts) re-exports only `default` + option types — not
+// StateInline/Token. Under exports-aware resolution (moduleResolution: bundler)
+// the named root import `{ StateInline, Token } from 'markdown-it'` therefore
+// fails, so we reach them at their subpath modules, where each is the default
+// export. The `.mjs` extension is required for TS to locate the `.d.mts`.
+//
+// Centralized here so use-sites keep clean named imports and this brittleness
+// (subpath layout + extension) lives in exactly one place.
+export type { default as StateInline } from 'markdown-it/lib/rules_inline/state_inline.mjs'
+export type { default as Token } from 'markdown-it/lib/token.mjs'

--- a/catalog/app/components/Markdown/parseTasklist.spec.ts
+++ b/catalog/app/components/Markdown/parseTasklist.spec.ts
@@ -1,4 +1,4 @@
-import type { StateInline, Token } from 'markdown-it'
+import type { StateInline, Token } from './markdownItTypes'
 import { describe, it, expect } from 'vitest'
 
 import * as tasklist from './parseTasklist'

--- a/catalog/app/components/Markdown/parseTasklist.ts
+++ b/catalog/app/components/Markdown/parseTasklist.ts
@@ -1,4 +1,4 @@
-import type { StateInline } from 'markdown-it'
+import type { StateInline } from './markdownItTypes'
 
 export const CHECKED = 'tasklist_checked'
 export const UNCHECKED = 'tasklist_unchecked'

--- a/catalog/tsconfig.json
+++ b/catalog/tsconfig.json
@@ -1,15 +1,25 @@
 {
   "compilerOptions": {
+    // target stays ES5 + downlevelIteration (with ignoreDeprecations) until the
+    // aws-sdk v2 -> v3 migration: aws-sdk v2 invokes subclass constructors
+    // without `new` (ES5 inheritance), which native ES2020 classes reject.
+    // The ES2020 target bump rides along with that migration.
     "ignoreDeprecations": "6.0",
-    "baseUrl": "./app/",
     "paths": {
-      "*": ["*", "../../shared/*"]
+      // @finos/perspective 1.9.4 ships an `exports` map with no `types`
+      // condition, so `bundler` resolution can't see its shipped declarations.
+      // Point TS at them directly. Removable once Perspective -> 3.x (qhq-u477).
+      "@finos/perspective": ["./node_modules/@finos/perspective/index.d.ts"],
+      "@finos/perspective-viewer": [
+        "./node_modules/@finos/perspective-viewer/dist/esm/perspective-viewer.d.ts"
+      ],
+      "*": ["./app/*", "../shared/*"]
     },
     "sourceMap": true,
     "module": "ESNext",
     "target": "ES5",
     "downlevelIteration": true,
-    "moduleResolution": "node",
+    "moduleResolution": "bundler",
     "resolveJsonModule": true,
     "lib": ["DOM", "DOM.Iterable", "ESNext"],
     "jsx": "react",


### PR DESCRIPTION
**Replayed onto current master** (post oxc + webpack + TS6). Rescoped from the original "tsconfig for TS7 readiness": the **ES5→ES2020 target bump is deferred** (see below), so this PR is now just the **exports-aware module-resolution modernization**.

### Changes
- `moduleResolution` **node → bundler** (node10 is deprecated; bundler is exports-aware and webpack-appropriate).
- Remove `baseUrl`; rewrite `paths` relative to the tsconfig dir. Internal bare imports still resolve via tsc + oxlint's oxc-resolver; webpack (`resolve.modules`) and vitest (alias map) unaffected.
- Two pre-existing packaging quirks that `bundler` surfaces (fixed, no behavior change):
  - **@finos/perspective 1.9.4** `exports` map has no `types` condition → tsconfig `paths` redirect (removable at Perspective 3.x).
  - **markdown-it 14** ships no types; `@types/markdown-it`'s ESM entry re-exports only default+options, not `StateInline`/`Token` → reach them at their subpath default exports, centralized in `Markdown/markdownItTypes.ts` so use-sites keep clean named imports.

`target` stays **ES5** (+ `downlevelIteration` + `ignoreDeprecations`). This PR has **no runtime-semantic delta from master** — it's resolution/typecheck-only + type-only imports.

### ⚠️ ES2020 deferred to the aws-sdk v2 → v3 migration
The original ES2020 target bump **crashes the authenticated catalog at runtime**: aws-sdk **v2** invokes subclass constructors without `new` (ES5 inheritance), which native ES2020 classes reject — `TypeError: Class constructor SmartS3 cannot be invoked without 'new'`. It hits `SmartS3` (S3.jsx) + `RegistryCredentials`/`EmptyCredentials` (Credentials.jsx). Any `target ≥ ES2015` emits native classes, so this is ES5-or-bust until aws-sdk v3 (ESM/class-native). Tracked separately.

### Verification
- `tsc --noEmit` clean, oxlint+oxfmt clean, webpack build green (Node 26).
- **Live browser smoke vs the nightly stack (authenticated):** home + bucket overview render with **zero JS errors** (confirmed against an A/B where the ES2020 build crashed and this ES5 build renders identically to master).

🤖 Generated with [Claude Code](https://claude.com/claude-code)