### PR TITLE
fix(thumbnail): resolve LibreOffice binary (libreoffice or soffice) for PPTX

### DIFF
--- a/lambdas/thumbnail/CHANGELOG.md
+++ b/lambdas/thumbnail/CHANGELOG.md
@@ -17,6 +17,7 @@ where verb is one of
 
 ## Changes
 
+- [Fixed] Resolve the LibreOffice binary as `libreoffice` or `soffice` for `.pptx` thumbnails, so it works under Homebrew (macOS) and local dev ([#5105](https://github.com/quiltdata/quilt/pull/5105))
 - [Changed] Stream the source download to disk instead of into memory, lowering peak memory on large images ([#5000](https://github.com/quiltdata/quilt/pull/5000))
 - [Changed] Thumbnails are now 8-bit everywhere: normalized greyscale montages and Z-projections (multi-channel microscopy stacks, greyscale CZIs) are emitted as 8-bit PNGs (mode `L`) instead of 16-bit (`I;16`). These previews are already contrast-stretched per image, so the extra depth carried no recoverable pixel meaning; output is smaller and the affected thumbnails now resize at 8-bit like every other path (slightly coarser tonal steps) ([#4999](https://github.com/quiltdata/quilt/pull/4999))
 - [Fixed] Signed and wider-than-16-bit integer images (`uint32`/`uint64`, `int8`/`int16`/`int64`, and 32-bit-integer color) now preview — contrast-stretched to 8-bit — instead of failing with HTTP 500 (color and 64-bit integers) or rendering as a clamped/dark 16-bit image ([#4998](https://github.com/quiltdata/quilt/pull/4998))

--- a/lambdas/thumbnail/src/t4_lambda_thumbnail/__init__.py
+++ b/lambdas/thumbnail/src/t4_lambda_thumbnail/__init__.py
@@ -397,7 +397,7 @@ def pptx_to_pdf(*, path: str, page: int):
     # installs it as "soffice"; both are the same LibreOffice CLI.
     soffice_bin = shutil.which("libreoffice") or shutil.which("soffice")
     if soffice_bin is None:
-        raise PDFThumbError("Missing required command: libreoffice")
+        raise PDFThumbError("Missing required command: libreoffice or soffice")
     with tempfile.TemporaryDirectory() as out_dir:
         with tempfile.TemporaryDirectory() as tmp_dir:
             subprocess.run(

--- a/lambdas/thumbnail/src/t4_lambda_thumbnail/__init__.py
+++ b/lambdas/thumbnail/src/t4_lambda_thumbnail/__init__.py
@@ -393,11 +393,19 @@ def format_aicsimage_to_prepped(img: BioImage) -> tuple[da.Array, bool]:
 
 @contextlib.contextmanager
 def pptx_to_pdf(*, path: str, page: int):
+    # The binary is "libreoffice" on Lambda/Linux, but Homebrew (macOS) only
+    # installs it as "soffice"; both are the same LibreOffice CLI.
+    soffice_bin = shutil.which("libreoffice") or shutil.which("soffice")
+    if soffice_bin is None:
+        raise PDFThumbError("Missing required command: libreoffice")
     with tempfile.TemporaryDirectory() as out_dir:
         with tempfile.TemporaryDirectory() as tmp_dir:
             subprocess.run(
                 (
-                    "libreoffice",
+                    soffice_bin,
+                    "--headless",
+                    "--invisible",
+                    "--nologo",
                     "--convert-to",
                     'pdf:impress_pdf_Export:{"PageRange":{"type":"string","value":"%s-%s"}}' % (page, page),
                     "--outdir",


### PR DESCRIPTION
The PPTX -> PDF thumbnail step hardcoded the `libreoffice` command. That is the binary name on Lambda/Linux, but Homebrew (macOS) installs the same LibreOffice CLI only as `soffice`, so `.pptx` thumbnails fail in local dev with `Missing required command: libreoffice`.

## What
- Resolve the binary as `shutil.which("libreoffice") or shutil.which("soffice")`, raising the same `PDFThumbError` if neither is found.
- Pass the standard `--headless --invisible --nologo` flags so the conversion runs cleanly in a headless environment.
- Add a CHANGELOG entry.

## Why
- Unblocks `.pptx` thumbnail generation on macOS / local catalog dev.

## Behavior
- Zero production-behavior change: on Lambda/Linux `libreoffice` still resolves first and is invoked exactly as before (the added flags are no-ops for the already-headless conversion). Only the local-dev fallback path is new.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes `.pptx` thumbnail generation on macOS by resolving the LibreOffice binary dynamically (`libreoffice` first, then `soffice`) instead of hardcoding `libreoffice`, which is only the correct binary name on Linux. Three headless flags (`--headless`, `--invisible`, `--nologo`) are also added to the subprocess call.

- The binary resolution uses `shutil.which` with an `or`-fallback and raises `PDFThumbError` when neither is found, preserving the existing error-handling contract.
- On Lambda/Linux the behavior is unchanged — `libreoffice` still resolves first and the new flags are no-ops in a headless environment.
- Two minor issues are present: the CHANGELOG entry links to PR `#5100` instead of `#5105`, and the error message mentions only `libreoffice`, omitting `soffice` from the diagnostic hint.

<h3>Confidence Score: 4/5</h3>

Safe to merge; production Lambda behavior is unchanged and the macOS fallback path is straightforward.

The binary-resolution logic is correct and the change is well-scoped. The two issues — a stale PR link in the CHANGELOG and an error message that omits `soffice` from its diagnostic hint — are documentation-level problems that don't affect runtime correctness on either platform.

Both files have minor wording issues (CHANGELOG PR link and error message text) worth fixing before merge, but neither affects functional behavior.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| lambdas/thumbnail/src/t4_lambda_thumbnail/__init__.py | Replaces hardcoded `libreoffice` with `shutil.which` fallback to `soffice`; adds `--headless --invisible --nologo` flags. Logic is correct but the error message only mentions `libreoffice`, not the `soffice` alternative. |
| lambdas/thumbnail/CHANGELOG.md | Adds a changelog entry for the fix, but the PR link points to #5100 instead of the correct #5105. |

<h3>Flowchart</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[pptx_to_pdf called] --> B{shutil.which libreoffice}
    B -- found --> D[soffice_bin = libreoffice]
    B -- not found --> C{shutil.which soffice}
    C -- found --> E[soffice_bin = soffice]
    C -- not found --> F[raise PDFThumbError]
    D --> G[subprocess.run soffice_bin --headless --invisible --nologo --convert-to pdf ...]
    E --> G
    G --> H[yield PDF path]
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A[pptx_to_pdf called] --> B{shutil.which libreoffice}
    B -- found --> D[soffice_bin = libreoffice]
    B -- not found --> C{shutil.which soffice}
    C -- found --> E[soffice_bin = soffice]
    C -- not found --> F[raise PDFThumbError]
    D --> G[subprocess.run soffice_bin --headless --invisible --nologo --convert-to pdf ...]
    E --> G
    G --> H[yield PDF path]
```

</a>

<sub>Reviews (1): Last reviewed commit: ["fix(thumbnail): resolve libreoffice or s..."](https://github.com/quiltdata/quilt/commit/c2477e5581cdd4a961d91ecb5ba99555fd669728) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=42344065)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->