### PR TITLE
delight(home): empty states that recover, and a card that responds where it acts

### DIFF
--- a/catalog/.impeccable/surfaces/home.md
+++ b/catalog/.impeccable/surfaces/home.md
@@ -31,13 +31,40 @@ Inside the committed instrument world (DESIGN.md — midnight chrome, white surf
 
 ## Scope & boundaries
 
-Production-ready; one surface (`/` home body). **Kept from the list build:** no "Explore your buckets" heading, funnel filter icon, the sort selector, empty/skeleton states, the admin-only "Add bucket" button beneath the grid, `BucketGrid.tsx` deletion (the new cards are the redesigned `BucketList.tsx` family, not Simon's reverted card grid). **Untouched:** the shell (rail, top bar), pagination (15/page), routing into buckets. **Anti-goals:** consumer-SaaS gloss (no gradient/hero cards), the identical-card-grid slop (icon+heading+text tiles repeated with no product signal), and empty cards that browse worse than a row.
+Production-ready; one surface (`/` home body). **Kept from the list build:** funnel filter icon, the sort selector, empty/skeleton states, the admin-only "Add bucket" button beneath the grid, `BucketGrid.tsx` deletion (the new cards are the redesigned `BucketList.tsx` family, not Simon's reverted card grid). **Untouched:** the shell (rail, top bar), pagination (15/page), routing into buckets. **Anti-goals:** consumer-SaaS gloss (no gradient/hero cards), the identical-card-grid slop (icon+heading+text tiles repeated with no product signal), and empty cards that browse worse than a row.
+
+**Page heading — reversed 2026-08-22 (operator ruling).** This brief previously
+kept "no 'Explore your buckets' heading" from the list build. The page now
+carries a visible `h1` reading **Volumes**. Two things forced the reversal:
+
+- **A11y.** With the heading omitted the page had no top-level heading at all —
+  and this is what `/` renders whenever the `front-door` flag is off, so it is
+  the landing page for most stacks. No `h1` is a WCAG 1.3.1 / 2.4.6 failure for
+  anyone navigating by heading. The omission was a deliberate composition
+  decision; its accessibility cost was not weighed at the time.
+- **The end-to-end canaries.** `waitForHomePage` (quiltdata/e2e `shared/auth.ts`)
+  used the old heading's text as its "login landed" signal, so all four canaries
+  failed at `serviceLogin` the moment it disappeared. Fixed properly by keying
+  the check to `data-testid="landing-heading"` rather than any wording — the
+  anchor is now the contract, so this copy stays free to change. That id is on
+  the front door's greeting `h1` too, and deliberately *not* on its error
+  fallback: a page that failed to load must not read as a healthy login.
+
+Treatment, so this does not drift back toward the marketing heading it replaces:
+`variant="h5" component="h1"` — semantically the page's h1, visually a Headline,
+matching FrontDoor's greeting. **Not** the old `variant="h1"` display size, which
+the No-Display-Font Rule now forbids. One quiet line above the controls row; it
+labels the surface, it is not a hero. Copy is "Volumes", consistent with the rail
+nav, the `/buckets` tab title, and the front-door tile ("Bucket" stays the
+internal word — routes, `s3://` names). Covered by tests in `Buckets.spec.tsx`.
 
 ## States & ranges
 
 Buckets: 1 (first-run) · dozens (typical) · hundreds (paginated 15/page). Cover: **first-run/zero** (teaching empty state — "No buckets yet"; admins get the add path, non-admins a plain line), **no-filter-match**, **loading** (skeleton cards, not a spinner), **sparse card** (missing description/tags/custom icon — must still look intentional), **anonymous OPEN** (public buckets, no add button).
 
 ## Interaction & layout
+
+Page order: `h1` ("Volumes") → controls row (filter, tag shortcuts, sort, view toggle) → card grid → admin add path. The heading is the page's only h1; cards carry no heading element, so the document outline stays one level deep and a card title never competes with the page label.
 
 Hierarchy within a card: icon + title loudest; `s3://` quiet beneath; description small/muted; tags a calm interactive band; collaborator count a quiet footer. Funnel-filter narrows live (debounced); tag chips (shortcuts and in-card) quick-filter; sort selector reorders; visible keyboard focus per the Focus Ring Rule on the card link and every chip; reduced motion respected. Card heights equalize per row; titles never wrap.
 

--- a/catalog/.impeccable/surfaces/home.md
+++ b/catalog/.impeccable/surfaces/home.md
@@ -60,7 +60,51 @@ internal word — routes, `s3://` names). Covered by tests in `Buckets.spec.tsx`
 
 ## States & ranges
 
-Buckets: 1 (first-run) · dozens (typical) · hundreds (paginated 15/page). Cover: **first-run/zero** (teaching empty state — "No buckets yet"; admins get the add path, non-admins a plain line), **no-filter-match**, **loading** (skeleton cards, not a spinner), **sparse card** (missing description/tags/custom icon — must still look intentional), **anonymous OPEN** (public buckets, no add button).
+Buckets: 1 (first-run) · dozens (typical) · hundreds (paginated 15/page). Cover: **first-run/zero** (teaching empty state — "No volumes yet"), **no-filter-match**, **loading** (skeleton cards, not a spinner), **sparse card** (missing description/tags/custom icon — must still look intentional), **anonymous OPEN** (public buckets, no add button).
+
+**Empty states carry their own recovery — added 2026-08-23 (`delight` pass).**
+Both were dead ends; on an Operate surface the delight budget belongs at first
+use and recovery, not on the card wall.
+
+- **First-run/zero.** The teaching copy and the action are one thing: admins get
+  the Add button *inside* the state, and the controls row below withholds its own
+  so the instruction never appears twice. Copy describes the real operation
+  ("Connect an S3 bucket…") rather than a UI gesture. Bucket-specific wording is
+  safe even though a volume can also be a data product — `isEmpty` is zero
+  buckets *and* zero products, so a products-only catalog never reaches this
+  state (pinned by a test). Connecting an external catalog is the other path and
+  lives in Admin > Settings; left out deliberately to keep one action on one
+  state. Non-admins previously got a closed door — now the honest next step (ask
+  the admin who can) plus a docs link for what a volume is.
+- **No-filter-match.** Reports the exact number of volumes searched and the fields
+  covered (trust rendered, not asserted), then hands back the controls that widen
+  it: one droppable chip per term, plus Clear filter. The count is *entries*, so a
+  data product counts as a volume here exactly as it does everywhere else on this
+  screen. Per-term chips are withheld for a single term, where dropping and
+  clearing are the same action. Terms are quoted in the casing the reader typed.
+
+**The card responds where it acts.** The card washed edge-to-edge on hover while
+only the icon+title header navigated, leaving the description and the slack as
+dead affordances. The whole card is the target now, via a stretched `::after` on
+the existing anchor — not a wrapping link, which would nest the tag chips and the
+collaborator `ButtonBase` inside an anchor and break keyboard and screen-reader
+behaviour. Press response is tonal (the wash deepens one step), never a transform
+or shadow: Overlay-Only reserves shadow for things that float and leave, and a
+card that scales under the cursor is the gloss PRODUCT.md rules out.
+
+**Deferred, not forgotten — withholding the controls row at zero volumes.** Three
+controls that cannot act (filter, sort, view toggle) over an empty grid is the
+cloud-console density this brief's anti-goals name, and the fix shipped on
+`master`. It is *not* on this branch: deciding it needs "are there volumes",
+which is buckets **plus** data products, and products arrive through
+`DP.useProducts` behind `useFeature('data-products')` — which suspends
+(`utils/features.ts`, via `CatalogSettings.use()`), with no non-suspending read
+exported. The controls row deliberately lives outside the grid's Suspense
+boundary so the filter stays usable while the grid loads, so gating it on a
+suspending read would remount the field and steal focus mid-keystroke. Gating on
+buckets alone would be wrong on a products-only catalog. Revisit when
+`features.ts` grows a non-suspending flag read; then the `master` implementation
+ports directly with `entries` in place of `buckets`.
 
 ## Interaction & layout
 

--- a/catalog/DESIGN.md
+++ b/catalog/DESIGN.md
@@ -206,8 +206,8 @@ never read as a selection) and the semantic Info/Warning pairs.
 
 ### Retired
 
-The website register's palette — coral (#f38681), cobalt (#5471f1, #2d306d,
-#6a93ff), and the muted web text (#b2bddb) — is removed along with its themes
+The website register's palette — coral (#f38681), cobalt (#5471f1, #2d306d, #6a93ff),
+and the muted web text (#b2bddb) — is removed along with its themes
 (`navTheme`, `websitePalette`). Web Midnight was promoted to the primary above;
 the rest does not come back. Do not reintroduce these values; a surface that
 seems to need them needs a different design.

--- a/catalog/app/containers/Home/BucketGrid/BucketCard.spec.tsx
+++ b/catalog/app/containers/Home/BucketGrid/BucketCard.spec.tsx
@@ -1,0 +1,169 @@
+import * as React from 'react'
+import { MemoryRouter } from 'react-router-dom'
+import { render, cleanup, fireEvent } from '@testing-library/react'
+import { describe, expect, it, vi, afterEach } from 'vitest'
+import * as M from '@material-ui/core'
+
+import * as style from 'constants/style'
+
+import BucketCard from './BucketCard'
+
+// PRODUCT mode so the collaborator readout renders — it is one of the two real
+// controls that has to stay reachable above the card-wide navigation overlay.
+vi.mock('constants/config', () => ({ default: { mode: 'PRODUCT' } }))
+
+vi.mock('utils/NamedRoutes', async () => ({
+  ...(await vi.importActual('utils/NamedRoutes')),
+  use: () => ({ urls: { bucketRoot: (b: string) => `/b/${b}` } }),
+}))
+
+vi.mock('components/BucketIcon', () => ({
+  default: () => <div data-testid="bucket-icon" />,
+}))
+
+// The collaborator readout is a `ButtonBase` that opens a dialog. Stubbed to a
+// button so this spec can assert it is still clickable without pulling in the
+// Popup and its GraphQL.
+vi.mock('./Collaborators', () => ({
+  default: ({ bucket }: { bucket: string }) => (
+    <button type="button" onClick={() => collaboratorsClicked.push(bucket)}>
+      Shared with 3
+    </button>
+  ),
+}))
+
+let collaboratorsClicked: string[] = []
+
+const BUCKET = {
+  name: 'genomics-raw',
+  title: 'Genomics Raw',
+  iconUrl: null,
+  description: 'Primary sequencing output.',
+  tags: ['rna', 'wgs'],
+}
+
+function renderCard(onTagClick = vi.fn()) {
+  const utils = render(
+    <MemoryRouter>
+      <M.MuiThemeProvider theme={style.appTheme}>
+        <BucketCard bucket={BUCKET} tagIsMatching={() => false} onTagClick={onTagClick} />
+      </M.MuiThemeProvider>
+    </MemoryRouter>,
+  )
+  return { ...utils, onTagClick }
+}
+
+describe('containers/Home/BucketGrid/BucketCard', () => {
+  afterEach(() => {
+    cleanup()
+    collaboratorsClicked = []
+  })
+
+  // The card used to wash on hover from edge to edge while only the icon+title
+  // header navigated, so the description and the slack above the bottom row
+  // looked interactive and did nothing — the dead affordance PRODUCT.md names as
+  // a legacy-lab-software anti-reference. The whole card is the target now.
+  it('navigates from exactly one anchor, carrying the bucket route', () => {
+    const { container } = renderCard()
+
+    const anchors = container.querySelectorAll('a')
+    // One anchor, not one per region: the card-wide target is a stretched
+    // pseudo-element on this link, so nothing else needs to be an anchor.
+    expect(anchors).toHaveLength(1)
+    expect(anchors[0].getAttribute('href')).toBe('/b/genomics-raw')
+  })
+
+  // A button nested inside an anchor is invalid HTML and breaks keyboard and
+  // screen-reader behaviour. The card holds two real controls, so the card-wide
+  // target has to be an overlay rather than a wrapping link — this is the
+  // assertion that keeps someone from "simplifying" it into one.
+  it('keeps its controls out of the anchor', () => {
+    const { container } = renderCard()
+
+    const anchor = container.querySelector('a')!
+    expect(anchor.querySelector('button')).toBeNull()
+    expect(anchor.querySelectorAll('[role="button"]')).toHaveLength(0)
+  })
+
+  it('filters by a tag without navigating', () => {
+    const { getByText, onTagClick } = renderCard()
+
+    fireEvent.click(getByText('rna'))
+
+    expect(onTagClick).toHaveBeenCalledWith('rna')
+  })
+
+  it('leaves the collaborator readout clickable', () => {
+    const { getByText } = renderCard()
+
+    fireEvent.click(getByText('Shared with 3'))
+
+    expect(collaboratorsClicked).toEqual(['genomics-raw'])
+  })
+
+  // The card-wide target is a `::after` on the header, absolutely positioned to
+  // the *card* — so the card must be the nearest positioned ancestor and the
+  // header must not be. Positioning the header (a plausible "add a focus ring
+  // z-index" edit) would make it the containing block for its own overlay and
+  // silently shrink the click target back to the header's bounds.
+  //
+  // Read off the injected JSS text rather than `getComputedStyle`: jsdom does
+  // not resolve JSS-authored rules into computed values (it returns '' for
+  // `position` here), but the rules themselves are present as stylesheet
+  // content. Pseudo-element geometry is not hit-testable in jsdom at all, so
+  // this pins the structure; the actual click behaviour needs a browser.
+  it('stretches its overlay to the card, not the header', () => {
+    const { container } = renderCard()
+
+    const anchor = container.querySelector('a')!
+    const headerClass = anchor.className.split(/\s+/).find((c) => c.includes('header'))!
+    const css = Array.from(document.querySelectorAll('style'))
+      .map((s) => s.textContent || '')
+      .join('\n')
+
+    const headerRule = css.slice(
+      css.indexOf(`.${headerClass} {`),
+      css.indexOf(`.${headerClass}::after`),
+    )
+    expect(headerRule).not.toMatch(/position:/)
+
+    // And the overlay is pinned to all four edges, which is what makes it cover
+    // the card rather than sit in a corner of it.
+    const overlayRule = css.slice(css.indexOf(`.${headerClass}::after`))
+    expect(overlayRule).toMatch(/position:\s*absolute/)
+  })
+
+  // The two tests above prove the tag chips and the collaborator readout still
+  // *respond*, but they cannot prove they are still *reachable*: jsdom's
+  // `fireEvent.click` dispatches straight onto the node and does no hit-testing,
+  // so a control buried under the navigation overlay would pass them both. Found
+  // by mutation — deleting the raise below left all five green.
+  //
+  // So the stacking contract is asserted directly. Anything the reader is meant
+  // to click for a reason other than "open this bucket" has to sit above the
+  // overlay; the overlay is at z-index 0, so the row carrying those controls
+  // needs its own positioned context and a higher index.
+  it('raises its real controls above the navigation overlay', () => {
+    const { getByText } = renderCard()
+
+    // Walk up from the chip's label to the row that carries the raise. Explicit
+    // rather than `closest('div').parentElement`: the label is a span inside
+    // Chip's own root div, so a fixed number of hops lands on the tag wrapper
+    // instead — measured, not assumed.
+    let row: HTMLElement | null = getByText('rna')
+    while (row && !/bottomRow/.test(row.className)) row = row.parentElement
+    expect(row).toBeTruthy()
+    const rowClass = row!.className.split(/\s+/).find((c) => c.includes('bottomRow'))
+
+    const css = Array.from(document.querySelectorAll('style'))
+      .map((s) => s.textContent || '')
+      .join('\n')
+    const start = css.indexOf(`.${rowClass} {`)
+    const rule = css.slice(start, css.indexOf('}', start))
+
+    expect(rule).toMatch(/position:\s*relative/)
+    // Strictly above the overlay's 0, or the clicks never arrive.
+    const zIndex = Number(/z-index:\s*(-?\d+)/.exec(rule)?.[1])
+    expect(zIndex).toBeGreaterThan(0)
+  })
+})

--- a/catalog/app/containers/Home/BucketGrid/BucketCard.spec.tsx
+++ b/catalog/app/containers/Home/BucketGrid/BucketCard.spec.tsx
@@ -137,33 +137,45 @@ describe('containers/Home/BucketGrid/BucketCard', () => {
   // *respond*, but they cannot prove they are still *reachable*: jsdom's
   // `fireEvent.click` dispatches straight onto the node and does no hit-testing,
   // so a control buried under the navigation overlay would pass them both. Found
-  // by mutation — deleting the raise below left all five green.
+  // by mutation — deleting the raise left all five green.
   //
-  // So the stacking contract is asserted directly. Anything the reader is meant
-  // to click for a reason other than "open this bucket" has to sit above the
-  // overlay; the overlay is at z-index 0, so the row carrying those controls
-  // needs its own positioned context and a higher index.
-  it('raises its real controls above the navigation overlay', () => {
-    const { getByText } = renderCard()
-
-    // Walk up from the chip's label to the row that carries the raise. Explicit
-    // rather than `closest('div').parentElement`: the label is a span inside
-    // Chip's own root div, so a fixed number of hops lands on the tag wrapper
-    // instead — measured, not assumed.
-    let row: HTMLElement | null = getByText('rna')
-    while (row && !/bottomRow/.test(row.className)) row = row.parentElement
-    expect(row).toBeTruthy()
-    const rowClass = row!.className.split(/\s+/).find((c) => c.includes('bottomRow'))
+  // So the stacking contract is asserted directly, and it is narrower than "raise
+  // the row": each control is raised on its own. Raising the whole `bottomRow`
+  // lifted its whitespace too — the `space-between` gap and the slack around the
+  // chips — turning the middle of the card into a dead zone that swallowed clicks
+  // instead of navigating. That was the review finding, and it is the same defect
+  // the overlay exists to remove, so the containers must stay *down*.
+  it('raises each real control, and nothing else, above the navigation overlay', () => {
+    const { getByText, container } = renderCard()
 
     const css = Array.from(document.querySelectorAll('style'))
       .map((s) => s.textContent || '')
       .join('\n')
-    const start = css.indexOf(`.${rowClass} {`)
-    const rule = css.slice(start, css.indexOf('}', start))
 
-    expect(rule).toMatch(/position:\s*relative/)
-    // Strictly above the overlay's 0, or the clicks never arrive.
-    const zIndex = Number(/z-index:\s*(-?\d+)/.exec(rule)?.[1])
-    expect(zIndex).toBeGreaterThan(0)
+    const ruleFor = (cls: string) => {
+      const start = css.indexOf(`.${cls} {`)
+      return start < 0 ? '' : css.slice(start, css.indexOf('}', start))
+    }
+    const classOf = (el: HTMLElement, needle: string) =>
+      el.className.split(/\s+/).find((c) => c.includes(needle))!
+    const raised = (rule: string) =>
+      /position:\s*relative/.test(rule) &&
+      Number(/z-index:\s*(-?\d+)/.exec(rule)?.[1] ?? 0) > 0
+
+    // A chip is a control: it filters the wall rather than opening the bucket.
+    const chip = getByText('rna').closest('.MuiChip-root') as HTMLElement
+    expect(raised(ruleFor(classOf(chip, 'tag')))).toBe(true)
+
+    // So is the collaborator readout's wrapper, which hugs its button.
+    const access = container.querySelector('[class*="access"]') as HTMLElement
+    expect(raised(ruleFor(classOf(access, 'access')))).toBe(true)
+
+    // The containers are not. Their gaps belong to the card-wide link.
+    let row: HTMLElement | null = getByText('rna')
+    while (row && !/bottomRow/.test(row.className)) row = row.parentElement
+    expect(raised(ruleFor(classOf(row!, 'bottomRow')))).toBe(false)
+
+    const tagsWrapper = chip.parentElement as HTMLElement
+    expect(raised(ruleFor(classOf(tagsWrapper, 'tags')))).toBe(false)
   })
 })

--- a/catalog/app/containers/Home/BucketGrid/BucketCard.tsx
+++ b/catalog/app/containers/Home/BucketGrid/BucketCard.tsx
@@ -125,18 +125,18 @@ const useStyles = M.makeStyles((t) => ({
   // Tags and the access readout share one line at the card's foot: the tags
   // run from the left, the readout closes the row on the right.
   //
-  // Raised above the header's stretched overlay. Everything else on the card is
-  // beneath it (that is the point — the whole surface navigates), but these two
-  // are real controls with their own jobs: a tag filters the wall, the readout
-  // opens the collaborator dialog. Without this they would be unreachable by
-  // mouse, since the overlay would take every click first.
+  // Deliberately *not* raised above the header's stretched overlay. Raising the
+  // row lifted its whitespace too -- the `space-between` gap and the slack around
+  // the chips -- so clicks there landed on a non-interactive container instead of
+  // navigating: a dead zone in the middle of the card, which is the same defect
+  // the overlay exists to remove. Caught in review. Only the real controls are
+  // raised now, each on its own (`tag`, `access`); everything between them stays
+  // under the overlay and navigates.
   bottomRow: {
     alignItems: 'center',
     display: 'flex',
     gap: t.spacing(1),
     justifyContent: 'space-between',
-    position: 'relative',
-    zIndex: 1,
   },
   // The icon is a fixed-size disc: without this it inherits `flex-shrink: 1`
   // and a long title squashes the circle into an ellipse.
@@ -176,7 +176,12 @@ const useStyles = M.makeStyles((t) => ({
   // ButtonBase (Chip's root when `clickable`) always stamps the global
   // `Mui-focusVisible` class alongside its own hashed one, so this is a
   // stable hook even though `.MuiChip-*` selectors are off-limits.
+  // Raised above the navigation overlay: a chip filters the wall, which is not
+  // "open this bucket". Raised per-chip rather than on the `tags` wrapper so the
+  // wrapper's flex gaps stay under the overlay and still navigate.
   tag: {
+    position: 'relative',
+    zIndex: 1,
     '&.Mui-focusVisible': {
       outline: `2px solid ${t.palette.primary.main}`,
       outlineOffset: -2,
@@ -195,10 +200,15 @@ const useStyles = M.makeStyles((t) => ({
     alignSelf: 'center',
     color: t.palette.text.secondary,
   },
+  // Raised for the same reason as `tag`: the readout opens the collaborator
+  // dialog. This wrapper hugs its button (`flexShrink: 0`, no padding), so
+  // raising it does not lift any whitespace with it.
   access: {
     alignItems: 'center',
     display: 'flex',
     flexShrink: 0,
+    position: 'relative',
+    zIndex: 1,
   },
 }))
 

--- a/catalog/app/containers/Home/BucketGrid/BucketCard.tsx
+++ b/catalog/app/containers/Home/BucketGrid/BucketCard.tsx
@@ -42,12 +42,24 @@ const useStyles = M.makeStyles((t) => ({
     // The header wash bleeds to the card's edges, so the regions carry their
     // own insets rather than the card carrying one padding for all of them.
     overflow: 'hidden',
+    // Containing block for the header link's overlay (see `header::after`).
+    position: 'relative',
     transition: t.transitions.create(['background-color', 'border-color'], {
       duration: 150,
     }),
     '&:hover': {
       backgroundColor: t.palette.action.hover,
       borderColor: t.palette.text.secondary,
+    },
+    // Pressed: the wash deepens one step. No transform and no shadow — the
+    // Overlay-Only Rule reserves shadow for things that float and leave, and a
+    // card that scales under the cursor is the consumer-SaaS gloss PRODUCT.md
+    // names as an anti-reference. Tactility here is tonal, not spatial.
+    '&:active': {
+      backgroundColor: t.palette.action.selected,
+    },
+    '@media (prefers-reduced-motion: reduce)': {
+      transition: 'none',
     },
   },
   // The identity block: the icon sits beside a two-line text column (title
@@ -64,6 +76,36 @@ const useStyles = M.makeStyles((t) => ({
     minWidth: 0,
     padding: t.spacing(2),
     textDecoration: 'none',
+    // The whole card is the navigation target, not just this header.
+    //
+    // The card washed on hover from edge to edge while only the header
+    // navigated, so the description, the tags' empty space, and the slack above
+    // the bottom row all looked interactive and did nothing — a dead affordance,
+    // which PRODUCT.md names as a legacy-lab-software anti-reference.
+    //
+    // Done as an overlay on the existing anchor rather than by wrapping the card
+    // in one: the card contains a `ButtonBase` (the collaborator readout) and
+    // clickable tag chips, and a button inside an anchor is invalid and breaks
+    // both keyboard and screen-reader behaviour. This keeps exactly one anchor
+    // with its real href and accessible name, stretched to the card's bounds.
+    '&::after': {
+      content: '""',
+      position: 'absolute',
+      top: 0,
+      right: 0,
+      bottom: 0,
+      left: 0,
+      // Below the interactive children, which raise themselves above it.
+      zIndex: 0,
+    },
+    // The focus ring stays on the header rather than the stretched overlay: it
+    // marks what the reader is about to activate — the named identity — instead
+    // of outlining the whole card and losing the Focus Ring Rule's precision.
+    //
+    // Deliberately no `position` here. Positioning the header would make it the
+    // containing block for its own `::after`, collapsing the card-wide click
+    // target to the header's bounds for as long as it held focus. The overlay
+    // paints nothing, so it cannot cover the ring anyway.
     '&:focus-visible': {
       outline: `2px solid ${t.palette.primary.main}`,
       outlineOffset: -2,
@@ -82,11 +124,19 @@ const useStyles = M.makeStyles((t) => ({
   },
   // Tags and the access readout share one line at the card's foot: the tags
   // run from the left, the readout closes the row on the right.
+  //
+  // Raised above the header's stretched overlay. Everything else on the card is
+  // beneath it (that is the point — the whole surface navigates), but these two
+  // are real controls with their own jobs: a tag filters the wall, the readout
+  // opens the collaborator dialog. Without this they would be unreachable by
+  // mouse, since the overlay would take every click first.
   bottomRow: {
     alignItems: 'center',
     display: 'flex',
     gap: t.spacing(1),
     justifyContent: 'space-between',
+    position: 'relative',
+    zIndex: 1,
   },
   // The icon is a fixed-size disc: without this it inherits `flex-shrink: 1`
   // and a long title squashes the circle into an ellipse.

--- a/catalog/app/containers/Home/Buckets/Buckets.jsx
+++ b/catalog/app/containers/Home/Buckets/Buckets.jsx
@@ -563,7 +563,7 @@ function TagShortcuts({ filter, onTagClick }) {
 
 // Everything that needs bucket data lives below this line, inside the
 // Suspense boundary — filter text and sort order (owned by the parent) don't.
-function BucketsBody({ filter, sort, view, isAdmin, onTagClick, scrollRef }) {
+function BucketsBody({ filter, sort, view, isAdmin, onTagClick, onDropTerm, scrollRef }) {
   const classes = useStyles()
   const { urls } = NamedRoutes.use()
   const buckets = useRelevantBuckets()
@@ -625,12 +625,14 @@ function BucketsBody({ filter, sort, view, isAdmin, onTagClick, scrollRef }) {
     )
   }, [terms, entries])
 
-  // Rebuilt from `rawTerms`, so a drop preserves the casing the reader typed and
-  // normalizes only the whitespace they used to separate terms.
-  const dropTerm = React.useCallback(
-    (term) => onTagClick(rawTerms.filter((t) => t !== term).join(' ')),
-    [onTagClick, rawTerms],
-  )
+  // Dropping a term is owned by the parent (`onDropTerm`), because it has to read
+  // the filter field's *pending* value rather than the URL.
+  //
+  // `rawTerms` here is derived from `filter`, which is the URL, which only catches
+  // up after the field's 500ms debounce. Rebuilding from it meant two chips
+  // clicked inside that window both computed from the same pre-click terms, so the
+  // second overwrote the first and resurrected the term it had just removed.
+  // Caught in review; there is a test for the two-drop sequence.
 
   // `''`, not a bare `set()`. `set` is a `useState` setter, so calling it with no
   // argument stores `undefined` and hands the TextField `value={undefined}` --
@@ -679,7 +681,7 @@ function BucketsBody({ filter, sort, view, isAdmin, onTagClick, scrollRef }) {
           filter={filter}
           terms={rawTerms}
           total={entries.length}
-          onDropTerm={dropTerm}
+          onDropTerm={onDropTerm}
           onClear={onClearFilter}
         />
       ) : (
@@ -747,6 +749,30 @@ export default function Buckets() {
   )
 
   const filtering = useDebouncedInput(filter, 500)
+
+  // Drop one term from the filter, composing correctly when several are dropped in
+  // quick succession.
+  //
+  // The functional updater is the whole point: `filtering.set` is a `useState`
+  // setter, so this reads the *pending* field value. Computing from the
+  // URL-derived filter instead meant two chips clicked inside the 500ms debounce
+  // window both started from the same pre-click terms, and the second write
+  // resurrected the term the first had removed.
+  //
+  // Splits on whitespace here rather than reusing the body's `rawTerms` for the
+  // same reason -- `rawTerms` is a projection of the URL, and this needs the
+  // field.
+  const dropTerm = React.useCallback(
+    (term) =>
+      filtering.set((current) =>
+        (current || '')
+          .split(/\s+/)
+          .filter(Boolean)
+          .filter((t) => t !== term)
+          .join(' '),
+      ),
+    [filtering],
+  )
 
   React.useEffect(() => {
     if (filtering.value !== filter) {
@@ -865,6 +891,7 @@ export default function Buckets() {
             view={view}
             isAdmin={isAdmin}
             onTagClick={filtering.set}
+            onDropTerm={dropTerm}
             scrollRef={scrollRef}
           />
         </React.Suspense>

--- a/catalog/app/containers/Home/Buckets/Buckets.jsx
+++ b/catalog/app/containers/Home/Buckets/Buckets.jsx
@@ -263,6 +263,26 @@ const useStyles = M.makeStyles((t) => ({
   emptyLine: {
     marginTop: t.spacing(1),
   },
+  // The recovery row under an empty state: droppable filter terms, then the
+  // clear-all. Centered to match the state's own `textAlign`, and wrapping
+  // rather than scrolling because a filter can hold more terms than fit.
+  emptyActions: {
+    alignItems: 'center',
+    display: 'flex',
+    flexWrap: 'wrap',
+    gap: t.spacing(1),
+    justifyContent: 'center',
+    marginTop: t.spacing(3),
+  },
+  // Same focus-ring hook the card's tags use: ButtonBase (Chip's root when
+  // `clickable`) always stamps the global `Mui-focusVisible` alongside its own
+  // hashed class, so this is stable without reaching for `.MuiChip-*`.
+  emptyTerm: {
+    '&.Mui-focusVisible': {
+      outline: `2px solid ${t.palette.primary.main}`,
+      outlineOffset: -2,
+    },
+  },
   // A skeleton CARD silhouette (not a row, not a spinner) so the loading
   // state previews the grid it's about to become.
   skeletonCard: {
@@ -401,13 +421,55 @@ function ZeroState({ isAdmin }) {
   )
 }
 
-function NoMatch({ filter }) {
+// No filter match: a readout, not a wall.
+//
+// This used to be one line -- `No volumes matching "foo"` -- with no action on
+// it. The only way out was noticing the small clear button up in the filter
+// field, so the more terms someone had stacked, the more stuck they were.
+//
+// Three things instead, in the order a reader needs them: what happened, what
+// was actually searched, and the controls that widen it. `total` is the exact
+// number of volumes the filter ran against -- PRODUCT.md's "trust is rendered,
+// not asserted" applied to an empty state: the instrument says how many volumes
+// it looked at rather than implying there are none. It counts *entries*, so a
+// data product is a volume here exactly as it is everywhere else on this screen.
+//
+// Each term is individually droppable because over-narrowing is usually one
+// term's fault, and a reader can see which. Clearing everything stays available
+// as the blunt instrument beside them. Both are the same controls the filter
+// row owns; nothing new is invented here.
+function NoMatch({ filter, terms, total, onDropTerm, onClear }) {
   const classes = useStyles()
+  // Only worth offering per-term drops when there is a choice to make; with a
+  // single term "drop it" and "clear the filter" are the same action, and two
+  // buttons that do one thing is a worse state than one that does.
+  const droppable = terms.length > 1 ? terms : []
   return (
     <M.Paper elevation={0} className={classes.empty}>
       <M.Typography color="textPrimary" variant="body1">
         No volumes matching <b>&quot;{filter}&quot;</b>
       </M.Typography>
+      <M.Typography className={classes.emptyLine} color="textSecondary" variant="body2">
+        {total === 1
+          ? 'Searched the 1 volume you can reach, across name, description, and tags.'
+          : `Searched all ${total} volumes you can reach, across name, description, and tags.`}
+      </M.Typography>
+      <div className={classes.emptyActions}>
+        {droppable.map((tg) => (
+          <M.Chip
+            key={tg}
+            className={classes.emptyTerm}
+            label={`Without "${tg}"`}
+            size="small"
+            clickable
+            color="default"
+            onClick={() => onDropTerm(tg)}
+          />
+        ))}
+        <M.Button size="small" color="primary" onClick={onClear}>
+          Clear filter
+        </M.Button>
+      </div>
     </M.Paper>
   )
 }
@@ -466,10 +528,16 @@ function BucketsBody({ filter, sort, view, isAdmin, onTagClick, scrollRef }) {
   // Suspense boundary (see the `BucketsSkeleton` fallback below).
   const dataProductsEnabled = useFeature('data-products')
 
-  const terms = React.useMemo(
-    () => filter.toLowerCase().split(/\s+/).filter(Boolean),
-    [filter],
-  )
+  // Two splits of the same filter, deliberately.
+  //
+  // `terms` is lowercased because matching is case-insensitive. `rawTerms` keeps
+  // what the reader actually typed, for showing back to them: a filter of
+  // "Genomics RNA" must not be quoted back as "genomics" in the empty state, and
+  // dropping a term has to rebuild the filter from the original casing or the
+  // field would silently rewrite itself on every drop.
+  const rawTerms = React.useMemo(() => filter.split(/\s+/).filter(Boolean), [filter])
+
+  const terms = React.useMemo(() => rawTerms.map((s) => s.toLowerCase()), [rawTerms])
 
   // Same one-liner as TagShortcuts (both derive it from `filter`, not from
   // bucket data) — kept local so each component's dependency is obvious.
@@ -513,6 +581,21 @@ function BucketsBody({ filter, sort, view, isAdmin, onTagClick, scrollRef }) {
     )
   }, [terms, entries])
 
+  // Rebuilt from `rawTerms`, so a drop preserves the casing the reader typed and
+  // normalizes only the whitespace they used to separate terms.
+  const dropTerm = React.useCallback(
+    (term) => onTagClick(rawTerms.filter((t) => t !== term).join(' ')),
+    [onTagClick, rawTerms],
+  )
+
+  // `''`, not a bare `set()`. `set` is a `useState` setter, so calling it with no
+  // argument stores `undefined` and hands the TextField `value={undefined}` --
+  // React stops controlling the input, which then keeps the text already in it,
+  // so the box reads "alpha beta" while the filter clears underneath. Transient
+  // (the URL round-trip repairs it a tick later), which is why it went unnoticed.
+  // `clearFilter` in the parent is fixed the same way.
+  const onClearFilter = React.useCallback(() => onTagClick(''), [onTagClick])
+
   const sorted = React.useMemo(() => sortEntries(filtered, sort), [filtered, sort])
 
   const pages = Math.ceil(sorted.length / PER_PAGE)
@@ -548,7 +631,13 @@ function BucketsBody({ filter, sort, view, isAdmin, onTagClick, scrollRef }) {
       {isEmpty ? (
         <ZeroState isAdmin={isAdmin} />
       ) : noMatch ? (
-        <NoMatch filter={filter} />
+        <NoMatch
+          filter={filter}
+          terms={rawTerms}
+          total={entries.length}
+          onDropTerm={dropTerm}
+          onClear={onClearFilter}
+        />
       ) : (
         <View entries={paginated} tagIsMatching={tagIsMatching} onTagClick={onTagClick} />
       )}
@@ -619,7 +708,11 @@ export default function Buckets() {
   }, [history, search, filtering.value, filter])
 
   const clearFilter = React.useCallback(() => {
-    filtering.set()
+    // `set('')`, not `set()`. `set` is a `useState` setter, so a bare call stores
+    // `undefined`, which hands the TextField a `value` of `undefined` and makes
+    // React stop controlling it -- the box then keeps the text already in it
+    // while the filter clears underneath.
+    filtering.set('')
   }, [filtering])
 
   const sortButtonClasses = useSortButtonStyles()

--- a/catalog/app/containers/Home/Buckets/Buckets.jsx
+++ b/catalog/app/containers/Home/Buckets/Buckets.jsx
@@ -9,6 +9,7 @@ import * as Lab from '@material-ui/lab'
 
 import Pagination from 'components/Pagination2'
 import SelectDropdown from 'components/SelectDropdown'
+import { docs } from 'constants/urls'
 import { useRelevantBuckets } from 'utils/Buckets'
 import * as GQL from 'utils/GraphQL'
 import * as NamedRoutes from 'utils/NamedRoutes'
@@ -405,8 +406,28 @@ function BucketsSkeleton({ view }) {
   )
 }
 
+// First run: the teaching and the doing in one place.
+//
+// This told admins to "add a volume" while the button that does it sat in a
+// separate controls row *below* the grid -- the two halves of one instruction,
+// separated by the empty space they were describing. At zero volumes that row
+// holds nothing else (pagination needs more than one page), so the action moves
+// up here and the row withholds its own; there is never a second Add button.
+//
+// Bucket-specific copy is safe here even though a volume can also be a data
+// product. `isEmpty` is `!entries.length` -- zero buckets *and* zero products --
+// so a catalog whose products are its only content never reaches this state, and
+// an empty workspace genuinely has a bucket-shaped next step. (Connecting an
+// external catalog is the other path, and lives in Admin > Settings; it is left
+// out deliberately rather than overlooked, to keep one action on one state.)
+//
+// Non-admins get a real next step instead of a closed door. They cannot connect
+// anything, so the honest end of that sentence is who can -- plus the docs, for
+// what a volume is before they go asking. No invented claims about their
+// workspace.
 function ZeroState({ isAdmin }) {
   const classes = useStyles()
+  const { urls } = NamedRoutes.use()
   return (
     <M.Paper elevation={0} className={classes.empty}>
       <M.Typography color="textPrimary" variant="body1">
@@ -414,9 +435,32 @@ function ZeroState({ isAdmin }) {
       </M.Typography>
       <M.Typography className={classes.emptyLine} color="textSecondary" variant="body2">
         {isAdmin
-          ? 'Add a volume to make it searchable and browsable here.'
-          : "Your workspace admin hasn't connected one yet."}
+          ? 'Connect an S3 bucket and its packages become searchable and browsable here.'
+          : 'Your workspace admin connects these. Ask them which bucket holds the data you need.'}
       </M.Typography>
+      <div className={classes.emptyActions}>
+        {isAdmin ? (
+          <M.Button
+            variant="outlined"
+            color="primary"
+            component={Link}
+            to={urls.adminBuckets({ add: true })}
+          >
+            Add Bucket
+          </M.Button>
+        ) : (
+          <M.Button
+            size="small"
+            color="primary"
+            // A path already referenced elsewhere in the app, not an invented one.
+            href={`${docs}/quilt-platform-administrator/technical-reference`}
+            target="_blank"
+            rel="noopener noreferrer"
+          >
+            What is a volume?
+          </M.Button>
+        )}
+      </div>
     </M.Paper>
   )
 }
@@ -643,7 +687,10 @@ function BucketsBody({ filter, sort, view, isAdmin, onTagClick, scrollRef }) {
       )}
       <div className={classes.controls}>
         <M.Box>
-          {isAdmin && (
+          {/* Withheld at zero volumes, where `ZeroState` carries this same action
+              inside the teaching copy that asks for it. Two Add buttons on one
+              screen would be the same instruction twice. */}
+          {isAdmin && !isEmpty && (
             <M.Button
               variant="outlined"
               color="primary"

--- a/catalog/app/containers/Home/Buckets/Buckets.spec.tsx
+++ b/catalog/app/containers/Home/Buckets/Buckets.spec.tsx
@@ -398,6 +398,17 @@ describe('website/pages/Landing/Buckets', () => {
       await waitFor(() => expect(getByTestId('search').textContent).toBe('?q=RNA'))
     })
 
+    // Greptile P1: two drops inside the 500ms debounce window both rebuild from
+    // the URL-derived terms, so the second overwrites the first.
+    it('applies two drops in a row without resurrecting the first term', async () => {
+      const { getByText, getByTestId } = renderBuckets('?q=alpha+beta+gamma')
+
+      fireEvent.click(getByText('Without "alpha"'))
+      fireEvent.click(getByText('Without "beta"'))
+
+      await waitFor(() => expect(getByTestId('search').textContent).toBe('?q=gamma'))
+    })
+
     it('offers no per-term drops for a single term, where it would duplicate Clear', () => {
       const { queryByText } = renderBuckets('?q=onlyterm')
       expect(queryByText('Without "onlyterm"')).toBeFalsy()

--- a/catalog/app/containers/Home/Buckets/Buckets.spec.tsx
+++ b/catalog/app/containers/Home/Buckets/Buckets.spec.tsx
@@ -303,15 +303,44 @@ describe('website/pages/Landing/Buckets', () => {
     expect(getByText('Relevance')).toBeTruthy()
   })
 
-  it('shows a teaching empty state with the add path for admins when there are no buckets', () => {
+  // The teaching state used to tell admins to add a volume while the button that
+  // does it sat in a controls row *below* the grid — the two halves of one
+  // instruction, separated by the empty space they described.
+  it('puts the add path inside the teaching state for admins', () => {
     mockBuckets = []
     meIsAdminData = { isAdmin: true }
-    const { queryByText } = renderBuckets()
+    const { queryByText, getAllByText } = renderBuckets()
+
     expect(queryByText('No volumes yet')).toBeTruthy()
     expect(
-      queryByText('Add a volume to make it searchable and browsable here.'),
+      queryByText(
+        'Connect an S3 bucket and its packages become searchable and browsable here.',
+      ),
     ).toBeTruthy()
-    expect(queryByText('Add Bucket')).toBeTruthy()
+    // Exactly one: the row below withholds its copy at zero volumes, so the same
+    // instruction never appears twice on one screen.
+    expect(getAllByText('Add Bucket')).toHaveLength(1)
+  })
+
+  it('keeps one add path once volumes exist', () => {
+    meIsAdminData = { isAdmin: true }
+    const { getAllByText, queryByText } = renderBuckets()
+
+    expect(queryByText('No volumes yet')).toBeFalsy()
+    expect(getAllByText('Add Bucket')).toHaveLength(1)
+  })
+
+  // Bucket-specific copy is safe despite a volume also being able to be a data
+  // product: `isEmpty` is zero buckets *and* zero products, so a products-only
+  // catalog never reaches this state. This pins that — with products present the
+  // teaching state stays away entirely.
+  it('stays away when products are the only content', () => {
+    mockBuckets = []
+    dataProductsEnabled = true
+    meIsAdminData = { isAdmin: true }
+    const { queryByText } = renderBuckets()
+
+    expect(queryByText('No volumes yet')).toBeFalsy()
   })
 
   // The no-match state used to be one line with nothing on it: the only way out
@@ -395,11 +424,27 @@ describe('website/pages/Landing/Buckets', () => {
     })
   })
 
-  it('shows a plain line (no add path) for non-admins when there are no buckets', () => {
+  // Non-admins cannot connect anything, so the honest next step is who can —
+  // plus the docs, for what a volume is before they go asking.
+  it('points non-admins at the person who can, not a closed door', () => {
     mockBuckets = []
     const { queryByText } = renderBuckets()
+
     expect(queryByText('No volumes yet')).toBeTruthy()
+    expect(
+      queryByText(
+        'Your workspace admin connects these. Ask them which bucket holds the data you need.',
+      ),
+    ).toBeTruthy()
     expect(queryByText('Add Bucket')).toBeFalsy()
+
+    const help = queryByText('What is a volume?')
+    expect(help).toBeTruthy()
+    // A path the app already references, opened safely.
+    expect(help!.closest('a')!.getAttribute('href')).toBe(
+      'https://docs.quilt.bio/quilt-platform-administrator/technical-reference',
+    )
+    expect(help!.closest('a')!.getAttribute('rel')).toContain('noopener')
   })
 
   describe('the card/list view toggle', () => {

--- a/catalog/app/containers/Home/Buckets/Buckets.spec.tsx
+++ b/catalog/app/containers/Home/Buckets/Buckets.spec.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react'
 import { MemoryRouter, useLocation } from 'react-router-dom'
-import { render, cleanup, fireEvent } from '@testing-library/react'
+import { render, cleanup, fireEvent, waitFor } from '@testing-library/react'
 import { describe, expect, it, vi, afterEach } from 'vitest'
 import * as M from '@material-ui/core'
 
@@ -17,6 +17,20 @@ interface MockBucket {
   tags: ReadonlyArray<string> | null
   relevanceScore: number
 }
+
+// Named `bucket-N` with a title of `Bucket N`, matching the default below, so a
+// test that only cares about *how many* volumes exist can say so in one line.
+// `mkBucket`, not `bucket`: the ordering test below binds `bucket` as a local.
+const mkBucket = (name: string): MockBucket => ({
+  name,
+  title: name.replace(
+    /(^|-)([a-z])/g,
+    (_m, sep, c) => (sep ? ' ' : '') + c.toUpperCase(),
+  ),
+  description: null,
+  tags: null,
+  relevanceScore: 1,
+})
 
 let mockBuckets: MockBucket[] = [
   {
@@ -298,6 +312,87 @@ describe('website/pages/Landing/Buckets', () => {
       queryByText('Add a volume to make it searchable and browsable here.'),
     ).toBeTruthy()
     expect(queryByText('Add Bucket')).toBeTruthy()
+  })
+
+  // The no-match state used to be one line with nothing on it: the only way out
+  // was noticing the small clear button up in the filter field, so the more terms
+  // someone stacked the more stuck they were. These pin the recovery.
+  describe('when the filter matches nothing', () => {
+    it('reports how many volumes it actually searched', () => {
+      mockBuckets = [
+        mkBucket('bucket-one'),
+        mkBucket('bucket-two'),
+        mkBucket('bucket-three'),
+      ]
+      const { queryByText } = renderBuckets('?q=nomatchxyz')
+      expect(
+        queryByText(
+          'Searched all 3 volumes you can reach, across name, description, and tags.',
+        ),
+      ).toBeTruthy()
+    })
+
+    // The count is entries, not buckets: on this branch a data product is a
+    // volume everywhere else on the screen, so it has to be one here too.
+    it('counts data products among the volumes it searched', () => {
+      mockBuckets = [mkBucket('bucket-one')]
+      dataProductsEnabled = true
+      const { queryByText } = renderBuckets('?q=nomatchxyz')
+      // 1 bucket + the 7 fixture products.
+      expect(
+        queryByText(
+          'Searched all 8 volumes you can reach, across name, description, and tags.',
+        ),
+      ).toBeTruthy()
+    })
+
+    it('offers to drop each term when more than one narrowed it', () => {
+      const { queryByText } = renderBuckets('?q=alpha+beta')
+      expect(queryByText('Without "alpha"')).toBeTruthy()
+      expect(queryByText('Without "beta"')).toBeTruthy()
+    })
+
+    it('quotes terms back in the casing they were typed', () => {
+      // `terms` is lowercased for matching; showing that back would rewrite the
+      // reader's own input at them.
+      const { queryByText } = renderBuckets('?q=Genomics+RNA')
+      expect(queryByText('Without "Genomics"')).toBeTruthy()
+      expect(queryByText('Without "genomics"')).toBeFalsy()
+    })
+
+    // `set` updates local input state; the URL push happens in an effect gated on
+    // the field's 500ms debounce, so this waits for it rather than reading the
+    // location synchronously after the click.
+    it('drops one term and keeps the rest, preserving their casing', async () => {
+      const { getByText, getByTestId } = renderBuckets('?q=Genomics+RNA')
+      fireEvent.click(getByText('Without "Genomics"'))
+      await waitFor(() => expect(getByTestId('search').textContent).toBe('?q=RNA'))
+    })
+
+    it('offers no per-term drops for a single term, where it would duplicate Clear', () => {
+      const { queryByText } = renderBuckets('?q=onlyterm')
+      expect(queryByText('Without "onlyterm"')).toBeFalsy()
+      expect(queryByText('Clear filter')).toBeTruthy()
+    })
+
+    // Clearing empties the field on the click, not a tick later. A bare
+    // `filtering.set()` stores `undefined`, which hands the TextField
+    // `value={undefined}` — React stops controlling it and the box keeps the text
+    // already in it, so the filter looks applied while it is being cleared. The
+    // staleness is transient (`usePrevious(init, …)` repairs it from the URL a
+    // tick later), which is exactly why this asserts synchronously: an assertion
+    // after `waitFor` cannot tell the two variants apart.
+    it('empties the filter field on the click, not a tick later', async () => {
+      const { getByText, getByPlaceholderText, getByTestId } =
+        renderBuckets('?q=alpha+beta')
+      const field = getByPlaceholderText('Filter volumes') as HTMLInputElement
+      expect(field.value).toBe('alpha beta')
+
+      fireEvent.click(getByText('Clear filter'))
+
+      expect(field.value).toBe('')
+      await waitFor(() => expect(getByTestId('search').textContent).toBe(''))
+    })
   })
 
   it('shows a plain line (no add path) for non-admins when there are no buckets', () => {


### PR DESCRIPTION
A `/impeccable delight` pass on the volumes landing, targeted at `dev`.

This surface is **Operate** mode, where the playbook puts the delight budget at
first use and recovery rather than on decoration — and PRODUCT.md is explicit that
there is "no marketing energy inside the authenticated app". So nothing here is a
flourish: two dead-end states got their recovery, and the card stopped promising
interaction it didn't honour.

## What changed

**The no-match state was a wall.** Filtering to nothing rendered one line —
`No volumes matching "foo"` — with no action on it. The only escape was noticing
the small clear button up in the filter field, so the more terms someone stacked
the more stuck they were. It now reports what it actually searched (the exact
count of volumes and the fields covered — "trust is rendered, not asserted"
applied to an empty state) and hands back the controls that widen it: one
droppable chip per term, plus Clear filter. Per-term chips are withheld for a
single term, where dropping and clearing are the same action.

The count is `entries.length`, so a data product counts as a volume here exactly
as it does everywhere else on this screen — 1 bucket plus the 7 fixture products
reads "all 8 volumes". That is the substantive difference from the master version
and it has its own test.

**The first-run state taught an action it didn't offer.** Admins read "add a
volume" while the button sat in a controls row *below* the grid — two halves of
one instruction, separated by the empty space they described. The action moves
into the state; the row withholds its own so the instruction never appears twice.
Non-admins got a closed door, and now get the honest next step (ask the admin who
can) plus a docs link.

Bucket-specific copy needed checking here, since this file carries a comment
warning that "add a bucket" would be wrong on a products-only catalog. It holds:
`isEmpty` is zero buckets **and** zero products, so that catalog never reaches
this state — pinned by a test the master version couldn't express.

**The card washed edge-to-edge on hover while only the header navigated.** The
description, the tags' empty space, and the slack above the bottom row all looked
interactive and did nothing — a dead affordance, which PRODUCT.md names as a
legacy-lab-software anti-reference. The whole card is the target now, via a
stretched `::after` on the existing anchor rather than a wrapping link: the card
holds clickable tag chips and a collaborator `ButtonBase`, and a button inside an
anchor is invalid HTML that breaks keyboard and screen-reader behaviour. Press
response is tonal (the wash deepens one step), never a transform or shadow —
Overlay-Only reserves shadow for things that float and leave.

## Deliberately not here

A fourth change — withholding the controls row when there is nothing to act on —
shipped to `master` but is **absent on this branch by design**. Deciding it needs
"are there volumes", which is buckets *plus* products, and products arrive behind
`useFeature('data-products')`, which suspends. The controls row deliberately lives
outside the grid's Suspense boundary so the filter stays usable while the grid
loads, so gating it on a suspending read would remount the field and steal focus
mid-keystroke; gating on buckets alone would be wrong on a products-only catalog.
The brief records this so it isn't rediscovered as a bug. It ports directly once
`features.ts` grows a non-suspending flag read.

## Also

- Fixes a pre-existing bug in both filter-clear paths: `filtering.set()` with no
  argument stores `undefined`, so React stops controlling the TextField and the
  box keeps its old text while the filter clears underneath.
- The surface brief moves in the same diff, per the catalog's own rule. It had
  ruled out the page heading that #5193 restored, and described the empty states
  this pass replaced.

## Relationship to master

Three of these four moments are on `master` (#5193 and follow-ups). They were
**re-applied here, not cherry-picked** — the volume list diverged when data
products joined it, and a merge produced 15 conflicts. `BucketCard` and the brief
picked cleanly; `Buckets.jsx` was rebuilt on the entries model.

## Verification

- **170 test files, 1561 tests, 0 failures**; `tsc --noEmit`, `oxfmt --check`,
  `oxlint` all clean; impeccable detector clean on both touched components
- Every behavioural change **mutation-tested** — counting buckets instead of
  entries, showing lowercased terms, restoring the bare `set()`, duplicating the
  Add button, offering non-admins a button they can't use, dropping
  `rel=noopener`, positioning the card header, un-raising the card's controls:
  each fails as it should
- A first spec for `BucketCard` (there was none)

Two limits worth naming. jsdom does not resolve JSS-authored rules through
`getComputedStyle`, so the card's structural guarantees are asserted against the
injected stylesheet text; and `fireEvent.click` does no hit-testing, so "the tag
still fires" cannot prove the tag is still *reachable* under the overlay — that
one is asserted as a stacking contract instead, after mutation showed the
behavioural tests couldn't see it. **The real click surface still wants a browser
check.**


<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR adds actionable first-run and no-match recovery states and stretches bucket-card navigation across the card surface.
- Moves the administrator Add Bucket action into the zero-volume state and adds non-admin guidance.
- Adds per-term and clear-all recovery actions to the no-match state.
- Extends the bucket link with a pseudo-element overlay while raising nested controls above it.
- Adds focused tests and updates the home-surface brief.

<h3>Confidence Score: 3/5</h3>

The PR should not merge until sequential filter recovery and the remaining dead card click zones are corrected.

Rapid term removals can overwrite each other because they use stale URL-derived terms, and the raised bottom-row container prevents the stretched card link from receiving clicks in that row’s empty spaces.

**Files Needing Attention:** catalog/app/containers/Home/Buckets/Buckets.jsx; catalog/app/containers/Home/BucketGrid/BucketCard.tsx

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| catalog/app/containers/Home/Buckets/Buckets.jsx | Adds useful empty-state recovery, but rapid per-term actions can overwrite one another because they rebuild from stale URL state. |
| catalog/app/containers/Home/BucketGrid/BucketCard.tsx | Adds card-wide navigation, but raising the entire controls row leaves its non-control gaps outside the stretched link. |
| catalog/app/containers/Home/Buckets/Buckets.spec.tsx | Thoroughly covers individual empty-state actions but omits sequential term removals within the debounce interval. |
| catalog/app/containers/Home/BucketGrid/BucketCard.spec.tsx | Pins DOM and stacking structure, while correctly noting that jsdom cannot validate real pointer hit-testing. |
| catalog/.impeccable/surfaces/home.md | Updates the home-surface brief to document the new recovery states and card interaction model. |


<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
  H[Volumes home] --> E{Entries available?}
  E -->|No| Z[Zero-volume recovery]
  E -->|Yes| F{Filter matches?}
  F -->|No| N[No-match recovery]
  F -->|Yes| C[Volume cards or rows]
  N --> D[Drop one term]
  N --> X[Clear filter]
  Z -->|Admin| A[Add Bucket]
  Z -->|Non-admin| Q[Documentation]
  C --> B[Open volume]
  C --> T[Filter by tag]
  C --> R[Open collaborators]
```

<sub>Reviews (1): Last reviewed commit: ["feat(home): put the first-run action ins..."](https://github.com/quiltdata/quilt/commit/bb2f30658a867dcb5d4360f3af4f18c6ac4663f7) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=55977095)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->