### PR TITLE
catalog: teach the design sidecar about identity tints

### DIFF
--- a/catalog/.impeccable/design.json
+++ b/catalog/.impeccable/design.json
@@ -1,45 +1,330 @@
 {
   "schemaVersion": 2,
-  "generatedAt": "2026-07-23T00:00:00Z",
+  "generatedAt": "2026-08-24T22:46:44Z",
   "title": "Design System: Quilt Catalog",
   "extensions": {
     "colorMeta": {
-      "midnight-chassis": { "role": "primary", "displayName": "Midnight Chassis", "canonical": "#19163b", "tonalRamp": ["#0a0918", "#100e28", "#19163b", "#2a265c", "#3f3a80", "#5a55a3", "#7d79bd", "#a5a2d4"] },
-      "amber-indicator": { "role": "secondary", "displayName": "Amber Indicator", "canonical": "#fb8c00", "tonalRamp": ["#4a2900", "#7a4400", "#b06200", "#fb8c00", "#ffa733", "#ffc066", "#ffd699", "#ffeacc"] },
-      "navigation-text": { "role": "neutral", "displayName": "Navigation Text", "canonical": "rgba(255,255,255,0.85)" },
-      "navigation-text-muted": { "role": "neutral", "displayName": "Navigation Text Muted", "canonical": "rgba(255,255,255,0.6)" },
-      "navigation-hover": { "role": "neutral", "displayName": "Navigation Hover Wash", "canonical": "rgba(255,255,255,0.06)" },
-      "navigation-selected": { "role": "neutral", "displayName": "Navigation Selected Wash", "canonical": "rgba(255,255,255,0.18)" },
-      "canvas": { "role": "neutral", "displayName": "Canvas", "canonical": "#fafafa" },
-      "surface": { "role": "neutral", "displayName": "Surface", "canonical": "#ffffff" },
-      "ink": { "role": "neutral", "displayName": "Ink", "canonical": "rgba(0,0,0,0.87)" },
-      "ink-secondary": { "role": "neutral", "displayName": "Ink Secondary", "canonical": "rgba(0,0,0,0.54)" },
-      "divider": { "role": "neutral", "displayName": "Divider", "canonical": "rgba(0,0,0,0.12)" }
+      "midnight-chassis": {
+        "role": "primary",
+        "displayName": "Midnight Chassis",
+        "canonical": "#19163b",
+        "tonalRamp": [
+          "#0a0918",
+          "#100e28",
+          "#19163b",
+          "#2a265c",
+          "#3f3a80",
+          "#5a55a3",
+          "#7d79bd",
+          "#a5a2d4"
+        ]
+      },
+      "amber-indicator": {
+        "role": "secondary",
+        "displayName": "Amber Indicator",
+        "canonical": "#fb8c00",
+        "tonalRamp": [
+          "#4a2900",
+          "#7a4400",
+          "#b06200",
+          "#fb8c00",
+          "#ffa733",
+          "#ffc066",
+          "#ffd699",
+          "#ffeacc"
+        ]
+      },
+      "navigation-text": {
+        "role": "neutral",
+        "displayName": "Navigation Text",
+        "canonical": "rgba(255,255,255,0.85)"
+      },
+      "navigation-text-muted": {
+        "role": "neutral",
+        "displayName": "Navigation Text Muted",
+        "canonical": "rgba(255,255,255,0.6)"
+      },
+      "navigation-hover": {
+        "role": "neutral",
+        "displayName": "Navigation Hover Wash",
+        "canonical": "rgba(255,255,255,0.06)"
+      },
+      "navigation-selected": {
+        "role": "neutral",
+        "displayName": "Navigation Selected Wash",
+        "canonical": "rgba(255,255,255,0.18)"
+      },
+      "canvas": {
+        "role": "neutral",
+        "displayName": "Canvas",
+        "canonical": "#fafafa"
+      },
+      "surface": {
+        "role": "neutral",
+        "displayName": "Surface",
+        "canonical": "#ffffff"
+      },
+      "ink": {
+        "role": "neutral",
+        "displayName": "Ink",
+        "canonical": "rgba(0,0,0,0.87)"
+      },
+      "ink-secondary": {
+        "role": "neutral",
+        "displayName": "Ink Secondary",
+        "canonical": "rgba(0,0,0,0.54)"
+      },
+      "divider": {
+        "role": "neutral",
+        "displayName": "Divider",
+        "canonical": "rgba(0,0,0,0.12)"
+      },
+      "tint-indigo": {
+        "role": "identity-tint",
+        "displayName": "Indigo (identity tint)",
+        "canonical": "#e8eaf6",
+        "ink": "#283593",
+        "materialTier": "50/800",
+        "tonalRamp": [
+          "#283593",
+          "#e8eaf6"
+        ]
+      },
+      "tint-indigo-deep": {
+        "role": "identity-tint",
+        "displayName": "Indigo Deep (identity tint)",
+        "canonical": "#c5cae9",
+        "ink": "#1a237e",
+        "materialTier": "100/900",
+        "tonalRamp": [
+          "#1a237e",
+          "#c5cae9"
+        ]
+      },
+      "tint-teal": {
+        "role": "identity-tint",
+        "displayName": "Teal (identity tint)",
+        "canonical": "#e0f2f1",
+        "ink": "#00695c",
+        "materialTier": "50/800",
+        "tonalRamp": [
+          "#00695c",
+          "#e0f2f1"
+        ]
+      },
+      "tint-teal-deep": {
+        "role": "identity-tint",
+        "displayName": "Teal Deep (identity tint)",
+        "canonical": "#b2dfdb",
+        "ink": "#004d40",
+        "materialTier": "100/900",
+        "tonalRamp": [
+          "#004d40",
+          "#b2dfdb"
+        ]
+      },
+      "tint-green": {
+        "role": "identity-tint",
+        "displayName": "Green (identity tint)",
+        "canonical": "#e8f5e9",
+        "ink": "#2e7d32",
+        "materialTier": "50/800",
+        "tonalRamp": [
+          "#2e7d32",
+          "#e8f5e9"
+        ]
+      },
+      "tint-light-green": {
+        "role": "identity-tint",
+        "displayName": "Light Green (identity tint)",
+        "canonical": "#dcedc8",
+        "ink": "#33691e",
+        "materialTier": "100/900",
+        "tonalRamp": [
+          "#33691e",
+          "#dcedc8"
+        ]
+      },
+      "tint-purple": {
+        "role": "identity-tint",
+        "displayName": "Purple (identity tint)",
+        "canonical": "#f3e5f5",
+        "ink": "#6a1b9a",
+        "materialTier": "50/800",
+        "tonalRamp": [
+          "#6a1b9a",
+          "#f3e5f5"
+        ]
+      },
+      "tint-deep-purple": {
+        "role": "identity-tint",
+        "displayName": "Deep Purple (identity tint)",
+        "canonical": "#d1c4e9",
+        "ink": "#4527a0",
+        "materialTier": "100/900",
+        "tonalRamp": [
+          "#4527a0",
+          "#d1c4e9"
+        ]
+      },
+      "tint-pink": {
+        "role": "identity-tint",
+        "displayName": "Pink (identity tint)",
+        "canonical": "#fce4ec",
+        "ink": "#ad1457",
+        "materialTier": "50/800",
+        "tonalRamp": [
+          "#ad1457",
+          "#fce4ec"
+        ]
+      },
+      "tint-pink-deep": {
+        "role": "identity-tint",
+        "displayName": "Pink Deep (identity tint)",
+        "canonical": "#f8bbd0",
+        "ink": "#880e4f",
+        "materialTier": "100/900",
+        "tonalRamp": [
+          "#880e4f",
+          "#f8bbd0"
+        ]
+      },
+      "tint-brown": {
+        "role": "identity-tint",
+        "displayName": "Brown (identity tint)",
+        "canonical": "#efebe9",
+        "ink": "#4e342e",
+        "materialTier": "50/800",
+        "tonalRamp": [
+          "#4e342e",
+          "#efebe9"
+        ]
+      },
+      "tint-brown-deep": {
+        "role": "identity-tint",
+        "displayName": "Brown Deep (identity tint)",
+        "canonical": "#d7ccc8",
+        "ink": "#3e2723",
+        "materialTier": "100/900",
+        "tonalRamp": [
+          "#3e2723",
+          "#d7ccc8"
+        ]
+      },
+      "tint-blue": {
+        "role": "identity-tint",
+        "displayName": "Blue (identity tint)",
+        "canonical": "#bbdefb",
+        "ink": "#0d47a1",
+        "materialTier": "100/900",
+        "tonalRamp": [
+          "#0d47a1",
+          "#bbdefb"
+        ]
+      },
+      "tint-cyan-deep": {
+        "role": "identity-tint",
+        "displayName": "Cyan Deep (identity tint)",
+        "canonical": "#b2ebf2",
+        "ink": "#006064",
+        "materialTier": "100/900",
+        "tonalRamp": [
+          "#006064",
+          "#b2ebf2"
+        ]
+      },
+      "tint-blue-grey": {
+        "role": "identity-tint",
+        "displayName": "Blue Grey (identity tint)",
+        "canonical": "#cfd8dc",
+        "ink": "#37474f",
+        "materialTier": "100/800",
+        "tonalRamp": [
+          "#37474f",
+          "#cfd8dc"
+        ]
+      }
     },
     "typographyMeta": {
-      "display": { "displayName": "Display", "purpose": "Legacy landing surfaces only, pending the homepage redesign; never inside the app." },
-      "headline": { "displayName": "Headline", "purpose": "Page-level headings in the app (Material h5)." },
-      "title": { "displayName": "Title", "purpose": "Section and card headings (Material h6)." },
-      "body": { "displayName": "Body", "purpose": "The workhorse: tables, descriptions, prose (Material body2)." },
-      "label": { "displayName": "Label", "purpose": "Buttons and control labels — uppercase Material button treatment." },
-      "caption": { "displayName": "Caption", "purpose": "Fine print and compact readouts: the version row, keycap hints, helper lines." },
-      "overline": { "displayName": "Overline", "purpose": "The chrome's section labels (the rail's 'Workspace'); a signpost step, never body text." },
-      "mono": { "displayName": "Mono", "purpose": "Machine-exact identity: hashes, s3:// URIs, package handles, versions." }
+      "display": {
+        "displayName": "Display",
+        "purpose": "Legacy landing surfaces only, pending the homepage redesign; never inside the app."
+      },
+      "headline": {
+        "displayName": "Headline",
+        "purpose": "Page-level headings in the app (Material h5)."
+      },
+      "title": {
+        "displayName": "Title",
+        "purpose": "Section and card headings (Material h6)."
+      },
+      "body": {
+        "displayName": "Body",
+        "purpose": "The workhorse: tables, descriptions, prose (Material body2)."
+      },
+      "label": {
+        "displayName": "Label",
+        "purpose": "Buttons and control labels — uppercase Material button treatment."
+      },
+      "caption": {
+        "displayName": "Caption",
+        "purpose": "Fine print and compact readouts: the version row, keycap hints, helper lines."
+      },
+      "overline": {
+        "displayName": "Overline",
+        "purpose": "The chrome's section labels (the rail's 'Workspace'); a signpost step, never body text."
+      },
+      "mono": {
+        "displayName": "Mono",
+        "purpose": "Machine-exact identity: hashes, s3:// URIs, package handles, versions."
+      }
     },
     "shadows": [
-      { "name": "overlay", "value": "0px 5px 5px -3px rgba(0,0,0,0.2), 0px 8px 10px 1px rgba(0,0,0,0.14), 0px 3px 14px 2px rgba(0,0,0,0.12)", "purpose": "Floating controls that will leave: menus, popovers, the search suggestions (Material elevation 8)." },
-      { "name": "modal", "value": "0px 11px 15px -7px rgba(0,0,0,0.2), 0px 24px 38px 3px rgba(0,0,0,0.14), 0px 9px 46px 8px rgba(0,0,0,0.12)", "purpose": "Dialogs — the strongest depth in the system (Material elevation 24)." }
+      {
+        "name": "overlay",
+        "value": "0px 5px 5px -3px rgba(0,0,0,0.2), 0px 8px 10px 1px rgba(0,0,0,0.14), 0px 3px 14px 2px rgba(0,0,0,0.12)",
+        "purpose": "Floating controls that will leave: menus, popovers, the search suggestions (Material elevation 8)."
+      },
+      {
+        "name": "modal",
+        "value": "0px 11px 15px -7px rgba(0,0,0,0.2), 0px 24px 38px 3px rgba(0,0,0,0.14), 0px 9px 46px 8px rgba(0,0,0,0.12)",
+        "purpose": "Dialogs — the strongest depth in the system (Material elevation 24)."
+      }
     ],
     "motion": [
-      { "name": "ease-standard", "value": "cubic-bezier(0.4, 0, 0.2, 1)", "purpose": "Default easing for state transitions." },
-      { "name": "duration-short", "value": "150ms", "purpose": "Hover/press feedback." },
-      { "name": "duration-standard", "value": "250ms", "purpose": "Panel and overlay transitions; motion conveys state, never decoration." }
+      {
+        "name": "ease-standard",
+        "value": "cubic-bezier(0.4, 0, 0.2, 1)",
+        "purpose": "Default easing for state transitions."
+      },
+      {
+        "name": "duration-short",
+        "value": "150ms",
+        "purpose": "Hover/press feedback."
+      },
+      {
+        "name": "duration-standard",
+        "value": "250ms",
+        "purpose": "Panel and overlay transitions; motion conveys state, never decoration."
+      }
     ],
     "breakpoints": [
-      { "name": "sm", "value": "600px" },
-      { "name": "md", "value": "960px" },
-      { "name": "lg", "value": "1280px" },
-      { "name": "xl", "value": "1920px" }
+      {
+        "name": "sm",
+        "value": "600px"
+      },
+      {
+        "name": "md",
+        "value": "960px"
+      },
+      {
+        "name": "lg",
+        "value": "1280px"
+      },
+      {
+        "name": "xl",
+        "value": "1920px"
+      }
     ]
   },
   "components": [
@@ -118,12 +403,41 @@
       "Standard Material affordances; density serves the task, calm serves everything else."
     ],
     "rules": [
-      { "name": "The Indicator Rule", "body": "Accents indicate — selection, state, attention. One selection vocabulary product-wide: the selected item wears the amber indicator (the rail's 3px bracket, a tab's underline) alongside its wash. An accent on ≤10% of any screen; an accent used as decoration is a defect. Amber is never a surface, a tint, or a fill.", "section": "colors" },
-      { "name": "The One-Register Rule", "body": "The product has one register: the instrument. No gradient CTAs, coral accents, hero typography, or marketing chrome anywhere — including sign-in, error pages, and anonymous surfaces, which wear the bare variant of the same register.", "section": "colors" },
-      { "name": "The Focus Ring Rule", "body": "Keyboard focus is never invisible: a 2px ring in the counter-color of the ground — Amber Indicator on midnight chrome, Midnight Chassis on light surfaces.", "section": "colors" },
-      { "name": "The Mono Identity Rule", "body": "Anything content-addressed or machine-exact — hashes, s3:// URIs, package handles, version ids — renders in Roboto Mono where it's read as identity: detail views, breadcrumbs, copy-affordance rows. A repeated scanning label in a dense list (e.g. the s3:// name on every row of the bucket list) is a carve-out — it renders in body type, secondary ink; a wall of mono there reads heavy, not exact. Prose never does.", "section": "typography" },
-      { "name": "The No-Display-Font Rule", "body": "Display sizes and the 300 weight have no home in the app; nothing outranks a Headline. They linger only on legacy landing surfaces pending the homepage redesign.", "section": "typography" },
-      { "name": "The Overlay-Only Rule", "body": "A shadow means 'this floats above the plane and will leave.' If it doesn't leave, it doesn't get a shadow — it gets a border.", "section": "elevation" }
+      {
+        "name": "The Indicator Rule",
+        "body": "Accents indicate — selection, state, attention. One selection vocabulary product-wide: the selected item wears the amber indicator (the rail's 3px bracket, a tab's underline) alongside its wash. An accent on ≤10% of any screen; an accent used as decoration is a defect. Amber is never a surface, a tint, or a fill.",
+        "section": "colors"
+      },
+      {
+        "name": "The Identity Tint Rule",
+        "body": "Identity tints encode *which object*, never *what state*. They are categorical — never semantic, never an accent, never emphasis, and never a page or panel surface. They appear only as the ground of an identity avatar, and they never carry meaning a label could not. The set is closed, and the exclusions are the load-bearing part: the Amber Indicator's hue (an identity must never read as a selection), the semantic Info/Warning pairs — note Light Blue 50 *is* the Info Blue wash — the error register (red, deep orange), and lime, which cannot clear AA against any ink of its own hue. Adding a tint means adding a pale ground with a dark same-hue ink that clears AA and sits visibly apart from every ground already here.",
+        "section": "colors"
+      },
+      {
+        "name": "The One-Register Rule",
+        "body": "The product has one register: the instrument. No gradient CTAs, coral accents, hero typography, or marketing chrome anywhere — including sign-in, error pages, and anonymous surfaces, which wear the bare variant of the same register.",
+        "section": "colors"
+      },
+      {
+        "name": "The Focus Ring Rule",
+        "body": "Keyboard focus is never invisible: a 2px ring in the counter-color of the ground — Amber Indicator on midnight chrome, Midnight Chassis on light surfaces.",
+        "section": "colors"
+      },
+      {
+        "name": "The Mono Identity Rule",
+        "body": "Anything content-addressed or machine-exact — hashes, s3:// URIs, package handles, version ids — renders in Roboto Mono where it's read as identity: detail views, breadcrumbs, copy-affordance rows. A repeated scanning label in a dense list (e.g. the s3:// name on every row of the bucket list) is a carve-out — it renders in body type, secondary ink; a wall of mono there reads heavy, not exact. Prose never does.",
+        "section": "typography"
+      },
+      {
+        "name": "The No-Display-Font Rule",
+        "body": "Display sizes and the 300 weight have no home in the app; nothing outranks a Headline. They linger only on legacy landing surfaces pending the homepage redesign.",
+        "section": "typography"
+      },
+      {
+        "name": "The Overlay-Only Rule",
+        "body": "A shadow means 'this floats above the plane and will leave.' If it doesn't leave, it doesn't get a shadow — it gets a border.",
+        "section": "elevation"
+      }
     ],
     "dos": [
       "Do keep the instrument quiet: white surfaces, midnight chrome, one accent indicating — the data is the loudest thing on screen.",


### PR DESCRIPTION
`.impeccable/design.json` never carried the identity tints — not the original six, not the fifteen that shipped in #5210. Its `colorMeta` covered the eleven chrome tokens and stopped, and its `generatedAt` was `2026-07-23`, predating the tint system entirely. So design tooling reading the sidecar saw a palette with no way to tell one object from another, and the rules list mirrored DESIGN.md's other six rules while omitting the Identity Tint Rule.

## Sidecar only

`DESIGN.md` is the normative source here and is already correct — it was updated in the same diff as the code in #5210. So the tint pairs and the rule text are **copied from it** rather than re-derived from the implementation, which keeps the hand-authored reasoning verbatim (including why Light Blue 50 is barred: it *is* the Info Blue wash).

`DESIGN.md` is untouched by this PR.

## Verification

- All 15 ground/ink pairs agree across **sidecar, DESIGN.md, and `BucketIcon.tsx`** — compared programmatically, all three equal
- **Zero leaf values lost**: 175 → 283, pure addition. Diffed old against new by walking every leaf path
- 8 components and 11 chrome `colorMeta` entries preserved

## Two judgment calls

**2-step tonal ramps, not 8.** The `document` playbook asks for an 8-step ramp per color. Each tint gets its ground and its ink instead, because that is what the system renders — synthesizing six intermediate steps would put values in the sidecar that no surface uses, which is the "fabricated tokens pollute the spec" failure the same playbook warns against.

**The diff is larger than the change.** `json.dumps(indent=2)` re-emits previously compact single-line entries one property per line. The 35 deletions are reformatting, not removal — see the leaf-count check above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Updates the Catalog design-tooling sidecar to expose the existing identity-tint system without changing runtime behavior.
- Adds metadata for all 15 identity tint ground/ink pairs.
- Adds the Identity Tint Rule already documented by the normative design system.
- Refreshes the generation timestamp and expands existing compact JSON formatting without removing prior metadata.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge because the sidecar-only additions are consistent with the existing design specification and no runtime or tooling failure was established.

The change adds documentation-oriented tint metadata and reformats preserved JSON; no repository consumer rejects the new shape, and the added palette agrees with the documented identity-tint system.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| catalog/.impeccable/design.json | Adds internally consistent identity-tint metadata and rule text while preserving the existing sidecar content; no actionable defect was identified. |

<sub>Reviews (1): Last reviewed commit: ["catalog: teach the design sidecar about ..."](https://github.com/quiltdata/quilt/commit/8194bf6d0f7dbe85a7e74fbf3a7590f4ee341d36) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=56447666)</sub>

<!-- /greptile_comment -->