### PR TITLE
Close preview lambda's streaming response via context manager

### DIFF
--- a/lambdas/preview/CHANGELOG.md
+++ b/lambdas/preview/CHANGELOG.md
@@ -17,6 +17,7 @@ where verb is one of
 
 ## Changes
 
+- [Fixed] Close the streaming HTTP response via a context manager so its socket is released deterministically ([#5121](https://github.com/quiltdata/quilt/pull/5121))
 - [Changed] Switch to uv ([#4650](https://github.com/quiltdata/quilt/pull/4650))
 - [Changed] Upgrade to Python 3.13 ([#4650](https://github.com/quiltdata/quilt/pull/4650))
 - [Changed] Upgrade to Python 3.11 ([#4241](https://github.com/quiltdata/quilt/pull/4241))

--- a/lambdas/preview/src/t4_lambda_preview/__init__.py
+++ b/lambdas/preview/src/t4_lambda_preview/__init__.py
@@ -125,8 +125,13 @@ def lambda_handler(request):
         )
 
     # stream=True saves memory almost equal to file size
-    resp = requests.get(url, stream=True)
-    if resp.ok:
+    with requests.get(url, stream=True) as resp:
+        if not resp.ok:
+            return make_json_response(resp.status_code, {
+                'error': resp.reason,
+                'text': resp.text,
+            })
+
         content_iter = resp.iter_content(CHUNK)
         if input_type == 'csv':
             html, info = extract_csv(
@@ -156,17 +161,10 @@ def lambda_handler(request):
         assert isinstance(html, str), 'expected html parameter as string'
         assert isinstance(info, dict), 'expected info metadata to be a dict'
 
-        ret_val = {
+        return make_json_response(resp.status_code, {
             'info': info,
             'html': html,
-        }
-    else:
-        ret_val = {
-            'error': resp.reason,
-            'text': resp.text,
-        }
-
-    return make_json_response(resp.status_code, ret_val)
+        })
 
 
 def extract_csv(head, separator):


### PR DESCRIPTION
# Description

Wrap the preview lambda's `requests.get(url, stream=True)` in a `with` block so the underlying socket is closed deterministically at the end of the handler instead of relying on garbage collection.

`requests.get` closes its internal `Session` (and connection pool) before returning, but with `stream=True` the in-flight socket is checked out of the pool and survives that close. Preview reads head-only via `iter_content` (bounded by `max_bytes`), so the body is never fully consumed and the connection is never auto-released — the socket lingers until the response object is GC'd. This is a hygiene/consistency cleanup, not a user-facing fix; the runtime impact in a single-invocation lambda is negligible.

Mirrors the thumbnail lambda's context-manager form. No `resp.raw.decode_content = True` is needed here (unlike thumbnail's `shutil.copyfileobj(resp.raw, ...)`): `iter_content` decodes internally. Restructured to a guard-clause early return so the `if/elif input_type` chain keeps its original indentation — the diff is head + tail only, and behavior (status codes and response bodies for both the OK and error paths) is unchanged.

# TODO

- [x] Unit tests — behavior-preserving; existing `lambdas/preview/test` suite passes (25 passed)
- [x] Security: Confirm that this change meets security best practices and does not violate the security model
- [x] Open: Confirm that this change doesn't break the Open variant
- [x] Changelog — added to `lambdas/preview/CHANGELOG.md` (per-lambda, matching the thumbnail precedent); root `docs/CHANGELOG.md` skipped as this isn't end-user-significant

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR closes the preview Lambda’s streaming HTTP response deterministically. The main changes are:

- Wraps the streamed request in a context manager.
- Preserves success and upstream-error response behavior.
- Documents the resource cleanup in the preview changelog.

<h3>Confidence Score: 5/5</h3>

This looks safe to merge.

- The response is closed on successful, error, and exception paths.
- The handler keeps the same status codes and response body shapes.
- No blocking issues were found in the updated code.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| lambdas/preview/src/t4_lambda_preview/__init__.py | Closes the streaming response on returns and exceptions while preserving the handler response contract. |
| lambdas/preview/CHANGELOG.md | Documents the deterministic streaming-response cleanup. |

<sub>Reviews (2): Last reviewed commit: ["Add CHANGELOG entry for #5121"](https://github.com/quiltdata/quilt/commit/240b1067fa0bab9a55a7d13c2816262e98c1bf41) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=44758967)</sub>

<!-- /greptile_comment -->