### PR TITLE
Make test_workflow_validation exercise the push copy loop

### DIFF
--- a/api/python/tests/integration/test_packages.py
+++ b/api/python/tests/integration/test_packages.py
@@ -1913,18 +1913,22 @@ class PackageTest(QuiltTestCase):
                     assert not calculate_missing_hashes.mock_calls
                     assert pkg._workflow is None
 
+    @patch('quilt3.packages.calculate_multipart_checksum')
     @patch('quilt3.packages.copy_file_list')
     @patch('quilt3.workflows.validate', return_value=mock.sentinel.returned_workflow)
     @patch('quilt3.Package._calculate_top_hash', mock.MagicMock(return_value=mock.sentinel.top_hash))
     @patch('quilt3.Package._set_commit_message', mock.MagicMock())
-    def test_workflow_validation(self, workflow_validate_mock, copy_file_list_mock):
+    def test_workflow_validation(self, workflow_validate_mock, copy_file_list_mock, calculate_checksum_mock):
         registry = 's3://test-bucket'
         pkg_registry = self.S3PackageRegistryDefault(PhysicalKey.from_url('s3://test-bucket'))
         self.patch_s3_registry('shorten_top_hash', return_value='7a67ff4')
+        copy_file_list_mock.side_effect = _mock_copy_file_list
+        calculate_checksum_mock.side_effect = lambda tasks: ['dummy_hash'] * len(tasks)
+        copied_physical_key = PhysicalKey.from_url('s3://test-bucket/test/pkg/foo')
 
         for method in (Package.build, partial(Package.push, force=True)):
             with self.subTest(method=method):
-                with patch('quilt3.Package._push_manifest') as push_manifest_mock:
+                with patch('quilt3.Package._push_manifest', autospec=True) as push_manifest_mock:
                     pkg = Package().set('foo', DATA_DIR / 'foo.txt')
                     method(pkg, 'test/pkg', registry)
                     workflow_validate_mock.assert_called_once_with(
@@ -1940,9 +1944,11 @@ class PackageTest(QuiltTestCase):
                     if method is not Package.build:
                         copy_file_list_mock.assert_called_once()
                         copy_file_list_mock.reset_mock()
+                        pushed_pkg = push_manifest_mock.call_args[0][0]
+                        assert pushed_pkg['foo'].physical_key == copied_physical_key
 
             with self.subTest(method=method):
-                with patch('quilt3.Package._push_manifest') as push_manifest_mock:
+                with patch('quilt3.Package._push_manifest', autospec=True) as push_manifest_mock:
                     pkg = Package().set('foo', DATA_DIR / 'foo.txt').set_meta(mock.sentinel.pkg_meta)
                     method(
                         pkg,
@@ -1964,6 +1970,8 @@ class PackageTest(QuiltTestCase):
                     if method is not Package.build:
                         copy_file_list_mock.assert_called_once()
                         copy_file_list_mock.reset_mock()
+                        pushed_pkg = push_manifest_mock.call_args[0][0]
+                        assert pushed_pkg['foo'].physical_key == copied_physical_key
 
     @patch('quilt3.workflows.validate', mock.MagicMock(return_value=None))
     def test_push_dest_fn_non_string(self):

--- a/api/python/tests/integration/test_packages.py
+++ b/api/python/tests/integration/test_packages.py
@@ -1923,7 +1923,8 @@ class PackageTest(QuiltTestCase):
         pkg_registry = self.S3PackageRegistryDefault(PhysicalKey.from_url('s3://test-bucket'))
         self.patch_s3_registry('shorten_top_hash', return_value='7a67ff4')
         copy_file_list_mock.side_effect = _mock_copy_file_list
-        calculate_checksum_mock.side_effect = lambda tasks: ['dummy_hash'] * len(tasks)
+        copied_hash = "a" * 64
+        calculate_checksum_mock.side_effect = lambda tasks: [copied_hash] * len(tasks)
         copied_physical_key = PhysicalKey.from_url('s3://test-bucket/test/pkg/foo')
 
         for method in (Package.build, partial(Package.push, force=True)):
@@ -1944,8 +1945,9 @@ class PackageTest(QuiltTestCase):
                     if method is not Package.build:
                         copy_file_list_mock.assert_called_once()
                         copy_file_list_mock.reset_mock()
-                        pushed_pkg = push_manifest_mock.call_args[0][0]
-                        assert pushed_pkg['foo'].physical_key == copied_physical_key
+                        pushed_entry = push_manifest_mock.call_args[0][0]['foo']
+                        assert pushed_entry.physical_key == copied_physical_key
+                        assert pushed_entry.hash == {'type': checksums.DEFAULT_HASH, 'value': copied_hash}
 
             with self.subTest(method=method):
                 with patch('quilt3.Package._push_manifest', autospec=True) as push_manifest_mock:
@@ -1970,8 +1972,9 @@ class PackageTest(QuiltTestCase):
                     if method is not Package.build:
                         copy_file_list_mock.assert_called_once()
                         copy_file_list_mock.reset_mock()
-                        pushed_pkg = push_manifest_mock.call_args[0][0]
-                        assert pushed_pkg['foo'].physical_key == copied_physical_key
+                        pushed_entry = push_manifest_mock.call_args[0][0]['foo']
+                        assert pushed_entry.physical_key == copied_physical_key
+                        assert pushed_entry.hash == {'type': checksums.DEFAULT_HASH, 'value': copied_hash}
 
     @patch('quilt3.workflows.validate', mock.MagicMock(return_value=None))
     def test_push_dest_fn_non_string(self):


### PR DESCRIPTION
# Description

`test_workflow_validation` patched `copy_file_list` without a `side_effect`, so the mock returned a bare `MagicMock`, which iterates as empty. `zip(entries, results)` in `Package._push` therefore yielded nothing — the copied entry was never `_set` on the new package, so the `push` subtests have been asserting against an empty manifest ever since the test was added. Line coverage of `packages.py` scoped to just this test confirms it: the whole loop body never executed, and the package passed to `_push_manifest` had no logical keys at all. The test didn't notice because it only checked `push_manifest_mock.assert_called_once()` — call count, never content.

Configuring that mock alone isn't sufficient. `_mock_copy_file_list` reports no checksum, which leaves the entry hashless and sends `_calculate_missing_hashes` to S3 (`UnStubbedResponseError` on `GetObject`), so `calculate_multipart_checksum` needs a stub too — the same pairing `test_push_selector_functions` already uses.

The added assertions make the coverage self-protecting: dropping the `copy_file_list` `side_effect` now fails with `KeyError: 'foo'`, and dropping the `calculate_multipart_checksum` one fails on the entry's `hash` — without the latter assertion that stub was dead weight, since `zip(self._incomplete_entries, results)` in `_calculate_missing_hashes` silently truncates against an empty MagicMock and leaves the entry hashless. `autospec=True` is what lets the mock record the package instance it was called on, since a plain `MagicMock` isn't a descriptor and never receives `self`.

This is also a prerequisite for enabling ruff's `B905` (`zip()` without explicit `strict=`), which would turn the silent truncation here into a hard error.

# TODO

- [x] Unit tests

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR strengthens workflow-validation coverage for package pushes.
- Exercises the copy loop by giving `copy_file_list` a realistic side effect.
- Stubs checksum calculation so copied entries can complete push processing without S3 access.
- Uses an autospecced `_push_manifest` mock to inspect the package instance and verify the copied entry’s physical key.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge with no actionable defects identified.

The new mock contracts match the production call shapes, the autospecced method records the intended package instance, and the added assertion verifies that the copied entry reaches the pushed manifest.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| api/python/tests/integration/test_packages.py | Updates the workflow-validation test to exercise and verify the push copy loop; no actionable issues found. |

<sub>Reviews (1): Last reviewed commit: ["Make test\_workflow\_validation exercise t..."](https://github.com/quiltdata/quilt/commit/e2edd45694359e0daaf2457fdfd5b024be99e3ad) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=47237977)</sub>

<!-- /greptile_comment -->
