### PR TITLE
catalog: unmount @testing-library/react-hooks roots after each test (de-flake test-catalog)

### DIFF
--- a/catalog/setup-vitest.ts
+++ b/catalog/setup-vitest.ts
@@ -1,5 +1,6 @@
 import { afterEach } from 'vitest'
 import { cleanup } from '@testing-library/react'
+import { cleanup as cleanupHooks } from '@testing-library/react-hooks'
 
 // Unmount components rendered by @testing-library/react after each test.
 // `globals` is off in vitest.config.ts, so RTL's own auto-cleanup (which only
@@ -9,6 +10,13 @@ import { cleanup } from '@testing-library/react'
 // when React was initialized, but is not defined anymore" as an unhandled
 // error that fails the run even when every test passed.
 afterEach(cleanup)
+// Same problem for hooks rendered via @testing-library/react-hooks: with
+// `globals` off its auto-cleanup never registers either, so hook roots that
+// kick off async work (e.g. Athena/model/requests' fetch-then-setState) stay
+// mounted and flush a deferred React commit after the jsdom env is torn down —
+// "window is not defined" in react-dom's getActiveElementDeep, failing the run
+// even when every test passed. Unmount those roots too.
+afterEach(cleanupHooks)
 
 // Suppress noisy AWS SDK v2 deprecation warnings during tests
 const originalEmitWarning = process.emitWarning


### PR DESCRIPTION
## Problem

`test-catalog` fails intermittently even when **every test passes** — the run dies on an unhandled error:

```
ReferenceError: window is not defined
  ❯ getActiveElementDeep → getSelectionInformation → prepareForCommit
  ❯ commitRootImpl → performSyncWorkOnRoot   (via the React scheduler)
```

Pre-existing on `master` (e.g. the run on `7ffeae30` failed the same way) — not tied to any one PR.

## Root cause

- vitest runs with `globals: false`, so Testing-Library's auto `afterEach` cleanup never registers.
- `setup-vitest.ts` already compensates for `@testing-library/react` with `afterEach(cleanup)` — but **18 specs also use the separate `@testing-library/react-hooks` library**, whose roots were **never unmounted**.
- A hook that starts async work keeps a live root. Concrete example — `Athena/model/requests.ts`:
  ```ts
  fetch…().then((d) => mounted && setData(d))   // `mounted` is cleared only in the effect's unmount cleanup
  ```
  With the root never unmounted, `mounted` stays `true`; the promise resolves after the test/file finishes and `setData` runs on a live root. On **React 17** that flushes a *synchronous* commit via the scheduler, and if that tick lands after the file's jsdom env is torn down, react-dom reads a now-undefined `window`.
- Parallel workers + `--coverage` instrumentation shift that timing → flaky.

## Fix

Register `@testing-library/react-hooks`' `cleanup` alongside the existing RTL one. Unmounting the hook root runs the effect cleanup (`mounted = false`), so the late `.then` is a no-op — no post-teardown commit. Also improves test isolation (no leaked hook roots across tests).

## Verification

- Reproduced locally with `npm test` (parallel + coverage) — hit on the **1st** run.
- **0/6** runs failed after the fix.
- Full suite green: 119 files, 1095 passed / 1 skipped, and the spurious `Errors: 1 error` line is gone.

## Follow-up (not this PR)

`@testing-library/react-hooks` is deprecated; its `renderHook` is built into `@testing-library/react` v13.1+, which requires React 18. The catalog is on React 17 + RTL 12 (no built-in `renderHook`), so migrating off the library is gated on the React 18 upgrade — a separate effort. This cleanup is the correct interim fix regardless.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes intermittent `test-catalog` failures caused by `@testing-library/react-hooks` roots never being unmounted between tests when vitest runs with `globals: false`. The existing `setup-vitest.ts` already registered `afterEach(cleanup)` for `@testing-library/react`, and this change extends the same pattern to `@testing-library/react-hooks`.

- Imports `cleanup` from `@testing-library/react-hooks` and registers it with `afterEach`, mirroring the existing RTL cleanup registration.
- The root cause is that hook roots keeping async work alive (e.g. `fetch…().then(setData)`) could flush a deferred React commit into a torn-down jsdom environment, producing the spurious `window is not defined` failure — unmounting the roots eliminates this timing window.

<h3>Confidence Score: 5/5</h3>

Safe to merge — one-line addition to test setup that directly mirrors an already-proven pattern in the same file.

The change is a two-line addition to the global test setup: import cleanup from @testing-library/react-hooks and call it in afterEach, exactly matching what was already done for @testing-library/react. The dependency is already listed in package.json. There is no application code touched, no runtime behaviour changed, and the fix aligns with the library's own documented cleanup API.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| catalog/setup-vitest.ts | Adds afterEach(cleanupHooks) from @testing-library/react-hooks to unmount hook roots after each test, mirroring the existing RTL cleanup registration — correct and minimal fix for flaky post-teardown commits. |

<h3>Flowchart</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Test runs] --> B[afterEach triggers]
    B --> C[cleanup — @testing-library/react]
    B --> D[cleanupHooks — @testing-library/react-hooks]
    C --> E[Unmount RTL component roots]
    D --> F[Unmount react-hooks roots]
    E --> G[Effect cleanup runs: mounted = false]
    F --> G
    G --> H[Deferred .then callbacks become no-ops]
    H --> I[jsdom env tears down safely]
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A[Test runs] --> B[afterEach triggers]
    B --> C[cleanup — @testing-library/react]
    B --> D[cleanupHooks — @testing-library/react-hooks]
    C --> E[Unmount RTL component roots]
    D --> F[Unmount react-hooks roots]
    E --> G[Effect cleanup runs: mounted = false]
    F --> G
    G --> H[Deferred .then callbacks become no-ops]
    H --> I[jsdom env tears down safely]
```

</a>

<sub>Reviews (1): Last reviewed commit: ["catalog: unmount @testing-library/react-..."](https://github.com/quiltdata/quilt/commit/48ec0151126c1feac5213812b29b83f0a1fa7f24) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=41066122)</sub>

<!-- /greptile_comment -->