### PR TITLE
[PARKED] catalog: convert APIConnector/Store/search/ResourceCache to TS (js→ts batch 7)

### DIFF
--- a/catalog/app/@types/redux-immutable.d.ts
+++ b/catalog/app/@types/redux-immutable.d.ts
@@ -1,0 +1,8 @@
+declare module 'redux-immutable' {
+  import type { Reducer } from 'redux'
+
+  export function combineReducers(
+    reducers: { [key: string]: Reducer<any, any> },
+    getDefaultState?: (...args: any[]) => any,
+  ): Reducer<any, any>
+}

--- a/catalog/app/utils/APIConnector.tsx
+++ b/catalog/app/utils/APIConnector.tsx
@@ -32,29 +32,32 @@ const actions = createActions(REDUX_KEY, 'API_REQUEST', 'API_RESPONSE')
  * The rest of the props are passed to the `fetch` call (identical to the
  * `Request` constructor) as they are. See for details:
  * https://developer.mozilla.org/en-US/docs/Web/API/Request/Request
- *
- * @typedef {Object} RequestOptions
- *
- * @property {string} endpoint
- *   An endpoint for request (appended to configured base URL).
- *
- * @property {string} url
- *   An absolute URL for the request.
- *
- * @property {boolean} json
- *   Whether to add JSON-related headers and parse the response body.
- *   Defaults to true.
  */
+export interface RequestOptions {
+  /** An endpoint for request (appended to configured base URL). */
+  endpoint?: string
+  /** An absolute URL for the request. */
+  url?: string
+  /**
+   * Whether to add JSON-related headers and parse the response body.
+   * Defaults to true.
+   */
+  json?: boolean | JsonOptions
+  // arbitrary properties consumed by middleware / passed to `fetch`
+  [key: string]: any
+}
+
+interface JsonOptions {
+  stringify?: boolean
+  parse?: boolean
+  contentType?: boolean
+  accepts?: boolean
+}
 
 /**
  * Action creator for API_REQUEST action.
  *
- * @param {RequestOptions|string} options
- *   When string, it is considered an endpoint.
- *
- * @param {utils/defer.Resolver} resolver
- *
- * @returns {redux.Action}
+ * When `options` is a string, it is considered an endpoint.
  */
 const request = actionCreator(actions.API_REQUEST, (payload, resolver) => ({
   payload: typeof payload === 'string' ? { endpoint: payload } : payload,
@@ -63,12 +66,6 @@ const request = actionCreator(actions.API_REQUEST, (payload, resolver) => ({
 
 /**
  * Action creator for API_RESPONSE action.
- *
- * @param {any} response
- *
- * @params {RequestOptions} requestOpts
- *
- * @returns {redux.Action}
  */
 const response = actionCreator(actions.API_RESPONSE, (payload, requestOpts) => ({
   payload,
@@ -80,17 +77,29 @@ const test = R.ifElse(R.is(RegExp), R.test, R.equals)
 export class HTTPError extends BaseError {
   static displayName = 'HTTPError'
 
-  static is = (e, status, msg) => {
+  status?: number
+
+  text?: string
+
+  json?: any
+
+  response?: Response
+
+  static is = (e: unknown, status?: number, msg?: string | RegExp) => {
     if (!(e instanceof HTTPError)) return false
     if (status && e.status !== status) return false
     if (msg && !(e.json && test(msg)(e.json.message))) return false
     return true
   }
 
-  constructor(resp, text, { message, status } = {}) {
+  constructor(
+    resp: Response,
+    text?: string,
+    { message, status }: { message?: string; status?: number } = {},
+  ) {
     let json
     try {
-      json = JSON.parse(text)
+      json = JSON.parse(text as string)
     } catch (e) {
       json = { message: message || text }
     }
@@ -107,14 +116,8 @@ export class HTTPError extends BaseError {
 /**
  * Request middleware saga.
  *
- * @typedef {function} Middleware
- *
- * @param {any} input
- *
- * @param {function} next
- *   Next middleware in chain (should be invoked with `yield call()`).
- *
- * @returns {any}
+ * Invoked with the request input and `next` (the next middleware in chain,
+ * which should be invoked with `yield call()`).
  *
  * @example
  * function* exampleMiddleware(opts, next) {
@@ -126,28 +129,24 @@ export class HTTPError extends BaseError {
  *   return yield resp.json();
  * }
  */
+export type Middleware = (input: any, next: any) => Generator<any, any, any>
 
 /**
  * Compose middleware sagas.
- *
- * @param {...Middleware} middleware
- *
- * @returns {function} Result of middleware composition.
  */
-const composeMiddleware = (handler, ...rest) =>
+const composeMiddleware = (...mws: Middleware[]) =>
   // TODO: optimize
-  function* composed(arg) {
+  function* composed(arg: any): Generator<any, any, any> {
+    const [handler, ...rest] = mws
     return yield call(handler, arg, composeMiddleware(...rest))
   }
 
 /**
  * Middleware for handling HTTP errors.
  *
- * @type {Middleware}
- *
  * @throws {HTTPError}
  */
-function* errorMiddleware(opts, next) {
+function* errorMiddleware(opts: any, next: any): Generator<any, any, any> {
   const resp = yield call(next, opts)
   if (!resp.ok) {
     const text = yield resp.text()
@@ -156,7 +155,10 @@ function* errorMiddleware(opts, next) {
   return resp
 }
 
-const isInstance = (cls) => (b) => (cls ? b instanceof cls : false)
+const isInstance =
+  <T,>(cls: { new (...args: any[]): T } | undefined) =>
+  (b: unknown) =>
+    cls ? b instanceof cls : false
 
 const validBodyTests = [
   isNil,
@@ -170,33 +172,16 @@ const validBodyTests = [
   isInstance(global.ReadableStream),
 ]
 
-const isValidBody = (b) => validBodyTests.some((t) => t && t(b))
-
-/**
- * Valid body type for fetch / Request. One of:
- *
- *   - ArrayBuffer
- *   - Buffer
- *   - TypedArray
- *   - String
- *   - Blob
- *   - FormData
- *   - URLSearchParams
- *   - ReadableStream
- *
- * Details: https://developer.mozilla.org/en-US/docs/Web/API/Request/Request
- *
- * @typedef {ArrayBuffer|Buffer|TypedArray|String|Blob|FormData|URLSearchParams|ReadableStream} Body
- */
+const isValidBody = (b: unknown) => validBodyTests.some((t) => t && t(b))
 
 /**
  * Stringify body if it's not of a type accepted by fetch / Request.
  *
- * @param {any} body
- *
- * @returns {Body}
+ * Valid body types: ArrayBuffer, Buffer, TypedArray, String, Blob, FormData,
+ * URLSearchParams, ReadableStream.
+ * Details: https://developer.mozilla.org/en-US/docs/Web/API/Request/Request
  */
-const stringifyBody = (body) => (isValidBody(body) ? body : JSON.stringify(body))
+const stringifyBody = (body: any) => (isValidBody(body) ? body : JSON.stringify(body))
 
 const jsonContentType = {
   'Content-Type': 'application/json',
@@ -210,12 +195,11 @@ const jsonAccepts = {
  * Middleware for working with JSON endpoints:
  *   - adds JSON-related headers
  *   - parses the response body
- *
- * @type {Middleware}
- *
- * @param {boolean} options.json Use JSON handling.
  */
-function* jsonMiddleware({ json = true, ...opts }, next) {
+function* jsonMiddleware(
+  { json = true, ...opts }: any,
+  next: any,
+): Generator<any, any, any> {
   if (!json) return yield call(next, opts)
 
   const {
@@ -244,33 +228,32 @@ function* jsonMiddleware({ json = true, ...opts }, next) {
 
 /**
  * Create fetch middleware.
- *
- * @param {Object} options
- *
- * @param {function} options.fetch
- *
- * @param {string} options.base
- *
- * @returns {Middleware}
  */
-const mkFetchMiddleware = ({ fetch, base }) =>
-  function* fetchMiddleware({ url, endpoint, ...init }) {
+const mkFetchMiddleware = ({
+  fetch,
+  base,
+}: {
+  fetch: typeof window.fetch
+  base: string
+}) =>
+  function* fetchMiddleware({ url, endpoint, ...init }: any): Generator<any, any, any> {
     return yield call(fetch, url || base + endpoint, init)
   }
 
+interface ApiSagaOptions {
+  fetch: typeof window.fetch
+  base?: string
+  middleware?: Middleware[]
+}
+
 /**
  * The saga that listens for API_REQUEST actions and executes the requests.
- *
- * @param {Object} options
- *
- * @param {function} options.fetch `fetch` implementation to use.
- *
- * @param {string} options.base
- *   API base URL, prepended to the `endpoint` for every request.
- *
- * @param {[Middleware]} options.middleware Middleware chain.
  */
-function* apiSaga({ fetch, base = '', middleware = [] }) {
+function* apiSaga({
+  fetch,
+  base = '',
+  middleware = [],
+}: ApiSagaOptions): Generator<any, any, any> {
   const execRequest = composeMiddleware(
     ...middleware,
     jsonMiddleware,
@@ -280,7 +263,10 @@ function* apiSaga({ fetch, base = '', middleware = [] }) {
 
   yield takeEvery(
     request.type,
-    function* handleRequest({ payload: opts, meta: { resolve, reject } }) {
+    function* handleRequest({
+      payload: opts,
+      meta: { resolve, reject },
+    }: any): Generator<any, any, any> {
       try {
         const result = yield call(execRequest, opts)
         yield put(response(result, opts))
@@ -295,34 +281,37 @@ function* apiSaga({ fetch, base = '', middleware = [] }) {
 
 /**
  * Make an API request.
- *
- * @param {Object} options
- *
- * @returns {any}
  */
-export function* apiRequest(opts) {
+export function* apiRequest(opts: RequestOptions | string): Generator<any, any, any> {
   const dfd = defer()
   yield put(request(opts, dfd.resolver))
   return yield dfd.promise
 }
 
-const Ctx = React.createContext()
+export type ApiRequest = (opts: RequestOptions | string) => Promise<any>
 
-export const useApi = () => React.useContext(Ctx)
+const Ctx = React.createContext<ApiRequest>(undefined as unknown as ApiRequest)
+
+export const useApi = (): ApiRequest => React.useContext(Ctx)
 
 export const use = useApi
 
-// fetch: window.fetch, middleware: ((any) => any)[]
-export function Provider({ fetch, middleware, children }) {
+interface ProviderProps {
+  fetch: typeof window.fetch
+  middleware?: Middleware[]
+  children?: React.ReactNode
+}
+
+export function Provider({ fetch, middleware, children }: ProviderProps) {
   const base = `${cfg.registryUrl}/api`
   SagaInjector.useSaga(apiSaga, { fetch, base, middleware })
 
   const dispatch = redux.useDispatch()
-  const req = React.useCallback(
+  const req = React.useCallback<ApiRequest>(
     (opts) => {
       const dfd = defer()
       dispatch(request(opts, dfd.resolver))
-      return dfd.promise
+      return dfd.promise as Promise<any>
     },
     [dispatch],
   )

--- a/catalog/app/utils/CatalogSettings.tsx
+++ b/catalog/app/utils/CatalogSettings.tsx
@@ -75,7 +75,6 @@ async function fetchSettings({ s3 }: { s3: S3 }) {
 const CatalogSettingsResource = Cache.createResource({
   name: 'CatalogSettings.config',
   fetch: fetchSettings,
-  // @ts-expect-error
   key: () => null,
 })
 

--- a/catalog/app/utils/ResourceCache.tsx
+++ b/catalog/app/utils/ResourceCache.tsx
@@ -11,30 +11,64 @@ import tagged from 'utils/tagged'
 import useConstant from 'utils/useConstant'
 import useMemoEq from 'utils/useMemoEq'
 
-const Ctx = React.createContext()
+export interface Resource<I, O> {
+  name: string
+  id: string
+  fetch: (input: I) => Promise<O>
+  key: (input: I) => unknown
+  persist: boolean
+}
+
+// AsyncResult value for an Entry: Init | Pending | Err(any) | Ok(O)
+export interface Entry<O> {
+  promise: Promise<O>
+  result: ReturnType<typeof AsyncResult.Init>
+  claimed: number
+  releasedAt?: Date
+}
+
+// State = Map<resource.id, Map<key, Entry<O>>>
+type State = I.Map<unknown, unknown>
+
+// The redux instance exposed via context. Typed loosely because the underlying
+// resource/entry generics are erased once stored in the Immutable state map.
+export interface CacheInstance {
+  access: (resource: any, input: any) => any
+  get: (resource: any, input: any) => any
+  patch: (
+    resource: any,
+    input: any,
+    update: (entry: any) => any,
+    silent?: boolean,
+  ) => void
+  patchOk: (
+    resource: any,
+    input: any,
+    updateOk: (value: any) => any,
+    silent?: boolean,
+  ) => void
+  claim: (resource: any, input: any) => void
+  release: (resource: any, input: any) => void
+  subscribe: (listener: () => void) => () => void
+}
+
+const Ctx = React.createContext<CacheInstance | null>(null)
 
 const RELEASE_TIME = 5000
 
-// Resource<I, O> = {
-//   name: string,
-//   id: string,
-//   fetch<I, O>: I -> Promise<O>,
-// }
-//
-// Entry<O> = {
-//   promise: Promise<O>,
-//   result: AsyncResult<{
-//     Init: void
-//     Pending: void
-//     Err: any
-//     Ok: O
-//   }),
-//   claimed: number,
-//   releasedAt: Date?
-// }
-// State = Map<string, Map<I, Entry<O>>>
+interface CreateResourceOptions<I, O> {
+  name: string
+  fetch: (input: I) => Promise<O>
+  key?: (input: I) => unknown
+  persist?: boolean
+}
 
-export const createResource = ({ name, fetch, key = R.identity, persist = false }) => ({
+export const createResource = <I, O>({
+  name,
+  fetch,
+  key = R.identity,
+  persist = false,
+}: CreateResourceOptions<I, O>): Resource<I, O> => ({
   name,
   fetch,
   id: uuid.v4(),
@@ -52,15 +86,18 @@ const Action = tagged([
   'CleanUp', // { time: Date }
 ])
 
-const keyFor = (resource, input) => [resource.id, I.fromJS(resource.key(input))]
+const keyFor = (resource: Resource<any, any>, input: any) => [
+  resource.id,
+  I.fromJS(resource.key(input)),
+]
 
-const reducer = reduxTools.withInitialState(
+const reducer = reduxTools.withInitialState<State>(
   I.Map(),
   Action.reducer({
     Init:
-      ({ resource, input, promise }) =>
-      (s) =>
-        s.updateIn(keyFor(resource, input), (entry) => {
+      ({ resource, input, promise }: any) =>
+      (s: State) =>
+        s.updateIn(keyFor(resource, input), (entry: any) => {
           if (entry) throw new Error('Init: entry already exists')
           return {
             promise,
@@ -69,9 +106,9 @@ const reducer = reduxTools.withInitialState(
           }
         }),
     Request:
-      ({ resource, input }) =>
-      (s) =>
-        s.updateIn(keyFor(resource, input), (entry) => {
+      ({ resource, input }: any) =>
+      (s: State) =>
+        s.updateIn(keyFor(resource, input), (entry: any) => {
           if (!entry) throw new Error('Request: entry does not exist')
           if (!AsyncResult.Init.is(entry.result)) {
             throw new Error('Request: invalid transition')
@@ -79,9 +116,9 @@ const reducer = reduxTools.withInitialState(
           return { ...entry, result: AsyncResult.Pending() }
         }),
     Response:
-      ({ resource, input, result }) =>
-      (s) =>
-        s.updateIn(keyFor(resource, input), (entry) => {
+      ({ resource, input, result }: any) =>
+      (s: State) =>
+        s.updateIn(keyFor(resource, input), (entry: any) => {
           if (!entry) return undefined // released before response
           if (!AsyncResult.Pending.is(entry.result)) {
             throw new Error('Response: invalid transition')
@@ -89,9 +126,9 @@ const reducer = reduxTools.withInitialState(
           return { ...entry, result }
         }),
     Patch:
-      ({ resource, input, update, silent = false }) =>
-      (s) =>
-        s.updateIn(keyFor(resource, input), (entry) => {
+      ({ resource, input, update, silent = false }: any) =>
+      (s: State) =>
+        s.updateIn(keyFor(resource, input), (entry: any) => {
           if (!entry) {
             if (silent) return entry
             throw new Error('Patch: entry does not exist')
@@ -99,35 +136,35 @@ const reducer = reduxTools.withInitialState(
           return update(entry)
         }),
     Claim:
-      ({ resource, input }) =>
-      (s) =>
-        s.updateIn(keyFor(resource, input), (entry) => {
+      ({ resource, input }: any) =>
+      (s: State) =>
+        s.updateIn(keyFor(resource, input), (entry: any) => {
           if (!entry) throw new Error('Claim: entry does not exist')
           return { ...entry, claimed: entry.claimed + 1 }
         }),
     Release:
-      ({ resource, input, releasedAt }) =>
-      (s) =>
-        s.updateIn(keyFor(resource, input), (entry) => {
+      ({ resource, input, releasedAt }: any) =>
+      (s: State) =>
+        s.updateIn(keyFor(resource, input), (entry: any) => {
           if (!entry) throw new Error('Release: entry does not exist')
           return { ...entry, claimed: entry.claimed - 1, releasedAt }
         }),
     CleanUp:
-      ({ time }) =>
-      (s) =>
-        s.map((r) =>
+      ({ time }: any) =>
+      (s: State) =>
+        (s as any).map((r: any) =>
           r.filter(
-            (entry) =>
+            (entry: any) =>
               entry.claimed >= 1 ||
               !entry.releasedAt ||
               time - entry.releasedAt < RELEASE_TIME,
           ),
         ),
     __: () => R.identity,
-  }),
+  }) as reduxTools.Reducer<State>,
 )
 
-export const suspend = ({ promise, result }) =>
+export const suspend = ({ promise, result }: Pick<Entry<any>, 'promise' | 'result'>) =>
   AsyncResult.case(
     {
       Init: () => {
@@ -136,7 +173,7 @@ export const suspend = ({ promise, result }) =>
       Pending: () => {
         throw promise
       },
-      Err: (e) => {
+      Err: (e: any) => {
         throw e
       },
       Ok: R.identity,
@@ -144,26 +181,30 @@ export const suspend = ({ promise, result }) =>
     result,
   )
 
-export const Provider = function ResourceCacheProvider({ children }) {
-  const { dispatch, subscribe, getState } = useConstant(() => redux.createStore(reducer))
+export const Provider = function ResourceCacheProvider({
+  children,
+}: React.PropsWithChildren<{}>) {
+  const { dispatch, subscribe, getState } = useConstant(() =>
+    redux.createStore(reducer as redux.Reducer),
+  )
 
   const getEntry = React.useCallback(
-    (resource, input) => getState().getIn(keyFor(resource, input)),
+    (resource: any, input: any) => getState().getIn(keyFor(resource, input)),
     [getState],
   )
 
   const init = React.useCallback(
-    (resource, input) => {
+    (resource: any, input: any) => {
       const { resolver, promise } = defer()
       dispatch(Action.Init({ resource, input, resolver, promise }))
       setTimeout(() => {
         dispatch(Action.Request({ resource, input }))
         resource.fetch(input).then(
-          (res) => {
+          (res: any) => {
             dispatch(Action.Response({ resource, input, result: AsyncResult.Ok(res) }))
             resolver.resolve(res)
           },
-          (e) => {
+          (e: any) => {
             dispatch(Action.Response({ resource, input, result: AsyncResult.Err(e) }))
             resolver.reject(e)
           },
@@ -175,23 +216,23 @@ export const Provider = function ResourceCacheProvider({ children }) {
   )
 
   const access = React.useCallback(
-    (resource, input) => getEntry(resource, input) ?? init(resource, input),
+    (resource: any, input: any) => getEntry(resource, input) ?? init(resource, input),
     [getEntry, init],
   )
 
   const get = React.useMemo(() => R.pipe(access, suspend), [access])
 
   const patch = React.useCallback(
-    (resource, input, update, silent) => {
+    (resource: any, input: any, update: (entry: any) => any, silent?: boolean) => {
       dispatch(Action.Patch({ resource, input, update, silent }))
     },
     [dispatch],
   )
 
   const patchOk = React.useCallback(
-    (resource, input, updateOk, silent) => {
+    (resource: any, input: any, updateOk: (value: any) => any, silent?: boolean) => {
       const update = R.when(
-        (s) => AsyncResult.Ok.is(s.result),
+        (s: any) => AsyncResult.Ok.is(s.result),
         R.evolve({
           result: AsyncResult.case({
             Ok: R.pipe(updateOk, AsyncResult.Ok),
@@ -206,14 +247,14 @@ export const Provider = function ResourceCacheProvider({ children }) {
   )
 
   const claim = React.useCallback(
-    (resource, input) => {
+    (resource: any, input: any) => {
       dispatch(Action.Claim({ resource, input }))
     },
     [dispatch],
   )
 
   const release = React.useCallback(
-    (resource, input) => {
+    (resource: any, input: any) => {
       const releasedAt = new Date()
       dispatch(Action.Release({ resource, input, releasedAt }))
     },
@@ -239,7 +280,7 @@ export const Provider = function ResourceCacheProvider({ children }) {
 }
 
 export function useResourceCache() {
-  return React.useContext(Ctx)
+  return React.useContext(Ctx) as CacheInstance
 }
 
 export const use = useResourceCache
@@ -247,7 +288,11 @@ export const use = useResourceCache
 /**
  * @deprecated Use @tanstack/react-query
  */
-export function useData(resource, input, opts = {}) {
+export function useData(
+  resource: any,
+  input: any,
+  opts: { suspend?: boolean } = {},
+): any {
   const { access, claim, release, subscribe } = use()
   const inputMemo = useMemoEq(input, R.identity)
   const [entry, setEntry] = React.useState(() => access(resource, input))

--- a/catalog/app/utils/Store.tsx
+++ b/catalog/app/utils/Store.tsx
@@ -1,7 +1,7 @@
 import { fromJS, Iterable } from 'immutable'
 import * as React from 'react'
 import { Provider as ReduxProvider } from 'react-redux'
-import { createStore, applyMiddleware, compose } from 'redux'
+import { createStore, applyMiddleware, compose, Reducer } from 'redux'
 import { composeWithDevTools } from 'redux-devtools-extension'
 import { combineReducers } from 'redux-immutable'
 import * as Sentry from '@sentry/react'
@@ -9,11 +9,17 @@ import * as Sentry from '@sentry/react'
 import { withInjectableReducers } from 'utils/ReducerInjector'
 import { withSaga } from 'utils/SagaInjector'
 
-const stateTransformer = (state) =>
+const stateTransformer = (state: any) =>
   // pure JS is easier to read than Immutable objects
   Iterable.isIterable(state) ? state.toJS() : state
 
-const actionTransformer = (action) => {
+interface AnyAction {
+  type: string
+  payload?: any
+  [key: string]: any
+}
+
+const actionTransformer = (action: AnyAction) => {
   switch (action.type) {
     case 'app/Auth/SIGN_UP':
     case 'app/Auth/SIGN_IN':
@@ -33,9 +39,9 @@ const composeEnhancers = composeWithDevTools({})
 
 const sentryEnhancer = Sentry.createReduxEnhancer({ actionTransformer, stateTransformer })
 
-const sentryfyReducer = (originalReducer) => {
-  let extracted
-  const extractReducer = (reducer) => {
+const sentryfyReducer = (originalReducer: Reducer) => {
+  let extracted: Reducer | undefined
+  const extractReducer = (reducer: Reducer) => {
     extracted = reducer
   }
   sentryEnhancer(extractReducer)(originalReducer, {})
@@ -44,10 +50,18 @@ const sentryfyReducer = (originalReducer) => {
 
 const createReducer = compose(sentryfyReducer, combineReducers)
 
-export const Provider = function StoreProvider({ initialState = {}, children }) {
+interface ProviderProps {
+  initialState?: object
+  children: React.ReactNode
+}
+
+export const Provider = function StoreProvider({
+  initialState = {},
+  children,
+}: ProviderProps) {
   // Create the store with asynchronously loaded reducers
   const [store] = React.useState(() => {
-    const middlewares = []
+    const middlewares: any[] = []
     // log redux state in development
     if (
       process.env.NODE_ENV === 'development' &&
@@ -58,13 +72,15 @@ export const Provider = function StoreProvider({ initialState = {}, children }) 
       middlewares.push(createLogger({ stateTransformer, collapsed: true }))
     }
 
-    return createStore(
-      (state) => state, // noop reducer, the actual ones will be injected
+    // redux's createStore generics don't model the Immutable preloaded state +
+    // custom enhancers (injectable reducers / saga); call through a cast.
+    return (createStore as any)(
+      (state: any) => state, // noop reducer, the actual ones will be injected
       fromJS(initialState),
       composeEnhancers(
         withSaga({ onError: Sentry.captureException }),
         applyMiddleware(...middlewares),
-        withInjectableReducers(createReducer),
+        withInjectableReducers(createReducer as (reducers: Record<string, any>) => any),
       ),
     )
   })

--- a/catalog/app/utils/search.ts
+++ b/catalog/app/utils/search.ts
@@ -9,34 +9,53 @@ import mkSearch from 'utils/mkSearch'
 
 export class SearchError extends BaseError {}
 
-const parseDate = (d) => d && new Date(d)
+const parseDate = (d: string | null | undefined): Date | undefined =>
+  d ? new Date(d) : undefined
 
-/*
-File: {
-  key: str,
-  type: 'object',
-  score: num,
-  bucket: str,
-  path: str,
-  versions: [
-    {
-      id: str,
-      score: num,
-      updated: ?Date,
-      lastModified: ?Date,
-      size: num,
-      meta: str,
-    },
-  ],
+interface FileVersion {
+  id: string
+  score: number
+  updated?: Date
+  lastModified?: Date
+  size: number
+  meta: string
+  deleteMarker?: boolean
 }
-*/
 
-const getBucketFromIndex = (idx) => {
+export interface File {
+  key: string
+  type: 'object'
+  score: number
+  bucket: string
+  path: string
+  versions: FileVersion[]
+}
+
+// Raw ElasticSearch hit as returned by the /search endpoint.
+interface Hit {
+  _score: number
+  _index: string
+  _source: {
+    key: string
+    version_id: string
+    updated?: string
+    last_modified?: string
+    size: number
+    user_meta: string
+    delete_marker?: boolean
+  }
+}
+
+const getBucketFromIndex = (idx: string): string => {
   const i = idx.lastIndexOf('-reindex-')
   return i === -1 ? idx : idx.slice(0, i)
 }
 
-const extractData = ({ _score: score, _source: src, _index: idx }) => {
+const extractData = ({
+  _score: score,
+  _source: src,
+  _index: idx,
+}: Hit): Record<string, File> => {
   const bucket = getBucketFromIndex(idx)
   const key = `object:${bucket}/${src.key}`
   return {
@@ -61,27 +80,46 @@ const extractData = ({ _score: score, _source: src, _index: idx }) => {
   }
 }
 
-const takeR = (_l, r) => r
+const takeR = <T>(_l: T, r: T): T => r
 
-const mkMerger = (cases) => (key, l, r) => (cases[key] || takeR)(l, r)
+type MergeCase = (l: any, r: any) => any
+
+const mkMerger =
+  (cases: Record<string, MergeCase>) =>
+  (key: string, l: unknown, r: unknown): unknown =>
+    (cases[key] || takeR)(l, r)
 
 const mergeHits = R.mergeDeepWithKey(
   mkMerger({
     score: R.max,
     versions: R.pipe(
-      R.concat,
-      R.sortBy((v) => -v.score),
+      R.concat as (a: FileVersion[], b: FileVersion[]) => FileVersion[],
+      R.sortBy((v: FileVersion) => -v.score),
     ),
   }),
-)
+) as (a: Record<string, File>, b: Record<string, File>) => Record<string, File>
 
-const mergeAllHits = R.pipe(
-  R.reduce((acc, hit) => mergeHits(acc, extractData(hit)), {}),
+const mergeAllHits: (hits: Hit[]) => File[] = R.pipe(
+  R.reduce(
+    (acc: Record<string, File>, hit: Hit) => mergeHits(acc, extractData(hit)),
+    {} as Record<string, File>,
+  ),
   R.values,
-  R.sortBy((h) => -h.score),
+  R.sortBy((h: File) => -h.score),
 )
 
-const unescape = (s) => s.replace(/\\n/g, '\n')
+const unescape = (s: string): string => s.replace(/\\n/g, '\n')
+
+interface SearchParams {
+  query: string
+  buckets?: string[]
+  retry?: number
+}
+
+export interface SearchResult {
+  hits: File[]
+  total: number
+}
 
 export default function useSearch() {
   const req = APIConnector.use()
@@ -89,7 +127,7 @@ export default function useSearch() {
   const allBuckets = React.useMemo(() => bucketList.map((b) => b.name), [bucketList])
 
   return React.useCallback(
-    async ({ query, buckets = [], retry }) => {
+    async ({ query, buckets = [], retry }: SearchParams): Promise<SearchResult> => {
       const index = (buckets.length ? buckets : allBuckets).join(',')
       try {
         const qs = mkSearch({ index, action: 'search', query, retry })
@@ -98,7 +136,7 @@ export default function useSearch() {
         return { hits, total: result.hits.total }
       } catch (e) {
         if (e instanceof APIConnector.HTTPError) {
-          const match = e.text.match(/^RequestError\((\d+), '(\w+)', '(.+)'\)$/)
+          const match = e.text?.match(/^RequestError\((\d+), '(\w+)', '(.+)'\)$/)
           if (match) {
             const code = match[2]
             const details = unescape(match[3])


### PR DESCRIPTION
## What

Batch 7 of the catalog **JS → TypeScript** stack (`qhq-ouqv`) — the Redux/saga **infrastructure** layer (two T3 files).

- **APIConnector.jsx** → `.tsx` (7 dependents): `HTTPError` class (static `.is`; `text` optional to match `new HTTPError(resp)` call sites), `RequestOptions` / `Middleware` / `ApiRequest` types, `Provider`. The generator-middleware sagas are annotated `Generator<any,any,any>` (otherwise their `yield`s are implicit-any under strict); `composeMiddleware` is made variadic so its recursive spread type-checks.
- **Store.jsx** → `.tsx`: `createStore` is called through a cast — redux generics do not model the Immutable preloaded state + custom (injectable-reducer / saga) enhancers.
- **search.js** → `.ts`: typed ES hit/result shapes.
- **ResourceCache.jsx** → `.tsx` (T3): `Resource<I,O>` / `Entry<O>` / `CacheInstance` generics; Immutable state typed loosely.

Supporting: `@types/redux-immutable.d.ts` for the untyped dependency; removed a now-unused `@ts-expect-error` in `CatalogSettings`.

## Verification

`npm run typecheck` ✓ · `npm run lint` ✓ · full `vitest` suite (1099 tests) ✓.

## Stack

Stacked on #5053 (batch 6). Base branch: `ts6-js2ts/06-barrels-charts`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR converts another catalog infrastructure batch from JavaScript to TypeScript. The main changes are:

- API connector types for requests, middleware, HTTP errors, and provider context.
- Resource cache generics and loose Redux/Immutable state typing.
- Store typing around Redux enhancers and the local redux-immutable declaration.
- Search result and error parsing types.
- Removal of an unused CatalogSettings type suppression.

<h3>Confidence Score: 5/5</h3>

This looks safe to merge.

- No blocking issues found in the changed code.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| catalog/app/utils/APIConnector.tsx | Converted the API connector, middleware, provider, and HTTPError helpers to TypeScript without changing the request flow. |
| catalog/app/utils/ResourceCache.tsx | Converted the resource cache provider, reducer, hooks, and resource definitions to TypeScript with erased generics and casts. |
| catalog/app/utils/Store.tsx | Converted the Redux store provider to TypeScript and kept the existing enhancer composition behind casts. |
| catalog/app/utils/search.ts | Converted search hit parsing, result shapes, and error wrapping to TypeScript. |
| catalog/app/@types/redux-immutable.d.ts | Added a local ambient declaration for the untyped redux-immutable dependency. |
| catalog/app/utils/CatalogSettings.tsx | Removed an unused type suppression from the ResourceCache key definition. |

<sub>Reviews (1): Last reviewed commit: ["catalog: convert APIConnector/Store/sear..."](https://github.com/quiltdata/quilt/commit/974cd35f0e1efb2b04e6830271d1748dbfc1488d) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=40361878)</sub>

<!-- /greptile_comment -->