### PR TITLE
Ignore and clean up testdocs/app-manifest.yaml

### DIFF
--- a/testdocs/.gitignore
+++ b/testdocs/.gitignore
@@ -5,3 +5,4 @@ references
 notebooks
 scripts
 data.csv
+app-manifest.yaml

--- a/testdocs/clean.sh
+++ b/testdocs/clean.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env zsh
 
-TEST_FILES=('data' 'notebooks' 'scripts' 'test_workflow' 'data.csv' 'example.jsonl' 'quilt_summarize.json' 'vega.json')
+TEST_FILES=('data' 'notebooks' 'scripts' 'test_workflow' 'data.csv' 'example.jsonl' 'quilt_summarize.json' 'vega.json' 'app-manifest.yaml')
 echo "Removing files and directories created by tests..."
 for x in $TEST_FILES; do
   echo " - " $x


### PR DESCRIPTION
# Description

`testdocs` runs `pytest --codeblocks ../docs`, which *executes* the fenced code blocks in the docs. One of them, in `docs/examples/benchling.md`, is:

```bash
npx @quiltdata/benchling-webhook@latest manifest
```

As the doc itself notes on the next line, that writes an `app-manifest.yaml` into the working directory — so every testdocs run leaves `testdocs/app-manifest.yaml` behind.

It was covered by neither of the two lists `testdocs` uses to manage its artifacts: the existing `*.json*` pattern in `.gitignore` doesn't match a `.yaml`, and `clean.sh`'s `TEST_FILES` doesn't name it. The file therefore shows up as untracked after every local run and is easy to stage by accident.

Both lists get the entry, because they do different jobs: `.gitignore` prevents the accidental commit, while `clean.sh` — a manual convenience documented in `testdocs/README.md`, not wired into any task — is what actually deletes it. Appended rather than sorted, matching the existing order in both.

Local hygiene only: CI runs testdocs but never commits, so this could only ever bite a human.

Worth noting for whoever owns `testdocs`: the two lists are hand-maintained and duplicate each other, so every future artifact-producing docs example has to be remembered twice. Pointing `clean.sh` at `git clean -Xfd` would make `.gitignore` the single source of truth, but it also deletes ignored-but-not-artifact files like `.venv`, which the current script deliberately leaves alone — a behavior change I left out of a hygiene fix.

# TODO

- [x] Unit tests — not applicable; verified by hand that `git check-ignore` matches the new rule and that `clean.sh` removes the file (and still parses under `zsh -n`)
- [x] Security: no security impact
- [x] Open: no effect on the Open variant
- [x] Changelog entry — skipped, developer tooling with no end-user-visible change

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds the generated Benchling manifest to testdocs artifact handling.
- Ignores `testdocs/app-manifest.yaml` to prevent accidental staging.
- Removes the manifest when the documented testdocs cleanup script runs.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge.

The ignored and deleted path matches the artifact generated in the documented testdocs working directory, with no automated callers or source-file consumers affected.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| testdocs/.gitignore | Adds the generated app manifest to the testdocs-local ignore list. |
| testdocs/clean.sh | Adds the generated app manifest to the existing cleanup artifact list. |

<sub>Reviews (1): Last reviewed commit: ["Ignore and clean up testdocs/app-manifes..."](https://github.com/quiltdata/quilt/commit/73f3bcc80f2dc724f1328ba63a3643e9a266c692) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=47188286)</sub>

<!-- /greptile_comment -->