### PR TITLE
Enable ruff B905 and make zip() strictness explicit

### DIFF
--- a/api/python/quilt3/data_transfer.py
+++ b/api/python/quilt3/data_transfer.py
@@ -604,7 +604,7 @@ def _copy_file_list_internal(file_list, results, message, callback, exceptions_t
 
     assert len(file_list) == len(results)
 
-    total_size = sum(size for (_, _, size), result in zip(file_list, results) if result is None)
+    total_size = sum(size for (_, _, size), result in zip(file_list, results, strict=True) if result is None)
 
     lock = Lock()
     futures = deque()
@@ -669,7 +669,7 @@ def _copy_file_list_internal(file_list, results, message, callback, exceptions_t
                     _copy_remote_file(ctx, size, src.bucket, src.path, src.version_id, dest.bucket, dest.path)
 
         try:
-            for idx, (args, result) in enumerate(zip(file_list, results)):
+            for idx, (args, result) in enumerate(zip(file_list, results, strict=True)):
                 if result is not None:
                     continue
                 run_task(idx, worker, idx, *args)
@@ -1019,7 +1019,9 @@ def _calculate_checksum_internal(
     results: list[str | Exception | None],
 ) -> list[str | Exception]:
     total_size = sum(
-        task.size for task, result in zip(tasks, results) if result is None or isinstance(result, Exception)
+        task.size
+        for task, result in zip(tasks, results, strict=True)
+        if result is None or isinstance(result, Exception)
     )
     stopped = False
 
@@ -1070,7 +1072,7 @@ def _calculate_checksum_internal(
 
         futures: list[tuple[int, type[checksums.MultiPartChecksumCalculator], list[Future]]] = []
 
-        for idx, (task, result) in enumerate(zip(tasks, results)):
+        for idx, (task, result) in enumerate(zip(tasks, results, strict=True)):
             if result is None or isinstance(result, Exception):
                 chunksize = checksums.get_checksum_chunksize(task.size)
 
@@ -1184,7 +1186,9 @@ def _legacy_calculate_hash_get_s3_chunks(ctx, src, size):
     retry_error_callback=lambda retry_state: retry_state.outcome.result(),
 )
 def _legacy_calculate_checksum_internal(src_list, sizes, results) -> list[str | Exception]:
-    total_size = sum(size for size, result in zip(sizes, results) if result is None or isinstance(result, Exception))
+    total_size = sum(
+        size for size, result in zip(sizes, results, strict=True) if result is None or isinstance(result, Exception)
+    )
     # This controls how many parts can be stored in the memory.
     # This includes the ones that are being downloaded or hashed.
     # The number was chosen empirically.
@@ -1247,7 +1251,7 @@ def _legacy_calculate_checksum_internal(src_list, sizes, results) -> list[str | 
         progress_update = with_lock(progress.update)
         future_to_idx = {
             executor.submit(_process_url, src, size): i
-            for i, (src, size, result) in enumerate(zip(src_list, sizes, results))
+            for i, (src, size, result) in enumerate(zip(src_list, sizes, results, strict=True))
             if result is None or isinstance(result, Exception)
         }
         try:

--- a/api/python/quilt3/packages.py
+++ b/api/python/quilt3/packages.py
@@ -85,7 +85,8 @@ class CopyFileListFn(T.Protocol):
         file_list: list[tuple[PhysicalKey, PhysicalKey, int]],
         message: str | None = None,
         callback: T.Callable | None = None,
-    ) -> list[tuple[PhysicalKey, str | None]]: ...
+    ) -> list[tuple[PhysicalKey, str | None]]:
+        """Returns one result per `file_list` entry, in the same order."""
 
 
 def _fix_docstring(**kwargs):
@@ -1005,11 +1006,11 @@ class Package:
         results = calculate_multipart_checksum(
             [
                 FileChecksumTask.create(physical_key, size, hash_type)
-                for physical_key, size in zip(physical_keys, sizes)
+                for physical_key, size in zip(physical_keys, sizes, strict=True)
             ]
         )
         exc = None
-        for entry, result in zip(self._incomplete_entries, results):
+        for entry, result in zip(self._incomplete_entries, results, strict=True):
             if isinstance(result, Exception):
                 exc = result
             else:
@@ -1617,7 +1618,7 @@ class Package:
 
         results = copy_file_list_fn(file_list, message="Copying objects")
 
-        for (logical_key, entry), (versioned_key, checksum) in zip(entries, results):
+        for (logical_key, entry), (versioned_key, checksum) in zip(entries, results, strict=True):
             # Create a new package entry pointing to the new remote key.
             assert versioned_key is not None
             new_entry = entry.with_physical_key(versioned_key)
@@ -1838,14 +1839,14 @@ class Package:
             return False
 
         hash_list = calculate_multipart_checksum(checksum_tasks)
-        for expected_hash, url_hash in zip(expected_hash_list, hash_list):
+        for expected_hash, url_hash in zip(expected_hash_list, hash_list, strict=True):
             if isinstance(url_hash, Exception):
                 raise url_hash
             if expected_hash != url_hash:
                 return False
 
         legacy_hash_list = legacy_calculate_checksum(legacy_url_list, legacy_size_list)
-        for expected_hash, url_hash in zip(legacy_expected_hash_list, legacy_hash_list):
+        for expected_hash, url_hash in zip(legacy_expected_hash_list, legacy_hash_list, strict=True):
             if isinstance(url_hash, Exception):
                 raise url_hash
             if expected_hash != url_hash:

--- a/api/python/quilt3/packages.py
+++ b/api/python/quilt3/packages.py
@@ -85,8 +85,7 @@ class CopyFileListFn(T.Protocol):
         file_list: list[tuple[PhysicalKey, PhysicalKey, int]],
         message: str | None = None,
         callback: T.Callable | None = None,
-    ) -> list[tuple[PhysicalKey, str | None]]:
-        """Returns one result per `file_list` entry, in the same order."""
+    ) -> list[tuple[PhysicalKey, str | None]]: ...
 
 
 def _fix_docstring(**kwargs):

--- a/api/python/tests/test_formats.py
+++ b/api/python/tests/test_formats.py
@@ -73,7 +73,7 @@ def test_formats_serdes():
     ]
     metadata = [{} for o in objects]
 
-    for obj, meta in zip(objects, metadata):
+    for obj, meta in zip(objects, metadata, strict=True):
         data, format_meta = FormatRegistry.serialize(obj, meta)
         meta.update(format_meta)
         assert FormatRegistry.deserialize(data, meta) == obj

--- a/lambdas/access_counts/src/t4_lambda_access_counts/index.py
+++ b/lambdas/access_counts/src/t4_lambda_access_counts/index.py
@@ -466,7 +466,7 @@ def handler(event, context):
 
     execution_ids = run_multiple_queries([query for _, query in queries])
 
-    for (filename, _), execution_id in zip(queries, execution_ids):
+    for (filename, _), execution_id in zip(queries, execution_ids, strict=True):
         src_bucket, src_key = get_result_location(execution_id)
         dest_key = f'{ACCESS_COUNTS_OUTPUT_DIR}/{filename}.csv'
 

--- a/py-shared/tests/test_athena.py
+++ b/py-shared/tests/test_athena.py
@@ -86,7 +86,7 @@ def test_run_multiple_queries(query_runner, stubbed_athena_client):
     execution_ids = ["exec_id_1", "exec_id_2"]
 
     # Stub start_query_execution responses
-    for query, execution_id in zip(queries, execution_ids):
+    for query, execution_id in zip(queries, execution_ids, strict=True):
         stubbed_athena_client.add_response(
             "start_query_execution",
             {"QueryExecutionId": execution_id},

--- a/ruff.toml
+++ b/ruff.toml
@@ -44,7 +44,6 @@ ignore = [
     "B011",  # Do not assert False
     "B018",  # Found useless expression
     "B028",  # No explicit stacklevel keyword argument found
-    "B905",  # zip() without an explicit strict= (behavioral; clean up separately)
     "C408",  # Unnecessary dict() call (rewrite as a literal)
     "E402",  # Module level import not at top of file
     "F401",  # Imported but unused


### PR DESCRIPTION
# Description

Drops `B905` from `ruff.toml`'s ignore list and adds an explicit `strict=True` at all 14 flagged `zip()` calls. The rule was ignored when `target-version` moved to `py310` — dropping Python 3.9 made it newly applicable — and deferred as "clean up separately".

Every flagged site pairs iterables that are equal-length by construction, so `strict=True` is a latent-bug detector rather than a behavior change on any reachable path. Two shapes cover all 14:

- **Built in lockstep in the same loop** — `_calculate_missing_hashes`'s `physical_keys`/`sizes`, `_push`'s `entries`/`file_list`, `verify`'s expected-hash lists, `access_counts`'s query list, and the two tests.
- **A results accumulator pre-allocated as `[None] * len(input)` and only ever mutated in place** — all six `data_transfer.py` sites, plus the two that consume `calculate_multipart_checksum` and `copy_file_list_fn` results. Tenacity retries replay the same list object, so a retry can't desync the lengths.

The one site with real committed side effects at the zip is `_push`: `copy_file_list_fn` has already uploaded bytes by then, and entries needing a copy are `_set` on the new package *only* inside that loop. Silent truncation there means a push that reports success while publishing a manifest missing files it just uploaded, so this is where `strict=True` earns the most.

Two sites keep their existing `assert len(a) == len(b)`. Those are eager — they fire before any transfer task is dispatched — whereas `strict=` is lazy and only raises once the shorter iterable is exhausted. Complementary, so the asserts stay.

Note that `verify()` gets less protection than the rest: it returns `False` on the first hash mismatch, so its two loops usually exit before the length check can fire.

Not done by autofix — `ruff check --unsafe-fixes` writes `strict=False`, which silences the rule without adding the check.

Removing the ignore enables the rule everywhere: only `api/python/pyproject.toml` defines `[tool.ruff]`, and it does `extend = "../../ruff.toml"`. CI's two ruff jobs (`lint-quilt3` in `api/python`, `lint-rest` over the rest) together cover the same file set as a root-level run.

No CHANGELOG entry: no reachable call path changes behavior.

# TODO

- [x] Unit tests — no new tests; the existing `api/python`, `py-shared`, and `access_counts` suites pass unchanged

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Makes iterable-length assumptions explicit across Python code and tests.
- Enables Ruff rule B905 globally by removing it from the ignore list.
- Adds `strict=True` to 14 existing `zip()` calls in package transfer, checksum, verification, analytics, and test code.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge.

No blocking failure remains.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| api/python/quilt3/data_transfer.py | Adds strict length validation to lockstep transfer and checksum task/result iteration. |
| api/python/quilt3/packages.py | Adds strict length validation when associating package entries, transfer results, and checksum results. |
| lambdas/access_counts/src/t4_lambda_access_counts/index.py | Requires Athena query metadata and execution IDs to have matching lengths before copying result files. |
| api/python/tests/test_formats.py | Makes the equal-length object and metadata test fixture invariant explicit. |
| py-shared/tests/test_athena.py | Makes the equal-length Athena query and stubbed execution-ID fixture invariant explicit. |
| ruff.toml | Enables Ruff B905 so future zip calls must state their strictness explicitly. |

<sub>Reviews (2): Last reviewed commit: ["Drop the CopyFileListFn docstring"](https://github.com/quiltdata/quilt/commit/02523705145a3bec698b4dcac152e164fcfdb2c7) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=47335273)</sub>

<!-- /greptile_comment -->