### PR TITLE
catalog: raise PDF/PPTX preview resolution to 2048x1536

### DIFF
--- a/catalog/app/components/Preview/loaders/Pdf.js
+++ b/catalog/app/components/Preview/loaders/Pdf.js
@@ -3,22 +3,22 @@ import { HTTPError } from 'utils/APIConnector'
 import * as AWS from 'utils/AWS'
 import * as Data from 'utils/Data'
 import { mkSearch } from 'utils/NamedRoutes'
+import useMemoEq from 'utils/useMemoEq'
 
 import { PreviewData, PreviewError } from '../types'
 import * as utils from './utils'
 
 export const detect = utils.extIn(['.pdf', '.pptx'])
 
-async function loadPdf({ sign, handle }) {
+async function loadPdf({ url, handle }) {
   try {
-    const url = sign(handle)
     const type = (handle.logicalKey || handle.key).toLowerCase().endsWith('.pptx')
       ? 'pptx'
       : 'pdf'
     const search = mkSearch({
       url,
       input: type,
-      size: 'w1024h768',
+      size: 'w2048h1536',
       countPages: true,
     })
     const r = await fetch(`${cfg.apiGatewayEndpoint}/thumbnail${search}`)
@@ -40,12 +40,20 @@ async function loadPdf({ sign, handle }) {
     console.warn('error loading pdf preview', { ...e })
     // eslint-disable-next-line no-console
     console.error(e)
+    // Re-throw the raw error so useErrorHandling wraps it into
+    // PreviewError.Unexpected with `retry: data.fetch` attached. Building the
+    // PreviewError here would bake in `retry: null` and pass through
+    // useErrorHandling's `R.unless(PreviewError.is, …)` unchanged, leaving
+    // transient failures (timeouts, temporary 5xx) with no retry button.
     throw e
   }
 }
 
 export const Loader = function PdfLoader({ handle, children }) {
   const sign = AWS.Signer.useS3Signer()
-  const data = Data.use(loadPdf, { sign, handle })
+  const url = useMemoEq([sign, handle.bucket, handle.key, handle.version], () =>
+    sign(handle),
+  )
+  const data = Data.use(loadPdf, { url, handle })
   return children(utils.useErrorHandling(data.result, { handle, retry: data.fetch }))
 }

--- a/catalog/app/components/Preview/loaders/Pdf.spec.ts
+++ b/catalog/app/components/Preview/loaders/Pdf.spec.ts
@@ -69,7 +69,8 @@ vi.mock('../types', () => ({
   },
 }))
 vi.mock('./utils', () => ({
-  GLACIER_ERROR_RE: /storage class/i,
+  GLACIER_ERROR_RE:
+    /<Code>InvalidObjectState<\/Code><Message>The operation is not valid for the object's storage class<\/Message>/,
   extIn: (extensions: string[]) => (key: string) =>
     extensions.some((ext) => key.toLowerCase().endsWith(ext)),
   useErrorHandling,
@@ -220,7 +221,7 @@ describe('components/Preview/loaders/Pdf', () => {
         new Response(
           JSON.stringify({
             error: 'Forbidden',
-            text: "The operation is not valid for the object's storage class",
+            text: "<Error><Code>InvalidObjectState</Code><Message>The operation is not valid for the object's storage class</Message></Error>",
           }),
           { status: 403 },
         ),

--- a/catalog/app/components/Preview/loaders/Pdf.spec.ts
+++ b/catalog/app/components/Preview/loaders/Pdf.spec.ts
@@ -1,0 +1,280 @@
+import * as React from 'react'
+import { render } from '@testing-library/react'
+import { afterAll, beforeEach, describe, expect, it, vi } from 'vitest'
+
+const { dataUse, fetchMock, memoEq, pending, sign, useErrorHandling, warnSpy, errorSpy } =
+  vi.hoisted(() => ({
+    dataUse: vi.fn(),
+    fetchMock: vi.fn(),
+    memoEq: vi.fn(),
+    pending: [] as Promise<unknown>[],
+    sign: vi.fn(),
+    useErrorHandling: vi.fn((value: unknown, options: unknown) => ({ value, options })),
+    warnSpy: vi.spyOn(console, 'warn').mockImplementation(() => {}),
+    errorSpy: vi.spyOn(console, 'error').mockImplementation(() => {}),
+  }))
+
+vi.mock('constants/config', () => ({
+  default: { apiGatewayEndpoint: 'https://api.example.com' },
+}))
+vi.mock('utils/APIConnector', () => ({
+  HTTPError: class HTTPError extends Error {
+    response: Response
+
+    json: any
+
+    constructor(response: Response, text: string) {
+      super(text)
+      this.response = response
+      try {
+        this.json = JSON.parse(text)
+      } catch {
+        this.json = null
+      }
+    }
+  },
+}))
+vi.mock('utils/AWS', () => ({
+  Signer: { useS3Signer: () => sign },
+}))
+vi.mock('utils/Data', () => ({ use: dataUse }))
+vi.mock('utils/NamedRoutes', () => ({
+  mkSearch: (params: Record<string, unknown>) =>
+    `?${Object.entries(params)
+      .map(([k, v]) => `${k}=${encodeURIComponent(String(v))}`)
+      .join('&')}`,
+}))
+vi.mock('utils/useMemoEq', () => ({
+  default: memoEq,
+}))
+vi.mock('../types', () => ({
+  PreviewData: {
+    Pdf: (value: unknown) => ({ tag: 'Pdf', value }),
+  },
+  PreviewError: {
+    Archived: (value: unknown) => {
+      const err: Error & { tag: string; value: unknown } = Object.assign(
+        new Error('Archived'),
+        { tag: 'Archived', value },
+      )
+      return err
+    },
+    Forbidden: (value: unknown) => {
+      const err: Error & { tag: string; value: unknown } = Object.assign(
+        new Error('Forbidden'),
+        { tag: 'Forbidden', value },
+      )
+      return err
+    },
+  },
+}))
+vi.mock('./utils', () => ({
+  GLACIER_ERROR_RE: /storage class/i,
+  extIn: (extensions: string[]) => (key: string) =>
+    extensions.some((ext) => key.toLowerCase().endsWith(ext)),
+  useErrorHandling,
+}))
+
+import { detect, Loader } from './Pdf'
+
+describe('components/Preview/loaders/Pdf', () => {
+  afterAll(() => {
+    warnSpy.mockRestore()
+    errorSpy.mockRestore()
+  })
+
+  describe('detect', () => {
+    it('detects .pdf files', () => {
+      expect(detect('report.pdf')).toBe(true)
+      expect(detect('REPORT.PDF')).toBe(true)
+    })
+
+    it('detects .pptx files', () => {
+      expect(detect('slides.pptx')).toBe(true)
+      expect(detect('DECK.PPTX')).toBe(true)
+    })
+
+    it('rejects other extensions', () => {
+      expect(detect('doc.docx')).toBe(false)
+      expect(detect('image.png')).toBe(false)
+      expect(detect('data.csv')).toBe(false)
+    })
+
+    it('rejects files without extensions', () => {
+      expect(detect('README')).toBe(false)
+    })
+  })
+
+  describe('loadPdf', () => {
+    beforeEach(() => {
+      pending.length = 0
+      dataUse.mockReset()
+      fetchMock.mockReset()
+      memoEq.mockReset()
+      sign.mockReset()
+      useErrorHandling.mockClear()
+      warnSpy.mockClear()
+      errorSpy.mockClear()
+      memoEq.mockImplementation((_deps: unknown[], fn: () => unknown) => fn())
+      dataUse.mockImplementation(
+        (fn: (value: unknown) => Promise<unknown>, value: unknown) => {
+          pending.push(fn(value))
+          return { result: { tag: 'Loading' }, fetch: 'retry-fetch' }
+        },
+      )
+      sign.mockReturnValue('https://signed-url.example.com/doc.pdf')
+      vi.stubGlobal('fetch', fetchMock)
+    })
+
+    it('fetches thumbnail with correct parameters for pdf', async () => {
+      const blob = new Blob(['fake-pdf'], { type: 'application/pdf' })
+      const headers = new Headers({ 'X-Quilt-Info': JSON.stringify({ page_count: 3 }) })
+      fetchMock.mockResolvedValue(new Response(blob, { status: 200, headers }))
+
+      const handle = { bucket: 'demo', key: 'report.pdf', version: '123' }
+      const handled = {
+        value: { tag: 'Handled' },
+        options: { handle, retry: 'retry-fetch' },
+      }
+      const children = vi.fn(() => null)
+      useErrorHandling.mockReturnValueOnce(handled)
+      render(
+        React.createElement(Loader, {
+          handle: handle as never,
+          children: children as never,
+        }),
+      )
+
+      expect(memoEq).toHaveBeenCalledWith(
+        [sign, handle.bucket, handle.key, handle.version],
+        expect.any(Function),
+      )
+      expect(sign).toHaveBeenCalledWith(handle)
+      expect(dataUse).toHaveBeenCalledWith(expect.any(Function), {
+        url: 'https://signed-url.example.com/doc.pdf',
+        handle,
+      })
+      expect(useErrorHandling).toHaveBeenCalledWith(
+        { tag: 'Loading' },
+        { handle, retry: 'retry-fetch' },
+      )
+      expect(children).toHaveBeenCalledWith(handled)
+
+      await expect(pending[0]).resolves.toMatchObject({
+        tag: 'Pdf',
+        value: expect.objectContaining({
+          handle,
+          pages: 3,
+          type: 'pdf',
+        }),
+      })
+      expect(fetchMock).toHaveBeenCalledTimes(1)
+      const requestUrl = new URL(fetchMock.mock.calls[0][0])
+      expect(requestUrl.pathname).toBe('/thumbnail')
+      expect(requestUrl.searchParams.get('url')).toBe(
+        'https://signed-url.example.com/doc.pdf',
+      )
+      expect(requestUrl.searchParams.get('input')).toBe('pdf')
+      expect(requestUrl.searchParams.get('size')).toBe('w2048h1536')
+      expect(requestUrl.searchParams.get('countPages')).toBe('true')
+      expect(Array.from(requestUrl.searchParams.keys()).sort()).toEqual([
+        'countPages',
+        'input',
+        'size',
+        'url',
+      ])
+    })
+
+    it('loads pptx previews based on the logical key extension', async () => {
+      fetchMock.mockResolvedValue(
+        new Response(new Blob(['fake-pptx'], { type: 'application/pdf' }), {
+          status: 200,
+          headers: new Headers({ 'X-Quilt-Info': JSON.stringify({ page_count: 7 }) }),
+        }),
+      )
+
+      render(
+        React.createElement(Loader, {
+          handle: {
+            bucket: 'demo',
+            key: 'hashed/asset',
+            logicalKey: 'slides.pptx',
+          } as never,
+          children: () => null,
+        }),
+      )
+
+      await expect(pending[0]).resolves.toEqual(
+        expect.objectContaining({
+          tag: 'Pdf',
+          value: expect.objectContaining({ type: 'pptx', pages: 7 }),
+        }),
+      )
+      expect(fetchMock).toHaveBeenCalledTimes(1)
+      const requestUrl = new URL(fetchMock.mock.calls[0][0])
+      expect(requestUrl.searchParams.get('input')).toBe('pptx')
+    })
+
+    it('maps forbidden glacier responses to Archived PreviewError', async () => {
+      fetchMock.mockResolvedValue(
+        new Response(
+          JSON.stringify({
+            error: 'Forbidden',
+            text: "The operation is not valid for the object's storage class",
+          }),
+          { status: 403 },
+        ),
+      )
+
+      render(
+        React.createElement(Loader, {
+          handle: { bucket: 'demo', key: 'report.pdf' } as never,
+          children: () => null,
+        }),
+      )
+
+      await expect(pending[0]).rejects.toMatchObject({ tag: 'Archived' })
+    })
+
+    it('maps non-glacier forbidden responses to Forbidden PreviewError', async () => {
+      fetchMock.mockResolvedValue(
+        new Response(
+          JSON.stringify({
+            error: 'Forbidden',
+            text: 'Access denied',
+          }),
+          { status: 403 },
+        ),
+      )
+
+      render(
+        React.createElement(Loader, {
+          handle: { bucket: 'demo', key: 'report.pdf' } as never,
+          children: () => null,
+        }),
+      )
+
+      await expect(pending[0]).rejects.toMatchObject({ tag: 'Forbidden' })
+    })
+
+    it('rethrows unexpected errors so retry handling can wrap them later', async () => {
+      fetchMock.mockRejectedValue(new Error('boom'))
+
+      render(
+        React.createElement(Loader, {
+          handle: { bucket: 'demo', key: 'report.pdf' } as never,
+          children: () => null,
+        }),
+      )
+
+      await expect(pending[0]).rejects.toThrow('boom')
+      expect(warnSpy).toHaveBeenCalledTimes(1)
+      expect(warnSpy).toHaveBeenCalledWith(
+        'error loading pdf preview',
+        expect.any(Object),
+      )
+      expect(errorSpy).toHaveBeenCalledTimes(1)
+      expect((errorSpy.mock.calls[0][0] as Error).message).toBe('boom')
+    })
+  })
+})

--- a/catalog/app/components/Preview/renderers/Pdf.jsx
+++ b/catalog/app/components/Preview/renderers/Pdf.jsx
@@ -22,14 +22,14 @@ function useBlob(blob) {
   return url
 }
 
-async function loadBlob({ sign, handle, page, firstPageBlob, type }) {
-  if (page === 1) return firstPageBlob
+async function loadBlob({ signRef, handle, page, type, firstPageBlobRef }) {
+  if (page === 1) return firstPageBlobRef.current
   try {
-    const url = sign(handle)
+    const url = signRef.current(handle)
     const search = mkSearch({
       url,
       input: type,
-      size: 'w1024h768',
+      size: 'w2048h1536',
       page,
     })
     const r = await fetch(`${cfg.apiGatewayEndpoint}/thumbnail${search}`)
@@ -109,7 +109,12 @@ function Pdf({ handle, firstPageBlob, pages, type }, { className, ...props }) {
   const [page, setPage] = React.useState(1)
   const [pageValue, setPageValue] = React.useState(page)
 
-  const data = Data.use(loadBlob, { sign, handle, page, firstPageBlob, type })
+  const signRef = React.useRef(sign)
+  signRef.current = sign
+  const firstPageBlobRef = React.useRef(firstPageBlob)
+  firstPageBlobRef.current = firstPageBlob
+
+  const data = Data.use(loadBlob, { signRef, handle, page, type, firstPageBlobRef })
 
   const [blob, setBlob] = React.useState(firstPageBlob)
 


### PR DESCRIPTION
## Summary

Bumps the PDF/PPTX thumbnail preview request from `w1024h768` to `w2048h1536` for a noticeably sharper on-screen preview. The thumbnail lambda's `SUPPORTED_SIZES` already includes `(2048, 1536)`, so no lambda change is required — this is a frontend-only change.

Alongside the size bump, this hardens the PDF loader/renderer:

- **Fix an infinite re-render loop** in the loader by pre-signing the S3 URL with `useMemoEq` keyed on the handle (`bucket`/`key`/`version`) so the `Data.use` input is stable across renders.
- **Preserve the retry button on transient errors**: `loadPdf` re-throws the raw error so `useErrorHandling` wraps it into `PreviewError.Unexpected` with `retry: data.fetch` attached, instead of baking in `retry: null`.
- **Stabilize multi-page navigation** in the renderer via `signRef` / `firstPageBlobRef` so paging doesn't churn the `Data.use` input.

Adds `Pdf.spec.ts` covering `detect()`, request parameters (including the new `w2048h1536` size), glacier→Archived / forbidden→Forbidden mapping, and the unexpected-error rethrow path.

## Note

Sibling of #5108 (replace pdf2image with pypdfium2 for PDF thumbnails), which edits `lambdas/thumbnail/src/t4_lambda_thumbnail/__init__.py`. A trivial merge-order conflict is expected and resolvable by taking both hunks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR raises the PDF/PPTX thumbnail resolution from `w1024h768` to `w2048h1536` (already in the lambda's `SUPPORTED_SIZES`) and hardens both the loader and renderer against re-render instability.

- **Loader (`Pdf.js`)**: pre-signs the S3 URL with `useMemoEq` keyed on `[sign, bucket, key, version]` primitives so the `Data.use` params carry a stable string instead of a function reference, breaking a previous infinite re-render loop; non-Forbidden errors are re-thrown raw so `useErrorHandling` can attach `retry: data.fetch`.
- **Renderer (`Pdf.jsx`)**: replaces `sign` and `firstPageBlob` directly in `Data.use` params with `useRef` wrappers (`signRef`, `firstPageBlobRef`) so `R.equals` sees the same object identity across renders and page navigation doesn't trigger spurious re-fetches.
- **Tests (`Pdf.spec.ts`)**: new suite validates `detect()`, request shape (including the new size), glacier→Archived / forbidden→Forbidden branching, and the retry-rethrow path.

<h3>Confidence Score: 4/5</h3>

Safe to merge; the stabilization logic is sound and the size bump requires no lambda change.

The loader and renderer refactors are well-reasoned and address real re-render and retry issues. The only gap is in the new test suite: the GLACIER_ERROR_RE mock uses a plain-text regex while the production utility uses an XML-anchored pattern, so the glacier-mapping test doesn't fully exercise the real detection path.

The glacier-detection assertion in Pdf.spec.ts deserves a second look to align the mock regex with the real pattern.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| catalog/app/components/Preview/loaders/Pdf.js | Pre-signs the S3 URL with useMemoEq keyed on handle primitives to break the sign-function-reference re-render loop; bumps thumbnail size to w2048h1536; re-throws raw errors to preserve the retry button via useErrorHandling. |
| catalog/app/components/Preview/loaders/Pdf.spec.ts | New test suite covering detect(), request parameters (w2048h1536), glacier/forbidden branching, and the retry-rethrow path; GLACIER_ERROR_RE mock uses a simpler regex than the production pattern, slightly weakening the glacier-mapping assertion. |
| catalog/app/components/Preview/renderers/Pdf.jsx | Replaces direct sign/firstPageBlob props in Data.use params with stable refs so page navigation doesn't churn the R.equals comparison and re-trigger unnecessary fetches; bumps thumbnail size to w2048h1536. |

<h3>Sequence Diagram</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant C as PdfLoader
    participant M as useMemoEq
    participant D as Data.use
    participant T as Thumbnail API
    participant EH as useErrorHandling

    C->>M: [sign, bucket, key, version]
    M-->>C: url (stable string)
    C->>D: "loadPdf({ url, handle })"
    D->>T: "GET /thumbnail?url=...&size=w2048h1536&input=pdf&countPages=true"
    alt Success
        T-->>D: 200 + blob + X-Quilt-Info
        D-->>EH: AsyncResult.Ok(PreviewData.Pdf)
    else Glacier 403
        T-->>D: "403 { error: Forbidden, text: XML }"
        D-->>EH: AsyncResult.Err(PreviewError.Archived)
    else Other 403
        T-->>D: "403 { error: Forbidden }"
        D-->>EH: AsyncResult.Err(PreviewError.Forbidden)
    else Unexpected error
        T-->>D: network/5xx error (raw)
        D-->>EH: AsyncResult.Err(rawError)
        EH-->>C: "PreviewError.Unexpected{ retry: data.fetch }"
    end
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant C as PdfLoader
    participant M as useMemoEq
    participant D as Data.use
    participant T as Thumbnail API
    participant EH as useErrorHandling

    C->>M: [sign, bucket, key, version]
    M-->>C: url (stable string)
    C->>D: "loadPdf({ url, handle })"
    D->>T: "GET /thumbnail?url=...&size=w2048h1536&input=pdf&countPages=true"
    alt Success
        T-->>D: 200 + blob + X-Quilt-Info
        D-->>EH: AsyncResult.Ok(PreviewData.Pdf)
    else Glacier 403
        T-->>D: "403 { error: Forbidden, text: XML }"
        D-->>EH: AsyncResult.Err(PreviewError.Archived)
    else Other 403
        T-->>D: "403 { error: Forbidden }"
        D-->>EH: AsyncResult.Err(PreviewError.Forbidden)
    else Unexpected error
        T-->>D: network/5xx error (raw)
        D-->>EH: AsyncResult.Err(rawError)
        EH-->>C: "PreviewError.Unexpected{ retry: data.fetch }"
    end
```

</a>

<sub>Reviews (1): Last reviewed commit: ["feat(catalog): raise PDF preview resolut..."](https://github.com/quiltdata/quilt/commit/1fb4a93a1d3721f586d5b856643793fbb378b130) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=42346228)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->