### PR TITLE
chore: use stdlib typing instead of typing_extensions

### DIFF
--- a/lambdas/s3hash/src/t4_lambda_s3hash/__init__.py
+++ b/lambdas/s3hash/src/t4_lambda_s3hash/__init__.py
@@ -14,7 +14,6 @@ import aiobotocore.response
 import aiobotocore.session
 import botocore.exceptions
 import pydantic.v1
-import typing_extensions as TX
 
 from quilt3.data_transfer import get_checksum_chunksize, is_mpu
 from quilt_shared.aws import AWSCredentials
@@ -351,7 +350,7 @@ async def compute_checksum(
     elif algorithm is ChecksumAlgorithm.SHA256_CHUNKED:
         checksum = Checksum.sha256_chunked_from_parts(part_checksums)
     else:
-        TX.assert_never(algorithm)
+        T.assert_never(algorithm)
 
     logger.info(f"[PERF] compute_checksum END: {location} -> {checksum.type}")
     return ChecksumResult(checksum=checksum)

--- a/py-shared/CHANGELOG.md
+++ b/py-shared/CHANGELOG.md
@@ -17,6 +17,7 @@ where verb is one of
 
 ## Changes
 
+- [Removed] Drop the `typing-extensions` dependency from the `pydantic` extra ([#5149](https://github.com/quiltdata/quilt/pull/5149))
 - [Changed] **BREAKING**: Raise minimum Python to 3.12 ([#5018](https://github.com/quiltdata/quilt/pull/5018))
 - [Changed] **BREAKING**: Retarget `QueryMaker` to per-bucket Iceberg tables (`{bucket}_{table}`) ([#4930](https://github.com/quiltdata/quilt/pull/4930))
 - [Added] Add CRC64NVME checksum type support ([#4623](https://github.com/quiltdata/quilt/pull/4623))

--- a/py-shared/pyproject.toml
+++ b/py-shared/pyproject.toml
@@ -13,7 +13,6 @@ dependencies = [
 [project.optional-dependencies]
 pydantic = [
   "pydantic ~= 2.10",
-  "typing-extensions ~= 4.9",
 ]
 boto = [
   "boto3 ~= 1.34",

--- a/py-shared/src/quilt_shared/pkgpush.py
+++ b/py-shared/src/quilt_shared/pkgpush.py
@@ -8,7 +8,6 @@ import random
 import typing as T
 
 import pydantic.v1
-import typing_extensions as TX
 
 from .aws import AWSCredentials
 from .crc64 import combine_crc64nvme
@@ -83,7 +82,7 @@ class ChecksumAlgorithm(str, enum.Enum):
             return "SHA256"
         if self is self.CRC64NVME:
             return "CRC64NVME"
-        TX.assert_never(self)
+        T.assert_never(self)
 
     @property
     def s3_checksum_field(self):
@@ -91,7 +90,7 @@ class ChecksumAlgorithm(str, enum.Enum):
             return "ChecksumSHA256"
         if self is self.CRC64NVME:
             return "ChecksumCRC64NVME"
-        TX.assert_never(self)
+        T.assert_never(self)
 
 
 class ChecksumType(str, enum.Enum):

--- a/py-shared/src/quilt_shared/types.py
+++ b/py-shared/src/quilt_shared/types.py
@@ -2,7 +2,6 @@ import functools
 import typing as T
 
 import pydantic.v1
-import typing_extensions as TX
 
 
 class NonEmptyStr(pydantic.v1.ConstrainedStr):
@@ -10,7 +9,7 @@ class NonEmptyStr(pydantic.v1.ConstrainedStr):
     strip_whitespace = True
 
 
-ConsParams = TX.ParamSpec("ConsParams")
+ConsParams = T.ParamSpec("ConsParams")
 ConsReturn = T.TypeVar("ConsReturn")
 FnReturn = T.TypeVar("FnReturn")
 

--- a/py-shared/uv.lock
+++ b/py-shared/uv.lock
@@ -560,7 +560,6 @@ es = [
 ]
 pydantic = [
     { name = "pydantic" },
-    { name = "typing-extensions" },
 ]
 quilt = [
     { name = "quilt3" },
@@ -585,7 +584,6 @@ requires-dist = [
     { name = "quilt3", marker = "extra == 'quilt'", specifier = ">=7,<8" },
     { name = "types-aiobotocore", extras = ["s3"], marker = "extra == 'boto'", specifier = "~=2.11" },
     { name = "types-boto3", extras = ["athena", "s3", "sts"], marker = "extra == 'boto'", specifier = "~=1.34" },
-    { name = "typing-extensions", marker = "extra == 'pydantic'", specifier = "~=4.9" },
 ]
 provides-extras = ["pydantic", "boto", "quilt", "es"]
 


### PR DESCRIPTION
# Description

`py-shared` floors at Python >= 3.12 and `s3hash` at 3.13, so the two `typing_extensions` symbols they use are already in the stdlib: `assert_never` (3.11+) and `ParamSpec` (3.10+). This swaps them for `typing` and drops `typing-extensions` from `quilt-shared`'s `pydantic` extra.

`s3hash` was also importing `typing_extensions` without declaring it, relying on `quilt-shared[pydantic]` to pull it in — that undeclared dependency goes away too.

Note that `typing_extensions` remains installed and imported at runtime everywhere, because pydantic 2.x depends on it; it stays in the lockfiles as a pydantic transitive. The change removes our own dependency on the backport, not the package from the closure — so a missed call site would not have raised, and `git grep typing_extensions` (empty outside lockfiles) is what establishes the swap is complete.

Only `py-shared/uv.lock` changes: consumer lambdas pin `quilt-shared` to a GitHub archive SHA, so they pick this up whenever their pin is next bumped.

# TODO

- [x] Unit tests — behavior-preserving refactor; covered by the existing suites (`py-shared` 32 passed, `s3hash` 23 passed). Verified no new `mypy` errors against a master baseline, since the repo has no type checker in CI.
- [x] Security: no security impact (typing-only change)
- [x] Changelog — entry added to `py-shared/CHANGELOG.md`, whose declared dependency set changes. Nothing in `docs/CHANGELOG.md` (no `quilt3`/CLI surface) and nothing in `lambdas/s3hash/CHANGELOG.md` (that side is an internal import swap; s3hash declares pydantic directly, so its dependency set and image are unchanged).

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR replaces `typing_extensions` usages with supported stdlib `typing` equivalents and removes the redundant direct dependency.
- Uses `typing.assert_never` in shared checksum logic and the s3hash Lambda.
- Uses `typing.ParamSpec` in shared type helpers.
- Removes `typing-extensions` from the `pydantic` extra and regenerates the lockfile.
- Documents the dependency change in the changelog.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge with no actionable correctness, compatibility, or security issues identified.

The stdlib symbols exist on all declared and in-repository consumer runtimes, the remaining dependency resolution is valid, and the project metadata and lockfile stay consistent.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| lambdas/s3hash/src/t4_lambda_s3hash/__init__.py | Replaces `typing_extensions.assert_never` with the Python 3.13 stdlib equivalent without changing checksum behavior. |
| py-shared/src/quilt_shared/pkgpush.py | Moves exhaustive enum assertions to stdlib `typing`, which is available under the package's Python 3.12 minimum. |
| py-shared/src/quilt_shared/types.py | Moves `ParamSpec` to stdlib `typing`, available on every supported runtime. |
| py-shared/pyproject.toml | Removes a redundant direct dependency while retaining `pydantic`, which supplies `typing-extensions` transitively. |
| py-shared/uv.lock | Consistently updates the optional dependency metadata while retaining the transitive package through pydantic. |

<sub>Reviews (1): Last reviewed commit: ["py-shared: add changelog entry"](https://github.com/quiltdata/quilt/commit/98100f4393b9b476beffa7b6e004ef186e724d89) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=47212701)</sub>

<!-- /greptile_comment -->