### PR TITLE
fix(landing): give the volume list an h1, and the canaries a stable anchor

### DIFF
--- a/catalog/app/containers/Home/Buckets/Buckets.jsx
+++ b/catalog/app/containers/Home/Buckets/Buckets.jsx
@@ -587,6 +587,26 @@ export default function Buckets() {
   return (
     <M.Container maxWidth={false} disableGutters className={classes.container}>
       <div className={classes.wrapper} ref={scrollRef}>
+        {/* The page's h1, sized as an h5 -- same treatment FrontDoor's greeting
+            uses, per DESIGN.md's No-Display-Font Rule (nothing outranks a
+            Headline). The predecessor heading here was a `variant="h1"` display
+            size on the old marketing-style landing; it does not come back at
+            that weight.
+
+            `data-testid` is the end-to-end canaries' "login landed" signal
+            (quiltdata/e2e `shared/auth.ts`, `waitForHomePage`). They used to key
+            off the literal string "Explore your buckets" and went red the moment
+            it was dropped. The same hook is on FrontDoor's h1, so the check holds
+            whichever side of the `front-door` flag a stack is on, and the visible
+            words stay free to change. */}
+        <M.Typography
+          variant="h5"
+          component="h1"
+          color="textPrimary"
+          data-testid="landing-heading"
+        >
+          Volumes
+        </M.Typography>
         <div className={classes.filterRow}>
           <M.TextField
             className={classes.filter}

--- a/catalog/app/containers/Home/Buckets/Buckets.spec.tsx
+++ b/catalog/app/containers/Home/Buckets/Buckets.spec.tsx
@@ -151,6 +151,38 @@ describe('website/pages/Landing/Buckets', () => {
     expect(queryByText('bucket:bucket-one')).toBeTruthy()
   })
 
+  // This page is what `/` renders whenever the `front-door` flag is off, so it
+  // is the catalog's landing page for most stacks -- and it had no `h1` at all.
+  // Two things went wrong at once when the old `Explore your buckets` heading
+  // was dropped in the shell re-home: a page with no top-level heading is a
+  // WCAG 1.3.1 / 2.4.6 failure for anyone navigating by heading, and the
+  // end-to-end canaries used that heading as their "login landed" signal
+  // (quiltdata/e2e `shared/auth.ts`, `waitForHomePage`), so all four went red
+  // on deploy. Nothing in this spec asserted a heading, which is why neither
+  // was caught here.
+  it('gives the page a top-level heading, as an h1 sized to the ramp', () => {
+    const { getByRole } = renderBuckets()
+
+    const heading = getByRole('heading', { level: 1, name: 'Volumes' })
+    expect(heading).toBeTruthy()
+    // Semantically the page's h1; visually an h5. DESIGN.md's No-Display-Font
+    // Rule caps the app at Headline, so this must not come back as the old
+    // `variant="h1"` display size.
+    expect(heading.classList.contains('MuiTypography-h5')).toBe(true)
+  })
+
+  // A `data-testid` rather than the heading text, because the text is a product
+  // decision that has already moved twice ("Explore your buckets" -> nothing,
+  // "Volumes" <-> "Buckets"), while the canary only needs to know the landing
+  // page rendered. FrontDoor.tsx carries the same hook, so `waitForHomePage`
+  // works whichever side of the `front-door` flag a stack is on.
+  it('marks the heading as the landing-page anchor the canaries wait on', () => {
+    const { getByTestId } = renderBuckets()
+
+    const anchor = getByTestId('landing-heading')
+    expect(anchor.tagName).toBe('H1')
+  })
+
   it('treats a signed-out (null) me as not-admin instead of crashing', () => {
     // Reachable anonymously: this is the same component OpenLanding mounts,
     // and OPEN mode allows unauthenticated visitors.

--- a/catalog/app/website/pages/Landing/FrontDoor/FrontDoor.fallback.spec.tsx
+++ b/catalog/app/website/pages/Landing/FrontDoor/FrontDoor.fallback.spec.tsx
@@ -79,6 +79,19 @@ describe('website/pages/Landing/FrontDoor page-level fallback', () => {
     expect(queryByText('This page could not be loaded')).toBeTruthy()
   })
 
+  // The fallback has an `h1` of its own, and it must not wear the canaries'
+  // landing-page hook. `waitForHomePage` (quiltdata/e2e `shared/auth.ts`) treats
+  // that hook as "login landed on a working page"; if the error state carried it,
+  // a front door that failed to render would report as a healthy login and the
+  // canaries would go green on a broken catalog. The whole point of a synthetic
+  // check is that it cannot be satisfied by the failure it exists to catch.
+  it('does not claim the landing-page anchor for its error state', () => {
+    const { queryByTestId, queryByText } = renderFailingPage()
+
+    expect(queryByText('This page could not be loaded')).toBeTruthy()
+    expect(queryByTestId('landing-heading')).toBeNull()
+  })
+
   it('does not re-enter the data path that failed', () => {
     renderFailingPage()
     // The whole point. A fallback that reads the same GraphQL as the page it is

--- a/catalog/app/website/pages/Landing/FrontDoor/FrontDoor.spec.tsx
+++ b/catalog/app/website/pages/Landing/FrontDoor/FrontDoor.spec.tsx
@@ -46,6 +46,19 @@ describe('website/pages/Landing/FrontDoor/FrontDoor', () => {
     expect(getByText('Unified bar')).toBeTruthy()
   })
 
+  // The end-to-end canaries wait on this hook to know login landed on a working
+  // landing page (quiltdata/e2e `shared/auth.ts`, `waitForHomePage`). The volume
+  // list carries the same one, so the check does not care which side of the
+  // `front-door` flag a stack is on -- and neither page's visible wording is
+  // pinned by it, which is what broke last time.
+  it('marks the greeting as the landing-page anchor the canaries wait on', () => {
+    const { getByTestId } = render(<FrontDoor />)
+
+    const anchor = getByTestId('landing-heading')
+    expect(anchor.tagName).toBe('H1')
+    expect(anchor.textContent).toBe('What are you looking for?')
+  })
+
   it('collapses a single failing tile without removing the rest of the page', () => {
     const { getByText } = render(
       <div>

--- a/catalog/app/website/pages/Landing/FrontDoor/FrontDoor.tsx
+++ b/catalog/app/website/pages/Landing/FrontDoor/FrontDoor.tsx
@@ -258,12 +258,21 @@ export function FrontDoorContent() {
       <M.Collapse in={!active}>
         <div className={classes.greeting}>
           {/* The page's h1, sized as an h5: a working page heading, not a
-              marketing hero. */}
+              marketing hero.
+
+              `data-testid` is the canaries' "login landed" signal, matching the
+              volume list's h1 so `waitForHomePage` (quiltdata/e2e
+              `shared/auth.ts`) resolves whichever side of the `front-door` flag
+              a stack is on. Deliberately *not* on `PageFallback`'s h1 above: that
+              one means the front door failed to render, and a canary that
+              accepted it would report a broken landing page as a successful
+              login. */}
           <M.Typography
             variant="h5"
             component="h1"
             color="textPrimary"
             className={classes.greetingTitle}
+            data-testid="landing-heading"
           >
             What are you looking for?
           </M.Typography>


### PR DESCRIPTION
Nightly's canaries have been red since deployment#2599 pinned the catalog to
#5189. Root cause is a missing page heading, which is also a real a11y defect.

## What broke

All four canaries (`stage-ctlg-uri`, `-bucket-ac`, `-search`, `-pkg-create`)
fail identically at `serviceLogin`, in shared code at quiltdata/e2e
`shared/auth.ts:55`:

```ts
await page.waitForSelector('xpath/.//h1[contains(., "Explore your buckets")]')
```

That is `waitForHomePage`, which every canary calls after login — one selector,
four failures.

The heading is gone. It lived in `website/pages/Landing/Buckets/Buckets.jsx:155`;
the shell re-home replaced that page with `containers/Home/Buckets`, whose
outermost element is a bare `M.Container` with **no `h1` anywhere**. Nightly has
`front-door` **off** (`settings.json` is `{"beta": true}`), so `/` renders that
volume list.

Timing is unambiguous:

| | |
|---|---|
| Last PASSED | 14:27:58Z |
| deployment#2599 applied | ~15:18Z |
| First FAILED | 15:27:58Z |
| Stack | `26.7.1-26-g883e70ab`, catalog `0ce2dfb3` (= #5189) |

The artifacts confirm the page itself is healthy: `executionStatus: SUCCEEDED`,
only the `serviceLogin` step FAILED, and the HTTP report has **zero 4xx/5xx**.
Login works, the page loads, the string the canary waits for no longer exists.

For the record: the heading was removed by the shell-re-home commits
(`f481766e`, `934bbbb0`, `84b75500`), not by the front door. #5189 is what
carried them to `master`.

## The fix

**A real `h1` on the volume list.** Worth doing on its own merits — a landing
page with no top-level heading is a WCAG 1.3.1 / 2.4.6 failure for anyone
navigating by heading, and `Buckets.spec.tsx` asserted no heading, which is why
nothing caught it here.

It returns as `variant="h5" component="h1"` reading **Volumes**, matching
FrontDoor's greeting: semantically the page's h1, visually a Headline. It does
*not* come back at the old `variant="h1"` display size — DESIGN.md's
**No-Display-Font Rule** now forbids that.

**A `data-testid="landing-heading"` on both landing headings**, so the canary
keys off a hook instead of the words. The wording here has already moved three
times ("Explore your buckets" → nothing, "Volumes" ↔ "Buckets"); a synthetic
check should not be the thing that pins a product decision. Carrying it on both
pages means `waitForHomePage` works whichever side of the `front-door` flag a
stack is on.

Deliberately **not** on `PageFallback`'s `h1`: that one means the front door
failed to render, and a canary that accepted it would report a broken catalog as
a healthy login. A synthetic check must not be satisfiable by the failure it
exists to catch. There is a test pinning that.

## Sequencing — please merge this before the e2e change

The canary fix in quiltdata/e2e must land *after* this is deployed to nightly,
or the selector will wait on a hook that isn't in the bundle yet. Order:

1. Merge this
2. Bump the catalog pin in deployment (nightly)
3. Merge the e2e selector change

Canaries stay red until step 3. They are already red, so this does not make
anything worse — but it does mean the red isn't cleared by this PR alone.

## Verification

- `Buckets.spec.tsx`: heading level + anchor, both written failing-first
- `FrontDoor.spec.tsx`: greeting carries the anchor
- `FrontDoor.fallback.spec.tsx`: error state does *not* carry it
- **Mutation-tested** — each of these fails as it should: dropping the anchor,
  restoring `variant="h1"`, moving the anchor onto the fallback
- Full suite: **162 files, 1413 passed, 1 skipped, 0 failed** (+4)
- `tsc --noEmit`, `oxfmt --check`, `oxlint`: clean

Not verified by me: the rendered page in a browser, and the canary actually
going green — that needs steps 2 and 3 above.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR restores a semantic top-level heading to the volume-list landing page and adds a shared, wording-independent readiness anchor to both successful landing variants. It also adds coverage ensuring the error fallback cannot satisfy that readiness check.
- Adds an `h1` styled as an `h5` to the volume list.
- Adds `data-testid="landing-heading"` to the Buckets and FrontDoor headings.
- Verifies heading semantics, styling, anchor presence, and fallback exclusion.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge, with the successful landing variants consistently exposing the intended semantic heading and readiness anchor.

The changed headings fit the mutually exclusive landing compositions, the Buckets layout remains normal-flow and properly spaced, and the fallback is explicitly prevented from advertising successful readiness.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| catalog/app/containers/Home/Buckets/Buckets.jsx | Adds a semantic, visually ramp-constrained page heading and stable landing readiness anchor without conflicting with the existing layout. |
| catalog/app/containers/Home/Buckets/Buckets.spec.tsx | Covers the new heading level, accessible name, visual variant, and readiness anchor. |
| catalog/app/website/pages/Landing/FrontDoor/FrontDoor.tsx | Adds the shared readiness anchor to the successful FrontDoor heading while leaving the fallback unmarked. |
| catalog/app/website/pages/Landing/FrontDoor/FrontDoor.spec.tsx | Verifies that the successful FrontDoor exposes the expected anchored h1. |
| catalog/app/website/pages/Landing/FrontDoor/FrontDoor.fallback.spec.tsx | Prevents the failure fallback from falsely satisfying the landing readiness contract. |


<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Landing route] --> B{front-door enabled?}
    B -- No --> C[Buckets volume list]
    B -- Yes --> D[FrontDoor]
    C --> E[Successful h1 with landing-heading anchor]
    D --> F{Page renders successfully?}
    F -- Yes --> G[Greeting h1 with landing-heading anchor]
    F -- No --> H[Fallback h1 without readiness anchor]
```

<sub>Reviews (1): Last reviewed commit: ["fix(landing): give the volume list an h1..."](https://github.com/quiltdata/quilt/commit/cf09c8bd603dc937ecf853d346bc340be6537e83) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=55923032)</sub>

<!-- /greptile_comment -->