### PR TITLE
Fix local delete_package wiping the whole user namespace

### DIFF
--- a/api/python/quilt3/backends/local.py
+++ b/api/python/quilt3/backends/local.py
@@ -29,7 +29,8 @@ class LocalPackageRegistryV1(PackageRegistryV1):
                 yield path, f.read()
 
     def delete_package(self, pkg_name: str):
-        shutil.rmtree(self._pointers_usr_dir(pkg_name).path)
+        shutil.rmtree(self.pointers_dir(pkg_name).path)
+        delete_url(self._pointers_usr_dir(pkg_name))
 
     def delete_package_version(self, pkg_name: str, top_hash: str):
         super().delete_package_version(pkg_name, top_hash)

--- a/api/python/tests/integration/test_packages.py
+++ b/api/python/tests/integration/test_packages.py
@@ -1034,6 +1034,18 @@ class PackageTest(QuiltTestCase):
         quilt3.delete_package('Quilt/Test')
         assert 'Quilt/Test' not in quilt3.list_packages()
 
+    def test_local_package_delete_keeps_sibling_packages(self):
+        """delete_package must remove only the named package, not the whole user namespace."""
+        Package().build("Quilt/Test1")
+        Package().build("Quilt/Test2")
+        assert {"Quilt/Test1", "Quilt/Test2"} <= set(quilt3.list_packages())
+
+        quilt3.delete_package("Quilt/Test1")
+
+        packages = set(quilt3.list_packages())
+        assert "Quilt/Test1" not in packages
+        assert "Quilt/Test2" in packages
+
     def test_local_delete_package_revision(self):
         pkg_name = 'Quilt/Test'
         top_hash1 = 'top_hash1'

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -22,6 +22,7 @@ Entries inside each section should be ordered by type:
 
 * [Removed] Drop support for Python 3.9 (end-of-life); `quilt3` now requires Python >= 3.10 ([#4941](https://github.com/quiltdata/quilt/pull/4941))
 * [Fixed] `quilt3.admin.buckets.list` no longer raises `TypeError` when its type hints are introspected on Python 3.14 ([#4940](https://github.com/quiltdata/quilt/pull/4940))
+* [Fixed] `quilt3.delete_package()` on a local registry no longer deletes other packages sharing the same namespace ([#5140](https://github.com/quiltdata/quilt/pull/5140))
 
 ### CLI
 


### PR DESCRIPTION
# Description

`LocalPackageRegistryV1.delete_package` removed `named_packages/<usr>/` — the entire user namespace — instead of the package's own pointers directory, so `quilt3.delete_package("foo/bar")` against a local registry also deleted `foo/baz`, `foo/qux`, and every other package sharing the `foo` namespace. Silent data loss, no error.

The fix targets the package-scoped `pointers_dir`, which is what `LocalPackageRegistryV2.delete_package` and `S3PackageRegistryV1.delete_package` already do. The now-possibly-empty parent namespace directory is then cleaned up with `delete_url`, which is a no-op unless the directory is empty — the same pattern `delete_package_version` uses two lines below.

Scope: local registries on registry version 1 (the default) only. V2 is unaffected because its flat `usr@pkg` layout has no shared parent directory, and the S3 backend was already correct.

Regressed in ae8521ff (#1678), which split `delete_package` into `delete_package`/`delete_package_version` and changed the `rmtree` target along the way; the pre-split code removed `pointers_dir`.

`test_local_package_delete` only ever built a single package per namespace, so it passed either way. The new test builds two sibling packages and asserts the untouched one survives — it fails on the old code (verified: red before, green after) and runs under both the V1 and V2 test classes.

# TODO

- [x] Unit tests
- [x] Security: Confirm that this change meets security best practices and does not violate the security model
- [x] Open: Confirm that this change doesn't break the Open variant
- [x] [Changelog](../tree/master/docs/CHANGELOG.md) entry

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Fixes local V1 package deletion so it preserves sibling packages.
- Deletes only the named package’s pointer directory before cleaning up an empty namespace directory.
- Adds regression coverage for deleting one of two sibling packages under both local registry versions.
- Documents the fix in the changelog.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge because deletion is now package-scoped and the empty-only namespace cleanup preserves sibling packages.

The changed deletion target matches the V1 pointer layout, while delete_url removes the namespace directory only when it is empty; the added inherited test covers both local V1 and V2 registries.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| api/python/quilt3/backends/local.py | Correctly narrows V1 deletion to the package pointer directory and performs best-effort empty-parent cleanup. |
| api/python/tests/integration/test_packages.py | Adds regression coverage proving sibling packages remain listed after deletion under both local registry versions. |
| docs/CHANGELOG.md | Accurately documents the corrected local delete_package behavior. |

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart LR
  A["delete_package('Quilt/Test1')"] --> B["Remove named_packages/Quilt/Test1"]
  B --> C{"Is named_packages/Quilt empty?"}
  C -->|Yes| D["Remove empty Quilt namespace"]
  C -->|No| E["Preserve namespace and sibling packages"]
```

<sub>Reviews (2): Last reviewed commit: ["Add CHANGELOG entry"](https://github.com/quiltdata/quilt/commit/1aa2d9cae69c8729f02317f8052b43da4532f254) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=47061364)</sub>

**Context used:**

- Knowledge Base — [quilt3 Python client](https://app.greptile.com/quilt-bio/-/custom-context/knowledge-base/quiltdata/quilt/-/docs/quilt3-python-client.md)

<!-- /greptile_comment -->