### PR TITLE
docs: CONTRIBUTING.md + issue templates (open-source intake)

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,118 @@
+name: Bug report
+description: Report something that is broken or behaving incorrectly in Quilt.
+title: "[Bug]: "
+labels: ["bug", "needs-triage"]
+body:
+  - type: markdown
+    attributes:
+      value: >-
+        Thanks for taking the time to file a bug report! A clear report with
+        reproduction steps is the fastest path to a fix.
+
+
+        Not sure whether this is a bug, or have a usage question? Please ask in
+        the [Quilt Slack community](https://slack.quilt.bio) instead of opening
+        an issue.
+
+  - type: checkboxes
+    id: preflight
+    attributes:
+      label: Before you file
+      options:
+        - label: I searched [existing issues](https://github.com/quiltdata/quilt/issues) and this hasn't been reported.
+          required: true
+        - label: This is a bug (something broken), not a feature request or a usage question.
+          required: true
+
+  - type: dropdown
+    id: component
+    attributes:
+      label: Affected component
+      description: Which part of Quilt is affected? (See the README repository map.)
+      options:
+        - Python SDK / CLI (quilt3, api/python)
+        - Web catalog (catalog)
+        - Lambda services (lambdas)
+        - Documentation (docs)
+        - Infrastructure / deployment / CI (core-team owned — see note below)
+        - Not sure
+    validations:
+      required: true
+
+  - type: textarea
+    id: what-happened
+    attributes:
+      label: What happened?
+      description: Describe the bug. What did you observe?
+    validations:
+      required: true
+
+  - type: textarea
+    id: expected
+    attributes:
+      label: Expected behavior
+      description: What did you expect to happen instead?
+    validations:
+      required: true
+
+  - type: textarea
+    id: repro
+    attributes:
+      label: Steps to reproduce
+      description: >-
+        Minimal, reliable steps to reproduce. Include a code snippet, CLI
+        command, or click-path. Sample data or a screenshot helps a lot.
+      placeholder: |
+        1. Run `quilt3 ...`
+        2. Open the catalog at ...
+        3. See error ...
+    validations:
+      required: true
+
+  - type: textarea
+    id: logs
+    attributes:
+      label: Logs / error output
+      description: Paste any relevant traceback or console output. This is automatically formatted as code.
+      render: shell
+    validations:
+      required: false
+
+  - type: textarea
+    id: environment
+    attributes:
+      label: Environment
+      description: >-
+        Where did this happen? Include versions where relevant.
+      value: |
+        - quilt3 version (`quilt3 --version`):
+        - Python version:
+        - Browser (for catalog bugs):
+        - Deployment type (open.quiltdata.com / enterprise stack / local):
+    validations:
+      required: false
+
+  - type: dropdown
+    id: open-variant
+    attributes:
+      label: Does this affect the Open (open-source) variant?
+      description: >-
+        Quilt ships an Open variant. If you know whether this reproduces there,
+        tell us — it helps us scope the fix. "Not sure" is fine.
+      options:
+        - "Yes"
+        - "No"
+        - Not sure
+    validations:
+      required: false
+
+  - type: markdown
+    attributes:
+      value: >-
+        **A note on infrastructure & deployment bugs.** Bugs in CloudFormation /
+        deployment templates, IAM and AWS resource configuration, CI workflows
+        (`.github/workflows/`), or release/packaging tooling are owned by the
+        Quilt core team because they are coupled to the internal release and
+        enterprise-deployment process. Please still file the report here so we
+        can track it — but expect the core team to drive the fix rather than
+        accepting an external PR against those surfaces. See `CONTRIBUTING.md`.

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,21 @@
+# Turning off blank issues forces everything through a structured form, which is
+# what enforces the feature-request-first intake model. Questions and "is this a
+# bug?" conversations are routed to Slack instead of becoming issues.
+blank_issues_enabled: false
+contact_links:
+  - name: Questions & community support
+    url: https://slack.quilt.bio
+    about: >-
+      Have a question, need help, or not sure whether something is a bug? Join
+      the Quilt Slack community — that's the fastest way to get an answer.
+      Please don't open an issue for general support.
+  - name: Documentation
+    url: https://docs.quilt.bio
+    about: >-
+      Product, platform, and API documentation. Check here before filing a
+      docs issue.
+  - name: Security vulnerabilities
+    url: mailto:dev@quiltdata.io
+    about: >-
+      Please report security issues privately by email — do NOT open a public
+      issue for a suspected vulnerability.

--- a/.github/ISSUE_TEMPLATE/documentation.yml
+++ b/.github/ISSUE_TEMPLATE/documentation.yml
@@ -1,0 +1,51 @@
+name: Documentation issue
+description: Report missing, unclear, or incorrect documentation.
+title: "[Docs]: "
+labels: ["documentation", "needs-triage"]
+body:
+  - type: markdown
+    attributes:
+      value: >-
+        Thanks for helping improve the Quilt docs! Small docs fixes are always
+        welcome as a direct pull request — you don't need to wait on this issue.
+        Use this form when you want to report a gap or aren't sure of the fix.
+
+  - type: dropdown
+    id: doc-type
+    attributes:
+      label: What kind of docs problem is this?
+      options:
+        - Incorrect / outdated information
+        - Missing documentation
+        - Unclear or confusing explanation
+        - Broken link or example
+        - Other
+    validations:
+      required: true
+
+  - type: input
+    id: location
+    attributes:
+      label: Where is it?
+      description: >-
+        Link to the page on https://docs.quilt.bio or the file path under
+        `docs/` (or a docstring in `api/python`).
+      placeholder: "https://docs.quilt.bio/... or docs/.../file.md"
+    validations:
+      required: true
+
+  - type: textarea
+    id: problem
+    attributes:
+      label: What's wrong or missing?
+      description: Describe the problem and, if you can, what the docs should say instead.
+    validations:
+      required: true
+
+  - type: checkboxes
+    id: contribution
+    attributes:
+      label: Contribution
+      options:
+        - label: I'd be willing to open a PR to fix this.
+          required: false

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,147 @@
+# This form mirrors the shape the Quilt Engineering team already uses for its
+# own internal feature requests: problem/motivation first, then proposed
+# solution, alternatives considered, acceptance criteria, and scope/non-goals.
+# Filling these in well is what lets a maintainer turn the request into an
+# accepted, well-scoped piece of work quickly.
+name: Feature request
+description: Propose a new capability or an enhancement. Please file this BEFORE writing a large change.
+title: "[Feature]: "
+labels: ["enhancement", "needs-triage"]
+body:
+  - type: markdown
+    attributes:
+      value: >-
+        Thanks for proposing an improvement to Quilt!
+
+
+        **File the request before you write the code.** For anything beyond a
+        small, self-contained fix, opening an issue first is the fastest path to
+        getting your contribution merged — it lets us confirm the problem is one
+        we want to solve and agree on the shape of the solution before you
+        invest effort. When we accept a request, the core team turns it into an
+        internal design and acceptance criteria, and implementation follows from
+        there.
+
+
+        Describe the **problem and the use case first**, and the proposed
+        solution second. That ordering is what makes a request actionable.
+
+  - type: checkboxes
+    id: preflight
+    attributes:
+      label: Before you file
+      options:
+        - label: I searched [existing issues](https://github.com/quiltdata/quilt/issues) and this hasn't already been requested.
+          required: true
+        - label: This is a feature/enhancement request, not a bug report or a usage question.
+          required: true
+
+  - type: textarea
+    id: problem
+    attributes:
+      label: Problem / motivation
+      description: >-
+        What problem are you trying to solve? What's missing or painful today,
+        and what's the current behavior or workaround? Who is affected, and what
+        does this cost them? Concrete is better than abstract.
+      placeholder: >-
+        As a [Quilt Catalog admin / quilt3 user / ...] I want [capability] so
+        that [benefit]. Today, [current behavior / workaround], which means
+        [impact]. This came up for [me / a teammate / a customer] when ...
+    validations:
+      required: true
+
+  - type: textarea
+    id: proposed-solution
+    attributes:
+      label: Proposed solution
+      description: >-
+        How would you like it to work? Describe the behavior or API you'd
+        expect. It's fine if you don't know the implementation — focus on the
+        outcome. If you do know the relevant component or code area, point to it.
+    validations:
+      required: true
+
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives considered
+      description: >-
+        What other approaches did you consider, and why did you rule them out?
+        If there are a few viable options with trade-offs, list them — naming
+        the trade-offs helps us pick a direction faster.
+    validations:
+      required: false
+
+  - type: textarea
+    id: acceptance-criteria
+    attributes:
+      label: Acceptance criteria / definition of done
+      description: >-
+        How would we know this is done and working? List the observable
+        behaviors that must be true. Include any hard rules or invariants that
+        must NOT be broken (e.g. "must not expose data the user isn't entitled
+        to see", "must not change existing X").
+      placeholder: |
+        - [ ] When I do X, the catalog shows Y
+        - [ ] Existing behavior Z is unchanged
+        - [ ] Invariant: must not ...
+    validations:
+      required: false
+
+  - type: textarea
+    id: scope
+    attributes:
+      label: Scope & non-goals
+      description: >-
+        What is explicitly IN scope, and what is explicitly OUT of scope for
+        this request? Calling out non-goals prevents scope creep and keeps the
+        change reviewable.
+    validations:
+      required: false
+
+  - type: dropdown
+    id: component
+    attributes:
+      label: Affected component
+      description: Which part of Quilt would this touch? (See the README repository map.)
+      options:
+        - Python SDK / CLI (quilt3, api/python)
+        - Web catalog (catalog)
+        - Lambda services (lambdas)
+        - Documentation (docs)
+        - Infrastructure / deployment / CI (core-team owned — see note below)
+        - Not sure / multiple
+    validations:
+      required: true
+
+  - type: textarea
+    id: references
+    attributes:
+      label: References
+      description: >-
+        Screenshots, sample data, links to related issues/PRs, or external docs
+        that add context.
+    validations:
+      required: false
+
+  - type: checkboxes
+    id: contribution
+    attributes:
+      label: Contribution
+      options:
+        - label: I'd be willing to help implement this (after we agree on the approach).
+          required: false
+
+  - type: markdown
+    attributes:
+      value: >-
+        **Infrastructure & deployment requests.** If your request involves
+        CloudFormation / deployment templates, IAM and AWS resource
+        configuration, CI workflows (`.github/workflows/`), or release/packaging
+        tooling, please describe the problem and the outcome you need — but note
+        that these surfaces are owned by the Quilt core team and are coupled to
+        the internal release and enterprise-deployment process. We'll evaluate
+        the request and either take it on or work with you on the right
+        approach; please don't open a PR that changes those surfaces directly.
+        See `CONTRIBUTING.md` for the full policy.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -154,52 +154,35 @@ If you believe an infrastructure change is needed:
 Keeping infrastructure out of feature PRs keeps your contribution reviewable and
 mergeable, and keeps deployment changes on a controlled path.
 
-## Setting up a local dev environment
+## You don't need to run Quilt locally to contribute
 
-Detailed, component-by-component setup lives in
-[`docs/CONTRIBUTING.md`](docs/CONTRIBUTING.md). In brief:
+The most valuable community contributions are **feature requirements and
+documentation**, not implementation. When you file a feature request you
+describe the problem and the behavior you need; the Quilt team then designs,
+builds, and tests the implementation. There's nothing for you to deploy or run
+end-to-end, so a local Quilt stack is **not** an expectation and is never a
+blocker to contributing:
 
-- **Python SDK / CLI (`api/python`):** we use [`uv`](https://github.com/astral-sh/uv)
-  for dependency management. Install `uv`, then `uv run poe test` runs the test
-  suite. Run `uv run poe` to list all tasks. This path works fully locally.
-- **Catalog frontend (`catalog`):** `npm install`, then `npm start` for a
-  live-reloading dev server, `npm run build` for a static bundle.
+- **Feature requests and bug reports:** no setup required — just open an issue.
+- **Documentation fixes:** edit the Markdown and open a PR; no stack required.
 
-### Do you actually need a running stack?
-
-For most contributions, **no.** Be honest with yourself about what your change
-needs:
-
-- **Filing a feature request or bug report:** no stack required. Just open an
-  issue.
-- **Docs fixes, and small or self-contained code changes:** no stack required.
-  Many parts of the codebase can be developed and tested in isolation — the
-  Python SDK/CLI (`api/python`) runs and tests fully locally (`uv run poe
-  test`), and the catalog frontend (`catalog`) builds and runs its unit tests
-  locally (`npm run build`, `npm run test`).
-- **Substantial catalog or lambda changes that need live backend services:**
-  these do need a deployed stack to exercise end-to-end. The catalog depends on
-  services (AWS Lambda, Elasticsearch/OpenSearch) that don't run standalone, so
-  a local catalog expects a Quilt stack already deployed to AWS. The
-  component-by-component setup for this path is documented in
-  [`docs/CONTRIBUTING.md`](docs/CONTRIBUTING.md).
-
-If your change needs end-to-end validation against backend services and you
-can't deploy a stack, say so in your issue or PR: open the issue first, describe
-what you've verified locally (unit tests, local catalog/CLI behavior), and a
-maintainer will help validate the change against an internal stack during
-review. We'd rather review a focused change you've tested as far as you can
-locally than have you blocked on infrastructure.
+For the rare case where you want to send a deeper code change, the detailed,
+component-by-component development setup lives in
+[`docs/CONTRIBUTING.md`](docs/CONTRIBUTING.md). Even then, verify what you
+reasonably can and open the PR — the Quilt team owns full end-to-end testing
+against an internal stack as part of review.
 
 ## Testing and quality checks
 
-- **All new code is expected to ship with tests** and to pass the existing
-  suite.
+Most contributors never reach this step — the Quilt team implements and tests
+accepted requests, and owns full end-to-end testing against an internal stack
+during review. If you are sending a code change, the local checks worth running
+first are:
+
 - **Python (`api/python`):** `uv run poe test` (and `test-verbose`, `test-cov`).
 - **Catalog (`catalog`):** `npm run test`.
 - Linting and formatting are configured in-repo (for example, `ruff` for Python
-  and the catalog's lint/format tooling). Run the project's lint tasks before
-  opening a PR so CI passes on the first try; `uv run poe` lists the available
+  and the catalog's lint/format tooling). `uv run poe` lists the available
   Python tasks, and the catalog's scripts are defined in `catalog/package.json`.
 
 ## Code of Conduct

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,216 @@
+# Contributing to Quilt
+
+Thanks for your interest in contributing to Quilt! Quilt is an open-source
+scientific data management platform, and we genuinely welcome contributions from
+the community — bug reports, feature ideas, docs fixes, and code.
+
+This page is the front door. For the detailed development setup, testing, and
+release mechanics, see [`docs/CONTRIBUTING.md`](docs/CONTRIBUTING.md).
+
+## Where to ask questions
+
+- **Questions / discussion / "is this a bug?":** join the
+  [Quilt Slack community](https://slack.quilt.bio).
+- **Bugs:** file a [GitHub issue](https://github.com/quiltdata/quilt/issues).
+- **Feature ideas:** file a feature request (see below) before writing a large
+  change.
+
+All participation is governed by our
+[Code of Conduct](docs/CODE_OF_CONDUCT.md). Please read it. Reports can be sent
+to `dev@quiltdata.io`.
+
+## How we take in new work: file a request first
+
+For anything beyond a small, self-contained fix, **open an issue before you open
+a pull request.** This is the fastest path to getting your contribution merged,
+and it saves you from investing effort in a change we can't accept as-is.
+
+Why we ask for this:
+
+- **Alignment up front.** A short discussion on an issue lets us confirm the
+  problem is one we want to solve and agree on the shape of the solution before
+  you write code.
+- **We turn accepted requests into an internal spec.** When the core team
+  accepts a feature request, we write up the design and acceptance criteria on
+  our side, and implementation follows from there. You do **not** need access to
+  any internal spec corpus to contribute — the GitHub issue is the shared
+  contract between you and the maintainers. Work the issue, and we'll handle the
+  internal planning.
+- **Less wasted work.** Large unsolicited PRs are hard to review and often
+  conflict with work already in flight.
+
+Good feature requests describe the *problem* and the *use case* first, and the
+proposed solution second. Screenshots, sample data, and reproduction steps all
+help. See [What a good feature request looks like](#what-a-good-feature-request-looks-like)
+for a concrete checklist.
+
+When you open an issue, pick the matching template:
+
+- **[Feature request](.github/ISSUE_TEMPLATE/feature_request.yml)** — propose a
+  new capability or enhancement. File this *before* writing a large change.
+- **[Bug report](.github/ISSUE_TEMPLATE/bug_report.yml)** — report something
+  that's broken, with reproduction steps.
+- **[Documentation issue](.github/ISSUE_TEMPLATE/documentation.yml)** — report
+  missing, unclear, or incorrect docs.
+
+These are structured forms: filling in the fields is what lets a maintainer turn
+your request into accepted, well-scoped work quickly. General questions and
+"is this a bug?" discussions belong in the
+[Quilt Slack community](https://slack.quilt.bio), not in an issue.
+
+## What a good feature request looks like
+
+A well-formed feature request leads with the *problem*, not the *patch*. The
+strongest requests we get follow the same shape our own engineers use
+internally, so the more of this you can fill in, the faster we can say "yes" and
+scope the work. The [feature request form](.github/ISSUE_TEMPLATE/feature_request.yml)
+walks you through it; here's the checklist:
+
+- **Problem / motivation.** What's missing or painful today, what the current
+  behavior or workaround is, who is affected, and what it costs them. A
+  user-story framing works well: *"As a [Catalog admin / quilt3 user] I want
+  [capability] so that [benefit]; today [current behavior], which means
+  [impact]."*
+- **Proposed solution.** How you'd like it to work — the behavior or API you'd
+  expect. You don't need to know the implementation; focus on the outcome.
+- **Alternatives considered.** Other approaches you weighed and why you ruled
+  them out. If there are a few viable options with trade-offs, name them — that
+  helps us pick a direction faster.
+- **Acceptance criteria / definition of done.** The observable behaviors that
+  must be true for this to be "done," plus any hard rules or invariants that
+  must *not* be broken (for example, "must not expose data the user isn't
+  entitled to see").
+- **Scope & non-goals.** What's explicitly in scope and, just as importantly,
+  what's out. Calling out non-goals keeps the change reviewable.
+- **References.** Screenshots, sample data, related issues/PRs, or external docs.
+
+You don't have to fill in every section perfectly — a clear problem statement
+and use case is the one part we really need. We'll work the rest out with you on
+the issue. (Internally, the core team adds its own triage and ownership fields
+when it accepts a request; you don't need to touch those.)
+
+## Small fixes are always welcome
+
+You don't need to file an issue first for small, low-risk changes — typo fixes,
+docs clarifications, obvious one-line bug fixes. Use judgment: if the change is
+big, changes behavior, or touches shared interfaces, start with an issue.
+
+## Code contribution workflow
+
+1. **Fork** the repo (or branch directly if you're a maintainer).
+2. **Clone** and create a topic branch:
+
+   ```bash
+   git clone https://github.com/quiltdata/quilt
+   cd quilt
+   git checkout -b my-change
+   ```
+
+3. **Make your change** in the relevant area. The
+   [README repository map](README.md) shows where each component lives; the
+   short version:
+   - `api/python` — `quilt3` Python SDK and CLI
+   - `catalog` — web catalog frontend (TypeScript/JavaScript)
+   - `lambdas` — AWS Lambda services
+   - `docs` — product, platform, and contributor documentation
+4. **Add tests** (see [Testing](#testing-and-quality-checks) below) and make
+   sure existing tests pass.
+5. **Open a pull request** against `master`. Fill out the
+   [pull request template](.github/pull_request_template.md) — it includes a
+   checklist for tests, docs, changelog, and the security/Open-variant impact of
+   your change.
+6. **Reference the issue** your PR addresses (e.g. "Closes #123").
+
+### Commit and PR conventions
+
+- Keep PRs focused: one logical change per PR. Smaller PRs get reviewed faster.
+- Write clear commit messages that explain *why*, not just *what*.
+- Update [`docs/CHANGELOG.md`](docs/CHANGELOG.md) when your change is meaningful
+  to end users (docs-only changes can skip this).
+- Keep documentation in sync with behavior changes — the PR template lists the
+  doc surfaces to check.
+
+## Infrastructure and deployment changes are owned by the core team
+
+**Please do not bundle infrastructure, deployment, or CI/CD changes into a
+feature or bug-fix PR.** This includes (non-exhaustively): CloudFormation /
+deployment templates, IAM and other AWS resource configuration, CI workflow
+changes under `.github/workflows/`, release tooling, and anything that changes
+how Quilt is built, packaged, or deployed.
+
+These surfaces are tightly coupled to Quilt's internal release and enterprise
+deployment process, and changes to them carry operational and security risk that
+the core team needs to own and sequence. A change that looks self-contained from
+the outside can break enterprise deployments in ways that aren't visible from
+the public repo.
+
+If you believe an infrastructure change is needed:
+
+- **Open an issue describing the problem**, not a PR with the fix. Explain what
+  you're trying to achieve and why the current setup blocks you.
+- The core team will evaluate it, and either take it on or work with you on the
+  right approach.
+
+Keeping infrastructure out of feature PRs keeps your contribution reviewable and
+mergeable, and keeps deployment changes on a controlled path.
+
+## Setting up a local dev environment
+
+Detailed, component-by-component setup lives in
+[`docs/CONTRIBUTING.md`](docs/CONTRIBUTING.md). In brief:
+
+- **Python SDK / CLI (`api/python`):** we use [`uv`](https://github.com/astral-sh/uv)
+  for dependency management. Install `uv`, then `uv run poe test` runs the test
+  suite. Run `uv run poe` to list all tasks. This path works fully locally.
+- **Catalog frontend (`catalog`):** `npm install`, then `npm start` for a
+  live-reloading dev server, `npm run build` for a static bundle.
+
+### Do you actually need a running stack?
+
+For most contributions, **no.** Be honest with yourself about what your change
+needs:
+
+- **Filing a feature request or bug report:** no stack required. Just open an
+  issue.
+- **Docs fixes, and small or self-contained code changes:** no stack required.
+  Many parts of the codebase can be developed and tested in isolation — the
+  Python SDK/CLI (`api/python`) runs and tests fully locally (`uv run poe
+  test`), and the catalog frontend (`catalog`) builds and runs its unit tests
+  locally (`npm run build`, `npm run test`).
+- **Substantial catalog or lambda changes that need live backend services:**
+  these do need a deployed stack to exercise end-to-end. The catalog depends on
+  services (AWS Lambda, Elasticsearch/OpenSearch) that don't run standalone, so
+  a local catalog expects a Quilt stack already deployed to AWS. The
+  component-by-component setup for this path is documented in
+  [`docs/CONTRIBUTING.md`](docs/CONTRIBUTING.md).
+
+If your change needs end-to-end validation against backend services and you
+can't deploy a stack, say so in your issue or PR: open the issue first, describe
+what you've verified locally (unit tests, local catalog/CLI behavior), and a
+maintainer will help validate the change against an internal stack during
+review. We'd rather review a focused change you've tested as far as you can
+locally than have you blocked on infrastructure.
+
+## Testing and quality checks
+
+- **All new code is expected to ship with tests** and to pass the existing
+  suite.
+- **Python (`api/python`):** `uv run poe test` (and `test-verbose`, `test-cov`).
+- **Catalog (`catalog`):** `npm run test`.
+- Linting and formatting are configured in-repo (for example, `ruff` for Python
+  and the catalog's lint/format tooling). Run the project's lint tasks before
+  opening a PR so CI passes on the first try; `uv run poe` lists the available
+  Python tasks, and the catalog's scripts are defined in `catalog/package.json`.
+
+## Code of Conduct
+
+This project follows the [Contributor Covenant](docs/CODE_OF_CONDUCT.md). By
+participating, you agree to uphold it. Report unacceptable behavior to
+`dev@quiltdata.io`.
+
+## License and contributor terms
+
+Quilt is open source under the
+[Apache License, Version 2.0](LICENSE). By contributing, you agree that your
+contributions are licensed under the same terms (Apache-2.0 inbound = outbound,
+per section 5 of the license).


### PR DESCRIPTION
> **Draft — not ready to merge.** Opened to get @nl0's input on the open questions below before this lands on `master`. Please do not merge yet.

## Summary

Adds the community-facing contribution-intake docs for the open-source repo:

- **`CONTRIBUTING.md`** at the repo root — a friendly "front door" for community contributors. It links out to the existing detailed `docs/CONTRIBUTING.md` for dev/test/release mechanics rather than duplicating them, and adds:
  - a **feature-request-first intake model** ("file an issue before a large PR"),
  - guidance on what a good feature request looks like,
  - an explicit policy that **infrastructure / deployment / CI changes are owned by the core team**,
  - a **requirements-first framing**: community contributors provide feature requirements and docs while the Quilt team implements and tests, so a local stack is not an expectation or a blocker to contributing.
- **`.github/ISSUE_TEMPLATE/`** structured GitHub Issue Forms:
  - `feature_request.yml` — modeled on the shape the engineering team already uses for its own Asana Engineering tickets (problem/motivation → proposed solution → alternatives → acceptance criteria → scope/non-goals),
  - `bug_report.yml`,
  - `documentation.yml`,
  - `config.yml` — disables blank issues and routes questions / support to the Quilt Slack community (GitHub Discussions is currently disabled on this repo).

## Rationale

- **Feature-request-first intake** was decided in the **Jun 29 engineering standup**: accepted requests get turned into an internal spec by the core team, so the GitHub issue is the shared contract with external contributors — they don't need access to any internal spec corpus.
- **Infra/CI changes are core-team-owned** because those surfaces are coupled to the internal release and enterprise-deployment process; a change that looks self-contained from the public repo can break enterprise deployments.
- The **feature-request template is modeled on the team's Asana Engineering tickets**, so external requests arrive in a shape the team can triage and scope quickly.

## Open questions for Alexei (@nl0)

- [ ] **CLA vs. Apache-2.0 inbound=outbound.** There is no separate CLA file in the repo. The draft currently states contributions are licensed under Apache-2.0 (inbound = outbound, per section 5). Do we want to keep that, or require a Contributor License Agreement (CLA bot / signing step)? If a CLA is required, we need to add the signing step and a pointer before this ships.
- [ ] **Exact per-component lint commands.** The draft points contributors at `uv run poe` (Python) and `catalog/package.json` scripts (catalog) without hardcoding specific lint task names, since those weren't verified. Should we spell out the exact one-line lint commands per component, and if so, what are the canonical ones?

## Notes

- Base branch is `master` (this repo's default).
- No existing root `CONTRIBUTING.md` or `.github/ISSUE_TEMPLATE/` directory existed, so nothing was overwritten.
- The four issue-form YAMLs were validated to parse.

Made with [Cursor](https://cursor.com)