### PR TITLE
Quilt3 v8.0.0

### DIFF
--- a/api/python/pyproject.toml
+++ b/api/python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "uv_build"
 
 [project]
 name = "quilt3"
-version = "7.3.0"
+version = "8.0.0"
 description = "Quilt: where data comes together"
 readme = "README.rst"
 requires-python = ">=3.10"

--- a/api/python/uv.lock
+++ b/api/python/uv.lock
@@ -2969,7 +2969,7 @@ wheels = [
 
 [[package]]
 name = "quilt3"
-version = "7.3.0"
+version = "8.0.0"
 source = { editable = "." }
 dependencies = [
     { name = "awscrt" },

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -16,7 +16,7 @@ Entries inside each section should be ordered by type:
 
 # Changelog
 
-## unreleased - YYYY-MM-DD
+## 8.0.0 - 2026-08-04
 
 ### Python API
 

--- a/gendocs/uv.lock
+++ b/gendocs/uv.lock
@@ -617,7 +617,7 @@ wheels = [
 
 [[package]]
 name = "quilt3"
-version = "7.3.0"
+version = "8.0.0"
 source = { editable = "../api/python" }
 dependencies = [
     { name = "awscrt" },

--- a/testdocs/uv.lock
+++ b/testdocs/uv.lock
@@ -441,7 +441,7 @@ wheels = [
 
 [[package]]
 name = "quilt3"
-version = "7.3.0"
+version = "8.0.0"
 source = { editable = "../api/python" }
 dependencies = [
     { name = "awscrt" },


### PR DESCRIPTION
# Description

Release `quilt3` 8.0.0 — version bump plus the release date for the CHANGELOG entries queued since 7.3.0.

Major rather than minor because the queued changes drop Python 3.9 (EOL). `requires-python` already pins `>=3.10`, so a 3.9 user's resolver holds them at 7.3.0 either way; the major makes the break explicit rather than implicit in resolver behavior.

The CHANGELOG has the full list. The reason for cutting now is that it includes two silent data-loss fixes — `delete_package()` on a local registry deleting other packages that share its namespace, and `Bucket.delete_dir()` stopping partway on zero-byte directory markers — plus `Package.push()` no longer failing after the data is uploaded during temp-file cleanup, and no longer breaking inside prefork workers.

Verified against the built wheel before tagging: clean-venv install and import on 3.14 (confirming the workflow JSON schema ships in the wheel), `typing.get_type_hints()` over all 71 public `quilt3.admin` callables, and a live push / `delete_dir` / `delete_package` smoke on a dev stack. The three delete-and-cleanup fixes each pass on this branch and each fail on released 7.3.0, so the smoke discriminates rather than just passing.

Note for after publish: the in-repo lambdas constrain `quilt3 >= 7, < 8`, so none of them pick up 8.0.0 until those constraints are widened. That is a separate follow-up — it can only land once 8.0.0 exists on PyPI.

# TODO

- [x] [Changelog](../tree/master/docs/CHANGELOG.md) entry (skip if change is not significant to end users, e.g. docs only)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR prepares the Quilt Python SDK 8.0.0 release.
- Updates the project version from 7.3.0 to 8.0.0.
- Synchronizes the editable Quilt package version across the API and documentation lockfiles.
- Finalizes the changelog heading with version 8.0.0 and the 2026-08-04 release date.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge because its release metadata is internally consistent and introduces no dependency-resolution or runtime behavior changes.

The project manifest, all three affected lockfiles, and the changelog consistently identify quilt3 8.0.0, while every third-party dependency remains unchanged from the base branch.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| api/python/pyproject.toml | Updates the published quilt3 project version to 8.0.0 while retaining the existing Python 3.10 minimum. |
| api/python/uv.lock | Synchronizes the editable quilt3 lock entry to 8.0.0 without changing dependency resolution. |
| docs/CHANGELOG.md | Converts the queued unreleased section into the dated 8.0.0 release entry. |
| gendocs/uv.lock | Synchronizes the documentation generator's editable quilt3 entry to 8.0.0. |
| testdocs/uv.lock | Synchronizes the documentation test environment's editable quilt3 entry to 8.0.0. |

<sub>Reviews (1): Last reviewed commit: ["Quilt3 v8.0.0"](https://github.com/quiltdata/quilt/commit/56226fa3d4f2dd70e1fcf92acd872862b13335c4) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=50107660)</sub>

<!-- /greptile_comment -->