### PR TITLE
chore(lambdas): normalize t4-lambda-shared pin declarations

### DIFF
--- a/lambdas/access_counts/pyproject.toml
+++ b/lambdas/access_counts/pyproject.toml
@@ -4,7 +4,7 @@ version = "0.1.0"
 requires-python = "==3.13.*"
 dependencies = [
     "boto3[crt]~=1.40",
-    "t4_lambda_shared",
+    "t4-lambda-shared",
 ]
 
 [build-system]
@@ -23,4 +23,4 @@ test = [
 default-groups = ["test"]
 
 [tool.uv.sources]
-t4_lambda_shared = { url = "https://github.com/quiltdata/quilt/archive/d496dffbfb4b7a2ae05f6c1f7f0cb7d5d43bc984.zip", subdirectory = "lambdas/shared" }
+t4-lambda-shared = { url = "https://github.com/quiltdata/quilt/archive/d496dffbfb4b7a2ae05f6c1f7f0cb7d5d43bc984.zip", subdirectory = "lambdas/shared" }

--- a/lambdas/indexer/pyproject.toml
+++ b/lambdas/indexer/pyproject.toml
@@ -14,7 +14,7 @@ dependencies = [
     "strict-rfc3339~=0.7",  # for jsonschema format
     "tenacity~=9.0",
     "quilt-shared[boto,es]",
-    "t4_lambda_shared[mem,preview]",
+    "t4-lambda-shared[mem,preview]",
 ]
 
 [build-system]

--- a/lambdas/thumbnail/pyproject.toml
+++ b/lambdas/thumbnail/pyproject.toml
@@ -10,7 +10,7 @@ dependencies = [
   "pillow~=12.2",
   "python-pptx~=1.0.0",
   "requests>=2.26.0,<3",
-  "t4_lambda_shared @ https://github.com/quiltdata/quilt/archive/d496dffbfb4b7a2ae05f6c1f7f0cb7d5d43bc984.zip#subdirectory=lambdas/shared",
+  "t4-lambda-shared",
   "bioio~=3.0",
   "bioio-base~=3.0",
   "bioio-czi~=2.7",
@@ -37,4 +37,7 @@ prod = [
 
 [tool.uv]
 default-groups = ["test"]
+
+[tool.uv.sources]
+t4-lambda-shared = { url = "https://github.com/quiltdata/quilt/archive/d496dffbfb4b7a2ae05f6c1f7f0cb7d5d43bc984.zip", subdirectory = "lambdas/shared" }
 


### PR DESCRIPTION
# Description

The nine lambda consumers of `t4-lambda-shared` declare the same dependency in three different shapes:

- most: bare name in `dependencies`, URL in a `[tool.uv.sources]` entry keyed `t4-lambda-shared`;
- `access_counts`: same structure, but spelled `t4_lambda_shared`;
- `thumbnail`: the URL embedded inline in `dependencies` as a PEP 508 direct reference, no sources table.

Package-name normalization (PEP 503) makes all three resolve identically, but a shared-lib bump can't be a single mechanical find-and-replace when the pin lives in two structures under two spellings — every script or reviewer has to handle three variants.

This normalizes all consumers to the majority form: hyphenated (PyPA-normalized) name in `dependencies`, URL in `[tool.uv.sources]`.

**Zero behavior change**: no pinned SHAs move, and the lockfiles are byte-identical after `uv lock` (uv already stores normalized names internally); `uv lock --check` passes for all three touched lambdas. (`quilt-shared` pins were already uniform; `lambdas/shared`'s own `name = "t4_lambda_shared"` is left as-is — wheel filenames normalize to underscores regardless.)

This is the pin-shape part of the mechanical cleanup discussed in #4933, split out so it lands independently of the packaging-model decision.

# TODO

- [x] Security: no security impact (metadata shape only, no version/SHA changes)
- [x] Changelog entry — skipped, not user-facing

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR normalizes the `t4-lambda-shared` dependency declaration across three lambda consumers (`access_counts`, `indexer`, `thumbnail`) to a single canonical shape: hyphenated name in `dependencies` + URL in `[tool.uv.sources]`. No pinned SHAs, versions, or lockfile contents change.

- **`access_counts`**: underscore spelling in both `dependencies` and `[tool.uv.sources]` renamed to hyphenated form.
- **`indexer`**: underscore spelling in `dependencies` renamed; the `[tool.uv.sources]` entry was already hyphenated and is untouched.
- **`thumbnail`**: inline PEP 508 direct-reference URL replaced with a bare hyphenated name, and a matching `[tool.uv.sources]` table entry is added (same SHA).

<h3>Confidence Score: 5/5</h3>

Pure metadata normalization with no version, SHA, or lockfile changes — safe to merge.

All three files consistently use the same hyphenated name and the same pinned SHA (`d496dffb…`) they had before. The only change is spelling: `t4_lambda_shared` → `t4-lambda-shared` in the `dependencies` list and the `[tool.uv.sources]` key, and the inline URL in `thumbnail` is split into the two-field form that the other lambdas already used. uv normalizes package names per PEP 503, so resolution is identical.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| lambdas/access_counts/pyproject.toml | Renames `t4_lambda_shared` to `t4-lambda-shared` in both `dependencies` and `[tool.uv.sources]`; no SHA or version changes. |
| lambdas/indexer/pyproject.toml | Renames `t4_lambda_shared[mem,preview]` to `t4-lambda-shared[mem,preview]` in `dependencies`; the `[tool.uv.sources]` entry was already hyphenated and is unchanged. |
| lambdas/thumbnail/pyproject.toml | Converts the inline PEP 508 direct-reference URL in `dependencies` to a bare `t4-lambda-shared` name, and adds the equivalent `[tool.uv.sources]` table entry; same SHA. |

<h3>Flowchart</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    subgraph Before["Before (3 variants)"]
        A["access_counts\ndependencies: t4_lambda_shared\nsources: t4_lambda_shared = …"]
        B["indexer\ndependencies: t4_lambda_shared\nsources: t4-lambda-shared = …"]
        C["thumbnail\ndependencies: t4_lambda_shared @ URL\n(no sources table)"]
    end

    subgraph After["After (1 uniform shape)"]
        D["access_counts\ndependencies: t4-lambda-shared\nsources: t4-lambda-shared = …"]
        E["indexer\ndependencies: t4-lambda-shared\nsources: t4-lambda-shared = …"]
        F["thumbnail\ndependencies: t4-lambda-shared\nsources: t4-lambda-shared = …"]
    end

    A --> D
    B --> E
    C --> F
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    subgraph Before["Before (3 variants)"]
        A["access_counts\ndependencies: t4_lambda_shared\nsources: t4_lambda_shared = …"]
        B["indexer\ndependencies: t4_lambda_shared\nsources: t4-lambda-shared = …"]
        C["thumbnail\ndependencies: t4_lambda_shared @ URL\n(no sources table)"]
    end

    subgraph After["After (1 uniform shape)"]
        D["access_counts\ndependencies: t4-lambda-shared\nsources: t4-lambda-shared = …"]
        E["indexer\ndependencies: t4-lambda-shared\nsources: t4-lambda-shared = …"]
        F["thumbnail\ndependencies: t4-lambda-shared\nsources: t4-lambda-shared = …"]
    end

    A --> D
    B --> E
    C --> F
```

</a>

<sub>Reviews (1): Last reviewed commit: ["chore(lambdas): normalize t4-lambda-shar..."](https://github.com/quiltdata/quilt/commit/dfd5e12becdf0d242fd14d70f427e3bfb3cf7a26) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=42278725)</sub>

<!-- /greptile_comment -->