### PR TITLE
design(home): record the page-heading reversal in the surface brief

### DIFF
--- a/catalog/.impeccable/surfaces/home.md
+++ b/catalog/.impeccable/surfaces/home.md
@@ -31,13 +31,40 @@ Inside the committed instrument world (DESIGN.md — midnight chrome, white surf
 
 ## Scope & boundaries
 
-Production-ready; one surface (`/` home body). **Kept from the list build:** no "Explore your buckets" heading, funnel filter icon, the sort selector, empty/skeleton states, the admin-only "Add bucket" button beneath the grid, `BucketGrid.tsx` deletion (the new cards are the redesigned `BucketList.tsx` family, not Simon's reverted card grid). **Untouched:** the shell (rail, top bar), pagination (15/page), routing into buckets. **Anti-goals:** consumer-SaaS gloss (no gradient/hero cards), the identical-card-grid slop (icon+heading+text tiles repeated with no product signal), and empty cards that browse worse than a row.
+Production-ready; one surface (`/` home body). **Kept from the list build:** funnel filter icon, the sort selector, empty/skeleton states, the admin-only "Add bucket" button beneath the grid, `BucketGrid.tsx` deletion (the new cards are the redesigned `BucketList.tsx` family, not Simon's reverted card grid). **Untouched:** the shell (rail, top bar), pagination (15/page), routing into buckets. **Anti-goals:** consumer-SaaS gloss (no gradient/hero cards), the identical-card-grid slop (icon+heading+text tiles repeated with no product signal), and empty cards that browse worse than a row.
+
+**Page heading — reversed 2026-08-22 (operator ruling).** This brief previously
+kept "no 'Explore your buckets' heading" from the list build. The page now
+carries a visible `h1` reading **Volumes**. Two things forced the reversal:
+
+- **A11y.** With the heading omitted the page had no top-level heading at all —
+  and this is what `/` renders whenever the `front-door` flag is off, so it is
+  the landing page for most stacks. No `h1` is a WCAG 1.3.1 / 2.4.6 failure for
+  anyone navigating by heading. The omission was a deliberate composition
+  decision; its accessibility cost was not weighed at the time.
+- **The end-to-end canaries.** `waitForHomePage` (quiltdata/e2e `shared/auth.ts`)
+  used the old heading's text as its "login landed" signal, so all four canaries
+  failed at `serviceLogin` the moment it disappeared. Fixed properly by keying
+  the check to `data-testid="landing-heading"` rather than any wording — the
+  anchor is now the contract, so this copy stays free to change. That id is on
+  the front door's greeting `h1` too, and deliberately *not* on its error
+  fallback: a page that failed to load must not read as a healthy login.
+
+Treatment, so this does not drift back toward the marketing heading it replaces:
+`variant="h5" component="h1"` — semantically the page's h1, visually a Headline,
+matching FrontDoor's greeting. **Not** the old `variant="h1"` display size, which
+the No-Display-Font Rule now forbids. One quiet line above the controls row; it
+labels the surface, it is not a hero. Copy is "Volumes", consistent with the rail
+nav, the `/buckets` tab title, and the front-door tile ("Bucket" stays the
+internal word — routes, `s3://` names). Covered by tests in `Buckets.spec.tsx`.
 
 ## States & ranges
 
 Buckets: 1 (first-run) · dozens (typical) · hundreds (paginated 15/page). Cover: **first-run/zero** (teaching empty state — "No buckets yet"; admins get the add path, non-admins a plain line), **no-filter-match**, **loading** (skeleton cards, not a spinner), **sparse card** (missing description/tags/custom icon — must still look intentional), **anonymous OPEN** (public buckets, no add button).
 
 ## Interaction & layout
+
+Page order: `h1` ("Volumes") → controls row (filter, tag shortcuts, sort, view toggle) → card grid → admin add path. The heading is the page's only h1; cards carry no heading element, so the document outline stays one level deep and a card title never competes with the page label.
 
 Hierarchy within a card: icon + title loudest; `s3://` quiet beneath; description small/muted; tags a calm interactive band; collaborator count a quiet footer. Funnel-filter narrows live (debounced); tag chips (shortcuts and in-card) quick-filter; sort selector reorders; visible keyboard focus per the Focus Ring Rule on the card link and every chip; reduced motion respected. Card heights equalize per row; titles never wrap.
 


### PR DESCRIPTION
Follow-up to #5193, which is already merged. That PR added the `h1`; this one
records the decision in the surface brief that had ruled it out.

## Why this is a separate PR

I got the cause wrong in #5193. Its description — and my note in Alexei's
#engineering thread — said the heading had fallen out accidentally during the
shell re-home. It hadn't. `.impeccable/surfaces/home.md` explicitly kept
**"no 'Explore your buckets' heading"** from the list build. It was a deliberate
composition decision for an Operate-mode surface whose brand rule is "no
marketing energy inside the authenticated app".

The fix in #5193 is still right, but for one of its two stated reasons rather
than both:

- **Still valid:** the canaries needed an anchor that isn't wording.
  `data-testid="landing-heading"` is correct regardless of whether a visible
  heading exists.
- **Corrected here:** the visible `h1` is a *change* to a design decision, not
  the restoration of something lost. Simon ruled 2026-08-22 that it stays.

## What changed

Only `catalog/.impeccable/surfaces/home.md` — no code.

- Drops the "no heading" clause from **Scope & boundaries**.
- Records the reversal, dated and attributed, with both forcing reasons: no `h1`
  on the flag-off landing page is a WCAG 1.3.1 / 2.4.6 failure for heading
  navigation, and the canaries had keyed `waitForHomePage` to the old text.
- **Pins the treatment** so this cannot drift back into the marketing heading it
  replaces: `variant="h5" component="h1"`, one quiet line above the controls row,
  explicitly *not* the `variant="h1"` display size the No-Display-Font Rule now
  forbids.
- Adds the page's heading order to **Interaction & layout**, and notes that cards
  carry no heading element — verified, the page `h1` is the only heading in
  `containers/Home`.
- Notes the anchor is on the front door's greeting `h1` too, and deliberately not
  on its error fallback: a page that failed to load must not read as a healthy
  login.

## Why bother

Contract moves in the same diff as the change it authorizes — the catalog's own
CLAUDE.md rule. Left alone, the next person reading this brief would find it
forbidding a heading that ships in `master`, and would have no record of the
a11y cost that overrode it.

`impeccable doctor` reports no drift. The brief is not linted by CI
(`markdownlint .` doesn't traverse dotted directories), and the MD013 long-line
style matches the rest of the file.


<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This documentation-only PR reconciles the Home surface brief with the visible page heading already shipped in master.
- Records why the earlier no-heading decision was reversed.
- Defines the heading’s semantic level, visual treatment, copy, placement, and stable test anchor.
- Documents the intended page outline and the FrontDoor error fallback’s deliberate exclusion from the healthy-login signal.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge because it only updates documentation and the documented heading behavior matches the current implementation and tests.

The revised surface brief accurately records the existing heading semantics, styling, ordering, selector placement, and error-state behavior without changing runtime code.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| catalog/.impeccable/surfaces/home.md | Updates the design contract to accurately reflect the existing Home and FrontDoor heading implementations, accessibility rationale, tests, and canary anchor. |

<sub>Reviews (1): Last reviewed commit: ["design(home): record the page-heading re..."](https://github.com/quiltdata/quilt/commit/634076bee482741620722e3893592c784d628a42) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=55946050)</sub>

<!-- /greptile_comment -->