### PR TITLE
Drop dead MANIFEST.in from status_reports lambda

### DIFF
--- a/lambdas/status_reports/MANIFEST.in
+++ b/lambdas/status_reports/MANIFEST.in
@@ -1,1 +1,0 @@
-include src/t4_lambda_status_reports/templates/*


### PR DESCRIPTION
`lambdas/status_reports/MANIFEST.in` is dead config: the package builds with `uv_build`, and `MANIFEST.in` is a setuptools mechanism that `uv_build` never reads. The templates ship because `uv_build` includes everything under the module directory by default — so the file implies protection it does not provide. This is the only lambda shipping package data, and it builds a `jinja2.PackageLoader` plus `get_template("entry.html.jinja")` at module import, so an incomplete wheel would fail to import rather than degrade silently.

Verified with the pinned backend (`uv build --wheel --force-pep517` → `uv-build==0.9.30`): a `MANIFEST.in` carrying `prune` / `exclude` / `global-exclude *.jinja` directives, which would strip the templates under setuptools, yields a wheel with the same contents as one built with no `MANIFEST.in` at all — templates included either way.

If template inclusion ever needs to be explicit, the right knob is `[tool.uv.build-backend]`, not `MANIFEST.in`. The check that would actually catch an exclusion already exists: the `test-lambda` job's `uv run --no-editable pytest --collect-only`, which imports from the built wheel.

No CHANGELOG entry — the built wheel is byte-for-byte unaffected.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Removes the unused setuptools `MANIFEST.in` directive from the `status_reports` Lambda package; its `uv_build` packaging behavior remains unchanged.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge with no actionable issues identified.

The deleted manifest is not used by the configured build or deployment paths, while the templates remain inside the packaged module tree and the wheel-based CI collection check covers their availability.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| lambdas/status_reports/MANIFEST.in | Deletes a packaging directive that is not consumed by the configured `uv_build` backend. |

<sub>Reviews (1): Last reviewed commit: ["Drop dead MANIFEST.in from status\_report..."](https://github.com/quiltdata/quilt/commit/1efab9c6896a8c184ffb01a4687e34d2bd75c621) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=47865333)</sub>

<!-- /greptile_comment -->