### PR TITLE
preview: make test_ipynb_chop robust to highlighter markup drift

### DIFF
--- a/lambdas/preview/test/test_index.py
+++ b/lambdas/preview/test/test_index.py
@@ -245,8 +245,7 @@ class TestIndex:
             '<span class="p">'
         ) in body_html, 'Last cell output missing'
 
-    # Comfortably below the ~89 KB fixture size so the gate fires without depending on
-    # its exact byte count; the test only needs output exclusion triggered, not a boundary.
+    # well below the fixture size so the gate fires regardless of its exact bytes
     @patch('t4_lambda_preview.LAMBDA_MAX_OUT', 40_000)
     @responses.activate
     def test_ipynb_chop(self):
@@ -263,15 +262,12 @@ class TestIndex:
         body = json.loads(read_body(resp))
         assert resp['statusCode'] == 200, 'preview failed on nb_1200727.ipynb'
         body_html = body['html']
-        # The size gate (file > LAMBDA_MAX_OUT) should force output exclusion. Assert that
-        # behavior rather than an exact HTML byte-count: nbconvert/pygments markup drifts
-        # version-to-version, so a hardcoded length is fragile. The warnings message appears
-        # only on the size-triggered exclude path, so it proves the gate fired.
+        # Assert the exclusion behavior, not an exact HTML length: nbconvert/pygments markup
+        # drifts across versions. This warning is emitted only on the size-triggered path.
         assert body['info'].get('warnings') == "Omitted cell outputs to reduce notebook size", \
             'size gate should have set the exclude_output warning'
-        # Anchor on the output data, not on nbconvert's <pre> wrapper: if that template markup
-        # drifts, a <pre>-anchored `not in` would pass vacuously and hide a chopping regression.
-        # This list-repr appears only in cell 3's output, never in a retained source cell.
+        # Match the output data, not nbconvert's <pre> wrapper, else a wrapper change makes
+        # `not in` pass vacuously. This list-repr is unique to cell 3's output.
         assert "['SEE', 'SE', 'SHW', 'SIG'," not in body_html, 'output cell should have been omitted'
         assert 'SVD of Minute-Market-Data' in body_html, 'code/markdown cells should remain'
 
@@ -302,8 +298,8 @@ class TestIndex:
         # check for some strings we know should be in there
         assert 'SVD of Minute-Market-Data' in body_html, 'missing expected contents'
         assert 'Preprocessing' in body_html, 'missing expected contents'
-        # anchor on the output data, not nbconvert's <pre> wrapper, so template drift can't
-        # make this `not in` pass vacuously (see test_ipynb_chop)
+        # match the output data, not the <pre> wrapper, so `not in` can't pass vacuously
+        # (see test_ipynb_chop)
         assert "['SEE', 'SE', 'SHW', 'SIG'," not in body_html, \
             'Unexpected output cell; exclude_output:true was given'
         assert (

--- a/lambdas/preview/test/test_index.py
+++ b/lambdas/preview/test/test_index.py
@@ -245,7 +245,9 @@ class TestIndex:
             '<span class="p">'
         ) in body_html, 'Last cell output missing'
 
-    @patch('t4_lambda_preview.LAMBDA_MAX_OUT', 89_322)
+    # Comfortably below the ~89 KB fixture size so the gate fires without depending on
+    # its exact byte count; the test only needs output exclusion triggered, not a boundary.
+    @patch('t4_lambda_preview.LAMBDA_MAX_OUT', 40_000)
     @responses.activate
     def test_ipynb_chop(self):
         """test that we eliminate output cells when we're in danger of breaking
@@ -265,8 +267,12 @@ class TestIndex:
         # behavior rather than an exact HTML byte-count: nbconvert/pygments markup drifts
         # version-to-version, so a hardcoded length is fragile. The warnings message appears
         # only on the size-triggered exclude path, so it proves the gate fired.
-        assert body['info'].get('warnings') == "Omitted cell outputs to reduce notebook size"
-        assert "<pre>['SEE', 'SE', 'SHW', 'SIG'," not in body_html, 'output cell should have been omitted'
+        assert body['info'].get('warnings') == "Omitted cell outputs to reduce notebook size", \
+            'size gate should have set the exclude_output warning'
+        # Anchor on the output data, not on nbconvert's <pre> wrapper: if that template markup
+        # drifts, a <pre>-anchored `not in` would pass vacuously and hide a chopping regression.
+        # This list-repr appears only in cell 3's output, never in a retained source cell.
+        assert "['SEE', 'SE', 'SHW', 'SIG'," not in body_html, 'output cell should have been omitted'
         assert 'SVD of Minute-Market-Data' in body_html, 'code/markdown cells should remain'
 
     @responses.activate
@@ -296,7 +302,9 @@ class TestIndex:
         # check for some strings we know should be in there
         assert 'SVD of Minute-Market-Data' in body_html, 'missing expected contents'
         assert 'Preprocessing' in body_html, 'missing expected contents'
-        assert "<pre>['SEE', 'SE', 'SHW', 'SIG'," not in body_html, \
+        # anchor on the output data, not nbconvert's <pre> wrapper, so template drift can't
+        # make this `not in` pass vacuously (see test_ipynb_chop)
+        assert "['SEE', 'SE', 'SHW', 'SIG'," not in body_html, \
             'Unexpected output cell; exclude_output:true was given'
         assert (
             '<span class="n">batch_size</span><span class="o">=</span><span class="mi">100</span>'

--- a/lambdas/preview/test/test_index.py
+++ b/lambdas/preview/test/test_index.py
@@ -2,7 +2,6 @@
 Test functions for preview endpoint
 """
 import json
-import math
 import os
 import re
 from pathlib import Path
@@ -262,8 +261,13 @@ class TestIndex:
         body = json.loads(read_body(resp))
         assert resp['statusCode'] == 200, 'preview failed on nb_1200727.ipynb'
         body_html = body['html']
-        # isclose bc string sizes differ, e.g. on Linux
-        assert math.isclose(len(body_html), 18084, abs_tol=300), "Hmm, didn't chop nb_1200727.ipynb"
+        # The size gate (file > LAMBDA_MAX_OUT) should force output exclusion. Assert that
+        # behavior rather than an exact HTML byte-count: nbconvert/pygments markup drifts
+        # version-to-version, so a hardcoded length is fragile. The warnings message appears
+        # only on the size-triggered exclude path, so it proves the gate fired.
+        assert body['info'].get('warnings') == "Omitted cell outputs to reduce notebook size"
+        assert "<pre>['SEE', 'SE', 'SHW', 'SIG'," not in body_html, 'output cell should have been omitted'
+        assert 'SVD of Minute-Market-Data' in body_html, 'code/markdown cells should remain'
 
     @responses.activate
     def test_ipynb_exclude(self):


### PR DESCRIPTION
# Description

`test_ipynb_chop` (preview lambda) asserted an exact chopped-notebook HTML byte-length (`18084 ± 300`). That length is a function of nbconvert/pygments markup, so it drifts on dependency bumps — pygments 2.20 renders 18471 bytes, which breaks the pygments-bump PR #5083 with a test failure unrelated to any behavior change.

This rewrites the assertion to check the actual behavior the test name promises: the size gate (`file > LAMBDA_MAX_OUT`) forces output exclusion. It asserts the `"Omitted cell outputs to reduce notebook size"` warning (emitted only on the size-triggered exclude path, so it proves the gate fired), that output cells are dropped, and that code/markdown cells remain. This mirrors the sibling `test_ipynb_exclude`, whose comment already flags exact-HTML checks as fragile. Verified passing under both pygments 2.18 and 2.20.

Two adjacent hardening tweaks while here: the output-absence checks (in both `test_ipynb_chop` and `test_ipynb_exclude`) now match on the output data rather than nbconvert's `<pre>` wrapper, so a future wrapper change can't make `not in` pass vacuously; and the `LAMBDA_MAX_OUT` test patch is moved off its 1-byte boundary against the fixture size so a benign fixture re-save can't silently stop the size gate firing.

# TODO

- [x] Unit tests

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR replaces a fragile exact-byte-count assertion in `test_ipynb_chop` with behavioral checks that verify the actual semantic behavior: the size gate fires, the "Omitted cell outputs" warning is emitted, output cells are dropped, and code/markdown cells survive. The `import math` that was only used for the old assertion is also cleaned up.

- The old `math.isclose(len(body_html), 18084, abs_tol=300)` assertion would break on any nbconvert/pygments version bump that altered rendered HTML markup length, even with no behavior change.
- The new assertions directly test what the test name promises: the `LAMBDA_MAX_OUT` size gate triggers output exclusion, verified through the warning string (set only when `exclude_output=True`), absence of a known output-cell string, and presence of a known code/markdown string.

<h3>Confidence Score: 5/5</h3>

Safe to merge — test-only change that removes a known source of false failures on dependency bumps.

The change touches only the test file: it removes an HTML byte-count assertion that would break on any nbconvert/pygments version bump and replaces it with three assertions tied directly to the production code path (the warning string, output-cell exclusion, and markdown/code-cell presence). The production source is untouched. The test's patch decorator and event setup are unchanged, so the gate-trigger scenario is still exercised correctly.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| lambdas/preview/test/test_index.py | Replaces fragile HTML byte-count assertion with three behavioral assertions (warning message, output-cell absence, code/markdown-cell presence); removes unused import math. |

<h3>Flowchart</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A["test_ipynb_chop\n(@patch LAMBDA_MAX_OUT=89_322)"] --> B["lambda_handler(event, None)"]
    B --> C["extract_ipynb(file_, exclude_output=False)"]
    C --> D{"size > LAMBDA_MAX_OUT\n(notebook > 89,322 bytes)?"}
    D -- Yes --> E["exclude_output = True\ninfo['warnings'] = 'Omitted cell outputs...'"]
    D -- No --> F["exclude_output stays False\nno warning set"]
    E --> G["HTMLExporter(exclude_output=True)\nstrips output cells"]
    G --> H["Return html, info"]
    H --> I["Assert: info.warnings == 'Omitted cell outputs...'"]
    H --> J["Assert: output-cell string NOT in html"]
    H --> K["Assert: markdown/code string IN html"]
    style E fill:#d4edda
    style I fill:#d4edda
    style J fill:#d4edda
    style K fill:#d4edda
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A["test_ipynb_chop\n(@patch LAMBDA_MAX_OUT=89_322)"] --> B["lambda_handler(event, None)"]
    B --> C["extract_ipynb(file_, exclude_output=False)"]
    C --> D{"size > LAMBDA_MAX_OUT\n(notebook > 89,322 bytes)?"}
    D -- Yes --> E["exclude_output = True\ninfo['warnings'] = 'Omitted cell outputs...'"]
    D -- No --> F["exclude_output stays False\nno warning set"]
    E --> G["HTMLExporter(exclude_output=True)\nstrips output cells"]
    G --> H["Return html, info"]
    H --> I["Assert: info.warnings == 'Omitted cell outputs...'"]
    H --> J["Assert: output-cell string NOT in html"]
    H --> K["Assert: markdown/code string IN html"]
    style E fill:#d4edda
    style I fill:#d4edda
    style J fill:#d4edda
    style K fill:#d4edda
```

</a>

<sub>Reviews (1): Last reviewed commit: ["preview: make test\_ipynb\_chop robust to ..."](https://github.com/quiltdata/quilt/commit/63f63f1e3eea518b7059c859aaff00744c576e72) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=41580416)</sub>

<!-- /greptile_comment -->
