### PR TITLE
ci: back-merge master into dev after every landing

### DIFF
--- a/.github/workflows/back-merge-dev.yaml
+++ b/.github/workflows/back-merge-dev.yaml
@@ -1,0 +1,81 @@
+name: Back-merge master into dev
+
+# `dev` is long-lived, and the merge queue squashes. A squash means dev's commits
+# never become ancestors of master, so the merge base freezes at whatever it was
+# when dev last received master — and every later dev->master merge conflicts on
+# files both branches "independently invented". Merging master back into dev after
+# each landing keeps master an ancestor, which keeps those merges trivial.
+#
+# Runs on every push to master because every squash refreezes the base. When dev
+# already contains master the merge is a no-op and nothing is pushed.
+
+on:
+  push:
+    branches:
+      - master
+  workflow_dispatch:
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  back-merge:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          # Full history: a shallow clone cannot compute the merge.
+          fetch-depth: 0
+
+      - name: Merge master into dev
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+
+          git config user.name 'github-actions[bot]'
+          git config user.email '41898282+github-actions[bot]@users.noreply.github.com'
+
+          git checkout dev
+
+          if git merge-base --is-ancestor origin/master HEAD; then
+            echo "dev already contains master; nothing to do."
+            exit 0
+          fi
+
+          if git merge --no-edit -m "Merge master into dev
+
+          Automated: keeps master an ancestor of dev so the next dev->master merge
+          stays trivial. See .github/workflows/back-merge-dev.yaml." origin/master; then
+            git push origin dev
+            echo "Back-merged and pushed."
+            exit 0
+          fi
+
+          # Conflicts need a person. Leave dev untouched and raise a PR against it
+          # so the resolution happens in review rather than in this runner.
+          git merge --abort
+
+          if [ -n "$(gh pr list --base dev --head master --state open --json number --jq '.[].number')" ]; then
+            echo "A master->dev PR is already open; leaving it to the existing one."
+            exit 0
+          fi
+
+          gh pr create \
+            --base dev \
+            --head master \
+            --title 'Back-merge master into dev (conflicts need resolving)' \
+            --body 'Automated back-merge hit conflicts, so `dev` was left untouched.
+
+          Resolve locally and merge:
+
+          ```
+          git fetch origin master dev
+          git checkout dev
+          git merge origin/master
+          ```
+
+          Until this lands, `master` is not an ancestor of `dev` and the next
+          `dev` -> `master` merge will conflict on every file the two branches
+          have both touched. See `.github/workflows/back-merge-dev.yaml`.'

--- a/.github/workflows/back-merge-dev.yaml
+++ b/.github/workflows/back-merge-dev.yaml
@@ -19,11 +19,23 @@ permissions:
   contents: write
   pull-requests: write
 
+# Serialized: two overlapping runs would both merge from the same `dev` tip, and
+# whichever pushed second would be rejected as non-fast-forward, leaving the newer
+# master revision outside `dev`. `cancel-in-progress: false` lets the in-flight
+# merge finish; a superseded *pending* run is safe to drop, because the run that
+# replaces it merges a newer master that already contains the one it would have.
+concurrency:
+  group: back-merge-dev
+  cancel-in-progress: false
+
 jobs:
   back-merge:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v7
+      # Pinned to a SHA, unlike the `@v7` the other workflows here use: this is the
+      # first workflow in this repo with `contents: write`, so a moved tag would
+      # execute new code against a token that can push branches.
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           # Full history: a shallow clone cannot compute the merge.
           fetch-depth: 0
@@ -37,25 +49,46 @@ jobs:
           git config user.name 'github-actions[bot]'
           git config user.email '41898282+github-actions[bot]@users.noreply.github.com'
 
-          git checkout dev
+          # Retried, because `dev` can move under us between the merge and the push
+          # from something this workflow does not serialize with -- a PR merging into
+          # dev, or a direct push. A rejected push would otherwise leave the newest
+          # master revision outside dev until the next landing.
+          conflicted=no
 
-          if git merge-base --is-ancestor origin/master HEAD; then
-            echo "dev already contains master; nothing to do."
-            exit 0
-          fi
+          for attempt in 1 2 3; do
+            git fetch --quiet origin master dev
+            git checkout --quiet -B dev origin/dev
 
-          if git merge --no-edit -m "Merge master into dev
+            if git merge-base --is-ancestor origin/master HEAD; then
+              echo "dev already contains master; nothing to do."
+              exit 0
+            fi
+
+            if ! git merge --no-edit -m "Merge master into dev
 
           Automated: keeps master an ancestor of dev so the next dev->master merge
           stays trivial. See .github/workflows/back-merge-dev.yaml." origin/master; then
-            git push origin dev
-            echo "Back-merged and pushed."
-            exit 0
-          fi
+              # Conflicts need a person: stop retrying and raise a PR below.
+              git merge --abort
+              conflicted=yes
+              break
+            fi
 
-          # Conflicts need a person. Leave dev untouched and raise a PR against it
-          # so the resolution happens in review rather than in this runner.
-          git merge --abort
+            if git push origin dev; then
+              echo "Back-merged and pushed."
+              exit 0
+            fi
+
+            echo "Push rejected (dev moved); retrying (attempt $attempt)."
+          done
+
+          # Exhausting the retries without conflicting is a different failure: the
+          # merge works, something just keeps winning the race. Fail loudly rather
+          # than opening a PR that blames conflicts which never happened.
+          if [ "$conflicted" = no ]; then
+            echo "::error::Could not push dev after 3 attempts; it kept moving. Re-run this workflow."
+            exit 1
+          fi
 
           if [ -n "$(gh pr list --base dev --head master --state open --json number --jq '.[].number')" ]; then
             echo "A master->dev PR is already open; leaving it to the existing one."


### PR DESCRIPTION
Closes the loop on the `master`/`dev` drift: automates the back-merge so the merge
base cannot freeze again.

## The problem it solves

`dev` is long-lived and the merge queue's `merge_method` is `SQUASH`. A squash means
dev's commits never become ancestors of `master`, so the merge base freezes at
whatever it was when `dev` last received `master`. Every later `dev` → `master`
merge then conflicts on files git believes both branches invented independently.

Measured, not hypothetical: the base sat at **2026-08-14** while #5189's content
shipped to master on **08-21**. Reconciling took 14 conflicted files — **9 of them
artifacts of the frozen base**, where one side of the hunk was empty or held code
the other side's fix had already replaced.

It also recurs immediately. #5177 merged an hour ago and `master` stopped being an
ancestor of `dev` again on that one commit.

## Behaviour

Runs on every push to `master`, because every squash refreezes the base.

| Situation | Action |
|---|---|
| `dev` already contains `master` | no-op, nothing pushed |
| Merges cleanly | push (usually a zero-content ancestry link) |
| Conflicts | abort, leave `dev` untouched, open a PR against `dev` |

Conflicts go to a PR rather than being resolved in the runner — a bot picking
`--ours` on a real disagreement is how you lose work silently. It also checks for an
existing `master` → `dev` PR so a stuck conflict doesn't spawn one per push.

## Verified

All three paths exercised against a scratch clone of this repo, with a simulated
squash on `master` and a simulated conflicting edit on both sides:

- ancestor case → exits 0 without pushing
- clean case → merges, and `master` is an ancestor afterwards
- conflict case → `git merge --abort` leaves `dev` with 0 uncommitted files

`yaml.safe_load` parses the workflow; `bash -n` accepts the extracted `run` block.

## Note on scope

This does not change the queue's squash method, which stays right for the
short-lived branches it was set up for. It removes the *consequence* of squashing a
long-lived branch instead. If `dev` ever becomes short-lived, this workflow becomes
a no-op rather than something to unwind.


<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds a GitHub Actions workflow that merges every new master revision back into the long-lived dev branch, avoiding merge-base drift from squash landings.
- Exits without pushing when dev already contains master.
- Pushes clean merges directly to dev.
- Aborts conflicts and opens or reuses a master-to-dev pull request for human resolution.

<h3>Confidence Score: 4/5</h3>

The workflow should not merge until concurrent master landings are serialized or a rejected dev push is retried, because the newest landing can otherwise remain unmerged.

Independent runs can derive merge commits from the same dev tip, causing one plain push to fail as non-fast-forward with no automatic recovery; the mutable action reference is an additional non-blocking supply-chain weakness.

**Files Needing Attention:** .github/workflows/back-merge-dev.yaml

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| .github/workflows/back-merge-dev.yaml | Adds the complete back-merge workflow, but concurrent runs can race on the dev push and the privileged checkout action is not immutably pinned. |


<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Push to master] --> B[Checkout full history]
    B --> C{Master already ancestor of dev?}
    C -->|Yes| D[No-op]
    C -->|No| E{Merge master into dev cleanly?}
    E -->|Yes| F[Push dev]
    E -->|Conflict| G[Abort merge]
    G --> H{Existing master to dev PR?}
    H -->|Yes| I[Leave existing PR]
    H -->|No| J[Open conflict-resolution PR]
```

<sub>Reviews (1): Last reviewed commit: ["ci: back-merge master into dev after eve..."](https://github.com/quiltdata/quilt/commit/421eb6d53ce3a1c2ec4f9cd2bb32423eb5d5e166) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=56037734)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->