### PR TITLE
Delete directory markers in Bucket.delete_dir

### DIFF
--- a/api/python/quilt3/bucket.py
+++ b/api/python/quilt3/bucket.py
@@ -140,7 +140,9 @@ class Bucket:
         """
         results = list_objects(self._pk.bucket, path)
         for result in results:
-            self.delete(result['Key'])
+            # Not self.delete(): it rejects keys ending in '/' to steer callers here, but
+            # directory markers (zero-byte placeholder objects) are contents to delete.
+            delete_object(self._pk.bucket, result['Key'])
 
     def ls(self, path=None, recursive=False):
         """List data from the specified path.

--- a/api/python/quilt3/bucket.py
+++ b/api/python/quilt3/bucket.py
@@ -140,8 +140,6 @@ class Bucket:
         """
         results = list_objects(self._pk.bucket, path)
         for result in results:
-            # Not self.delete(): it rejects keys ending in '/' to steer callers here, but
-            # directory markers (zero-byte placeholder objects) are contents to delete.
             delete_object(self._pk.bucket, result['Key'])
 
     def ls(self, path=None, recursive=False):

--- a/api/python/tests/test_bucket.py
+++ b/api/python/tests/test_bucket.py
@@ -285,8 +285,7 @@ class TestBucket(QuiltTestCase):
             bucket.delete_dir('dir')
 
     def test_remote_delete_dir_with_directory_marker(self):
-        # Zero-byte "folder" placeholders are part of the directory's contents; they must not
-        # abort the loop partway through.
+        # 'dir/sub/' is a zero-byte placeholder object, listed like any other key.
         self.s3_stubber.add_response(
             method='list_objects_v2',
             service_response={

--- a/api/python/tests/test_bucket.py
+++ b/api/python/tests/test_bucket.py
@@ -283,3 +283,37 @@ class TestBucket(QuiltTestCase):
 
         with pytest.raises(ValueError):
             bucket.delete_dir('dir')
+
+    def test_remote_delete_dir_with_directory_marker(self):
+        # Zero-byte "folder" placeholders are part of the directory's contents; they must not
+        # abort the loop partway through.
+        self.s3_stubber.add_response(
+            method='list_objects_v2',
+            service_response={
+                'IsTruncated': False,
+                'Contents': [{'Key': 'dir/sub/'}, {'Key': 'dir/a'}],
+            },
+            expected_params={
+                'Bucket': 'test-bucket',
+                'Prefix': 'dir/',
+            },
+        )
+        for key in ('dir/sub/', 'dir/a'):
+            self.s3_stubber.add_response(
+                method='head_object',
+                service_response={},
+                expected_params={
+                    'Bucket': 'test-bucket',
+                    'Key': key,
+                },
+            )
+            self.s3_stubber.add_response(
+                method='delete_object',
+                service_response={},
+                expected_params={
+                    'Bucket': 'test-bucket',
+                    'Key': key,
+                },
+            )
+
+        Bucket('s3://test-bucket').delete_dir('dir/')

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -23,6 +23,7 @@ Entries inside each section should be ordered by type:
 * [Removed] Drop support for Python 3.9 (end-of-life); `quilt3` now requires Python >= 3.10 ([#4941](https://github.com/quiltdata/quilt/pull/4941))
 * [Fixed] `quilt3.admin.buckets.list` no longer raises `TypeError` when its type hints are introspected on Python 3.14 ([#4940](https://github.com/quiltdata/quilt/pull/4940))
 * [Fixed] `quilt3.delete_package()` on a local registry no longer deletes other packages sharing the same namespace ([#5140](https://github.com/quiltdata/quilt/pull/5140))
+* [Fixed] `Bucket.delete_dir()` no longer stops partway through on buckets containing zero-byte directory markers, leaving the directory half deleted ([#5158](https://github.com/quiltdata/quilt/pull/5158))
 
 ### CLI
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -23,7 +23,7 @@ Entries inside each section should be ordered by type:
 * [Removed] Drop support for Python 3.9 (end-of-life); `quilt3` now requires Python >= 3.10 ([#4941](https://github.com/quiltdata/quilt/pull/4941))
 * [Fixed] `quilt3.admin.buckets.list` no longer raises `TypeError` when its type hints are introspected on Python 3.14 ([#4940](https://github.com/quiltdata/quilt/pull/4940))
 * [Fixed] `quilt3.delete_package()` on a local registry no longer deletes other packages sharing the same namespace ([#5140](https://github.com/quiltdata/quilt/pull/5140))
-* [Fixed] `Bucket.delete_dir()` no longer stops partway through on buckets containing zero-byte directory markers, leaving the directory half deleted ([#5158](https://github.com/quiltdata/quilt/pull/5158))
+* [Fixed] `Bucket.delete_dir()` no longer stops partway through on zero-byte directory markers, leaving the directory half deleted ([#5158](https://github.com/quiltdata/quilt/pull/5158))
 
 ### CLI
 


### PR DESCRIPTION
# Description

`Bucket.delete_dir()` deleted each listed key through `Bucket.delete()`, which raises `QuiltException("Must use delete_dir to delete directories")` for any key ending in `/` (`bucket.py:130-131`). S3 buckets routinely contain zero-byte "directory marker" objects — the console's *Create folder* button makes them, as do Hadoop/EMR and several sync tools — and `list_objects` returns them like any other key. So on such a bucket `delete_dir` raised **partway through the loop**: some keys deleted, the rest left behind, and an error telling the caller to use the very method they were already calling.

The trailing-slash guard exists to steer callers from `delete()` to `delete_dir()`. Inside `delete_dir` that reasoning is inverted — the marker is part of the directory's contents — so this calls `delete_object` directly.

`test_remote_delete_dir_with_directory_marker` stubs a listing of `dir/sub/` followed by `dir/a`. On master it fails with the `QuiltException` and 4 unconsumed stub responses (the head+delete pair for each remaining key — the partial delete made visible); it passes with this change.

# TODO

<!-- Remove items that are irrelevant to this PR -->

- [x] Unit tests
- [x] [Changelog](../tree/master/docs/CHANGELOG.md) entry

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR makes `Bucket.delete_dir()` delete S3 directory-marker objects without aborting partway through.
- Calls the underlying object-deletion helper directly for every listed key.
- Adds regression coverage for a directory containing a zero-byte marker.
- Documents the fix in the changelog.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge with no actionable defects identified.

The changed path intentionally bypasses only `Bucket.delete()` validation that rejects trailing-slash keys and otherwise invokes the same object-deletion helper, with regression coverage for both the marker and following object.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| api/python/quilt3/bucket.py | Bypasses the single-object trailing-slash guard within directory deletion while preserving the same underlying deletion behavior. |
| api/python/tests/test_bucket.py | Adds focused stubbed-S3 coverage proving directory markers and subsequent objects are both deleted. |
| docs/CHANGELOG.md | Accurately records the partial-directory-deletion fix. |

<sub>Reviews (1): Last reviewed commit: ["Add changelog entry"](https://github.com/quiltdata/quilt/commit/245f02e4b15fb66062d789ad03dd8f33bdcd8b68) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=47577604)</sub>

<!-- /greptile_comment -->