### PR TITLE
[PARKED] catalog: convert AWS Credentials/Config + Bucket boundary to TS (js→ts batch 9)

### DIFF
--- a/catalog/app/containers/Bucket/FileView.tsx
+++ b/catalog/app/containers/Bucket/FileView.tsx
@@ -14,14 +14,20 @@ export * from './Meta'
 
 // TODO: move here everything that's reused btw Bucket/File, Bucket/PackageTree and Embed/File
 
-export function DownloadButton({ className, handle }) {
-  return AWS.Signer.withDownloadUrl(handle, (url) => (
+interface DownloadButtonProps {
+  className?: string
+  handle: Parameters<typeof AWS.Signer.withDownloadUrl>[0]
+}
+
+export function DownloadButton({ className, handle }: DownloadButtonProps) {
+  return AWS.Signer.withDownloadUrl(handle, (url: string) => (
     <Buttons.Iconized
       className={className}
-      href={url}
-      download
+      // Iconized forwards these to the underlying anchor, but its props type
+      // does not model them
+      {...({ href: url, download: true } as object)}
       label="Download file"
-      icon="arrow_downward"
+      icon={'arrow_downward' as Buttons.StrIcon}
     />
   ))
 }
@@ -37,7 +43,9 @@ const useViewModeSelectorStyles = M.makeStyles((t) => ({
   },
 }))
 
-export function ViewModeSelector({ className, ...props }) {
+type ViewModeSelectorProps = Omit<Parameters<typeof SelectDropdown>[0], 'children'>
+
+export function ViewModeSelector({ className, ...props }: ViewModeSelectorProps) {
   const classes = useViewModeSelectorStyles()
   const t = M.useTheme()
   const sm = M.useMediaQuery(t.breakpoints.down('sm'))
@@ -48,23 +56,22 @@ export function ViewModeSelector({ className, ...props }) {
   )
 }
 
+interface ZipDownloadFormProps {
+  className?: string
+  suffix?: string
+  children?: React.ReactNode
+  newTab?: boolean
+  files?: string[]
+}
+
 /** Child button must have `type="submit"` */
-/**
- * @param {{
- *   className?: string
- *   suffix?: string
- *   children?: React.ReactNode
- *   newTab?: boolean
- *   files?: string[]
- * }} props
- */
 export function ZipDownloadForm({
   className = '',
   suffix,
   children,
   newTab = false,
   files = [],
-}) {
+}: ZipDownloadFormProps) {
   const { token } = redux.useSelector(tokensSelector) || {}
   if (!token || cfg.noDownload) return null
   const action = `${cfg.s3Proxy}/zip/${suffix}`
@@ -85,7 +92,7 @@ export function ZipDownloadForm({
   )
 }
 
-export function Root(props) {
+export function Root(props: M.BoxProps) {
   return <M.Box pt={2} pb={4} {...props} />
 }
 

--- a/catalog/app/containers/Bucket/renderPreview.tsx
+++ b/catalog/app/containers/Bucket/renderPreview.tsx
@@ -8,7 +8,13 @@ const Message = M.styled('div')({
   width: '100%',
 })
 
-const renderMessage = ({ heading, body, action }) => (
+interface MessageData {
+  heading?: React.ReactNode
+  body?: React.ReactNode
+  action?: React.ReactNode
+}
+
+const renderMessage = ({ heading, body, action }: MessageData) => (
   <Message>
     {!!heading && (
       <M.Typography variant="h6" gutterBottom>
@@ -30,4 +36,5 @@ const renderProgress = () => (
   </Message>
 )
 
-export default (onData) => Preview.display({ renderMessage, renderProgress, onData })
+export default (onData?: (data: $TSFixMe) => void) =>
+  Preview.display({ renderMessage, renderProgress, onData })

--- a/catalog/app/utils/AWS/Config.tsx
+++ b/catalog/app/utils/AWS/Config.tsx
@@ -6,15 +6,17 @@ import useMemoEq from 'utils/useMemoEq'
 
 import * as Credentials from './Credentials'
 
-const Ctx = React.createContext()
+const Ctx = React.createContext<AWS.ConfigurationOptions | undefined>(undefined)
 
-const useConfig = (props) => {
+const useConfig = (props: AWS.ConfigurationOptions | undefined) => {
   const credentials = Credentials.use()
   // TODO: use cache?
   return useMemoEq({ credentials, ...props }, (input) => new AWS.Config(input))
 }
 
-export function Provider({ children, ...props }) {
+type ProviderProps = React.PropsWithChildren<AWS.ConfigurationOptions>
+
+export function Provider({ children, ...props }: ProviderProps) {
   return <Ctx.Provider value={props}>{children}</Ctx.Provider>
 }
 

--- a/catalog/app/utils/AWS/Credentials.tsx
+++ b/catalog/app/utils/AWS/Credentials.tsx
@@ -10,7 +10,7 @@ import { BaseError } from 'utils/error'
 import logout from 'utils/logout'
 
 export class CredentialsError extends BaseError {
-  constructor(headline, detail, object) {
+  constructor(headline: string, detail?: string, object?: {}) {
     super(headline, { headline, detail, object })
   }
 }
@@ -21,31 +21,56 @@ class InvalidTokenError extends CredentialsError {}
 
 class NewExpirationInThePastError extends CredentialsError {}
 
-class RegistryCredentials extends AWS.Credentials {
-  constructor({ req, reqOpts }) {
+interface RegistryCredentialsOptions {
+  req: APIConnector.ApiRequest
+  reqOpts?: APIConnector.RequestOptions
+}
+
+interface CredentialsResponse {
+  Expiration?: string
+  AccessKeyId: string
+  SecretAccessKey: string
+  SessionToken: string
+}
+
+// aws-sdk's Credentials constructor requires args; cast the base to a 0-arg
+// constructor (instances are still AWS.Credentials, so they stay assignable
+// where Credentials is expected) to allow super() without altering behavior.
+class RegistryCredentials extends (AWS.Credentials as unknown as {
+  new (): AWS.Credentials
+}) {
+  req: APIConnector.ApiRequest
+
+  reqOpts?: APIConnector.RequestOptions
+
+  refreshing?: Promise<void>
+
+  error?: CredentialsError
+
+  constructor({ req, reqOpts }: RegistryCredentialsOptions) {
     super()
     this.req = req
     this.reqOpts = reqOpts
   }
 
-  refresh(callback) {
+  refresh(callback?: (err?: any) => void): Promise<void> {
     if (!this.refreshing) {
       this.refreshing = this.req({ endpoint: '/auth/get_credentials', ...this.reqOpts })
-        .then((data) => {
+        .then((data: CredentialsResponse) => {
           const expireTime = data.Expiration ? new Date(data.Expiration) : null
-          if (expireTime?.getTime() < Date.now()) {
+          if (expireTime != null && expireTime.getTime() < Date.now()) {
             throw new NewExpirationInThePastError(
               `We're getting credentials that are already expired. Check your computer's clock, please`,
             )
           }
-          this.expireTime = expireTime
+          this.expireTime = expireTime as Date
           this.accessKeyId = data.AccessKeyId
           this.secretAccessKey = data.SecretAccessKey
           this.sessionToken = data.SessionToken
           delete this.refreshing
           if (callback) callback()
         })
-        .catch((e) => {
+        .catch((e: Error) => {
           delete this.refreshing
           if (/Outdated access token: please log in again/.test(e.message)) {
             this.error = new OutdatedTokenError(e.message)
@@ -72,7 +97,9 @@ class RegistryCredentials extends AWS.Credentials {
   }
 }
 
-class EmptyCredentials extends AWS.Credentials {
+class EmptyCredentials extends (AWS.Credentials as unknown as {
+  new (): AWS.Credentials
+}) {
   suspend() {
     return this
   }
@@ -93,22 +120,26 @@ function useCredentialsMemo() {
   return empty
 }
 
-const Ctx = React.createContext()
+// The context always holds one of our subclasses (both expose `suspend()`), or
+// null before the provider has run.
+type Credentials = RegistryCredentials | EmptyCredentials
 
-export function AWSCredentialsProvider({ children }) {
+const Ctx = React.createContext<Credentials | null>(null)
+
+export function AWSCredentialsProvider({ children }: React.PropsWithChildren<{}>) {
   return <Ctx.Provider value={useCredentialsMemo()}>{children}</Ctx.Provider>
 }
 
-export function useCredentials() {
+export function useCredentials(): Credentials {
   const credentials = React.useContext(Ctx)
   if (!credentials) throw new CredentialsError('Failed to get credentials')
   if (
-    credentials.error instanceof OutdatedTokenError ||
-    credentials.error instanceof InvalidTokenError
+    (credentials as RegistryCredentials).error instanceof OutdatedTokenError ||
+    (credentials as RegistryCredentials).error instanceof InvalidTokenError
   ) {
     logout()
   }
-  return React.useContext(Ctx)
+  return React.useContext(Ctx)!
 }
 
 export { AWSCredentialsProvider as Provider, useCredentials as use }


### PR DESCRIPTION
## What

Batch 9 of the catalog **JS → TypeScript** stack (`qhq-ouqv`) — the AWS credentials/config layer + two Bucket boundary files (incl. the priority boundary `FileView`, deferred from batch 0).

- **utils/AWS/Credentials.jsx** → `.tsx` (priority boundary): `RegistryCredentials`/`EmptyCredentials` subclass aws-sdk `Credentials`. The base is cast to a 0-arg constructor so `super()` type-checks **while instances remain `AWS.Credentials`** (stay assignable where `Credentials` is expected, e.g. Config/electron); `refresh`'s callback error is typed loosely to satisfy the override. Typed `createContext` (gotcha #5) + provider props.
- **utils/AWS/Config.jsx** → `.tsx`: typed `createContext` default (gotcha #5).
- **containers/Bucket/FileView.jsx** → `.tsx` (priority boundary, JSDoc → real types): `ZipDownloadForm` options interface (gotcha #1); `ViewModeSelector` forwards `SelectDropdown` props; `DownloadButton` anchor props cast (`Iconized` doesn't model `href`/`download`).
- **containers/Bucket/renderPreview.jsx** → `.tsx`.

## Verification

`npm run typecheck` ✓ · `npm run lint` ✓ · full `vitest` suite ✓.

## Stack

Stacked on #5055 (batch 8). Base branch: `ts6-js2ts/08-data-preview-loaders`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR converts the AWS and Bucket boundary files to TypeScript. The main changes are:

- Typed AWS credentials and config contexts.
- Converted credential subclasses and refresh response shapes.
- Typed Bucket download, zip form, view selector, and preview helpers.
- Kept the UI and AWS boundary behavior mostly unchanged.

<h3>Confidence Score: 5/5</h3>

This looks safe to merge after a small credentials hardening cleanup.

- The changed UI and config wrappers preserve the previous runtime behavior.
- The credentials refresh path should handle a missing expiration explicitly so callers do not receive a null SDK expiration state.

catalog/app/utils/AWS/Credentials.tsx

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| catalog/app/utils/AWS/Credentials.tsx | Adds TypeScript types around AWS credential subclasses, refresh handling, and the credentials context. |
| catalog/app/utils/AWS/Config.tsx | Adds TypeScript types to the AWS config context and provider. |
| catalog/app/containers/Bucket/FileView.tsx | Adds TypeScript props for the Bucket file download, view mode, zip form, and layout helpers. |
| catalog/app/containers/Bucket/renderPreview.tsx | Adds TypeScript types to the preview message renderer and display wrapper. |

<sub>Reviews (1): Last reviewed commit: ["catalog: convert AWS Credentials/Config ..."](https://github.com/quiltdata/quilt/commit/5ad7bb6ef8b3e956f567bb5dc6f732e05ae3858c) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=40377709)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->