### PR TITLE
pkgevents: drop s3:TestEvent silently, report other failures per message

### DIFF
--- a/lambdas/pkgevents/CHANGELOG.md
+++ b/lambdas/pkgevents/CHANGELOG.md
@@ -17,6 +17,7 @@ where verb is one of
 
 ## Changes
 
+- [Fixed] Skip SQS messages without S3 records, e.g. `s3:TestEvent`, instead of failing the whole batch and dead-lettering the real package events in it ([#5162](https://github.com/quiltdata/quilt/pull/5162))
 - [Fixed] Process package pointers from year 2026+ ([#4683](https://github.com/quiltdata/quilt/pull/4683))
 - [Changed] Migrate to proper package structure ([#4647](https://github.com/quiltdata/quilt/pull/4647))
 - [Changed] Switch to uv ([#4647](https://github.com/quiltdata/quilt/pull/4647))

--- a/lambdas/pkgevents/CHANGELOG.md
+++ b/lambdas/pkgevents/CHANGELOG.md
@@ -17,7 +17,7 @@ where verb is one of
 
 ## Changes
 
-- [Fixed] Skip SQS messages without S3 records, e.g. `s3:TestEvent`, instead of failing the whole batch and dead-lettering the real package events in it ([#5162](https://github.com/quiltdata/quilt/pull/5162))
+- [Fixed] Drop `s3:TestEvent` messages and report other failures per message via `ReportBatchItemFailures`, instead of failing the whole SQS batch and dead-lettering the real package events in it ([#5162](https://github.com/quiltdata/quilt/pull/5162))
 - [Fixed] Process package pointers from year 2026+ ([#4683](https://github.com/quiltdata/quilt/pull/4683))
 - [Changed] Migrate to proper package structure ([#4647](https://github.com/quiltdata/quilt/pull/4647))
 - [Changed] Switch to uv ([#4647](https://github.com/quiltdata/quilt/pull/4647))

--- a/lambdas/pkgevents/src/t4_lambda_pkgevents/__init__.py
+++ b/lambdas/pkgevents/src/t4_lambda_pkgevents/__init__.py
@@ -1,4 +1,3 @@
-import itertools
 import json
 import re
 import time
@@ -94,11 +93,20 @@ def pkg_created_event(s3_event):
     }
 
 
+def iter_s3_events(sqs_records):
+    for record in sqs_records:
+        body = json.loads(record['body'])
+        if 'Records' not in body:
+            # `s3:TestEvent` (sent when a bucket's notification configuration is
+            # created) or another unexpected message: skip it instead of failing
+            # the whole batch, which would dead-letter the real events in it too.
+            logger.warning('skipping message without S3 records: %s', body)
+            continue
+        yield from body['Records']
+
+
 def handler(event, context):
-    s3_events = itertools.chain.from_iterable(
-        json.loads(record['body'])['Records']
-        for record in event['Records']
-    )
+    s3_events = iter_s3_events(event['Records'])
     queue = EventsQueue()
     for event in filter(None, map(pkg_created_event, s3_events)):
         queue.append(event)

--- a/lambdas/pkgevents/src/t4_lambda_pkgevents/__init__.py
+++ b/lambdas/pkgevents/src/t4_lambda_pkgevents/__init__.py
@@ -108,12 +108,16 @@ def iter_s3_events(sqs_records, failed_message_ids):
     """Yield (message id, S3 event) pairs, dropping S3 test events and
     reporting messages of unexpected shape as failed."""
     for record in sqs_records:
-        body = json.loads(record['body'])
-        if body.get('Event') == TEST_EVENT:
+        try:
+            body = json.loads(record['body'])
+        except json.JSONDecodeError:
+            body = None
+        if isinstance(body, dict) and body.get('Event') == TEST_EVENT:
             # arrives on every bucket add, not worth logging
             continue
-        if 'Records' not in body:
-            # report it as failed so it ends up in the DLQ
+        if not isinstance(body, dict) or 'Records' not in body:
+            # S3 is the expected producer, not the only possible one: report
+            # whatever else lands here as failed so it ends up in the DLQ
             # instead of being deleted without a trace
             logger.warning('no S3 records in message %s', record['messageId'])
             failed_message_ids.add(record['messageId'])

--- a/lambdas/pkgevents/src/t4_lambda_pkgevents/__init__.py
+++ b/lambdas/pkgevents/src/t4_lambda_pkgevents/__init__.py
@@ -1,3 +1,4 @@
+import itertools
 import json
 import re
 import time
@@ -12,49 +13,11 @@ EXPECTED_POINTER_SIZE = 64
 # configuration is created; it carries no 'Records'.
 TEST_EVENT = 's3:TestEvent'
 
+PUT_EVENTS_MAX_ENTRIES = 10  # PutEvents API limit
+
 event_bridge = boto3.client('events')
 s3 = boto3.client('s3')
 logger = get_quilt_logger()
-
-
-class EventsQueue:
-    MAX_SIZE = 10
-
-    def __init__(self):
-        self._events = []
-        self._message_ids = []
-        self._failed_message_ids = set()
-
-    def append(self, event, message_id):
-        self._events.append(event)
-        self._message_ids.append(message_id)
-        if len(self) >= self.MAX_SIZE:
-            self._flush()
-
-    def _flush(self):
-        events = self._events
-        message_ids = self._message_ids
-        self._events = []
-        self._message_ids = []
-        resp = event_bridge.put_events(Entries=events)
-        if resp['FailedEntryCount']:
-            # response entries are in the same order as the request entries
-            for message_id, entry in zip(message_ids, resp['Entries'], strict=True):
-                if 'ErrorCode' in entry:
-                    logger.warning('failed to publish event from message %s: %s', message_id, entry)
-                    self._failed_message_ids.add(message_id)
-
-    def flush(self):
-        """Flush pending events and return ids of the messages whose events failed to publish."""
-        if self:
-            self._flush()
-        return self._failed_message_ids
-
-    def __len__(self):
-        return len(self._events)
-
-    def __bool__(self):
-        return bool(self._events)
 
 
 PKG_POINTER_REGEX = re.compile(r'\.quilt/named_packages/([\w-]+/[\w-]+)/([0-9]{10})')
@@ -104,49 +67,54 @@ def pkg_created_event(s3_event):
     }
 
 
-def iter_s3_events(sqs_records, failed_message_ids):
-    """Yield (message id, S3 event) pairs, dropping S3 test events and
-    reporting messages of unexpected shape as failed."""
-    for record in sqs_records:
-        try:
-            body = json.loads(record['body'])
-        except json.JSONDecodeError:
-            body = None
-        if isinstance(body, dict) and body.get('Event') == TEST_EVENT:
-            # arrives on every bucket add, not worth logging
-            continue
-        if not isinstance(body, dict) or 'Records' not in body:
-            # S3 is the expected producer, not the only possible one: report
-            # whatever else lands here as failed so it ends up in the DLQ
-            # instead of being deleted without a trace
-            logger.warning('no S3 records in message %s', record['messageId'])
-            failed_message_ids.add(record['messageId'])
-            continue
-        for s3_event in body['Records']:
-            yield record['messageId'], s3_event
+def get_s3_events(body):
+    """Return the S3 events from an SQS message body ([] for S3 test events);
+    raise for any other unexpected shape."""
+    body = json.loads(body)
+    if body.get('Event') == TEST_EVENT:
+        # arrives on every bucket add, not worth logging
+        return []
+    return body['Records']
+
+
+def publish(entries):
+    """Publish (message id, event) pairs to EventBridge and return the ids of
+    the messages whose events failed to publish."""
+    failed_message_ids = set()
+    for chunk in itertools.batched(entries, PUT_EVENTS_MAX_ENTRIES):
+        resp = event_bridge.put_events(Entries=[event for _, event in chunk])
+        if resp['FailedEntryCount']:
+            # response entries are in the same order as the request entries
+            for (message_id, _), resp_entry in zip(chunk, resp['Entries'], strict=True):
+                if 'ErrorCode' in resp_entry:
+                    logger.warning('failed to publish event from message %s: %s', message_id, resp_entry)
+                    failed_message_ids.add(message_id)
+    return failed_message_ids
 
 
 def handler(event, context):
     failed_message_ids = set()
-    queue = EventsQueue()
-    for message_id, s3_event in iter_s3_events(event['Records'], failed_message_ids):
-        if message_id in failed_message_ids:
-            # the whole message will be retried, so don't publish the rest
-            # of its events now -- that'd make even more duplicates
-            continue
+    entries = []
+    for record in event['Records']:
+        message_id = record['messageId']
         try:
-            pkg_event = pkg_created_event(s3_event)
+            entries += [
+                (message_id, pkg_event)
+                for pkg_event in map(pkg_created_event, get_s3_events(record['body']))
+                if pkg_event is not None
+            ]
         except Exception:
-            logger.exception('failed to process S3 event from message %s', message_id)
+            # unexpected message shape (S3 is the expected producer, not the only
+            # possible one) or a failure while processing one of its events: fail
+            # the message alone so it's retried and dead-lettered by itself,
+            # ending up in the DLQ instead of being deleted without a trace
+            logger.exception('failed to process message %s', message_id)
             failed_message_ids.add(message_id)
-            continue
-        if pkg_event is not None:
-            queue.append(pkg_event, message_id)
 
-    failed_message_ids |= queue.flush()
-    # Messages not listed here are considered processed and get deleted from
-    # the queue, so on an error that can't be attributed to specific messages
-    # (e.g. a failed put_events call) we must raise, failing the whole batch.
+    failed_message_ids |= publish(entries)
+    # Messages not listed here are considered processed and get deleted from the
+    # queue, so an error that can't be attributed to specific messages (a failed
+    # put_events call) must raise, failing the whole batch.
     return {
         'batchItemFailures': [
             {'itemIdentifier': message_id} for message_id in failed_message_ids

--- a/lambdas/pkgevents/src/t4_lambda_pkgevents/__init__.py
+++ b/lambdas/pkgevents/src/t4_lambda_pkgevents/__init__.py
@@ -8,13 +8,13 @@ from t4_lambda_shared.utils import get_quilt_logger
 
 EXPECTED_POINTER_SIZE = 64
 
+# S3 sends this to the notification queue when a bucket's notification
+# configuration is created; it carries no 'Records'.
+TEST_EVENT = 's3:TestEvent'
+
 event_bridge = boto3.client('events')
 s3 = boto3.client('s3')
 logger = get_quilt_logger()
-
-
-class PutEventsException(Exception):
-    pass
 
 
 class EventsQueue:
@@ -22,22 +22,33 @@ class EventsQueue:
 
     def __init__(self):
         self._events = []
+        self._message_ids = []
+        self._failed_message_ids = set()
 
-    def append(self, event):
+    def append(self, event, message_id):
         self._events.append(event)
+        self._message_ids.append(message_id)
         if len(self) >= self.MAX_SIZE:
             self._flush()
 
     def _flush(self):
         events = self._events
+        message_ids = self._message_ids
         self._events = []
+        self._message_ids = []
         resp = event_bridge.put_events(Entries=events)
         if resp['FailedEntryCount']:
-            raise PutEventsException(resp)
+            # response entries are in the same order as the request entries
+            for message_id, entry in zip(message_ids, resp['Entries'], strict=True):
+                if 'ErrorCode' in entry:
+                    logger.warning('failed to publish event from message %s: %s', message_id, entry)
+                    self._failed_message_ids.add(message_id)
 
     def flush(self):
+        """Flush pending events and return ids of the messages whose events failed to publish."""
         if self:
             self._flush()
+        return self._failed_message_ids
 
     def __len__(self):
         return len(self._events)
@@ -93,22 +104,47 @@ def pkg_created_event(s3_event):
     }
 
 
-def iter_s3_events(sqs_records):
+def iter_s3_events(sqs_records, failed_message_ids):
+    """Yield (message id, S3 event) pairs, dropping S3 test events and
+    reporting messages of unexpected shape as failed."""
     for record in sqs_records:
         body = json.loads(record['body'])
-        if 'Records' not in body:
-            # `s3:TestEvent` (sent when a bucket's notification configuration is
-            # created) or another unexpected message: skip it instead of failing
-            # the whole batch, which would dead-letter the real events in it too.
-            logger.warning('skipping message without S3 records: %s', record['body'])
+        if body.get('Event') == TEST_EVENT:
+            # arrives on every bucket add, not worth logging
             continue
-        yield from body['Records']
+        if 'Records' not in body:
+            # report it as failed so it ends up in the DLQ
+            # instead of being deleted without a trace
+            logger.warning('no S3 records in message %s', record['messageId'])
+            failed_message_ids.add(record['messageId'])
+            continue
+        for s3_event in body['Records']:
+            yield record['messageId'], s3_event
 
 
 def handler(event, context):
-    s3_events = iter_s3_events(event['Records'])
+    failed_message_ids = set()
     queue = EventsQueue()
-    for pkg_event in filter(None, map(pkg_created_event, s3_events)):
-        queue.append(pkg_event)
+    for message_id, s3_event in iter_s3_events(event['Records'], failed_message_ids):
+        if message_id in failed_message_ids:
+            # the whole message will be retried, so don't publish the rest
+            # of its events now -- that'd make even more duplicates
+            continue
+        try:
+            pkg_event = pkg_created_event(s3_event)
+        except Exception:
+            logger.exception('failed to process S3 event from message %s', message_id)
+            failed_message_ids.add(message_id)
+            continue
+        if pkg_event is not None:
+            queue.append(pkg_event, message_id)
 
-    queue.flush()
+    failed_message_ids |= queue.flush()
+    # Messages not listed here are considered processed and get deleted from
+    # the queue, so on an error that can't be attributed to specific messages
+    # (e.g. a failed put_events call) we must raise, failing the whole batch.
+    return {
+        'batchItemFailures': [
+            {'itemIdentifier': message_id} for message_id in failed_message_ids
+        ],
+    }

--- a/lambdas/pkgevents/src/t4_lambda_pkgevents/__init__.py
+++ b/lambdas/pkgevents/src/t4_lambda_pkgevents/__init__.py
@@ -100,7 +100,7 @@ def iter_s3_events(sqs_records):
             # `s3:TestEvent` (sent when a bucket's notification configuration is
             # created) or another unexpected message: skip it instead of failing
             # the whole batch, which would dead-letter the real events in it too.
-            logger.warning('skipping message without S3 records: %s', body)
+            logger.warning('skipping message without S3 records: %s', record['body'])
             continue
         yield from body['Records']
 
@@ -108,7 +108,7 @@ def iter_s3_events(sqs_records):
 def handler(event, context):
     s3_events = iter_s3_events(event['Records'])
     queue = EventsQueue()
-    for event in filter(None, map(pkg_created_event, s3_events)):
-        queue.append(event)
+    for pkg_event in filter(None, map(pkg_created_event, s3_events)):
+        queue.append(pkg_event)
 
     queue.flush()

--- a/lambdas/pkgevents/tests/test_index.py
+++ b/lambdas/pkgevents/tests/test_index.py
@@ -172,6 +172,34 @@ def test_handler(pkg_created_event_mock, queue_append_mock, queue_flush_mock):
     queue_flush_mock.assert_called_once_with()
 
 
+@mock.patch("t4_lambda_pkgevents.EventsQueue.flush")
+@mock.patch("t4_lambda_pkgevents.EventsQueue.append")
+@mock.patch("t4_lambda_pkgevents.pkg_created_event", wraps=str)
+def test_handler_skips_messages_without_records(pkg_created_event_mock, queue_append_mock, queue_flush_mock):
+    event = {
+        'Records': [
+            {'body': json.dumps({'Records': (0, 1)})},
+            {
+                'body': json.dumps(
+                    {
+                        'Service': 'Amazon S3',
+                        'Event': 's3:TestEvent',
+                        'Time': '2026-07-30T00:38:18.000Z',
+                        'Bucket': 'test-bucket',
+                        'RequestId': 'AAAAAAAAAAAAAAAA',
+                        'HostId': 'aaaaaaaaaaaaaaaa',
+                    }
+                )
+            },
+            {'body': json.dumps({'Records': (2,)})},
+        ]
+    }
+    handler(event, None)
+    assert pkg_created_event_mock.call_args_list == [((x,),) for x in range(3)]
+    assert queue_append_mock.call_args_list == [((str(x),),) for x in range(3)]
+    queue_flush_mock.assert_called_once_with()
+
+
 @pytest.mark.parametrize('failed_count', (0, 1))
 def test_queue(failed_count):
     with mock.patch("t4_lambda_pkgevents.event_bridge.put_events") as put_events_mock:

--- a/lambdas/pkgevents/tests/test_index.py
+++ b/lambdas/pkgevents/tests/test_index.py
@@ -145,7 +145,7 @@ def test_pkg_created_event(pointer_file):
         stubber.assert_no_pending_responses()
 
 
-@mock.patch("t4_lambda_pkgevents.EventsQueue.flush", return_value=set())
+@mock.patch("t4_lambda_pkgevents.EventsQueue.flush", return_value=frozenset())
 @mock.patch("t4_lambda_pkgevents.EventsQueue.append")
 @mock.patch("t4_lambda_pkgevents.pkg_created_event", wraps=str)
 def test_handler(pkg_created_event_mock, queue_append_mock, queue_flush_mock):
@@ -178,7 +178,7 @@ def test_handler(pkg_created_event_mock, queue_append_mock, queue_flush_mock):
 
 
 @mock.patch("t4_lambda_pkgevents.logger")
-@mock.patch("t4_lambda_pkgevents.EventsQueue.flush", return_value=set())
+@mock.patch("t4_lambda_pkgevents.EventsQueue.flush", return_value=frozenset())
 @mock.patch("t4_lambda_pkgevents.EventsQueue.append")
 @mock.patch("t4_lambda_pkgevents.pkg_created_event", wraps=str)
 def test_handler_drops_test_events_silently(
@@ -213,7 +213,7 @@ def test_handler_drops_test_events_silently(
     logger_mock.exception.assert_not_called()
 
 
-@mock.patch("t4_lambda_pkgevents.EventsQueue.flush", return_value=set())
+@mock.patch("t4_lambda_pkgevents.EventsQueue.flush", return_value=frozenset())
 @mock.patch("t4_lambda_pkgevents.EventsQueue.append")
 @mock.patch("t4_lambda_pkgevents.pkg_created_event", wraps=str)
 def test_handler_reports_messages_without_records_as_failed(
@@ -231,7 +231,7 @@ def test_handler_reports_messages_without_records_as_failed(
     queue_flush_mock.assert_called_once_with()
 
 
-@mock.patch("t4_lambda_pkgevents.EventsQueue.flush", return_value=set())
+@mock.patch("t4_lambda_pkgevents.EventsQueue.flush", return_value=frozenset())
 @mock.patch("t4_lambda_pkgevents.EventsQueue.append")
 @mock.patch("t4_lambda_pkgevents.pkg_created_event")
 def test_handler_reports_message_with_failing_event(
@@ -251,7 +251,7 @@ def test_handler_reports_message_with_failing_event(
     queue_flush_mock.assert_called_once_with()
 
 
-@mock.patch("t4_lambda_pkgevents.EventsQueue.flush", return_value={'message-0'})
+@mock.patch("t4_lambda_pkgevents.EventsQueue.flush", return_value=frozenset({'message-0'}))
 @mock.patch("t4_lambda_pkgevents.EventsQueue.append")
 @mock.patch("t4_lambda_pkgevents.pkg_created_event", wraps=str)
 def test_handler_reports_publish_failures(

--- a/lambdas/pkgevents/tests/test_index.py
+++ b/lambdas/pkgevents/tests/test_index.py
@@ -172,25 +172,27 @@ def test_handler(pkg_created_event_mock, queue_append_mock, queue_flush_mock):
     queue_flush_mock.assert_called_once_with()
 
 
+@mock.patch("t4_lambda_pkgevents.logger")
 @mock.patch("t4_lambda_pkgevents.EventsQueue.flush")
 @mock.patch("t4_lambda_pkgevents.EventsQueue.append")
 @mock.patch("t4_lambda_pkgevents.pkg_created_event", wraps=str)
-def test_handler_skips_messages_without_records(pkg_created_event_mock, queue_append_mock, queue_flush_mock):
+def test_handler_skips_messages_without_records(
+    pkg_created_event_mock, queue_append_mock, queue_flush_mock, logger_mock
+):
+    test_event_body = json.dumps(
+        {
+            'Service': 'Amazon S3',
+            'Event': 's3:TestEvent',
+            'Time': '2026-07-30T00:38:18.000Z',
+            'Bucket': 'test-bucket',
+            'RequestId': 'AAAAAAAAAAAAAAAA',
+            'HostId': 'aaaaaaaaaaaaaaaa',
+        }
+    )
     event = {
         'Records': [
             {'body': json.dumps({'Records': (0, 1)})},
-            {
-                'body': json.dumps(
-                    {
-                        'Service': 'Amazon S3',
-                        'Event': 's3:TestEvent',
-                        'Time': '2026-07-30T00:38:18.000Z',
-                        'Bucket': 'test-bucket',
-                        'RequestId': 'AAAAAAAAAAAAAAAA',
-                        'HostId': 'aaaaaaaaaaaaaaaa',
-                    }
-                )
-            },
+            {'body': test_event_body},
             {'body': json.dumps({'Records': (2,)})},
         ]
     }
@@ -198,6 +200,10 @@ def test_handler_skips_messages_without_records(pkg_created_event_mock, queue_ap
     assert pkg_created_event_mock.call_args_list == [((x,),) for x in range(3)]
     assert queue_append_mock.call_args_list == [((str(x),),) for x in range(3)]
     queue_flush_mock.assert_called_once_with()
+    # the skipped message is the only thing an operator can see, so pin that it's
+    # logged as-received -- not the parsed dict, whose repr isn't JSON
+    assert logger_mock.warning.call_count == 1
+    assert test_event_body in logger_mock.warning.call_args.args
 
 
 @pytest.mark.parametrize('failed_count', (0, 1))

--- a/lambdas/pkgevents/tests/test_index.py
+++ b/lambdas/pkgevents/tests/test_index.py
@@ -8,7 +8,6 @@ from botocore.stub import Stubber
 
 from t4_lambda_pkgevents import (
     EventsQueue,
-    PutEventsException,
     handler,
     pkg_created_event,
     s3,
@@ -146,37 +145,43 @@ def test_pkg_created_event(pointer_file):
         stubber.assert_no_pending_responses()
 
 
-@mock.patch("t4_lambda_pkgevents.EventsQueue.flush")
+@mock.patch("t4_lambda_pkgevents.EventsQueue.flush", return_value=set())
 @mock.patch("t4_lambda_pkgevents.EventsQueue.append")
 @mock.patch("t4_lambda_pkgevents.pkg_created_event", wraps=str)
 def test_handler(pkg_created_event_mock, queue_append_mock, queue_flush_mock):
     event = {
         'Records': [
             {
+                'messageId': f'message-{idx}',
                 'body': json.dumps(
                     {
                         'Records': records
                     }
                 )
             }
-            for records in (
-                (0, 1),
-                (2, 3, 4),
-                (5,)
+            for idx, records in enumerate(
+                (
+                    (0, 1),
+                    (2, 3, 4),
+                    (5,)
+                )
             )
         ]
     }
-    handler(event, None)
+    assert handler(event, None) == {'batchItemFailures': []}
     assert pkg_created_event_mock.call_args_list == [((x,),) for x in range(6)]
-    assert queue_append_mock.call_args_list == [((str(x),),) for x in range(6)]
+    assert queue_append_mock.call_args_list == [
+        ((str(x), f'message-{idx}'),)
+        for x, idx in zip(range(6), (0, 0, 1, 1, 1, 2), strict=True)
+    ]
     queue_flush_mock.assert_called_once_with()
 
 
 @mock.patch("t4_lambda_pkgevents.logger")
-@mock.patch("t4_lambda_pkgevents.EventsQueue.flush")
+@mock.patch("t4_lambda_pkgevents.EventsQueue.flush", return_value=set())
 @mock.patch("t4_lambda_pkgevents.EventsQueue.append")
 @mock.patch("t4_lambda_pkgevents.pkg_created_event", wraps=str)
-def test_handler_skips_messages_without_records(
+def test_handler_drops_test_events_silently(
     pkg_created_event_mock, queue_append_mock, queue_flush_mock, logger_mock
 ):
     test_event_body = json.dumps(
@@ -191,33 +196,104 @@ def test_handler_skips_messages_without_records(
     )
     event = {
         'Records': [
-            {'body': json.dumps({'Records': (0, 1)})},
-            {'body': test_event_body},
-            {'body': json.dumps({'Records': (2,)})},
+            {'messageId': 'message-0', 'body': json.dumps({'Records': (0, 1)})},
+            {'messageId': 'message-1', 'body': test_event_body},
+            {'messageId': 'message-2', 'body': json.dumps({'Records': (2,)})},
         ]
     }
-    handler(event, None)
+    assert handler(event, None) == {'batchItemFailures': []}
     assert pkg_created_event_mock.call_args_list == [((x,),) for x in range(3)]
-    assert queue_append_mock.call_args_list == [((str(x),),) for x in range(3)]
+    assert queue_append_mock.call_args_list == [
+        ((str(x), message_id),)
+        for x, message_id in zip(range(3), ('message-0', 'message-0', 'message-2'), strict=True)
+    ]
     queue_flush_mock.assert_called_once_with()
-    # the skipped message is the only thing an operator can see, so pin that it's
-    # logged as-received -- not the parsed dict, whose repr isn't JSON
-    assert logger_mock.warning.call_count == 1
-    assert test_event_body in logger_mock.warning.call_args.args
+    # a test event arrives on every bucket add, it must not be logged
+    logger_mock.warning.assert_not_called()
+    logger_mock.exception.assert_not_called()
 
 
-@pytest.mark.parametrize('failed_count', (0, 1))
-def test_queue(failed_count):
+@mock.patch("t4_lambda_pkgevents.EventsQueue.flush", return_value=set())
+@mock.patch("t4_lambda_pkgevents.EventsQueue.append")
+@mock.patch("t4_lambda_pkgevents.pkg_created_event", wraps=str)
+def test_handler_reports_messages_without_records_as_failed(
+    pkg_created_event_mock, queue_append_mock, queue_flush_mock
+):
+    event = {
+        'Records': [
+            {'messageId': 'message-0', 'body': json.dumps({'Records': (0,)})},
+            {'messageId': 'message-1', 'body': json.dumps({'Event': 'unexpected'})},
+        ]
+    }
+    assert handler(event, None) == {'batchItemFailures': [{'itemIdentifier': 'message-1'}]}
+    assert pkg_created_event_mock.call_args_list == [((0,),)]
+    assert queue_append_mock.call_args_list == [(('0', 'message-0'),)]
+    queue_flush_mock.assert_called_once_with()
+
+
+@mock.patch("t4_lambda_pkgevents.EventsQueue.flush", return_value=set())
+@mock.patch("t4_lambda_pkgevents.EventsQueue.append")
+@mock.patch("t4_lambda_pkgevents.pkg_created_event")
+def test_handler_reports_message_with_failing_event(
+    pkg_created_event_mock, queue_append_mock, queue_flush_mock
+):
+    pkg_created_event_mock.side_effect = (None, Exception('boom'), None)
+    event = {
+        'Records': [
+            # the event after the failing one must not be processed
+            {'messageId': 'message-0', 'body': json.dumps({'Records': (0, 1, 2)})},
+            {'messageId': 'message-1', 'body': json.dumps({'Records': (3,)})},
+        ]
+    }
+    assert handler(event, None) == {'batchItemFailures': [{'itemIdentifier': 'message-0'}]}
+    assert pkg_created_event_mock.call_args_list == [((x,),) for x in (0, 1, 3)]
+    queue_append_mock.assert_not_called()
+    queue_flush_mock.assert_called_once_with()
+
+
+@mock.patch("t4_lambda_pkgevents.EventsQueue.flush", return_value={'message-0'})
+@mock.patch("t4_lambda_pkgevents.EventsQueue.append")
+@mock.patch("t4_lambda_pkgevents.pkg_created_event", wraps=str)
+def test_handler_reports_publish_failures(
+    pkg_created_event_mock, queue_append_mock, queue_flush_mock
+):
+    event = {
+        'Records': [
+            {'messageId': 'message-0', 'body': json.dumps({'Records': (0,)})},
+        ]
+    }
+    assert handler(event, None) == {'batchItemFailures': [{'itemIdentifier': 'message-0'}]}
+
+
+def test_queue_success():
     with mock.patch("t4_lambda_pkgevents.event_bridge.put_events") as put_events_mock:
-        put_events_mock.return_value = {'FailedEntryCount': failed_count}
+        put_events_mock.return_value = {'FailedEntryCount': 0}
         q = EventsQueue()
         for x in range(EventsQueue.MAX_SIZE - 1):
-            q.append(x)
+            q.append(x, f'message-{x}')
             put_events_mock.assert_not_called()
 
-        if failed_count:
-            with pytest.raises(PutEventsException):
-                q.append(EventsQueue.MAX_SIZE - 1)
-        else:
-            q.append(EventsQueue.MAX_SIZE - 1)
-            put_events_mock.assert_called_once_with(Entries=list(range(EventsQueue.MAX_SIZE)))
+        q.append(EventsQueue.MAX_SIZE - 1, 'message-9')
+        put_events_mock.assert_called_once_with(Entries=list(range(EventsQueue.MAX_SIZE)))
+        assert q.flush() == set()
+        put_events_mock.assert_called_once()
+
+
+def test_queue_failed_entries():
+    with mock.patch("t4_lambda_pkgevents.event_bridge.put_events") as put_events_mock:
+        first_entries = [{'EventId': str(x)} for x in range(EventsQueue.MAX_SIZE)]
+        first_entries[3] = {'ErrorCode': 'ThrottlingException', 'ErrorMessage': 'try later'}
+        put_events_mock.side_effect = (
+            {'FailedEntryCount': 1, 'Entries': first_entries},
+            {
+                'FailedEntryCount': 1,
+                'Entries': [{'ErrorCode': 'InternalFailure', 'ErrorMessage': 'oops'}],
+            },
+        )
+        q = EventsQueue()
+        for x in range(EventsQueue.MAX_SIZE + 1):
+            q.append(x, f'message-{x}')
+
+        # failures accumulate across flushes
+        assert q.flush() == {'message-3', f'message-{EventsQueue.MAX_SIZE}'}
+        assert put_events_mock.call_count == 2

--- a/lambdas/pkgevents/tests/test_index.py
+++ b/lambdas/pkgevents/tests/test_index.py
@@ -7,9 +7,10 @@ import pytest
 from botocore.stub import Stubber
 
 from t4_lambda_pkgevents import (
-    EventsQueue,
+    PUT_EVENTS_MAX_ENTRIES,
     handler,
     pkg_created_event,
+    publish,
     s3,
 )
 
@@ -145,10 +146,9 @@ def test_pkg_created_event(pointer_file):
         stubber.assert_no_pending_responses()
 
 
-@mock.patch("t4_lambda_pkgevents.EventsQueue.flush", return_value=frozenset())
-@mock.patch("t4_lambda_pkgevents.EventsQueue.append")
+@mock.patch("t4_lambda_pkgevents.publish", return_value=frozenset())
 @mock.patch("t4_lambda_pkgevents.pkg_created_event", wraps=str)
-def test_handler(pkg_created_event_mock, queue_append_mock, queue_flush_mock):
+def test_handler(pkg_created_event_mock, publish_mock):
     event = {
         'Records': [
             {
@@ -170,19 +170,19 @@ def test_handler(pkg_created_event_mock, queue_append_mock, queue_flush_mock):
     }
     assert handler(event, None) == {'batchItemFailures': []}
     assert pkg_created_event_mock.call_args_list == [((x,),) for x in range(6)]
-    assert queue_append_mock.call_args_list == [
-        ((str(x), f'message-{idx}'),)
-        for x, idx in zip(range(6), (0, 0, 1, 1, 1, 2), strict=True)
-    ]
-    queue_flush_mock.assert_called_once_with()
+    publish_mock.assert_called_once_with(
+        [
+            (f'message-{idx}', str(x))
+            for x, idx in zip(range(6), (0, 0, 1, 1, 1, 2), strict=True)
+        ]
+    )
 
 
 @mock.patch("t4_lambda_pkgevents.logger")
-@mock.patch("t4_lambda_pkgevents.EventsQueue.flush", return_value=frozenset())
-@mock.patch("t4_lambda_pkgevents.EventsQueue.append")
+@mock.patch("t4_lambda_pkgevents.publish", return_value=frozenset())
 @mock.patch("t4_lambda_pkgevents.pkg_created_event", wraps=str)
 def test_handler_drops_test_events_silently(
-    pkg_created_event_mock, queue_append_mock, queue_flush_mock, logger_mock
+    pkg_created_event_mock, publish_mock, logger_mock
 ):
     test_event_body = json.dumps(
         {
@@ -203,11 +203,12 @@ def test_handler_drops_test_events_silently(
     }
     assert handler(event, None) == {'batchItemFailures': []}
     assert pkg_created_event_mock.call_args_list == [((x,),) for x in range(3)]
-    assert queue_append_mock.call_args_list == [
-        ((str(x), message_id),)
-        for x, message_id in zip(range(3), ('message-0', 'message-0', 'message-2'), strict=True)
-    ]
-    queue_flush_mock.assert_called_once_with()
+    publish_mock.assert_called_once_with(
+        [
+            (message_id, str(x))
+            for x, message_id in zip(range(3), ('message-0', 'message-0', 'message-2'), strict=True)
+        ]
+    )
     # a test event arrives on every bucket add, it must not be logged
     logger_mock.warning.assert_not_called()
     logger_mock.exception.assert_not_called()
@@ -223,11 +224,10 @@ def test_handler_drops_test_events_silently(
         '"s3:TestEvent"',
     ),
 )
-@mock.patch("t4_lambda_pkgevents.EventsQueue.flush", return_value=frozenset())
-@mock.patch("t4_lambda_pkgevents.EventsQueue.append")
+@mock.patch("t4_lambda_pkgevents.publish", return_value=frozenset())
 @mock.patch("t4_lambda_pkgevents.pkg_created_event", wraps=str)
 def test_handler_reports_messages_without_records_as_failed(
-    pkg_created_event_mock, queue_append_mock, queue_flush_mock, bad_body
+    pkg_created_event_mock, publish_mock, bad_body
 ):
     event = {
         'Records': [
@@ -237,15 +237,13 @@ def test_handler_reports_messages_without_records_as_failed(
     }
     assert handler(event, None) == {'batchItemFailures': [{'itemIdentifier': 'message-1'}]}
     assert pkg_created_event_mock.call_args_list == [((0,),)]
-    assert queue_append_mock.call_args_list == [(('0', 'message-0'),)]
-    queue_flush_mock.assert_called_once_with()
+    publish_mock.assert_called_once_with([('message-0', '0')])
 
 
-@mock.patch("t4_lambda_pkgevents.EventsQueue.flush", return_value=frozenset())
-@mock.patch("t4_lambda_pkgevents.EventsQueue.append")
+@mock.patch("t4_lambda_pkgevents.publish", return_value=frozenset())
 @mock.patch("t4_lambda_pkgevents.pkg_created_event")
 def test_handler_reports_message_with_failing_event(
-    pkg_created_event_mock, queue_append_mock, queue_flush_mock
+    pkg_created_event_mock, publish_mock
 ):
     pkg_created_event_mock.side_effect = (None, Exception('boom'), None)
     event = {
@@ -257,15 +255,13 @@ def test_handler_reports_message_with_failing_event(
     }
     assert handler(event, None) == {'batchItemFailures': [{'itemIdentifier': 'message-0'}]}
     assert pkg_created_event_mock.call_args_list == [((x,),) for x in (0, 1, 3)]
-    queue_append_mock.assert_not_called()
-    queue_flush_mock.assert_called_once_with()
+    publish_mock.assert_called_once_with([])
 
 
-@mock.patch("t4_lambda_pkgevents.EventsQueue.flush", return_value=frozenset({'message-0'}))
-@mock.patch("t4_lambda_pkgevents.EventsQueue.append")
+@mock.patch("t4_lambda_pkgevents.publish", return_value=frozenset({'message-0'}))
 @mock.patch("t4_lambda_pkgevents.pkg_created_event", wraps=str)
 def test_handler_reports_publish_failures(
-    pkg_created_event_mock, queue_append_mock, queue_flush_mock
+    pkg_created_event_mock, publish_mock
 ):
     event = {
         'Records': [
@@ -275,23 +271,27 @@ def test_handler_reports_publish_failures(
     assert handler(event, None) == {'batchItemFailures': [{'itemIdentifier': 'message-0'}]}
 
 
-def test_queue_success():
+def test_publish_success():
     with mock.patch("t4_lambda_pkgevents.event_bridge.put_events") as put_events_mock:
         put_events_mock.return_value = {'FailedEntryCount': 0}
-        q = EventsQueue()
-        for x in range(EventsQueue.MAX_SIZE - 1):
-            q.append(x, f'message-{x}')
-            put_events_mock.assert_not_called()
+        entries = [(f'message-{x}', x) for x in range(PUT_EVENTS_MAX_ENTRIES + 1)]
 
-        q.append(EventsQueue.MAX_SIZE - 1, 'message-9')
-        put_events_mock.assert_called_once_with(Entries=list(range(EventsQueue.MAX_SIZE)))
-        assert q.flush() == set()
-        put_events_mock.assert_called_once()
+        assert publish(entries) == set()
+        assert put_events_mock.call_args_list == [
+            mock.call(Entries=list(range(PUT_EVENTS_MAX_ENTRIES))),
+            mock.call(Entries=[PUT_EVENTS_MAX_ENTRIES]),
+        ]
 
 
-def test_queue_failed_entries():
+def test_publish_nothing():
     with mock.patch("t4_lambda_pkgevents.event_bridge.put_events") as put_events_mock:
-        first_entries = [{'EventId': str(x)} for x in range(EventsQueue.MAX_SIZE)]
+        assert publish([]) == set()
+        put_events_mock.assert_not_called()
+
+
+def test_publish_failed_entries():
+    with mock.patch("t4_lambda_pkgevents.event_bridge.put_events") as put_events_mock:
+        first_entries = [{'EventId': str(x)} for x in range(PUT_EVENTS_MAX_ENTRIES)]
         first_entries[3] = {'ErrorCode': 'ThrottlingException', 'ErrorMessage': 'try later'}
         put_events_mock.side_effect = (
             {'FailedEntryCount': 1, 'Entries': first_entries},
@@ -300,10 +300,7 @@ def test_queue_failed_entries():
                 'Entries': [{'ErrorCode': 'InternalFailure', 'ErrorMessage': 'oops'}],
             },
         )
-        q = EventsQueue()
-        for x in range(EventsQueue.MAX_SIZE + 1):
-            q.append(x, f'message-{x}')
+        entries = [(f'message-{x}', x) for x in range(PUT_EVENTS_MAX_ENTRIES + 1)]
 
-        # failures accumulate across flushes
-        assert q.flush() == {'message-3', f'message-{EventsQueue.MAX_SIZE}'}
+        assert publish(entries) == {'message-3', f'message-{PUT_EVENTS_MAX_ENTRIES}'}
         assert put_events_mock.call_count == 2

--- a/lambdas/pkgevents/tests/test_index.py
+++ b/lambdas/pkgevents/tests/test_index.py
@@ -213,16 +213,26 @@ def test_handler_drops_test_events_silently(
     logger_mock.exception.assert_not_called()
 
 
+@pytest.mark.parametrize(
+    'bad_body',
+    (
+        json.dumps({'Event': 'unexpected'}),
+        'not JSON',
+        'null',
+        '[]',
+        '"s3:TestEvent"',
+    ),
+)
 @mock.patch("t4_lambda_pkgevents.EventsQueue.flush", return_value=frozenset())
 @mock.patch("t4_lambda_pkgevents.EventsQueue.append")
 @mock.patch("t4_lambda_pkgevents.pkg_created_event", wraps=str)
 def test_handler_reports_messages_without_records_as_failed(
-    pkg_created_event_mock, queue_append_mock, queue_flush_mock
+    pkg_created_event_mock, queue_append_mock, queue_flush_mock, bad_body
 ):
     event = {
         'Records': [
             {'messageId': 'message-0', 'body': json.dumps({'Records': (0,)})},
-            {'messageId': 'message-1', 'body': json.dumps({'Event': 'unexpected'})},
+            {'messageId': 'message-1', 'body': bad_body},
         ]
     }
     assert handler(event, None) == {'batchItemFailures': [{'itemIdentifier': 'message-1'}]}


### PR DESCRIPTION
# Description

The `pkgevents` lambda crashed with `KeyError: 'Records'` on `s3:TestEvent`, which S3 delivers whenever a bucket's notification configuration is created — i.e. on every bucket add. Because the S3 events were pulled lazily inside `itertools.chain.from_iterable`, that crash aborted the *whole* SQS batch: real `package-revision` events co-batched with the test event were retried and then dead-lettered, so EventBridge subscribers silently missed those package revisions.

`s3:TestEvent` messages are now dropped silently: they arrive on every bucket add, so a warning there would be 100% noise. `indexer` already guards against them and the inline S3→EventBridge lambda in the CloudFormation template was fixed separately, so `pkgevents` was the last S3-notification consumer without the guard.

Any other message without `Records` (including bodies that aren't valid JSON objects at all — S3 is the expected producer on this queue, not the only possible one) — plus per-event processing errors and entries rejected by `put_events` — is now reported via `ReportBatchItemFailures`, so only the affected messages are retried and eventually dead-lettered while the rest of the batch completes. Skipping such a message would delete it permanently; failing it keeps the payload recoverable in the DLQ, which also makes the previous log-the-whole-body warning redundant. When an error can't be attributed to specific messages (e.g. the `put_events` call itself fails), the handler still raises and fails the whole batch, because anything missing from `batchItemFailures` is treated as processed and deleted. Retries are message-grained, so a message whose events straddle a `put_events` batch boundary can republish a few events on retry — accepted, and strictly less duplication than today's whole-batch retry.

The new return value is inert until the SQS event source mapping sets `FunctionResponseTypes=["ReportBatchItemFailures"]`; a paired deployment-side change adds that flag, so the two changes can ship in either order.

Observed on an internal deployment: 30 errors / 2443 invocations over 7 days, with a matching `s3:TestEvent` message sitting in the lambda's DLQ. Not a regression — the crashing line is unchanged since #2074 (2021).

# TODO

- [x] Unit tests

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Updates the pkgevents Lambda to isolate SQS message failures while silently discarding S3 test notifications.
- Parses and processes each SQS message independently.
- Reports malformed messages, processing errors, and EventBridge entry failures through `batchItemFailures`.
- Adds coverage for test events, malformed payloads, per-message processing failures, EventBridge partial failures, and batching.

<h3>Confidence Score: 5/5</h3>

This follow-up appears safe to merge.

No blocking failure remains.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| lambdas/pkgevents/src/t4_lambda_pkgevents/__init__.py | Replaces whole-batch failure handling with per-message parsing, EventBridge failure attribution, and an SQS partial-batch response. |
| lambdas/pkgevents/tests/test_index.py | Expands tests to cover S3 test events, malformed messages, processing exceptions, partial EventBridge failures, and API-sized batches. |
| lambdas/pkgevents/CHANGELOG.md | Documents the corrected S3 test-event and partial-batch behavior. |

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
  participant S3
  participant SQS
  participant Lambda as pkgevents
  participant EB as EventBridge
  S3->>SQS: Notification message
  SQS->>Lambda: Batched records
  alt s3:TestEvent
    Lambda-->>Lambda: Drop silently
  else Valid package event
    Lambda->>EB: PutEvents (up to 10 entries)
    EB-->>Lambda: Per-entry results
  else Invalid or processing failure
    Lambda-->>Lambda: Record messageId as failed
  end
  Lambda-->>SQS: batchItemFailures
```

<sub>Reviews (5): Last reviewed commit: ["pkgevents: drop EventsQueue for buffer-t..."](https://github.com/quiltdata/quilt/commit/c42537e6a4440dafc7533653fb1b57d1e27d7352) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=48693644)</sub>

**Context used:**

- Knowledge Base — [Package events and push lambdas (pkgevents, pkgpush)](https://app.greptile.com/quilt-bio/-/custom-context/knowledge-base/quiltdata/quilt/-/docs/lambdas-package-events-push.md)

<!-- /greptile_comment -->