### PR TITLE
docs: move quilt3.admin into the SDK API Reference nav

### DIFF
--- a/docs/Catalog/Admin.md
+++ b/docs/Catalog/Admin.md
@@ -11,6 +11,9 @@ through the panel. Only admins may create other admins.
 
 Quilt requires at least one admin account per stack.
 
+Many of the settings below can also be managed programmatically with the
+[`quilt3.admin` Python API](../api-reference/Admin.md).
+
 
 ## Users and roles
 

--- a/docs/SUMMARY.md
+++ b/docs/SUMMARY.md
@@ -32,7 +32,6 @@
 * [Quilt Connect Server](Catalog/Connect.md)
 * [Cross-Account Access](CrossAccount.md)
 * [Enterprise Installs](technical-reference.md)
-* [quilt3.admin Python API](api-reference/Admin.md)
 * **Advanced**
   * [Package Events](advanced-features/package-events.md)
   * [Private Endpoints](advanced-features/private-endpoint-access.md)


### PR DESCRIPTION
# Description

Follow-up to #5169, which did not have the intended effect.

GitBook renders **one page per file**. When `SUMMARY.md` references the same file from two places, only the first occurrence becomes a page and the second is dropped without warning. #5169 added `api-reference/Admin.md` to the SDK's **API Reference** group while it was still listed under **Quilt Platform Administrator**, so the new entry never rendered.

The same thing is already happening to `Catalog/MCP-Server.md`, which is listed under both **Quilt Platform (Catalog) User** and **Quilt Ecosystem Integrations**: it renders at `/quilt-platform-catalog-user/mcp-server` and is absent from the Ecosystem Integrations nav. That one is left alone here — where the MCP Server page belongs is a separate editorial call — but it is the same defect.

This PR moves the entry rather than duplicating it: `quilt3.admin` is listed once, in the API Reference group alongside the other pydocmd-generated module references (`quilt3`, `quilt3.Package`, `quilt3.Bucket`, `quilt3.hooks`), and `Catalog/Admin.md` ("Admin Settings UI") gains a prose link so administrators still have a path to it.

Two side effects worth noting:

- The page moves off the `/quilt-platform-administrator/admin-1` slug. It only had the deduplicating `-1` suffix because `Catalog/Admin.md` already occupied `.../admin` in that same section; under the API Reference group the name is unclaimed. Anyone with the old URL bookmarked will need the new one.
- Existing in-repo links (`Quickstart.md`, `CrossAccount.md`, `advanced-features/tabulator.md`) are relative links to the file, so GitBook rewrites them to the new location automatically. No repo link needs updating, and there are no hardcoded `/admin-1` URLs in the tree.

# TODO

<!-- Remove items that are irrelevant to this PR -->

- [ ] Documentation
    - [x] Markdown somewhere in docs/**/*.md that explains the feature to end users (said .md files should be linked from SUMMARY.md so they appear on https://docs.quilt.bio)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Moves the `quilt3.admin` page from the administrator navigation into the Python SDK API Reference, ensuring it appears only once in `SUMMARY.md`.
- Adds a link from the Admin Settings UI guide to the Python API reference.
- Groups `quilt3.admin` with the other generated SDK module references.

<h3>Confidence Score: 5/5</h3>

The documentation-only change appears safe to merge.

The target API reference exists, the new relative link follows established documentation conventions, and the navigation entry matches its sibling API reference entries without leaving a duplicate.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| docs/Catalog/Admin.md | Adds a valid relative link from the administrator UI guide to the existing `quilt3.admin` API reference. |
| docs/SUMMARY.md | Relocates the single `quilt3.admin` navigation entry into the SDK API Reference group without changing its target file. |

<sub>Reviews (1): Last reviewed commit: ["docs: move quilt3.admin into the SDK API..."](https://github.com/quiltdata/quilt/commit/443c20d8c9721aeeb7f54f2b9f77d80489784ee8) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=50461147)</sub>

<!-- /greptile_comment -->