### PR TITLE
Drop Python 2.7 cruft from exception constructors

### DIFF
--- a/api/python/quilt3/data_transfer.py
+++ b/api/python/quilt3/data_transfer.py
@@ -65,6 +65,7 @@ class S3Api(Enum):
 class S3NoValidClientError(Exception):
     def __init__(self, message):
         super().__init__(message)
+        # Read from outside this package: the pkgpush lambda surfaces it as error detail.
         self.message = message
 
 

--- a/api/python/quilt3/data_transfer.py
+++ b/api/python/quilt3/data_transfer.py
@@ -63,15 +63,9 @@ class S3Api(Enum):
 
 
 class S3NoValidClientError(Exception):
-    def __init__(self, message, **kwargs):
-        # We use NewError("Prefix: " + str(error)) a lot.
-        # To be consistent across Python 2.7 and 3.x:
-        # 1) This `super` call must exist, or 2.7 will have no text for str(error)
-        # 2) This `super` call must have only one argument (the message) or str(error) will be a repr of args
+    def __init__(self, message):
         super().__init__(message)
         self.message = message
-        for k, v in kwargs.items():
-            setattr(self, k, v)
 
 
 class S3ClientProvider:

--- a/api/python/quilt3/util.py
+++ b/api/python/quilt3/util.py
@@ -102,8 +102,8 @@ def get_pos_int_from_env(var_name):
 
 class QuiltException(Exception):
     def __init__(self, message, **kwargs):
-        # `str(e)` is user-facing (printed to stderr, embedded in other messages), so pass only the
-        # message to `super` — with more args it renders the args tuple instead.
+        # Overwrites the `args` that `BaseException.__new__` seeded from a subclass's own positional
+        # args, so `str(e)` is the message; passing more than the message makes it an args repr.
         super().__init__(message)
         self.message = message
         for k, v in kwargs.items():

--- a/api/python/quilt3/util.py
+++ b/api/python/quilt3/util.py
@@ -102,10 +102,7 @@ def get_pos_int_from_env(var_name):
 
 class QuiltException(Exception):
     def __init__(self, message, **kwargs):
-        # We use NewError("Prefix: " + str(error)) a lot.
-        # To be consistent across Python 2.7 and 3.x:
-        # 1) This `super` call must exist, or 2.7 will have no text for str(error)
-        # 2) This `super` call must have only one argument (the message) or str(error) will be a repr of args
+        # Pass only the message to `super`, or `str(error)` becomes a repr of args.
         super().__init__(message)
         self.message = message
         for k, v in kwargs.items():

--- a/api/python/quilt3/util.py
+++ b/api/python/quilt3/util.py
@@ -102,7 +102,7 @@ def get_pos_int_from_env(var_name):
 
 class QuiltException(Exception):
     def __init__(self, message, **kwargs):
-        # Pass only the message to `super`, or `str(error)` becomes a repr of args.
+        # Pass only the message to `super`: with more args, `str()` renders the args tuple.
         super().__init__(message)
         self.message = message
         for k, v in kwargs.items():

--- a/api/python/quilt3/util.py
+++ b/api/python/quilt3/util.py
@@ -102,7 +102,8 @@ def get_pos_int_from_env(var_name):
 
 class QuiltException(Exception):
     def __init__(self, message, **kwargs):
-        # Pass only the message to `super`: with more args, `str()` renders the args tuple.
+        # `str(e)` is user-facing (printed to stderr, embedded in other messages), so pass only the
+        # message to `super` — with more args it renders the args tuple instead.
         super().__init__(message)
         self.message = message
         for k, v in kwargs.items():

--- a/api/python/tests/test_data_transfer.py
+++ b/api/python/tests/test_data_transfer.py
@@ -1148,6 +1148,16 @@ class S3HashingTest(QuiltTestCase):
         assert hash1 == '47DEQpj8HBSa+/TImW+5JCeuQeRkm5NMpJWZG3hSuFU='
 
 
+def test_s3_no_valid_client_error_renders_message():
+    msg = 'S3 AccessDenied for S3Api.LIST_OBJECTS_V2 on bucket: some-bucket'
+    err = data_transfer.S3NoValidClientError(msg)
+
+    assert str(err) == msg
+    assert err.args == (msg,)
+    # Consumed outside this package, so part of the error's contract rather than an implementation detail.
+    assert err.message == msg
+
+
 def test_crc64nvme_local_file(tmp_path):
     """Test CRC64NVME checksum calculation via calculate_multipart_checksum with local file."""
     data = b'Hello, World!'

--- a/api/python/tests/test_data_transfer.py
+++ b/api/python/tests/test_data_transfer.py
@@ -1148,16 +1148,6 @@ class S3HashingTest(QuiltTestCase):
         assert hash1 == '47DEQpj8HBSa+/TImW+5JCeuQeRkm5NMpJWZG3hSuFU='
 
 
-def test_s3_no_valid_client_error_renders_message():
-    msg = 'S3 AccessDenied for S3Api.LIST_OBJECTS_V2 on bucket: some-bucket'
-    err = data_transfer.S3NoValidClientError(msg)
-
-    assert str(err) == msg
-    assert err.args == (msg,)
-    # Consumed outside this package, so part of the error's contract rather than an implementation detail.
-    assert err.message == msg
-
-
 def test_crc64nvme_local_file(tmp_path):
     """Test CRC64NVME checksum calculation via calculate_multipart_checksum with local file."""
     data = b'Hello, World!'
@@ -1172,3 +1162,12 @@ def test_crc64nvme_local_file(tmp_path):
 
     assert result[0] == '1Km+Qyat0k0='  # Known CRC64NVME of "Hello, World!"
     assert result[0] == checksums.calculate_multipart_checksum_bytes(data, checksum_type=checksums.CRC64NVME_HASH_NAME)
+
+
+def test_s3_no_valid_client_error_renders_message():
+    msg = 'S3 AccessDenied for S3Api.LIST_OBJECTS_V2 on bucket: some-bucket'
+    err = data_transfer.S3NoValidClientError(msg)
+
+    assert str(err) == msg
+    assert err.args == (msg,)
+    assert err.message == msg

--- a/api/python/tests/test_util.py
+++ b/api/python/tests/test_util.py
@@ -117,9 +117,22 @@ def test_quilt_exception_renders_message():
 
 
 def test_quilt_exception_kwargs_become_attributes():
-    inner = ValueError('inner')
-    err = util.QuiltException('boom', original_error=inner)
+    err = util.QuiltException('boom', context='extra detail')
 
-    assert err.original_error is inner
+    assert err.context == 'extra detail'
     assert str(err) == 'boom'
     assert err.args == ('boom',)
+
+
+def test_quilt_exception_subclass_renders_message_not_own_args():
+    class Subclass(util.QuiltException):
+        def __init__(self, value):
+            self.value = value
+            super().__init__(f'bad value: {value}')
+
+    err = Subclass(42)
+
+    # Without QuiltException handing `super()` the message, `args` would keep Subclass's own
+    # positional and `str(err)` would be '42'.
+    assert str(err) == 'bad value: 42'
+    assert err.args == ('bad value: 42',)

--- a/api/python/tests/test_util.py
+++ b/api/python/tests/test_util.py
@@ -105,3 +105,21 @@ def test_get_pos_int_from_env_error(env_val):
         with pytest.raises(ValueError) as e:
             util.get_pos_int_from_env(var_name)
         assert f'{var_name} must be a positive integer' == str(e.value)
+
+
+def test_quilt_exception_renders_message():
+    msg = 'something went wrong'
+    err = util.QuiltException(msg)
+
+    assert str(err) == msg
+    assert err.args == (msg,)
+    assert err.message == msg
+
+
+def test_quilt_exception_kwargs_become_attributes():
+    inner = ValueError('inner')
+    err = util.QuiltException('boom', original_error=inner)
+
+    assert err.original_error is inner
+    assert str(err) == 'boom'
+    assert err.args == ('boom',)

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -23,7 +23,6 @@ Entries inside each section should be ordered by type:
 * [Removed] Drop support for Python 3.9 (end-of-life); `quilt3` now requires Python >= 3.10 ([#4941](https://github.com/quiltdata/quilt/pull/4941))
 * [Fixed] `quilt3.admin.buckets.list` no longer raises `TypeError` when its type hints are introspected on Python 3.14 ([#4940](https://github.com/quiltdata/quilt/pull/4940))
 * [Fixed] `quilt3.delete_package()` on a local registry no longer deletes other packages sharing the same namespace ([#5140](https://github.com/quiltdata/quilt/pull/5140))
-* [Changed] `quilt3.data_transfer.S3NoValidClientError` no longer accepts arbitrary keyword arguments; its constructor takes the message alone ([#5150](https://github.com/quiltdata/quilt/pull/5150))
 
 ### CLI
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -23,6 +23,7 @@ Entries inside each section should be ordered by type:
 * [Removed] Drop support for Python 3.9 (end-of-life); `quilt3` now requires Python >= 3.10 ([#4941](https://github.com/quiltdata/quilt/pull/4941))
 * [Fixed] `quilt3.admin.buckets.list` no longer raises `TypeError` when its type hints are introspected on Python 3.14 ([#4940](https://github.com/quiltdata/quilt/pull/4940))
 * [Fixed] `quilt3.delete_package()` on a local registry no longer deletes other packages sharing the same namespace ([#5140](https://github.com/quiltdata/quilt/pull/5140))
+* [Changed] `quilt3.data_transfer.S3NoValidClientError` no longer accepts arbitrary keyword arguments; its constructor takes the message alone ([#5150](https://github.com/quiltdata/quilt/pull/5150))
 
 ### CLI
 


### PR DESCRIPTION
# Description

`S3NoValidClientError` and `QuiltException` each carried a comment justifying their constructor shape for Python 2.7 compatibility. The package requires Python >= 3.10, and the zero-argument `super()` on the very line that comment defends would not parse under 2.7 anyway. Only the "pass a single argument to `super`, or `str(error)` becomes a repr of args" note still describes live behavior; it stays on `QuiltException` as a one-liner.

`S3NoValidClientError` additionally had a dead `**kwargs`/`setattr` path — it is raised at exactly one site (`data_transfer.py:157`) with a bare message and constructed nowhere else, so nothing ever landed in `kwargs`. `QuiltException` keeps its copy, which is live: `util.py:285` passes `original_error=error`.

`self.message` stays on both classes; it is read from outside each one — off `S3NoValidClientError` by the pkgpush lambda, off `QuiltException` by `main.py`.

`str(e)`, `e.message` and `e.args` are identical before and after for both classes, now pinned by tests rather than argued. Worth flagging for review: the retained `super().__init__(message)` is **not** redundant under Python 3 — `BaseException.__new__` seeds `args` from a *subclass's* own positional arguments, so that call is what keeps `str(e)` the message instead of a repr of whatever the subclass took. Deleting it turns `UnsupportedConfigurationVersionError`'s text into a bare version number, and `test_quilt_exception_subclass_renders_message_not_own_args` is the only test that reddens when it goes. The one observable change is `S3NoValidClientError`'s signature narrowing from `(message, **kwargs)` to `(message)`. No changelog entry: `data_transfer` is not part of quilt3's API surface — the package root does not import it and `gendocs/pydocmd.yml` does not document it, and quilt3 defines its public API by enumeration in that file rather than by underscore convention. The pkgpush lambda importing the class is a contract between our own components, not a public one.

# TODO

- [x] Unit tests
- [x] Security: Confirm that this change meets security best practices and does not violate the security model
- [x] Open: Confirm that this change doesn't break the Open variant

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Removes obsolete Python 2.7 compatibility comments and the unused keyword-attribute path from `S3NoValidClientError`, while preserving the live constructor behavior and explanatory note on `QuiltException`.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge with no actionable defects identified.

The exception behavior used by existing call paths remains unchanged, while only obsolete commentary and an unused keyword-attribute path are removed.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| api/python/quilt3/data_transfer.py | Simplifies `S3NoValidClientError` to accept only its sole observed input, preserving its message, args, and string representation. |
| api/python/quilt3/util.py | Condenses the `QuiltException` constructor comment without changing runtime behavior. |

<sub>Reviews (1): Last reviewed commit: ["Drop Python 2.7 cruft from exception con..."](https://github.com/quiltdata/quilt/commit/919db72a6768c9dcfc43deb207fdf8b76fd8af3f) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=47211465)</sub>

<!-- /greptile_comment -->


