### PR TITLE
Build the catalog image from a clean checkout

### DIFF
--- a/.github/workflows/deploy-catalog.yaml
+++ b/.github/workflows/deploy-catalog.yaml
@@ -8,26 +8,53 @@ on:
       - '.github/workflows/deploy-catalog.yaml'
       - 'catalog/**'
       - 'shared/**'
+  pull_request:
+    paths:
+      - '.github/workflows/deploy-catalog.yaml'
+      - 'catalog/**'
+      - 'shared/**'
 
 jobs:
-  deploy-catalog-ecr:
+  build-check:
+    if: github.event_name == 'pull_request'
     runs-on: ubuntu-latest
-    defaults:
-      run:
-        working-directory: catalog
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@v7
+      - uses: docker/setup-buildx-action@v3
+      - name: Build image (no push)
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: catalog/Dockerfile
+          push: false
+          # Scope shared with deploy-catalog-ecr so master builds warm the cache
+          # PRs read. ignore-error: fork PRs have no cache write access.
+          cache-from: type=gha,scope=catalog
+          cache-to: type=gha,mode=max,scope=catalog,ignore-error=true
+
+  deploy-catalog-ecr:
+    if: github.event_name == 'push'
+    runs-on: ubuntu-latest
     # These permissions are needed to interact with GitHub's OIDC Token endpoint.
     permissions:
       id-token: write
       contents: read
     steps:
       - uses: actions/checkout@v7
-      - uses: actions/setup-node@v7
+      - uses: docker/setup-buildx-action@v3
+      - name: Build image
+        uses: docker/build-push-action@v6
         with:
-          node-version-file: 'catalog/package.json'
-          cache: 'npm'
-          cache-dependency-path: 'catalog/package-lock.json'
-      - run: npm ci
-      - run: npm run build
+          context: .
+          file: catalog/Dockerfile
+          tags: catalog:${{ github.sha }}
+          push: false
+          # Load into the local docker store for the per-registry tag/push below.
+          load: true
+          cache-from: type=gha,scope=catalog
+          cache-to: type=gha,mode=max,scope=catalog
       - name: Configure AWS credentials from Prod account
         uses: aws-actions/configure-aws-credentials@v6
         with:
@@ -49,7 +76,7 @@ jobs:
       - name: Login to GovCloud ECR
         id: login-govcloud-ecr
         uses: aws-actions/amazon-ecr-login@v2
-      - name: Build and push Docker image to Prod, MP and GovCloud ECR
+      - name: Push Docker image to Prod, MP and GovCloud ECR
         env:
           ECR_REGISTRY_PROD: ${{ steps.login-prod-ecr.outputs.registry }}
           ECR_REGISTRY_GOVCLOUD: ${{ steps.login-govcloud-ecr.outputs.registry }}
@@ -58,11 +85,11 @@ jobs:
           ECR_REPOSITORY_MP: quilt-data/quilt-payg-catalog
           IMAGE_TAG: ${{ github.sha }}
         run: |
-          docker buildx build \
-            -t $ECR_REGISTRY_PROD/$ECR_REPOSITORY:$IMAGE_TAG \
-            -t $ECR_REGISTRY_GOVCLOUD/$ECR_REPOSITORY:$IMAGE_TAG \
-            -t $ECR_REGISTRY_MP/$ECR_REPOSITORY_MP:$IMAGE_TAG \
-            .
+          docker tag catalog:$IMAGE_TAG $ECR_REGISTRY_PROD/$ECR_REPOSITORY:$IMAGE_TAG
+          docker tag catalog:$IMAGE_TAG $ECR_REGISTRY_GOVCLOUD/$ECR_REPOSITORY:$IMAGE_TAG
+          docker tag catalog:$IMAGE_TAG $ECR_REGISTRY_MP/$ECR_REPOSITORY_MP:$IMAGE_TAG
           docker push $ECR_REGISTRY_PROD/$ECR_REPOSITORY:$IMAGE_TAG
           docker push $ECR_REGISTRY_GOVCLOUD/$ECR_REPOSITORY:$IMAGE_TAG
+          # push to MP last because it can't be re-pushed using the same tag,
+          # so the job can be re-run if something failed
           docker push $ECR_REGISTRY_MP/$ECR_REPOSITORY_MP:$IMAGE_TAG

--- a/.github/workflows/deploy-catalog.yaml
+++ b/.github/workflows/deploy-catalog.yaml
@@ -1,4 +1,4 @@
-name: Deploy catalog to ECR
+name: "Catalog: build & push"
 
 on:
   push:
@@ -15,31 +15,9 @@ on:
       - 'shared/**'
 
 jobs:
-  build-check:
-    if: github.event_name == 'pull_request'
+  build:
     runs-on: ubuntu-latest
     permissions:
-      contents: read
-    steps:
-      - uses: actions/checkout@v7
-      - uses: docker/setup-buildx-action@v4
-      - name: Build image (no push)
-        uses: docker/build-push-action@v7
-        with:
-          context: .
-          file: catalog/Dockerfile
-          push: false
-          # Scope shared with deploy-catalog-ecr so master builds warm the cache
-          # PRs read. ignore-error: fork PRs have no cache write access.
-          cache-from: type=gha,scope=catalog
-          cache-to: type=gha,mode=max,scope=catalog,ignore-error=true
-
-  deploy-catalog-ecr:
-    if: github.event_name == 'push'
-    runs-on: ubuntu-latest
-    # These permissions are needed to interact with GitHub's OIDC Token endpoint.
-    permissions:
-      id-token: write
       contents: read
     steps:
       - uses: actions/checkout@v7
@@ -51,45 +29,66 @@ jobs:
           file: catalog/Dockerfile
           tags: catalog:${{ github.sha }}
           push: false
-          # Load into the local docker store for the per-registry tag/push below.
-          load: true
+          # On master, export a tarball for the push jobs below; on pull
+          # requests the build itself is the check and nothing consumes it.
+          outputs: ${{ github.event_name == 'push' && 'type=docker,dest=/tmp/catalog-image.tar' || '' }}
+          # One cache scope for both events: master builds warm the cache PRs
+          # read (the reverse is impossible — PR caches are isolated).
+          # ignore-error: fork PRs can't write the cache; worst case anywhere
+          # is a colder next build.
           cache-from: type=gha,scope=catalog
-          cache-to: type=gha,mode=max,scope=catalog
-      - name: Configure AWS credentials from Prod account
-        uses: aws-actions/configure-aws-credentials@v6
+          cache-to: type=gha,mode=max,scope=catalog,ignore-error=true
+      - uses: actions/upload-artifact@v7
+        if: github.event_name == 'push'
         with:
-          role-to-assume: arn:aws:iam::730278974607:role/github/GitHub-Quilt
-          aws-region: us-east-1
-      - name: Login to Prod ECR
-        id: login-prod-ecr
-        uses: aws-actions/amazon-ecr-login@v2
-      - name: Login to MP ECR
-        id: login-mp-ecr
-        uses: aws-actions/amazon-ecr-login@v2
+          name: catalog-image
+          path: /tmp/catalog-image.tar
+          retention-days: 1
+
+  push:
+    if: github.event_name == 'push'
+    needs: build
+    runs-on: ubuntu-latest
+    # These permissions are needed to interact with GitHub's OIDC Token endpoint.
+    permissions:
+      id-token: write
+    strategy:
+      # Targets are independent, so a failed one is retried alone via "Re-run
+      # failed jobs" — necessary for mp, which can't be re-pushed under the
+      # same tag, so any re-run replaying its successful push would fail.
+      fail-fast: false
+      matrix:
+        include:
+          - target: prod
+            role: arn:aws:iam::730278974607:role/github/GitHub-Quilt
+            region: us-east-1
+            repository: quiltdata/catalog
+          - target: mp
+            role: arn:aws:iam::730278974607:role/github/GitHub-Quilt
+            region: us-east-1
+            registry_id: "709825985650"
+            repository: quilt-data/quilt-payg-catalog
+          - target: govcloud
+            role: arn:aws-us-gov:iam::313325871032:role/github/GitHub-Quilt
+            region: us-gov-east-1
+            repository: quiltdata/catalog
+    steps:
+      - uses: actions/download-artifact@v8
         with:
-          registries: 709825985650
-      - name: Configure AWS credentials from GovCloud account
-        uses: aws-actions/configure-aws-credentials@v6
+          name: catalog-image
+          path: /tmp
+      - run: docker load -i /tmp/catalog-image.tar
+      - uses: aws-actions/configure-aws-credentials@v6
         with:
-          role-to-assume: arn:aws-us-gov:iam::313325871032:role/github/GitHub-Quilt
-          aws-region: us-gov-east-1
-      - name: Login to GovCloud ECR
-        id: login-govcloud-ecr
-        uses: aws-actions/amazon-ecr-login@v2
-      - name: Push Docker image to Prod, MP and GovCloud ECR
+          role-to-assume: ${{ matrix.role }}
+          aws-region: ${{ matrix.region }}
+      - uses: aws-actions/amazon-ecr-login@v2
+        id: ecr
+        with:
+          registries: ${{ matrix.registry_id }}
+      - name: Tag and push
         env:
-          ECR_REGISTRY_PROD: ${{ steps.login-prod-ecr.outputs.registry }}
-          ECR_REGISTRY_GOVCLOUD: ${{ steps.login-govcloud-ecr.outputs.registry }}
-          ECR_REGISTRY_MP: ${{ steps.login-mp-ecr.outputs.registry }}
-          ECR_REPOSITORY: quiltdata/catalog
-          ECR_REPOSITORY_MP: quilt-data/quilt-payg-catalog
-          IMAGE_TAG: ${{ github.sha }}
+          IMAGE: ${{ steps.ecr.outputs.registry }}/${{ matrix.repository }}:${{ github.sha }}
         run: |
-          docker tag catalog:$IMAGE_TAG $ECR_REGISTRY_PROD/$ECR_REPOSITORY:$IMAGE_TAG
-          docker tag catalog:$IMAGE_TAG $ECR_REGISTRY_GOVCLOUD/$ECR_REPOSITORY:$IMAGE_TAG
-          docker tag catalog:$IMAGE_TAG $ECR_REGISTRY_MP/$ECR_REPOSITORY_MP:$IMAGE_TAG
-          docker push $ECR_REGISTRY_PROD/$ECR_REPOSITORY:$IMAGE_TAG
-          docker push $ECR_REGISTRY_GOVCLOUD/$ECR_REPOSITORY:$IMAGE_TAG
-          # push to MP last because it can't be re-pushed using the same tag,
-          # so the job can be re-run if something failed
-          docker push $ECR_REGISTRY_MP/$ECR_REPOSITORY_MP:$IMAGE_TAG
+          docker tag catalog:${{ github.sha }} "$IMAGE"
+          docker push "$IMAGE"

--- a/.github/workflows/deploy-catalog.yaml
+++ b/.github/workflows/deploy-catalog.yaml
@@ -22,9 +22,9 @@ jobs:
       contents: read
     steps:
       - uses: actions/checkout@v7
-      - uses: docker/setup-buildx-action@v3
+      - uses: docker/setup-buildx-action@v4
       - name: Build image (no push)
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@v7
         with:
           context: .
           file: catalog/Dockerfile
@@ -43,9 +43,9 @@ jobs:
       contents: read
     steps:
       - uses: actions/checkout@v7
-      - uses: docker/setup-buildx-action@v3
+      - uses: docker/setup-buildx-action@v4
       - name: Build image
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@v7
         with:
           context: .
           file: catalog/Dockerfile

--- a/catalog/.dockerignore
+++ b/catalog/.dockerignore
@@ -1,1 +1,0 @@
-**/node_modules

--- a/catalog/Dockerfile
+++ b/catalog/Dockerfile
@@ -1,3 +1,17 @@
+# Build context is the repo root, not catalog/ — the webpack build resolves
+# modules from ../shared (see internals/webpack/webpack.base.js).
+FROM node:26-trixie-slim@sha256:715e55e4b84e4bb0ff48e49b398a848f08e55daed8eb6a0ea1839ae53bc57583 AS build
+
+WORKDIR /src/catalog
+
+# Manifests only, so editing app sources doesn't invalidate `npm ci`.
+COPY catalog/package.json catalog/package-lock.json ./
+RUN --mount=type=cache,target=/root/.npm npm ci
+
+COPY shared /src/shared
+COPY catalog ./
+RUN npm run build
+
 FROM amazonlinux:2023.11.20260406.2
 MAINTAINER Quilt Data, Inc. support@quilt.bio
 
@@ -13,16 +27,15 @@ RUN ln -sf /dev/stdout /var/log/nginx/access.log && \
     ln -sf /dev/stderr /var/log/nginx/error.log
 
 # Set up nginx
-COPY nginx.conf /etc/nginx/nginx.conf
-COPY nginx-web.conf /etc/nginx/conf.d/default.conf
+COPY catalog/nginx.conf /etc/nginx/nginx.conf
+COPY catalog/nginx-web.conf /etc/nginx/conf.d/default.conf
 
 ARG NGINX_STATIC_DIR=/usr/share/nginx/html
-# Copy pre-built catalog assets to nginx
 RUN rm -rf $NGINX_STATIC_DIR
-COPY build $NGINX_STATIC_DIR
+COPY --from=build /src/catalog/build $NGINX_STATIC_DIR
 
 # Copy config file
-COPY config.json.tmpl config.json.tmpl
+COPY catalog/config.json.tmpl config.json.tmpl
 
 RUN ln -s /tmp/config.json $NGINX_STATIC_DIR/config.json && \
     ln -s /tmp/config.js $NGINX_STATIC_DIR/config.js

--- a/catalog/Dockerfile.dockerignore
+++ b/catalog/Dockerfile.dockerignore
@@ -1,0 +1,17 @@
+# Scoped to catalog/Dockerfile (BuildKit reads <dockerfile>.dockerignore), so
+# other images' build contexts are unaffected.
+#
+# The context is the repo root, but the build only needs catalog/ and shared/.
+# Allow-list rather than deny-list: a new top-level directory stays out by
+# default instead of silently bloating the context.
+*
+!catalog
+!shared
+
+# Local artifacts that would otherwise leak in from a dirty working tree.
+# catalog/build especially: a stale one must not shadow the in-image build.
+catalog/node_modules
+catalog/build
+catalog/coverage
+catalog/stats.json
+**/.DS_Store

--- a/catalog/internals/webpack/webpack.base.js
+++ b/catalog/internals/webpack/webpack.base.js
@@ -148,5 +148,3 @@ module.exports = (options) => ({
   target: 'web', // Make web variables accessible to webpack, e.g. window
   performance: options.performance || {},
 })
-
-// cache-measurement probe — reverted in the next commit

--- a/catalog/internals/webpack/webpack.base.js
+++ b/catalog/internals/webpack/webpack.base.js
@@ -148,3 +148,5 @@ module.exports = (options) => ({
   target: 'web', // Make web variables accessible to webpack, e.g. window
   performance: options.performance || {},
 })
+
+// cache-measurement probe — reverted in the next commit


### PR DESCRIPTION
`catalog/Dockerfile` assumed pre-built assets — `COPY build` — with `npm run build` run outside Docker in the deploy workflow. So `docker build catalog/` failed on a fresh clone, and the shipped artifact depended on whatever node/npm the CI runner resolved rather than on the Dockerfile. Catalog was the only image in the repo built this way.

The build now happens in a node stage inside the Dockerfile. The context moves from `catalog/` to the repo root, because the webpack build resolves modules from `shared/` (`internals/webpack/webpack.base.js` `resolve.modules`, and `tsconfig.json` paths) — app code imports `schemas/*.json` from there.

`deploy-catalog.yaml` drops its setup-node/`npm ci`/`npm run build` steps and is restructured into a single `build` job plus a per-registry `push` matrix. The build job runs on pull requests too, as a build-only check: previously the image build was exercised only on master push, so Dockerfile breakage surfaced after merge, and there was no way to rehearse a change to it. Because it is one job definition, the PR check and the master build can't drift apart. Both events share one buildx GHA cache scope (master builds warm the cache PRs read; the reverse is blocked by GitHub's cache isolation), which replaces the `setup-node` npm cache that an in-Docker build can't use.

On master, the build job hands the image to the push jobs as a short-lived workflow artifact (`docker load`-able tarball, 1-day retention), so each registry receives byte-for-byte the image that was built, and each push is an independent matrix job.

Marketplace can't be re-pushed under the same tag, which previously forced an implicit ordering — MP pushed last — to keep the job re-runnable. The matrix dissolves that constraint: a failed target is retried alone via "Re-run failed jobs", downloading the same image artifact, without replaying pushes that already succeeded.

### Verification

- Builds from a clean checkout with no `catalog/node_modules` and no `catalog/build` present.
- The 718 static assets are **byte-identical** (SHA-256) to an out-of-Docker `npm ci && npm run build` of the same source at the same node/npm. The image additionally contains the two pre-existing `config.js`/`config.json` symlinks.
- Image is unchanged in size (394 MB) and matches the previous one layer-for-layer.
- Container serves `/` and `/config.js` with `envsubst` substitution applied, as before.
- After a source-content change, `npm ci` stays cached and only the copy + webpack layers rebuild.

Measured on this PR's own runs: **3m28s** cold with no cache to read (webpack 67s, cache export 86s), and 22s when the build context is unchanged — but that second figure is the floor, not a steady state. It needs the workflow file to be the only change, since every committed file under the `catalog/**` and `shared/**` trigger paths is also in the build context.

The dominant path — app source changed, dependencies unchanged — measures **1m53s**: `npm ci` served from cache, ~18s importing cached layers, 2.7s re-copying the context, webpack 68s, cache export 6.3s. Roughly a third of runs will be closer to cold, because 12 of the last 25 catalog commits also touched `catalog/package-lock.json`, which invalidates the `npm ci` layer.

The previous pipeline's last five master runs took 2m31s-2m51s including the three registry pushes, so it isn't directly comparable to a build-only job. The narrower comparison: both pipelines re-run webpack on any catalog change, and both cache dependency installation (`setup-node` cached the npm download, buildx now caches the whole `npm ci` layer). What's genuinely added is the cache export: 86s on a cold full export, but only 6.3s on the dominant path and 1.3s when nothing changed. So on the common case the tax is single-digit seconds against a 68s webpack step that both pipelines pay.

The master-only artifact hand-off (tarball export + upload in `build`, download + `docker load` in each push job) is new overhead that PR runs don't exercise — its real cost shows up in the first master runs after merge.

### Notes

- No `catalog/CHANGELOG.md` entry: this has no runtime or user-facing effect, and every existing entry there is a product change. Happy to add one if you'd rather.
- The ignore file is `catalog/Dockerfile.dockerignore` (BuildKit's per-Dockerfile ignore) so no other image's build context is affected, and it is an allow-list — a new top-level directory stays out of the context by default. `catalog/.dockerignore` no longer applied once the context moved, so it's removed.
- `node:26-trixie-slim` is digest-pinned, matching the lambda Dockerfiles' convention. Debian rather than alpine because `esbuild` and `msgpackr-extract` ship glibc prebuilds.




