### PR TITLE
docs: Connect ALB follows the stack scheme

### DIFF
--- a/docs/Catalog/Connect.md
+++ b/docs/Catalog/Connect.md
@@ -118,9 +118,21 @@ are accepted alongside clients that derive the canonical resource from
 (as Claude.ai and Cursor do). The token `aud` claim is always the
 canonical `/mcp/platform` identifier regardless of input form.
 
+## Network Reachability
+
+The Connect ALB inherits your stack's load balancer scheme:
+
+- **Internet-facing stacks** expose the Connect ALB to the public internet.
+- **Internal stacks** (`elb_scheme=internal`) get an _internal_ Connect ALB,
+  reachable only from within the VPC or networks bridged to it (e.g. a VPN).
+  External AI assistants and desktop clients can reach Connect only over such
+  a network path.
+
 ## IP Allowlisting (Optional)
 
 To restrict which IP ranges can reach the Connect Server, create an EC2
 security group with inbound rules on port 443 for your trusted CIDR ranges,
 then pass the security group ID as `ConnectSecurityGroup`. If omitted, the
-Connect ALB accepts traffic from any IP.
+Connect ALB accepts traffic from any IP that can reach it — any IP on the
+internet for an internet-facing stack, or any IP that can reach the VPC for
+an internal stack.


### PR DESCRIPTION
# Description

Document that the Quilt Connect Server ALB inherits the stack's load balancer scheme. On an internal stack (`elb_scheme=internal`) the Connect ALB is **internal** — reachable only from within the VPC or a network bridged to it (e.g. a VPN) — rather than internet-facing.

Also corrects the IP-allowlisting note that claimed the ALB "accepts traffic from any IP": qualified as any IP that can reach the ALB (the public internet for an internet-facing stack, or any IP that can reach the VPC for an internal stack).

Pairs with a deployment-side change that makes the Connect ALB `Scheme` follow the stack's `elb_scheme`.

> **Draft — do not merge yet.** Parked behind the paired deployment-side change: this documents behavior that only goes live once that change ships in a cut release. Version-anchor this section ("Available in Quilt Platform version X.Y or later") and mark ready once that release is known.

# TODO

- [x] Documentation
    - [x] Markdown in docs/**/*.md that explains the behavior to end users
- [x] Changelog entry (skipped — docs only)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This docs-only PR adds a "Network Reachability" section to `Connect.md` explaining that the Connect ALB inherits the stack's `elb_scheme`, and refines the IP Allowlisting note from "any IP" to "any IP that can reach it."

- Adds a new section documenting that internal stacks (`elb_scheme=internal`) produce an internal Connect ALB reachable only within the VPC or bridged networks (e.g. VPN).
- Clarifies the IP Allowlisting default language to be scheme-aware, noting internet-facing vs. internal scope.

<h3>Confidence Score: 4/5</h3>

The change is documentation-only and the text itself is accurate, but it documents behavior that has not yet landed in the deployment template — merging in the wrong order could mislead operators about their Connect ALB scheme.

The Connect ALB Scheme is still hardcoded to internet-facing in the related deployment repo (t4/template/connect.py). If this doc PR ships first, users on internal stacks will follow documentation that doesn't match reality until the paired deployment change is also merged.

docs/Catalog/Connect.md — verify the paired deployment-side change (in quiltdata/deployment) is merged before or at the same time as this PR.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| docs/Catalog/Connect.md | Adds a new "Network Reachability" section and refines the IP Allowlisting note; documentation appears accurate but is ahead of the paired deployment-side change, which still hardcodes Scheme="internet-facing" in the related deployment repo. |

<h3>Flowchart</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Stack Deployment] --> B{elb_scheme}
    B -- internet-facing --> C[Internet-Facing Connect ALB]
    B -- internal --> D[Internal Connect ALB]
    C --> E[Accessible from public internet]
    D --> F[Accessible within VPC / bridged networks e.g. VPN only]
    E --> G[IP Allowlisting via ConnectSecurityGroup optional]
    F --> G
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A[Stack Deployment] --> B{elb_scheme}
    B -- internet-facing --> C[Internet-Facing Connect ALB]
    B -- internal --> D[Internal Connect ALB]
    C --> E[Accessible from public internet]
    D --> F[Accessible within VPC / bridged networks e.g. VPN only]
    E --> G[IP Allowlisting via ConnectSecurityGroup optional]
    F --> G
```

</a>

<sub>Reviews (1): Last reviewed commit: ["docs: Connect ALB follows the stack sche..."](https://github.com/quiltdata/quilt/commit/57b8239ec3363580aa65822021702203aee6b815) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=40794366)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->
