### PR TITLE
access_counts lambda: support a dedicated Athena workgroup

### DIFF
--- a/.github/workflows/deploy-lambdas.yaml
+++ b/.github/workflows/deploy-lambdas.yaml
@@ -4,6 +4,8 @@ on:
   push:
     branches:
       - master
+      # TEMP (revert before merge): build branch artifacts for the dev-stack smoke test
+      - access-counts-athena-workgroup
     paths:
       - '.github/workflows/deploy-lambdas.yaml'
       - 'lambdas/**'

--- a/.github/workflows/deploy-lambdas.yaml
+++ b/.github/workflows/deploy-lambdas.yaml
@@ -4,8 +4,6 @@ on:
   push:
     branches:
       - master
-      # TEMP (revert before merge): build branch artifacts for the dev-stack smoke test
-      - access-counts-athena-workgroup
     paths:
       - '.github/workflows/deploy-lambdas.yaml'
       - 'lambdas/**'

--- a/lambdas/access_counts/CHANGELOG.md
+++ b/lambdas/access_counts/CHANGELOG.md
@@ -17,6 +17,7 @@ where verb is one of
 
 ## Changes
 
+- [Added] Support running Athena queries in a dedicated workgroup via optional `ATHENA_WORKGROUP` env var ([#5136](https://github.com/quiltdata/quilt/pull/5136))
 - [Added] Make `s3.copy()` chunk size and concurrency configurable via env vars ([#4746](https://github.com/quiltdata/quilt/pull/4746))
 - [Added] Bundle `awscrt` via `boto3[crt]` for improved S3 transfer performance ([#4746](https://github.com/quiltdata/quilt/pull/4746))
 - [Changed] Migrate to proper package structure ([#4618](https://github.com/quiltdata/quilt/pull/4618))

--- a/lambdas/access_counts/CHANGELOG.md
+++ b/lambdas/access_counts/CHANGELOG.md
@@ -17,7 +17,7 @@ where verb is one of
 
 ## Changes
 
-- [Added] Run Athena queries in a dedicated workgroup (new required `ATHENA_WORKGROUP` env var) ([#5136](https://github.com/quiltdata/quilt/pull/5136))
+- [Added] Run Athena queries in a dedicated workgroup whose configuration owns the result location (new required `ATHENA_WORKGROUP` and `ATHENA_QUERY_RESULTS_PREFIX` env vars) ([#5136](https://github.com/quiltdata/quilt/pull/5136))
 - [Added] Make `s3.copy()` chunk size and concurrency configurable via env vars ([#4746](https://github.com/quiltdata/quilt/pull/4746))
 - [Added] Bundle `awscrt` via `boto3[crt]` for improved S3 transfer performance ([#4746](https://github.com/quiltdata/quilt/pull/4746))
 - [Changed] Migrate to proper package structure ([#4618](https://github.com/quiltdata/quilt/pull/4618))

--- a/lambdas/access_counts/CHANGELOG.md
+++ b/lambdas/access_counts/CHANGELOG.md
@@ -17,7 +17,7 @@ where verb is one of
 
 ## Changes
 
-- [Added] Support running Athena queries in a dedicated workgroup via optional `ATHENA_WORKGROUP` env var ([#5136](https://github.com/quiltdata/quilt/pull/5136))
+- [Added] Run Athena queries in a dedicated workgroup (new required `ATHENA_WORKGROUP` env var) ([#5136](https://github.com/quiltdata/quilt/pull/5136))
 - [Added] Make `s3.copy()` chunk size and concurrency configurable via env vars ([#4746](https://github.com/quiltdata/quilt/pull/4746))
 - [Added] Bundle `awscrt` via `boto3[crt]` for improved S3 transfer performance ([#4746](https://github.com/quiltdata/quilt/pull/4746))
 - [Changed] Migrate to proper package structure ([#4618](https://github.com/quiltdata/quilt/pull/4618))

--- a/lambdas/access_counts/pytest.ini
+++ b/lambdas/access_counts/pytest.ini
@@ -4,6 +4,7 @@ env =
     AWS_SECRET_ACCESS_KEY = test_secret
     AWS_DEFAULT_REGION = ng-north-1
     ATHENA_DATABASE = athena-db
+    ATHENA_WORKGROUP = test-workgroup
     CLOUDTRAIL_BUCKET = cloudtrail-bucket
     QUERY_RESULT_BUCKET = results-bucket
     ACCESS_COUNTS_OUTPUT_DIR = AccessCounts

--- a/lambdas/access_counts/pytest.ini
+++ b/lambdas/access_counts/pytest.ini
@@ -5,6 +5,7 @@ env =
     AWS_DEFAULT_REGION = ng-north-1
     ATHENA_DATABASE = athena-db
     ATHENA_WORKGROUP = test-workgroup
+    ATHENA_QUERY_RESULTS_PREFIX = AthenaQueryResults
     CLOUDTRAIL_BUCKET = cloudtrail-bucket
     QUERY_RESULT_BUCKET = results-bucket
     ACCESS_COUNTS_OUTPUT_DIR = AccessCounts

--- a/lambdas/access_counts/src/t4_lambda_access_counts/index.py
+++ b/lambdas/access_counts/src/t4_lambda_access_counts/index.py
@@ -6,6 +6,7 @@ and creates summaries of object and package access events.
 import os
 import textwrap
 import time
+import urllib.parse
 from datetime import datetime, timedelta, timezone
 
 import boto3
@@ -20,6 +21,8 @@ CLOUDTRAIL_BUCKET = os.environ['CLOUDTRAIL_BUCKET']
 QUERY_RESULT_BUCKET = os.environ['QUERY_RESULT_BUCKET']
 # Directory where the summary files will be stored.
 ACCESS_COUNTS_OUTPUT_DIR = os.environ['ACCESS_COUNTS_OUTPUT_DIR']
+# Athena workgroup to run queries in. If unset, the account default ("primary") is used.
+ATHENA_WORKGROUP = os.environ.get('ATHENA_WORKGROUP')
 
 MiB = 1024 * 1024
 S3_COPY_CHUNKSIZE = int(os.environ['S3_COPY_CHUNKSIZE_MIB']) * MiB
@@ -289,16 +292,31 @@ s3 = boto3.client('s3')
 def start_query(query_string):
     output = 's3://%s/%s/' % (QUERY_RESULT_BUCKET, QUERY_TEMP_DIR)
 
+    workgroup_params = {'WorkGroup': ATHENA_WORKGROUP} if ATHENA_WORKGROUP else {}
     response = athena.start_query_execution(
         QueryString=query_string,
         QueryExecutionContext=dict(Database=ATHENA_DATABASE),
-        ResultConfiguration=dict(OutputLocation=output)
+        ResultConfiguration=dict(OutputLocation=output),
+        **workgroup_params,
     )
     print("Started query:", response)
 
     execution_id = response['QueryExecutionId']
 
     return execution_id
+
+
+def get_result_location(execution_id):
+    """
+    Return (bucket, key) of the query's result file, as reported by Athena.
+    Not derived from QUERY_TEMP_DIR: an enforced workgroup configuration can
+    override the output location we request.
+    """
+    response = athena.get_query_execution(QueryExecutionId=execution_id)
+    url = response['QueryExecution']['ResultConfiguration']['OutputLocation']
+    parts = urllib.parse.urlparse(url)
+    assert parts.scheme == 's3', f"Unexpected result location: {url}"
+    return parts.netloc, parts.path.lstrip('/')
 
 
 def query_finished(execution_id):
@@ -453,12 +471,12 @@ def handler(event, context):
     execution_ids = run_multiple_queries([query for _, query in queries])
 
     for (filename, _), execution_id in zip(queries, execution_ids):
-        src_key = f'{QUERY_TEMP_DIR}/{execution_id}.csv'
+        src_bucket, src_key = get_result_location(execution_id)
         dest_key = f'{ACCESS_COUNTS_OUTPUT_DIR}/{filename}.csv'
 
         s3.copy(
             CopySource=dict(
-                Bucket=QUERY_RESULT_BUCKET,
+                Bucket=src_bucket,
                 Key=src_key
             ),
             Bucket=QUERY_RESULT_BUCKET,

--- a/lambdas/access_counts/src/t4_lambda_access_counts/index.py
+++ b/lambdas/access_counts/src/t4_lambda_access_counts/index.py
@@ -21,8 +21,7 @@ CLOUDTRAIL_BUCKET = os.environ['CLOUDTRAIL_BUCKET']
 QUERY_RESULT_BUCKET = os.environ['QUERY_RESULT_BUCKET']
 # Directory where the summary files will be stored.
 ACCESS_COUNTS_OUTPUT_DIR = os.environ['ACCESS_COUNTS_OUTPUT_DIR']
-# Athena workgroup to run queries in. If unset, the account default ("primary") is used.
-ATHENA_WORKGROUP = os.environ.get('ATHENA_WORKGROUP')
+ATHENA_WORKGROUP = os.environ['ATHENA_WORKGROUP']
 
 MiB = 1024 * 1024
 S3_COPY_CHUNKSIZE = int(os.environ['S3_COPY_CHUNKSIZE_MIB']) * MiB
@@ -292,12 +291,11 @@ s3 = boto3.client('s3')
 def start_query(query_string):
     output = 's3://%s/%s/' % (QUERY_RESULT_BUCKET, QUERY_TEMP_DIR)
 
-    workgroup_params = {'WorkGroup': ATHENA_WORKGROUP} if ATHENA_WORKGROUP else {}
     response = athena.start_query_execution(
         QueryString=query_string,
         QueryExecutionContext=dict(Database=ATHENA_DATABASE),
         ResultConfiguration=dict(OutputLocation=output),
-        **workgroup_params,
+        WorkGroup=ATHENA_WORKGROUP,
     )
     print("Started query:", response)
 
@@ -307,11 +305,7 @@ def start_query(query_string):
 
 
 def get_result_location(execution_id):
-    """
-    Return (bucket, key) of the query's result file, as reported by Athena.
-    Not derived from QUERY_TEMP_DIR: an enforced workgroup configuration can
-    override the output location we request.
-    """
+    """Return (bucket, key) of the result file (the workgroup config may override the requested location)."""
     response = athena.get_query_execution(QueryExecutionId=execution_id)
     url = response['QueryExecution']['ResultConfiguration']['OutputLocation']
     parts = urllib.parse.urlparse(url)

--- a/lambdas/access_counts/src/t4_lambda_access_counts/index.py
+++ b/lambdas/access_counts/src/t4_lambda_access_counts/index.py
@@ -23,6 +23,9 @@ ACCESS_COUNTS_OUTPUT_DIR = os.environ['ACCESS_COUNTS_OUTPUT_DIR']
 ATHENA_WORKGROUP = os.environ['ATHENA_WORKGROUP']
 # Prefix under QUERY_RESULT_BUCKET where the workgroup writes query results; wiped at the start of each run.
 ATHENA_QUERY_RESULTS_PREFIX = os.environ['ATHENA_QUERY_RESULTS_PREFIX']
+# An empty prefix would make the cleanup wipe the whole bucket.
+assert ATHENA_QUERY_RESULTS_PREFIX and not ATHENA_QUERY_RESULTS_PREFIX.startswith('/'), \
+    f"Bad ATHENA_QUERY_RESULTS_PREFIX: {ATHENA_QUERY_RESULTS_PREFIX!r}"
 
 MiB = 1024 * 1024
 S3_COPY_CHUNKSIZE = int(os.environ['S3_COPY_CHUNKSIZE_MIB']) * MiB

--- a/lambdas/access_counts/src/t4_lambda_access_counts/index.py
+++ b/lambdas/access_counts/src/t4_lambda_access_counts/index.py
@@ -6,7 +6,6 @@ and creates summaries of object and package access events.
 import os
 import textwrap
 import time
-import urllib.parse
 from datetime import datetime, timedelta, timezone
 
 import boto3
@@ -150,12 +149,15 @@ INSERT_INTO_OBJECT_ACCESS_LOG = textwrap.dedent("""\
           eventtime >= from_unixtime({start_ts:f}) AND eventtime < from_unixtime({end_ts:f})
 """)
 
-CREATE_PACKAGE_HASHES = textwrap.dedent(f"""\
+# No external_location: a CTAS that specifies one fails in a workgroup that enforces a query results
+# location; Athena instead writes the table data under the result location ("tables/<query-id>/"),
+# which is inside QUERY_TEMP_DIR and thus cleaned up by delete_dir.
+# https://docs.aws.amazon.com/athena/latest/ug/create-table-as.html
+CREATE_PACKAGE_HASHES = textwrap.dedent("""\
     CREATE TABLE package_hashes
     WITH (
         format = 'Parquet',
-        parquet_compression = 'SNAPPY',
-        external_location = 's3://{sql_escape(QUERY_RESULT_BUCKET)}/{sql_escape(QUERY_TEMP_DIR)}/package_hashes/'
+        parquet_compression = 'SNAPPY'
     )
     AS
     SELECT DISTINCT
@@ -308,9 +310,11 @@ def get_result_location(execution_id):
     """Return (bucket, key) of the result file (the workgroup config may override the requested location)."""
     response = athena.get_query_execution(QueryExecutionId=execution_id)
     url = response['QueryExecution']['ResultConfiguration']['OutputLocation']
-    parts = urllib.parse.urlparse(url)
-    assert parts.scheme == 's3', f"Unexpected result location: {url}"
-    return parts.netloc, parts.path.lstrip('/')
+    # Not urllib.parse.urlparse(): '?' and '#' are legal in S3 keys but would be parsed as query/fragment.
+    scheme, _, rest = url.partition('://')
+    assert scheme == 's3', f"Unexpected result location: {url}"
+    bucket, _, key = rest.partition('/')
+    return bucket, key
 
 
 def query_finished(execution_id):
@@ -374,7 +378,7 @@ def delete_dir(bucket, prefix):
             break
 
         delete_response = s3.delete_objects(
-            Bucket=QUERY_RESULT_BUCKET,
+            Bucket=bucket,
             Delete=dict(
                 Objects=[dict(
                     Key=obj['Key']

--- a/lambdas/access_counts/src/t4_lambda_access_counts/index.py
+++ b/lambdas/access_counts/src/t4_lambda_access_counts/index.py
@@ -21,6 +21,8 @@ QUERY_RESULT_BUCKET = os.environ['QUERY_RESULT_BUCKET']
 # Directory where the summary files will be stored.
 ACCESS_COUNTS_OUTPUT_DIR = os.environ['ACCESS_COUNTS_OUTPUT_DIR']
 ATHENA_WORKGROUP = os.environ['ATHENA_WORKGROUP']
+# Prefix under QUERY_RESULT_BUCKET where the workgroup writes query results; wiped at the start of each run.
+ATHENA_QUERY_RESULTS_PREFIX = os.environ['ATHENA_QUERY_RESULTS_PREFIX']
 
 MiB = 1024 * 1024
 S3_COPY_CHUNKSIZE = int(os.environ['S3_COPY_CHUNKSIZE_MIB']) * MiB
@@ -29,9 +31,6 @@ S3_COPY_CONFIG = TransferConfig(
     multipart_threshold=S3_COPY_CHUNKSIZE,
     max_concurrency=int(os.environ['S3_COPY_MAX_CONCURRENCY']),
 )
-
-# A temporary directory where Athena query results will be written.
-QUERY_TEMP_DIR = 'AthenaQueryResults'
 
 # Pre-processed CloudTrail logs, persistent across different runs of the lambda.
 OBJECT_ACCESS_LOG_DIR = 'ObjectAccessLog'
@@ -151,7 +150,7 @@ INSERT_INTO_OBJECT_ACCESS_LOG = textwrap.dedent("""\
 
 # No external_location: a CTAS that specifies one fails in a workgroup that enforces a query results
 # location; Athena instead writes the table data under the result location ("tables/<query-id>/"),
-# which is inside QUERY_TEMP_DIR and thus cleaned up by delete_dir.
+# which is inside ATHENA_QUERY_RESULTS_PREFIX and thus cleaned up by delete_dir.
 # https://docs.aws.amazon.com/athena/latest/ug/create-table-as.html
 CREATE_PACKAGE_HASHES = textwrap.dedent("""\
     CREATE TABLE package_hashes
@@ -291,12 +290,10 @@ s3 = boto3.client('s3')
 
 
 def start_query(query_string):
-    output = 's3://%s/%s/' % (QUERY_RESULT_BUCKET, QUERY_TEMP_DIR)
-
+    # No ResultConfiguration: the workgroup configuration owns the result location.
     response = athena.start_query_execution(
         QueryString=query_string,
         QueryExecutionContext=dict(Database=ATHENA_DATABASE),
-        ResultConfiguration=dict(OutputLocation=output),
         WorkGroup=ATHENA_WORKGROUP,
     )
     print("Started query:", response)
@@ -307,7 +304,7 @@ def start_query(query_string):
 
 
 def get_result_location(execution_id):
-    """Return (bucket, key) of the result file (the workgroup config may override the requested location)."""
+    """Return (bucket, key) of the query's result file, as reported by Athena."""
     response = athena.get_query_execution(QueryExecutionId=execution_id)
     url = response['QueryExecution']['ResultConfiguration']['OutputLocation']
     # Not urllib.parse.urlparse(): '?' and '#' are legal in S3 keys but would be parsed as query/fragment.
@@ -415,8 +412,8 @@ def handler(event, context):
     # and let the next invocation handle the rest.
     end_ts = min(end_ts, start_ts + timedelta(days=MAX_OPEN_PARTITIONS-1))
 
-    # Delete the temporary directory where Athena query results are written to.
-    delete_dir(QUERY_RESULT_BUCKET, QUERY_TEMP_DIR)
+    # Delete query results left by previous runs.
+    delete_dir(QUERY_RESULT_BUCKET, ATHENA_QUERY_RESULTS_PREFIX)
 
     # Find all accounts in the CloudTrail.
     accounts = []

--- a/lambdas/access_counts/src/t4_lambda_access_counts/index.py
+++ b/lambdas/access_counts/src/t4_lambda_access_counts/index.py
@@ -148,10 +148,8 @@ INSERT_INTO_OBJECT_ACCESS_LOG = textwrap.dedent("""\
           eventtime >= from_unixtime({start_ts:f}) AND eventtime < from_unixtime({end_ts:f})
 """)
 
-# No external_location: a CTAS that specifies one fails in a workgroup that enforces a query results
-# location; Athena instead writes the table data under the result location ("tables/<query-id>/"),
-# which is inside ATHENA_QUERY_RESULTS_PREFIX and thus cleaned up by delete_dir.
-# https://docs.aws.amazon.com/athena/latest/ug/create-table-as.html
+# Athena writes the table data under the workgroup's result location ("tables/<query-id>/"),
+# i.e. inside ATHENA_QUERY_RESULTS_PREFIX, so delete_dir cleans it up.
 CREATE_PACKAGE_HASHES = textwrap.dedent("""\
     CREATE TABLE package_hashes
     WITH (

--- a/lambdas/access_counts/tests/test_access_counts.py
+++ b/lambdas/access_counts/tests/test_access_counts.py
@@ -14,6 +14,7 @@ class TestQueries(TestCase):
     def test_no_ctas_external_location(self):
         # A CTAS specifying external_location fails outright in a workgroup that
         # enforces a query results location — keep it out.
+        # https://docs.aws.amazon.com/athena/latest/ug/create-table-as.html
         self.assertNotIn('external_location', index.CREATE_PACKAGE_HASHES)
 
 

--- a/lambdas/access_counts/tests/test_access_counts.py
+++ b/lambdas/access_counts/tests/test_access_counts.py
@@ -42,7 +42,6 @@ class TestAccessCounts(TestCase):
                     'Database': 'athena-db'
                 },
                 'QueryString': query,
-                'ResultConfiguration': {'OutputLocation': 's3://results-bucket/AthenaQueryResults/'},
                 'WorkGroup': 'test-workgroup',
             },
             service_response={

--- a/lambdas/access_counts/tests/test_access_counts.py
+++ b/lambdas/access_counts/tests/test_access_counts.py
@@ -11,7 +11,8 @@ from t4_lambda_access_counts import index
 
 
 class TestAccessCounts(TestCase):
-    """Tests S3 Select"""
+    workgroup = None
+
     def setUp(self):
         self.s3_stubber = Stubber(index.s3)
         self.s3_stubber.activate()
@@ -19,20 +20,28 @@ class TestAccessCounts(TestCase):
         self.athena_stubber = Stubber(index.athena)
         self.athena_stubber.activate()
 
+        workgroup_patcher = patch.object(index, 'ATHENA_WORKGROUP', self.workgroup)
+        workgroup_patcher.start()
+        self.addCleanup(workgroup_patcher.stop)
+
     def tearDown(self):
         self.athena_stubber.deactivate()
         self.s3_stubber.deactivate()
 
     def _start_query(self, query, execution_id):
+        expected_params = {
+            'QueryExecutionContext': {
+                'Database': 'athena-db'
+            },
+            'QueryString': query,
+            'ResultConfiguration': {'OutputLocation': 's3://results-bucket/AthenaQueryResults/'}
+        }
+        if self.workgroup is not None:
+            expected_params['WorkGroup'] = self.workgroup
+
         self.athena_stubber.add_response(
             method='start_query_execution',
-            expected_params={
-                'QueryExecutionContext': {
-                    'Database': 'athena-db'
-                },
-                'QueryString': query,
-                'ResultConfiguration': {'OutputLocation': 's3://results-bucket/AthenaQueryResults/'}
-            },
+            expected_params=expected_params,
             service_response={
                 'QueryExecutionId': execution_id
             },
@@ -146,6 +155,19 @@ class TestAccessCounts(TestCase):
         ])
 
         for idx, name in enumerate(['Objects', 'Packages', 'PackageVersions', 'Bucket', 'Exts']):
+            self.athena_stubber.add_response(
+                method='get_query_execution',
+                expected_params={
+                    'QueryExecutionId': str(idx),
+                },
+                service_response={
+                    'QueryExecution': {
+                        'ResultConfiguration': {
+                            'OutputLocation': f's3://results-bucket/AthenaQueryResults/{idx}.csv',
+                        },
+                    },
+                },
+            )
             self.s3_stubber.add_response(
                 method='head_object',
                 expected_params={
@@ -172,3 +194,7 @@ class TestAccessCounts(TestCase):
         with patch('t4_lambda_access_counts.index.now', return_value=now), \
              patch('time.sleep', return_value=None):
             index.handler(None, None)
+
+
+class TestAccessCountsWithWorkgroup(TestAccessCounts):
+    workgroup = 'test-workgroup'

--- a/lambdas/access_counts/tests/test_access_counts.py
+++ b/lambdas/access_counts/tests/test_access_counts.py
@@ -10,12 +10,11 @@ from botocore.stub import Stubber
 from t4_lambda_access_counts import index
 
 
-class TestQueries(TestCase):
-    def test_no_ctas_external_location(self):
-        # A CTAS specifying external_location fails outright in a workgroup that
-        # enforces a query results location — keep it out.
-        # https://docs.aws.amazon.com/athena/latest/ug/create-table-as.html
-        self.assertNotIn('external_location', index.CREATE_PACKAGE_HASHES)
+def test_no_ctas_external_location():
+    # A CTAS specifying external_location fails outright in a workgroup that
+    # enforces a query results location — keep it out.
+    # https://docs.aws.amazon.com/athena/latest/ug/create-table-as.html
+    assert 'external_location' not in index.CREATE_PACKAGE_HASHES
 
 
 class TestAccessCounts(TestCase):

--- a/lambdas/access_counts/tests/test_access_counts.py
+++ b/lambdas/access_counts/tests/test_access_counts.py
@@ -10,6 +10,13 @@ from botocore.stub import Stubber
 from t4_lambda_access_counts import index
 
 
+class TestQueries(TestCase):
+    def test_no_ctas_external_location(self):
+        # A CTAS specifying external_location fails outright in a workgroup that
+        # enforces a query results location — keep it out.
+        self.assertNotIn('external_location', index.CREATE_PACKAGE_HASHES)
+
+
 class TestAccessCounts(TestCase):
     # Effective result location reported by Athena; the redirect subclass simulates
     # a workgroup configuration overriding the requested location.

--- a/lambdas/access_counts/tests/test_access_counts.py
+++ b/lambdas/access_counts/tests/test_access_counts.py
@@ -11,7 +11,10 @@ from t4_lambda_access_counts import index
 
 
 class TestAccessCounts(TestCase):
-    workgroup = None
+    # Effective result location reported by Athena; the redirect subclass simulates
+    # a workgroup configuration overriding the requested location.
+    result_bucket = 'results-bucket'
+    result_prefix = 'AthenaQueryResults'
 
     def setUp(self):
         self.s3_stubber = Stubber(index.s3)
@@ -20,28 +23,21 @@ class TestAccessCounts(TestCase):
         self.athena_stubber = Stubber(index.athena)
         self.athena_stubber.activate()
 
-        workgroup_patcher = patch.object(index, 'ATHENA_WORKGROUP', self.workgroup)
-        workgroup_patcher.start()
-        self.addCleanup(workgroup_patcher.stop)
-
     def tearDown(self):
         self.athena_stubber.deactivate()
         self.s3_stubber.deactivate()
 
     def _start_query(self, query, execution_id):
-        expected_params = {
-            'QueryExecutionContext': {
-                'Database': 'athena-db'
-            },
-            'QueryString': query,
-            'ResultConfiguration': {'OutputLocation': 's3://results-bucket/AthenaQueryResults/'}
-        }
-        if self.workgroup is not None:
-            expected_params['WorkGroup'] = self.workgroup
-
         self.athena_stubber.add_response(
             method='start_query_execution',
-            expected_params=expected_params,
+            expected_params={
+                'QueryExecutionContext': {
+                    'Database': 'athena-db'
+                },
+                'QueryString': query,
+                'ResultConfiguration': {'OutputLocation': 's3://results-bucket/AthenaQueryResults/'},
+                'WorkGroup': 'test-workgroup',
+            },
             service_response={
                 'QueryExecutionId': execution_id
             },
@@ -163,7 +159,7 @@ class TestAccessCounts(TestCase):
                 service_response={
                     'QueryExecution': {
                         'ResultConfiguration': {
-                            'OutputLocation': f's3://results-bucket/AthenaQueryResults/{idx}.csv',
+                            'OutputLocation': f's3://{self.result_bucket}/{self.result_prefix}/{idx}.csv',
                         },
                     },
                 },
@@ -171,8 +167,8 @@ class TestAccessCounts(TestCase):
             self.s3_stubber.add_response(
                 method='head_object',
                 expected_params={
-                    'Bucket': 'results-bucket',
-                    'Key': f'AthenaQueryResults/{idx}.csv',
+                    'Bucket': self.result_bucket,
+                    'Key': f'{self.result_prefix}/{idx}.csv',
                 },
                 service_response={
                     'ContentLength': 123
@@ -182,8 +178,8 @@ class TestAccessCounts(TestCase):
                 method='copy_object',
                 expected_params={
                     'CopySource': {
-                        'Bucket': 'results-bucket',
-                        'Key': f'AthenaQueryResults/{idx}.csv',
+                        'Bucket': self.result_bucket,
+                        'Key': f'{self.result_prefix}/{idx}.csv',
                     },
                     'Bucket': 'results-bucket',
                     'Key': f'AccessCounts/{name}.csv',
@@ -196,5 +192,7 @@ class TestAccessCounts(TestCase):
             index.handler(None, None)
 
 
-class TestAccessCountsWithWorkgroup(TestAccessCounts):
-    workgroup = 'test-workgroup'
+class TestAccessCountsResultLocationOverride(TestAccessCounts):
+    """Workgroup config redirects results away from the requested location; the copy must follow it."""
+    result_bucket = 'workgroup-results-bucket'
+    result_prefix = 'EnforcedResults'


### PR DESCRIPTION
# Description

Let the access_counts lambda run its Athena queries in a dedicated workgroup instead of the account default (`primary`), so deployments can get per-workload isolation, per-workgroup CloudWatch metrics/cost controls, and a tighter IAM scope for the lambda role.

- Read the required `ATHENA_WORKGROUP` env var and pass `WorkGroup=` to `start_query_execution`.
- The workgroup configuration owns the result location: the lambda passes no client-side `ResultConfiguration`, derives each query's result file from `get_query_execution`, and cleans the results prefix given by the new required `ATHENA_QUERY_RESULTS_PREFIX` env var — supplied by the template from the same constant that configures the workgroup, replacing a hardcoded duplicate of the prefix.

Both env vars are required: the lambda crashes at startup if either is missing, so a lambda-version bump without the paired deployment-side change (which creates the workgroup, sets the env vars, and tightens the role's `athena:*` resource scope) fails loudly instead of silently running in the shared workgroup. Sequencing stays safe because deployments pin lambda versions per commit — existing stacks keep the current code until the paired change lands both the new version and the env var together.

Written with AI assistance (Claude Code), human-reviewed.

# TODO

- [x] Unit tests
- [x] Security: Confirm that this change meets security best practices and does not violate the security model
- [x] Changelog entry (lambdas/access_counts/CHANGELOG.md; pending PR number)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds dedicated Athena workgroup support to the access-counts Lambda.
- Requires workgroup and query-results-prefix environment variables.
- Uses Athena’s reported output location when copying generated CSV results.
- Removes the CTAS external location and cleans the configured results prefix.
- Extends tests to cover a workgroup-enforced result bucket and prefix.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge.

No blocking failure remains in the changes eligible for this follow-up review.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| lambdas/access_counts/src/t4_lambda_access_counts/index.py | Routes queries through the configured workgroup and resolves result objects from Athena’s effective output location. |
| lambdas/access_counts/tests/test_access_counts.py | The added override test exercises the previously untested distinct workgroup result bucket and prefix. |
| lambdas/access_counts/pytest.ini | Supplies the two newly required environment variables during tests. |
| lambdas/access_counts/CHANGELOG.md | Documents dedicated workgroup support and its required configuration. |

<sub>Reviews (3): Last reviewed commit: ["Revert &quot;TEMP: trigger deploy-lambdas on ..."](https://github.com/quiltdata/quilt/commit/285aa0613dcca8c8468bfca19eae06cac8f8828e) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=46651193)</sub>

<!-- /greptile_comment -->