### PR TITLE
quilt3 login: don't echo the pasted code to the terminal

### DIFF
--- a/api/python/quilt3/session.py
+++ b/api/python/quilt3/session.py
@@ -2,6 +2,7 @@
 Helper functions for connecting to the Quilt Registry.
 """
 
+import getpass
 import json
 import os
 import platform
@@ -247,7 +248,9 @@ def login():
     open_url(login_url)
 
     print()
-    refresh_token = input("Enter the code from the webpage: ")
+    # The code is a refresh token (a long-lived credential); read it without
+    # echoing so it doesn't land in terminal scrollback or screen shares.
+    refresh_token = getpass.getpass("Enter the code from the webpage: ")
 
     login_with_token(refresh_token)
 

--- a/api/python/quilt3/session.py
+++ b/api/python/quilt3/session.py
@@ -248,8 +248,6 @@ def login():
     open_url(login_url)
 
     print()
-    # The code is a refresh token (a long-lived credential); read it without
-    # echoing so it doesn't land in terminal scrollback or screen shares.
     refresh_token = getpass.getpass("Enter the code from the webpage: ")
 
     login_with_token(refresh_token)

--- a/api/python/tests/test_session.py
+++ b/api/python/tests/test_session.py
@@ -21,9 +21,9 @@ def format_date(date):
 
 class TestSession(QuiltTestCase):
     @patch('quilt3.session.open_url')
-    @patch('quilt3.session.input', return_value='123456')
+    @patch('quilt3.session.getpass.getpass', return_value='123456')
     @patch('quilt3.session.login_with_token')
-    def test_login(self, mock_login_with_token, mock_input, mock_open_url):
+    def test_login(self, mock_login_with_token, mock_getpass, mock_open_url):
         quilt3.login()
 
         url = quilt3.session.get_registry_url()

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -23,6 +23,10 @@ Entries inside each section should be ordered by type:
 * [Removed] Drop support for Python 3.9 (end-of-life); `quilt3` now requires Python >= 3.10 ([#4941](https://github.com/quiltdata/quilt/pull/4941))
 * [Fixed] `quilt3.admin.buckets.list` no longer raises `TypeError` when its type hints are introspected on Python 3.14 ([#4940](https://github.com/quiltdata/quilt/pull/4940))
 
+### CLI
+
+* [Changed] `quilt3 login` no longer echoes the pasted code to the terminal (it is a long-lived credential) ([#XXXX](https://github.com/quiltdata/quilt/pull/XXXX))
+
 ## 7.3.0 - 2026-04-07
 
 ### Python API

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -25,7 +25,7 @@ Entries inside each section should be ordered by type:
 
 ### CLI
 
-* [Changed] `quilt3 login` no longer echoes the pasted code to the terminal (it is a long-lived credential) ([#XXXX](https://github.com/quiltdata/quilt/pull/XXXX))
+* [Changed] `quilt3 login` no longer echoes the pasted code to the terminal (it is a long-lived credential) ([#5138](https://github.com/quiltdata/quilt/pull/5138))
 
 ## 7.3.0 - 2026-04-07
 


### PR DESCRIPTION
# Description

`quilt3 login` prompts for a "code from the webpage" and reads it with `input()`, which echoes it to the terminal. That code is a **long-lived refresh token** (it's passed straight to `login_with_token` → `/api/token`), so echoing it leaves a durable credential in terminal scrollback, screen shares, and any session logging.

This switches the prompt to `getpass.getpass()`, which reads the code without echoing. No other behavior changes; the exchanged token is stored exactly as before (`auth.json`, mode `0600`).

Note: with a non-TTY stdin, `getpass` falls back to reading stdin and prints a `Warning: Password input may be echoed` to stderr — standard, matches `getpass` everywhere else.

# TODO

- [x] Unit tests — existing `test_login` updated to patch `getpass.getpass`
- [x] Security: Confirm that this change meets security best practices and does not violate the security model
- [ ] Open: Confirm that this change doesn't break the Open variant — N/A (CLI-only, no variant-specific code)
- [x] [Changelog](../tree/master/docs/CHANGELOG.md) entry

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR prevents `quilt3 login` from echoing pasted credentials.
- Replaces `input()` with `getpass.getpass()` for the interactive login prompt.
- Updates the login unit test to mock the non-echoing prompt.
- Adds a changelog entry linked to PR #5138.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge.

No blocking failures remain, and the previous changelog-link issue has been fully addressed.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| api/python/quilt3/session.py | Changes the interactive refresh-token prompt to use Python's non-echoing getpass implementation. |
| api/python/tests/test_session.py | Updates the existing login test to patch getpass while preserving verification that the entered token reaches login_with_token. |
| docs/CHANGELOG.md | Documents the login prompt change and replaces the previously reported placeholder with the correct PR #5138 link. |

<sub>Reviews (2): Last reviewed commit: ["Drop redundant comment on the getpass pr..."](https://github.com/quiltdata/quilt/commit/073c77d449dac28be1b4aeb07e1bd8c5f83d895c) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=47030154)</sub>

**Context used:**

- Knowledge Base — [quilt3 Python client](https://app.greptile.com/quilt-bio/-/custom-context/knowledge-base/quiltdata/quilt/-/docs/quilt3-python-client.md)

<!-- /greptile_comment -->