### PR TITLE
Don't use a process pool to delete push temp files

### DIFF
--- a/api/python/quilt3/packages.py
+++ b/api/python/quilt3/packages.py
@@ -1639,24 +1639,18 @@ class Package:
                 return False
             return pathlib.Path(pk.path).parent.resolve() == APP_DIR_TEMPFILE_DIR.resolve()
 
-        # Materialized before the loop, because _set() below mutates what walk() iterates.
+        # Materialized first: _set() below mutates what walk() iterates.
         temp_file_logical_keys = [lk for lk, entry in self.walk() if physical_key_is_temp_file(entry.physical_key)]
         for lk in temp_file_logical_keys:
-            # Now that data has been pushed, delete tmp files created by pkg.set('KEY', obj).
-            # The data is already uploaded at this point, so a file we cannot remove is a
-            # leaked scratch file, not a reason to fail the push.
+            # Delete tmp files created by pkg.set('KEY', obj). The data is already uploaded, so a
+            # file we cannot remove is a leaked scratch file, not a reason to fail the push.
             temp_pk = self[lk].physical_key
             try:
-                # Not delete_url(): it falls back to an S3 delete for a non-local key, which is
-                # more power than removing a local scratch file needs.
                 pathlib.Path(temp_pk.path).unlink(missing_ok=True)
             except OSError as e:
-                # Not warnings.warn(): a caller running with -W error would turn best-effort
-                # cleanup back into a push that fails after the data is already uploaded.
                 logger.warning("Failed to remove temporary file %s: %s", temp_pk.path, e)
 
-            # Point the entry at the materialized location; the tempfile is no longer the copy to
-            # read from, whether or not removing it succeeded.
+            # Point the entry at the materialized location.
             self._set(lk, pkg[lk])
 
         # Check top hash again just before pushing, to minimize the race condition.

--- a/api/python/quilt3/packages.py
+++ b/api/python/quilt3/packages.py
@@ -16,7 +16,6 @@ import typing as T
 import uuid
 import warnings
 from collections import deque
-from multiprocessing import Pool
 
 import botocore.exceptions
 import jsonlines
@@ -102,11 +101,6 @@ _WORKFLOW_PARAM_DOCSTRING = (
     '        If not specified, the default workflow will be used.\n'
     '        For details see: https://docs.quilt.bio/advanced-usage/workflows\n'
 )
-
-
-def _delete_local_physical_key(pk):
-    assert pk.is_local(), "This function only works on files that live on a local disk"
-    pathlib.Path(pk.path).unlink()
 
 
 def _filesystem_safe_encode(key):
@@ -1647,11 +1641,15 @@ class Package:
 
         temp_file_logical_keys = [lk for lk, entry in self.walk() if physical_key_is_temp_file(entry.physical_key)]
         if temp_file_logical_keys:
-            temp_file_physical_keys = [self[lk].physical_key for lk in temp_file_logical_keys]
-
-            # Now that data has been pushed, delete tmp files created by pkg.set('KEY', obj)
-            with Pool(10) as p:
-                p.map(_delete_local_physical_key, temp_file_physical_keys)
+            # Now that data has been pushed, delete tmp files created by pkg.set('KEY', obj).
+            # The data is already uploaded at this point, so a file we cannot remove is a leaked
+            # scratch file, not a reason to fail the push.
+            for lk in temp_file_logical_keys:
+                temp_path = pathlib.Path(self[lk].physical_key.path)
+                try:
+                    temp_path.unlink(missing_ok=True)
+                except OSError as e:
+                    warnings.warn(f"Failed to remove temporary file {temp_path}: {e}")
 
             # Update old package to point to the materialized location of the file since the tempfile no longest exists
             for lk in temp_file_logical_keys:

--- a/api/python/quilt3/packages.py
+++ b/api/python/quilt3/packages.py
@@ -1649,9 +1649,11 @@ class Package:
                 try:
                     temp_path.unlink(missing_ok=True)
                 except OSError as e:
-                    warnings.warn(f"Failed to remove temporary file {temp_path}: {e}")
+                    # Not warnings.warn(): a caller running with -W error would turn best-effort
+                    # cleanup back into a push that fails after the data is already uploaded.
+                    logger.warning("Failed to remove temporary file %s: %s", temp_path, e)
 
-            # Update old package to point to the materialized location of the file since the tempfile no longest exists
+            # Update old package to point to the materialized location of the file since the tempfile no longer exists
             for lk in temp_file_logical_keys:
                 self._set(lk, pkg[lk])
 

--- a/api/python/quilt3/packages.py
+++ b/api/python/quilt3/packages.py
@@ -1642,8 +1642,8 @@ class Package:
         # Materialized first: _set() below mutates what walk() iterates.
         temp_file_logical_keys = [lk for lk, entry in self.walk() if physical_key_is_temp_file(entry.physical_key)]
         for lk in temp_file_logical_keys:
-            # Delete tmp files created by pkg.set('KEY', obj). The data is already uploaded, so a
-            # file we cannot remove is a leaked scratch file, not a reason to fail the push.
+            # Delete tmp files created by pkg.set('KEY', obj). Cleanup is best-effort: a file we
+            # cannot remove is a leaked scratch file, not a reason to fail a completed push.
             temp_pk = self[lk].physical_key
             try:
                 pathlib.Path(temp_pk.path).unlink(missing_ok=True)

--- a/api/python/quilt3/packages.py
+++ b/api/python/quilt3/packages.py
@@ -28,6 +28,7 @@ from .data_transfer import (
     calculate_multipart_checksum,
     copy_file,
     copy_file_list,
+    delete_url,
     get_bytes,
     get_size_and_version,
     legacy_calculate_checksum,
@@ -1639,23 +1640,22 @@ class Package:
                 return False
             return pathlib.Path(pk.path).parent.resolve() == APP_DIR_TEMPFILE_DIR.resolve()
 
+        # Materialized before the loop, because _set() below mutates what walk() iterates.
         temp_file_logical_keys = [lk for lk, entry in self.walk() if physical_key_is_temp_file(entry.physical_key)]
-        if temp_file_logical_keys:
+        for lk in temp_file_logical_keys:
             # Now that data has been pushed, delete tmp files created by pkg.set('KEY', obj).
-            # The data is already uploaded at this point, so a file we cannot remove is a leaked
-            # scratch file, not a reason to fail the push.
-            for lk in temp_file_logical_keys:
-                temp_path = pathlib.Path(self[lk].physical_key.path)
-                try:
-                    temp_path.unlink(missing_ok=True)
-                except OSError as e:
-                    # Not warnings.warn(): a caller running with -W error would turn best-effort
-                    # cleanup back into a push that fails after the data is already uploaded.
-                    logger.warning("Failed to remove temporary file %s: %s", temp_path, e)
+            # The data is already uploaded at this point, so a file we cannot remove is a
+            # leaked scratch file, not a reason to fail the push.
+            temp_pk = self[lk].physical_key
+            try:
+                delete_url(temp_pk)
+            except OSError as e:
+                # Not warnings.warn(): a caller running with -W error would turn best-effort
+                # cleanup back into a push that fails after the data is already uploaded.
+                logger.warning("Failed to remove temporary file %s: %s", temp_pk.path, e)
 
-            # Update old package to point to the materialized location of the file since the tempfile no longer exists
-            for lk in temp_file_logical_keys:
-                self._set(lk, pkg[lk])
+            # Point the entry at the materialized location, since the tempfile no longer exists.
+            self._set(lk, pkg[lk])
 
         # Check top hash again just before pushing, to minimize the race condition.
         if not force:

--- a/api/python/quilt3/packages.py
+++ b/api/python/quilt3/packages.py
@@ -28,7 +28,6 @@ from .data_transfer import (
     calculate_multipart_checksum,
     copy_file,
     copy_file_list,
-    delete_url,
     get_bytes,
     get_size_and_version,
     legacy_calculate_checksum,
@@ -1648,7 +1647,9 @@ class Package:
             # leaked scratch file, not a reason to fail the push.
             temp_pk = self[lk].physical_key
             try:
-                delete_url(temp_pk)
+                # Not delete_url(): it falls back to an S3 delete for a non-local key, which is
+                # more power than removing a local scratch file needs.
+                pathlib.Path(temp_pk.path).unlink(missing_ok=True)
             except OSError as e:
                 # Not warnings.warn(): a caller running with -W error would turn best-effort
                 # cleanup back into a push that fails after the data is already uploaded.

--- a/api/python/quilt3/packages.py
+++ b/api/python/quilt3/packages.py
@@ -1654,7 +1654,8 @@ class Package:
                 # cleanup back into a push that fails after the data is already uploaded.
                 logger.warning("Failed to remove temporary file %s: %s", temp_pk.path, e)
 
-            # Point the entry at the materialized location, since the tempfile no longer exists.
+            # Point the entry at the materialized location; the tempfile is no longer the copy to
+            # read from, whether or not removing it succeeded.
             self._set(lk, pkg[lk])
 
         # Check top hash again just before pushing, to minimize the race condition.

--- a/api/python/tests/integration/test_packages.py
+++ b/api/python/tests/integration/test_packages.py
@@ -822,6 +822,7 @@ class PackageTest(QuiltTestCase):
         gone = pathlib.Path(pkg["mydataframe1.parquet"].physical_key.path)
         remaining = pathlib.Path(pkg["mydataframe2.parquet"].physical_key.path)
         gone.unlink()
+        assert remaining.exists(), "the two entries must not share a temp file, or this test proves nothing"
 
         with (
             patch('quilt3.Package._push_manifest'),

--- a/api/python/tests/integration/test_packages.py
+++ b/api/python/tests/integration/test_packages.py
@@ -859,6 +859,8 @@ class PackageTest(QuiltTestCase):
             pkg.push('Quilt/test_pkg_name', 's3://test-bucket', force=True)
 
         assert any(f"Failed to remove temporary file {temp_path}" in line for line in logs.output)
+        assert temp_path.exists(), "a cleanup failure leaves the temp file behind"
+        temp_path.unlink()
 
     @patch("quilt3.packages.get_size_and_version", mock.Mock(return_value=(123, "v1")))
     def test_set_package_entry_unversioned_flag(self):

--- a/api/python/tests/integration/test_packages.py
+++ b/api/python/tests/integration/test_packages.py
@@ -831,6 +831,21 @@ class PackageTest(QuiltTestCase):
 
         assert not remaining.exists(), "Cleanup should continue past a temp file that is already gone"
 
+    @patch('quilt3.workflows.validate', mock.MagicMock(return_value=None))
+    def test_push_warns_when_temp_file_cannot_be_removed(self):
+        self.patch_s3_registry('shorten_top_hash', return_value='7a67ff4')
+        pkg = Package()
+        pkg.set("mydataframe1.parquet", pd.DataFrame({'col_num': [11, 22, 33]}))
+        pkg._calculate_missing_hashes()
+
+        with (
+            patch('quilt3.Package._push_manifest'),
+            patch('quilt3.packages.copy_file_list', _mock_copy_file_list),
+            patch('pathlib.Path.unlink', side_effect=PermissionError("file is in use")),
+            pytest.warns(UserWarning, match="Failed to remove temporary file"),
+        ):
+            pkg.push('Quilt/test_pkg_name', 's3://test-bucket', force=True)
+
     @patch("quilt3.packages.get_size_and_version", mock.Mock(return_value=(123, "v1")))
     def test_set_package_entry_unversioned_flag(self):
         for flag_value, version_id in {

--- a/api/python/tests/integration/test_packages.py
+++ b/api/python/tests/integration/test_packages.py
@@ -832,7 +832,7 @@ class PackageTest(QuiltTestCase):
         assert not remaining.exists(), "Cleanup should continue past a temp file that is already gone"
 
     @patch('quilt3.workflows.validate', mock.MagicMock(return_value=None))
-    def test_push_warns_when_temp_file_cannot_be_removed(self):
+    def test_push_logs_when_temp_file_cannot_be_removed(self):
         self.patch_s3_registry('shorten_top_hash', return_value='7a67ff4')
         pkg = Package()
         pkg.set("mydataframe1.parquet", pd.DataFrame({'col_num': [11, 22, 33]}))
@@ -842,9 +842,11 @@ class PackageTest(QuiltTestCase):
             patch('quilt3.Package._push_manifest'),
             patch('quilt3.packages.copy_file_list', _mock_copy_file_list),
             patch('pathlib.Path.unlink', side_effect=PermissionError("file is in use")),
-            pytest.warns(UserWarning, match="Failed to remove temporary file"),
+            self.assertLogs('quilt3.packages', level='WARNING') as logs,
         ):
             pkg.push('Quilt/test_pkg_name', 's3://test-bucket', force=True)
+
+        assert any("Failed to remove temporary file" in line for line in logs.output)
 
     @patch("quilt3.packages.get_size_and_version", mock.Mock(return_value=(123, "v1")))
     def test_set_package_entry_unversioned_flag(self):

--- a/api/python/tests/integration/test_packages.py
+++ b/api/python/tests/integration/test_packages.py
@@ -826,6 +826,8 @@ class PackageTest(QuiltTestCase):
         with (
             patch('quilt3.Package._push_manifest'),
             patch('quilt3.packages.copy_file_list', _mock_copy_file_list),
+            # An already-gone temp file is not worth telling the user about.
+            self.assertNoLogs('quilt3.packages', level='WARNING'),
         ):
             pkg.push('Quilt/test_pkg_name', 's3://test-bucket', force=True)
 
@@ -837,16 +839,25 @@ class PackageTest(QuiltTestCase):
         pkg = Package()
         pkg.set("mydataframe1.parquet", pd.DataFrame({'col_num': [11, 22, 33]}))
         pkg._calculate_missing_hashes()
+        temp_path = pathlib.Path(pkg["mydataframe1.parquet"].physical_key.path)
+        real_unlink = pathlib.Path.unlink
+
+        # Fail only for the temp file, so cleanup aimed at the wrong path fails this test
+        # instead of logging about whatever it did hit.
+        def unlink(self, *args, **kwargs):
+            if self == temp_path:
+                raise PermissionError("file is in use")
+            return real_unlink(self, *args, **kwargs)
 
         with (
             patch('quilt3.Package._push_manifest'),
             patch('quilt3.packages.copy_file_list', _mock_copy_file_list),
-            patch('pathlib.Path.unlink', side_effect=PermissionError("file is in use")),
+            patch('pathlib.Path.unlink', unlink),
             self.assertLogs('quilt3.packages', level='WARNING') as logs,
         ):
             pkg.push('Quilt/test_pkg_name', 's3://test-bucket', force=True)
 
-        assert any("Failed to remove temporary file" in line for line in logs.output)
+        assert any(f"Failed to remove temporary file {temp_path}" in line for line in logs.output)
 
     @patch("quilt3.packages.get_size_and_version", mock.Mock(return_value=(123, "v1")))
     def test_set_package_entry_unversioned_flag(self):

--- a/api/python/tests/integration/test_packages.py
+++ b/api/python/tests/integration/test_packages.py
@@ -827,7 +827,6 @@ class PackageTest(QuiltTestCase):
         with (
             patch('quilt3.Package._push_manifest'),
             patch('quilt3.packages.copy_file_list', _mock_copy_file_list),
-            # An already-gone temp file is not worth telling the user about.
             self.assertNoLogs('quilt3.packages', level='WARNING'),
         ):
             pkg.push('Quilt/test_pkg_name', 's3://test-bucket', force=True)
@@ -840,14 +839,12 @@ class PackageTest(QuiltTestCase):
         pkg = Package()
         pkg.set("mydataframe1.parquet", pd.DataFrame({'col_num': [11, 22, 33]}))
         pkg._calculate_missing_hashes()
-        # The logged path comes straight from the physical key, so compare against that string
-        # rather than str(Path(...)), which differs on Windows.
+        # temp_key, not str(temp_path): the log formats the physical key, whose separators differ
+        # from pathlib's on Windows.
         temp_key = pkg["mydataframe1.parquet"].physical_key.path
         temp_path = pathlib.Path(temp_key)
         real_unlink = pathlib.Path.unlink
 
-        # Fail only for the temp file, so cleanup aimed at the wrong path fails this test
-        # instead of logging about whatever it did hit.
         def unlink(self, *args, **kwargs):
             if self == temp_path:
                 raise PermissionError("file is in use")

--- a/api/python/tests/integration/test_packages.py
+++ b/api/python/tests/integration/test_packages.py
@@ -840,7 +840,10 @@ class PackageTest(QuiltTestCase):
         pkg = Package()
         pkg.set("mydataframe1.parquet", pd.DataFrame({'col_num': [11, 22, 33]}))
         pkg._calculate_missing_hashes()
-        temp_path = pathlib.Path(pkg["mydataframe1.parquet"].physical_key.path)
+        # The logged path comes straight from the physical key, so compare against that string
+        # rather than str(Path(...)), which differs on Windows.
+        temp_key = pkg["mydataframe1.parquet"].physical_key.path
+        temp_path = pathlib.Path(temp_key)
         real_unlink = pathlib.Path.unlink
 
         # Fail only for the temp file, so cleanup aimed at the wrong path fails this test
@@ -858,7 +861,7 @@ class PackageTest(QuiltTestCase):
         ):
             pkg.push('Quilt/test_pkg_name', 's3://test-bucket', force=True)
 
-        assert any(f"Failed to remove temporary file {temp_path}" in line for line in logs.output)
+        assert any(f"Failed to remove temporary file {temp_key}" in line for line in logs.output)
         assert temp_path.exists(), "a cleanup failure leaves the temp file behind"
         temp_path.unlink()
 

--- a/api/python/tests/integration/test_packages.py
+++ b/api/python/tests/integration/test_packages.py
@@ -809,6 +809,28 @@ class PackageTest(QuiltTestCase):
             file_path = pkg[lk].physical_key.path
             assert not pathlib.Path(file_path).exists(), "These temp files should have been deleted during push()"
 
+    @patch('quilt3.workflows.validate', mock.MagicMock(return_value=None))
+    def test_push_survives_missing_temp_file(self):
+        self.patch_s3_registry('shorten_top_hash', return_value='7a67ff4')
+        pkg = Package()
+        df = pd.DataFrame({'col_num': [11, 22, 33]})
+        pkg.set("mydataframe1.parquet", df)
+        pkg.set("mydataframe2.parquet", df)
+        pkg._calculate_missing_hashes()
+
+        # Something else removed one temp file already: a tempdir sweep, a retried push, another process.
+        gone = pathlib.Path(pkg["mydataframe1.parquet"].physical_key.path)
+        remaining = pathlib.Path(pkg["mydataframe2.parquet"].physical_key.path)
+        gone.unlink()
+
+        with (
+            patch('quilt3.Package._push_manifest'),
+            patch('quilt3.packages.copy_file_list', _mock_copy_file_list),
+        ):
+            pkg.push('Quilt/test_pkg_name', 's3://test-bucket', force=True)
+
+        assert not remaining.exists(), "Cleanup should continue past a temp file that is already gone"
+
     @patch("quilt3.packages.get_size_and_version", mock.Mock(return_value=(123, "v1")))
     def test_set_package_entry_unversioned_flag(self):
         for flag_value, version_id in {

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -23,6 +23,7 @@ Entries inside each section should be ordered by type:
 * [Removed] Drop support for Python 3.9 (end-of-life); `quilt3` now requires Python >= 3.10 ([#4941](https://github.com/quiltdata/quilt/pull/4941))
 * [Fixed] `quilt3.admin.buckets.list` no longer raises `TypeError` when its type hints are introspected on Python 3.14 ([#4940](https://github.com/quiltdata/quilt/pull/4940))
 * [Fixed] `quilt3.delete_package()` on a local registry no longer deletes other packages sharing the same namespace ([#5140](https://github.com/quiltdata/quilt/pull/5140))
+* [Fixed] `Package.push()` no longer fails after a successful upload when a temporary file created by `Package.set()` cannot be removed; cleanup now warns instead ([#5156](https://github.com/quiltdata/quilt/pull/5156))
 
 ### CLI
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -23,7 +23,8 @@ Entries inside each section should be ordered by type:
 * [Removed] Drop support for Python 3.9 (end-of-life); `quilt3` now requires Python >= 3.10 ([#4941](https://github.com/quiltdata/quilt/pull/4941))
 * [Fixed] `quilt3.admin.buckets.list` no longer raises `TypeError` when its type hints are introspected on Python 3.14 ([#4940](https://github.com/quiltdata/quilt/pull/4940))
 * [Fixed] `quilt3.delete_package()` on a local registry no longer deletes other packages sharing the same namespace ([#5140](https://github.com/quiltdata/quilt/pull/5140))
-* [Fixed] `Package.push()` no longer fails after a successful upload when a temporary file created by `Package.set()` cannot be removed; cleanup now logs a warning instead ([#5156](https://github.com/quiltdata/quilt/pull/5156))
+* [Fixed] `Package.push()` no longer fails after the data is uploaded when a temporary file created by `Package.set()` cannot be removed, or when two logical keys share one serialized object and its temporary file is deleted twice; cleanup now logs a warning instead ([#5156](https://github.com/quiltdata/quilt/pull/5156))
+* [Fixed] `Package.push()` no longer uses a process pool to delete temporary files, so it works from a daemonic process (e.g. a prefork worker) and no longer requires callers to guard their entry point with `if __name__ == "__main__":` ([#5156](https://github.com/quiltdata/quilt/pull/5156))
 
 ### CLI
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -23,7 +23,7 @@ Entries inside each section should be ordered by type:
 * [Removed] Drop support for Python 3.9 (end-of-life); `quilt3` now requires Python >= 3.10 ([#4941](https://github.com/quiltdata/quilt/pull/4941))
 * [Fixed] `quilt3.admin.buckets.list` no longer raises `TypeError` when its type hints are introspected on Python 3.14 ([#4940](https://github.com/quiltdata/quilt/pull/4940))
 * [Fixed] `quilt3.delete_package()` on a local registry no longer deletes other packages sharing the same namespace ([#5140](https://github.com/quiltdata/quilt/pull/5140))
-* [Fixed] `Package.push()` no longer fails after the data is uploaded when a temporary file created by `Package.set()` cannot be removed, or when two logical keys share one serialized object and its temporary file is deleted twice; cleanup now logs a warning instead ([#5156](https://github.com/quiltdata/quilt/pull/5156))
+* [Fixed] `Package.push()` no longer fails after the data is uploaded when cleaning up a temporary file created by `Package.set()`: a file that is already gone is ignored, which is also what happens when two logical keys share one serialized object and its temporary file is deleted twice, and any other removal error is logged instead of raised ([#5156](https://github.com/quiltdata/quilt/pull/5156))
 * [Fixed] `Package.push()` no longer uses a process pool to delete temporary files, so it works from a daemonic process (e.g. a prefork worker) and no longer requires callers to guard their entry point with `if __name__ == "__main__":` ([#5156](https://github.com/quiltdata/quilt/pull/5156))
 
 ### CLI

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -23,7 +23,7 @@ Entries inside each section should be ordered by type:
 * [Removed] Drop support for Python 3.9 (end-of-life); `quilt3` now requires Python >= 3.10 ([#4941](https://github.com/quiltdata/quilt/pull/4941))
 * [Fixed] `quilt3.admin.buckets.list` no longer raises `TypeError` when its type hints are introspected on Python 3.14 ([#4940](https://github.com/quiltdata/quilt/pull/4940))
 * [Fixed] `quilt3.delete_package()` on a local registry no longer deletes other packages sharing the same namespace ([#5140](https://github.com/quiltdata/quilt/pull/5140))
-* [Fixed] `Package.push()` no longer fails after a successful upload when a temporary file created by `Package.set()` cannot be removed; cleanup now warns instead ([#5156](https://github.com/quiltdata/quilt/pull/5156))
+* [Fixed] `Package.push()` no longer fails after a successful upload when a temporary file created by `Package.set()` cannot be removed; cleanup now logs a warning instead ([#5156](https://github.com/quiltdata/quilt/pull/5156))
 
 ### CLI
 


### PR DESCRIPTION
# Description

`Package.push` deleted the temp files created by `pkg.set('KEY', obj)` with `multiprocessing.Pool(10).map`. Two problems, neither of them about speed:

- The cleanup runs **after** the data upload but **before** `_push_manifest`, and `Pool.map` re-raises the first worker exception in the parent — so a temp file that was already gone (retried push, tempdir sweep, another process) or locked (Windows AV) failed a push whose bytes were already in S3. At that point an unremovable file is a leaked scratch file in quilt3's own app-data dir, not a reason to fail.
- On spawn platforms (macOS/Windows, and Linux from 3.14, which defaults to forkserver) pool workers re-import the caller's `__main__`, so the library silently imposed an `if __name__ == "__main__":` guard on user scripts. On Linux ≤3.13 it forks while telemetry's `ThreadPoolExecutor` and tqdm's monitor thread are alive — the multi-threaded-fork `DeprecationWarning` on 3.12+.

Concurrency buys nothing here. This deletes one file per in-memory object set on the package — typically a handful — always on a local disk. Measured on macOS/APFS with 5 files: sequential 0.17 ms, `Pool(10)` 93 ms, and worse in the real code where each spawn worker re-imports `quilt3.packages` (botocore included). A thread pool is no better: 2-3× slower than sequential at that size and a wash at 2000 files, because a local `unlink()` is ~47 µs of mostly-kernel metadata work with no latency to hide. `shutil.rmtree` — the stdlib's own bulk deleter — is sequential for the same reason, as are the other six local-delete sites in quilt3.

Cleanup is now a sequential best-effort loop: `unlink(missing_ok=True)`, warn on `OSError`.

`test_push_survives_missing_temp_file` removes one temp file before `push()`: red on master (the worker's `FileNotFoundError` propagates out of `Pool.map` and aborts the push), green with this change. That uses real filesystem state rather than mocking the deletion.

`test_push_logs_when_temp_file_cannot_be_removed` covers the `OSError` branch: it fails `unlink` only for the temp file and asserts the logged path, so cleanup aimed at the wrong path fails the test instead of logging about whatever it did hit. It is red on master too — `assertLogs` finds no warning there, because master raises instead of logging. Both tests were checked against the mutations they exist to catch: aiming cleanup at `pkg[lk]` instead of `self[lk]`, and dropping `missing_ok=True`. The spawn/fork hazards above aren't reachable from pytest at all.

# TODO

- [x] Unit tests
- [x] [Changelog](../tree/master/docs/CHANGELOG.md) entry

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR makes temporary-file cleanup during `Package.push()` sequential and best-effort.
- Removes the process pool previously used to delete temporary files.
- Ignores already-missing files and logs other removal failures before updating entries to their materialized locations.
- Adds integration coverage for missing and unremovable temporary files and documents the behavior change.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge.

No blocking failure remains; the previously reported warning-to-error path now uses logging and cannot be promoted into an exception by Python warning policy.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| api/python/quilt3/packages.py | Replaces process-pool cleanup with sequential `unlink(missing_ok=True)` calls and logging for removal errors; the prior warning-policy issue is fixed by using `logger.warning`. |
| api/python/tests/integration/test_packages.py | Adds integration tests confirming that missing files do not interrupt cleanup and other unlink failures are logged without aborting the push. |
| docs/CHANGELOG.md | Documents the best-effort cleanup behavior and removal of process-pool constraints. |

<sub>Reviews (7): Last reviewed commit: ["Trim the cleanup comments to the invaria..."](https://github.com/quiltdata/quilt/commit/152cc8271b081baf1e24852f3749d6ee83e512b2) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=47539315)</sub>

<!-- /greptile_comment -->