### PR TITLE
Catalog: Qurator-routing search bar + 1A sidebar volume selector

### DIFF
--- a/catalog/app/components/SearchBar/State.tsx
+++ b/catalog/app/components/SearchBar/State.tsx
@@ -2,6 +2,9 @@ import * as React from 'react'
 import * as RRDom from 'react-router-dom'
 import * as M from '@material-ui/core'
 
+import { Model as AssistantModel } from 'components/Assistant'
+
+import { classifyQuery } from './classify'
 import * as Suggestions from './Suggestions/model'
 
 export const expandAnimationDuration = 200
@@ -15,6 +18,12 @@ interface SearchState {
 
 export default function useState(): SearchState {
   const history = RRDom.useHistory()
+
+  // Qurator availability + entrypoint. When the assistant is disabled for this
+  // stack/user, `assist` is undefined and `classifyQuery` is told Qurator is
+  // off, so every submit falls back to catalog search — no behavior change.
+  const quratorEnabled = !!AssistantModel.useIsEnabled()
+  const assist = AssistantModel.useAssistant()
 
   const [value, setValue] = React.useState<string>('')
   const [helpOpen, setHelpOpen] = React.useState(false)
@@ -38,11 +47,18 @@ export default function useState(): SearchState {
   const handleSubmit = React.useCallback(
     (event: React.KeyboardEvent<HTMLInputElement>) => {
       event.preventDefault()
-      history.push(suggestions.url)
+      // Route natural-language queries to Qurator, keyword queries to search.
+      // Falls back to search when Qurator can't take it (disabled, or no
+      // `assist` entrypoint available).
+      if (assist && classifyQuery(value, quratorEnabled) === 'Qurator') {
+        assist(value.trim())
+      } else {
+        history.push(suggestions.url)
+      }
       handleCollapse()
       event.currentTarget.blur()
     },
-    [handleCollapse, history, suggestions],
+    [assist, handleCollapse, history, quratorEnabled, suggestions, value],
   )
 
   const handleEscape = React.useCallback(

--- a/catalog/app/components/SearchBar/classify.spec.ts
+++ b/catalog/app/components/SearchBar/classify.spec.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it } from 'vitest'
+
+import { classifyQuery } from './classify'
+
+describe('components/SearchBar/classify', () => {
+  it('classifies a short keyword query as Search', () => {
+    expect(classifyQuery('drugbank')).toBe('Search')
+    expect(classifyQuery('rna seq')).toBe('Search')
+  })
+
+  it('classifies trailing-question-mark queries as Qurator', () => {
+    expect(classifyQuery('drugbank?')).toBe('Qurator')
+  })
+
+  it('classifies wh-word / verb-of-inquiry leading queries as Qurator', () => {
+    expect(classifyQuery('what is in this bucket')).toBe('Qurator')
+    expect(classifyQuery('find packages with assays')).toBe('Qurator')
+    expect(classifyQuery('summarize ccle')).toBe('Qurator')
+  })
+
+  it('classifies long (>= 5 word) queries as Qurator', () => {
+    expect(classifyQuery('packages tagged with lc ms data')).toBe('Qurator')
+  })
+
+  it('always returns Search when Qurator is disabled', () => {
+    expect(classifyQuery('what is in this bucket', false)).toBe('Search')
+    expect(classifyQuery('drugbank?', false)).toBe('Search')
+  })
+
+  it('returns Search for an empty query', () => {
+    expect(classifyQuery('   ')).toBe('Search')
+  })
+})

--- a/catalog/app/components/SearchBar/classify.ts
+++ b/catalog/app/components/SearchBar/classify.ts
@@ -1,0 +1,38 @@
+export type RouteKind = 'Search' | 'Qurator'
+
+// Natural-language routing for the unified search bar. Ported from the
+// FrontDoor UnifiedBar (frontdoor/v3-eval) so the sidebar search bar shares the
+// exact same classification behavior: a question or an imperative/NL phrase
+// routes to Qurator, a short keyword phrase routes to catalog search.
+const QURATOR_PREFIXES = new Set([
+  'what',
+  'where',
+  'when',
+  'who',
+  'why',
+  'how',
+  'find',
+  'show',
+  'list',
+  'summarize',
+  'compare',
+  'create',
+  'run',
+  'explain',
+])
+
+export function classifyQuery(query: string, quratorEnabled = true): RouteKind {
+  if (!quratorEnabled) return 'Search'
+
+  const trimmed = query.trim()
+  if (!trimmed) return 'Search'
+  if (trimmed.endsWith('?')) return 'Qurator'
+
+  const words = trimmed.split(/\s+/).filter(Boolean)
+  const firstWord = words[0]?.toLowerCase().replace(/[^a-z]/g, '')
+
+  if (firstWord && QURATOR_PREFIXES.has(firstWord)) return 'Qurator'
+  if (words.length >= 5) return 'Qurator'
+
+  return 'Search'
+}

--- a/catalog/app/containers/Sidebar/Sidebar.tsx
+++ b/catalog/app/containers/Sidebar/Sidebar.tsx
@@ -14,6 +14,7 @@ import * as CatalogSettings from 'utils/CatalogSettings'
 import * as NamedRoutes from 'utils/NamedRoutes'
 
 import { Rail } from './Rail'
+import VolumeSelect from './VolumeSelect'
 
 const useStyles = M.makeStyles((t) => ({
   root: {
@@ -122,6 +123,7 @@ export function Sidebar() {
             </M.ListItemIcon>
             <M.ListItemText primary="Buckets" />
           </M.ListItem>
+          <VolumeSelect />
           <M.ListItem button onClick={bookmarks?.show} disabled={!bookmarks}>
             <M.ListItemIcon className={classes.icon}>
               <M.Badge color="primary" variant="dot" invisible={!bookmarks?.hasUpdates}>

--- a/catalog/app/containers/Sidebar/VolumeSelect.tsx
+++ b/catalog/app/containers/Sidebar/VolumeSelect.tsx
@@ -1,0 +1,177 @@
+import { matchSorter } from 'match-sorter'
+import * as React from 'react'
+import { Link, useHistory } from 'react-router-dom'
+import * as M from '@material-ui/core'
+
+import * as Buckets from 'utils/Buckets'
+import * as NamedRoutes from 'utils/NamedRoutes'
+
+// 1A "sidebar selector": the active volume lives in the rail as a rolled-up,
+// fuzzy-filtered picker. Collapsed it shows the current volume (or a prompt);
+// expanded it reveals a filter input over the relevant buckets. The whole
+// stack is one keystroke away but never rendered inline, replacing the old
+// always-visible bucket tree without losing fast switching. Reuses the same
+// primitives as NavBar/BucketSelect (useRelevantBuckets + matchSorter).
+
+const useStyles = M.makeStyles((t) => ({
+  root: {
+    padding: t.spacing(0, 1),
+  },
+  trigger: {
+    color: 'inherit',
+    justifyContent: 'flex-start',
+    padding: t.spacing(0.5, 1),
+    textTransform: 'none',
+    width: '100%',
+  },
+  dot: {
+    background: t.palette.primary.main,
+    borderRadius: '50%',
+    flexShrink: 0,
+    height: 6,
+    marginRight: t.spacing(1),
+    width: 6,
+  },
+  label: {
+    flexGrow: 1,
+    fontFamily: ['Roboto Mono', 'monospace'].join(','),
+    fontSize: 12,
+    overflow: 'hidden',
+    textAlign: 'left',
+    textOverflow: 'ellipsis',
+    whiteSpace: 'nowrap',
+  },
+  placeholder: {
+    color: t.palette.text.hint,
+    flexGrow: 1,
+    fontSize: 12,
+    textAlign: 'left',
+  },
+  paper: {
+    padding: t.spacing(1),
+    width: t.spacing(30),
+  },
+  list: {
+    maxHeight: t.spacing(36),
+    overflow: 'auto',
+  },
+  item: {
+    borderRadius: t.shape.borderRadius,
+    fontFamily: ['Roboto Mono', 'monospace'].join(','),
+    fontSize: 12.5,
+  },
+}))
+
+export function VolumeSelect() {
+  const classes = useStyles()
+  const history = useHistory()
+  const { urls } = NamedRoutes.use()
+  const currentBucket = Buckets.useCurrentBucket()
+  const buckets = Buckets.useRelevantBuckets()
+
+  const anchorRef = React.useRef<HTMLButtonElement>(null)
+  const [open, setOpen] = React.useState(false)
+  const [filter, setFilter] = React.useState('')
+
+  const filtered = React.useMemo(() => {
+    if (!filter) return buckets
+    return matchSorter(buckets, filter, {
+      keys: ['name', 'title', { key: 'tags' }],
+    })
+  }, [buckets, filter])
+
+  const close = React.useCallback(() => {
+    setOpen(false)
+    setFilter('')
+  }, [])
+
+  const pick = React.useCallback(
+    (name: string) => {
+      if (name && name !== currentBucket) history.push(urls.bucketRoot(name))
+      close()
+    },
+    [close, currentBucket, history, urls],
+  )
+
+  return (
+    <div className={classes.root}>
+      <M.Button
+        ref={anchorRef}
+        className={classes.trigger}
+        onClick={() => setOpen((o) => !o)}
+        size="small"
+      >
+        {currentBucket ? (
+          <>
+            <span className={classes.dot} />
+            <span className={classes.label}>{currentBucket}</span>
+          </>
+        ) : (
+          <span className={classes.placeholder}>Select a volume…</span>
+        )}
+        <M.Icon fontSize="small">expand_more</M.Icon>
+      </M.Button>
+      <M.Popper
+        anchorEl={anchorRef.current}
+        open={open}
+        placement="bottom-start"
+        style={{ zIndex: 1400 }}
+      >
+        <M.ClickAwayListener onClickAway={close}>
+          <M.Paper className={classes.paper} elevation={8}>
+            <M.TextField
+              autoFocus
+              fullWidth
+              margin="dense"
+              placeholder="Filter volumes…"
+              value={filter}
+              variant="outlined"
+              onChange={(e) => setFilter(e.target.value)}
+              InputProps={{
+                startAdornment: (
+                  <M.InputAdornment position="start">
+                    <M.Icon fontSize="small">search</M.Icon>
+                  </M.InputAdornment>
+                ),
+              }}
+            />
+            <M.List dense className={classes.list} disablePadding>
+              {filtered.map((b) => (
+                <M.ListItem
+                  button
+                  key={b.name}
+                  className={classes.item}
+                  component={Link}
+                  to={urls.bucketRoot(b.name)}
+                  selected={b.name === currentBucket}
+                  onClick={() => pick(b.name)}
+                >
+                  <M.ListItemText
+                    primary={b.name}
+                    primaryTypographyProps={{ noWrap: true }}
+                  />
+                </M.ListItem>
+              ))}
+              {!filtered.length && (
+                <M.ListItem>
+                  <M.ListItemText
+                    secondary={`No volumes matching "${filter}"`}
+                    secondaryTypographyProps={{ noWrap: true }}
+                  />
+                </M.ListItem>
+              )}
+            </M.List>
+          </M.Paper>
+        </M.ClickAwayListener>
+      </M.Popper>
+    </div>
+  )
+}
+
+export default function VolumeSelectSuspended() {
+  return (
+    <React.Suspense fallback={null}>
+      <VolumeSelect />
+    </React.Suspense>
+  )
+}


### PR DESCRIPTION
## What this is

Two additions on top of `catalog-sidebar` that close the gap between the sidebar shell and the redesign feedback: a search bar that routes to Qurator, and the **1A** volume selector in the rail.

Both are additive and gated by existing runtime behavior — nothing changes when Qurator is disabled.

## 1. Sidebar search bar routes NL queries to Qurator

`components/SearchBar/State.tsx` previously pushed `suggestions.url` on every Enter (search only). This ports the FrontDoor `classifyQuery` heuristic from `frontdoor/v3-eval` into the shared `SearchBar` so Enter routes:

- a question (`drugbank?`), a wh-/verb-of-inquiry lead (`what…`, `find…`, `summarize…`), or a phrase of 5+ words → **Qurator** (`assist(query)`)
- a short keyword phrase → **catalog search** (existing behavior, unchanged)

The handoff mechanism is deliberately simple — it calls the same `assist(query)` entrypoint the FAB used; how Qurator renders the answer is out of scope here. Falls back to search whenever Qurator is unavailable (disabled for the stack/user, or no `assist` entrypoint), so there is zero behavior change when the assistant is off. `classify.ts` + `classify.spec.ts` (6 tests, ported verbatim from frontdoor) live next to the SearchBar.

## 2. 1A volume selector in the rail — the committed direction

`containers/Sidebar/VolumeSelect.tsx` — a rolled-up, fuzzy-filtered volume picker mounted in the rail under **Buckets**. Collapsed it shows the current volume; expanded it filters relevant buckets and switches on select. Reuses the same primitives as `NavBar/BucketSelect` (`useRelevantBuckets` + `matchSorter`).

**We're unifying on 1A** (selector pinned in the sidebar), not 1B. The layout already supports this cleanly: `Layout.tsx` renders the rail + `ContentBar` (search) with no bucket anchor in the content header, so this rail selector is the single volume switcher. No 1B remnants to remove.

## Verification

- `tsc --noEmit`: clean
- `eslint` on all changed files: clean
- `vitest run components/SearchBar/classify.spec.ts`: 6/6 pass
- lint-staged (prettier + eslint) ran clean on both commits

## What this deliberately does NOT do

- No Tables-as-global-rail (that changes per-bucket → stack-level scoping and needs a data-source decision with Sergey first).
- Does not touch the frontdoor branch or delete the frontdoor `OmniSearch`/`UnifiedBar`. This keeps your `SearchBar` as the surviving search component and brings the Qurator-routing behavior to it, rather than importing frontdoor's component. (Flagging that "which search component survives" call for you/Alexei to ratify — it's the one architectural decision here.)