### PR TITLE
docs: list quilt3.admin under the Python SDK API Reference

### DIFF
--- a/docs/SUMMARY.md
+++ b/docs/SUMMARY.md
@@ -60,6 +60,7 @@
   * [quilt3.Package](api-reference/Package.md)
   * [quilt3.Bucket](api-reference/Bucket.md)
   * [quilt3.hooks](api-reference/Hooks.md)
+  * [quilt3.admin](api-reference/Admin.md)
   * [Local Catalog](Catalog/LocalMode.md)
   * [CLI, Environment](api-reference/cli.md)
   * [Known Limitations](api-reference/limitations.md)


### PR DESCRIPTION
# Description

`docs/api-reference/Admin.md` (the generated `quilt3.admin` reference) is linked from `SUMMARY.md` only under **Quilt Platform Administrator**. The **Quilt Python SDK → API Reference** group lists `quilt3`, `quilt3.Package`, `quilt3.Bucket` and `quilt3.hooks`, but not `quilt3.admin` — so a reader browsing the SDK's API reference has no path to the admin API, and the site's own front page advertises API docs only under the SDK.

This adds the missing entry alongside the other generated module references. The page keeps its existing URL; listing a file in two places is already how `Catalog/MCP-Server.md` is handled in this table of contents.

Note that the page's published URL is `/quilt-platform-administrator/admin-1` — GitBook derives the slug from the filename, and `Catalog/Admin.md` ("Admin Settings UI") already claims `/quilt-platform-administrator/admin` in the same section, so this one gets the de-duplicating `-1` suffix. That slug isn't controllable from the repo (`.gitbook.yaml` supports only `root`, `structure` and `redirects`), so it's left alone here; navigation is the part that can be fixed in git.

# TODO

<!-- Remove items that are irrelevant to this PR -->

- [ ] Documentation
    - [x] Markdown somewhere in docs/**/*.md that explains the feature to end users (said .md files should be linked from SUMMARY.md so they appear on https://docs.quilt.bio)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds the existing `quilt3.admin` API reference to the Quilt Python SDK navigation.
- Links `api-reference/Admin.md` alongside the other generated SDK module references.
- Keeps the existing administrator-section entry and published page URL unchanged.

<h3>Confidence Score: 5/5</h3>

The documentation-only change appears safe to merge.

The added navigation target exists with matching path and case, and the repository evidence reveals no documentation contract or validation rule violated by listing it in both relevant sections.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| docs/SUMMARY.md | Adds a valid navigation link to an existing API reference page; no actionable issue identified. |

<sub>Reviews (1): Last reviewed commit: ["docs: list quilt3.admin under the Python..."](https://github.com/quiltdata/quilt/commit/c2402561ff0825aa60855b04941100ef474cf089) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=50451363)</sub>

<!-- /greptile_comment -->