### PR TITLE
tabular_preview: make a zero-row preview a loadable Arrow file

### DIFF
--- a/lambdas/tabular_preview/CHANGELOG.md
+++ b/lambdas/tabular_preview/CHANGELOG.md
@@ -17,6 +17,7 @@ where verb is one of
 
 ## Changes
 
+- [Fixed] A preview with no rows is now a loadable Arrow file: a 0-row table yields no record batches, and a batch-less IPC file cannot be loaded, so a header-only file or one whose every data row was skipped as invalid failed to render instead of showing an empty table (PR-NUMBER)
 - [Added] Preview h5ad (anndata) files ([#4636](https://github.com/quiltdata/quilt/pull/4636))
 - [Changed] Switch to uv ([#4654](https://github.com/quiltdata/quilt/pull/4654))
 - [Changed] Upgrade to Python 3.13 ([#4654](https://github.com/quiltdata/quilt/pull/4654))

--- a/lambdas/tabular_preview/CHANGELOG.md
+++ b/lambdas/tabular_preview/CHANGELOG.md
@@ -17,7 +17,7 @@ where verb is one of
 
 ## Changes
 
-- [Fixed] A preview with no rows is now a loadable Arrow file: a 0-row table yields no record batches, and a batch-less IPC file cannot be loaded, so a header-only file or one whose every data row was skipped as invalid failed to render instead of showing an empty table ([#5214](https://github.com/quiltdata/quilt/pull/5214))
+- [Fixed] A preview with no rows renders as an empty table instead of failing ([#5214](https://github.com/quiltdata/quilt/pull/5214))
 - [Added] Preview h5ad (anndata) files ([#4636](https://github.com/quiltdata/quilt/pull/4636))
 - [Changed] Switch to uv ([#4654](https://github.com/quiltdata/quilt/pull/4654))
 - [Changed] Upgrade to Python 3.13 ([#4654](https://github.com/quiltdata/quilt/pull/4654))

--- a/lambdas/tabular_preview/CHANGELOG.md
+++ b/lambdas/tabular_preview/CHANGELOG.md
@@ -17,7 +17,7 @@ where verb is one of
 
 ## Changes
 
-- [Fixed] A preview with no rows renders as an empty table instead of failing ([#5214](https://github.com/quiltdata/quilt/pull/5214))
+- [Fixed] A zero-row preview now carries an empty record batch, without which the catalog cannot load it ([#5214](https://github.com/quiltdata/quilt/pull/5214))
 - [Added] Preview h5ad (anndata) files ([#4636](https://github.com/quiltdata/quilt/pull/4636))
 - [Changed] Switch to uv ([#4654](https://github.com/quiltdata/quilt/pull/4654))
 - [Changed] Upgrade to Python 3.13 ([#4654](https://github.com/quiltdata/quilt/pull/4654))

--- a/lambdas/tabular_preview/CHANGELOG.md
+++ b/lambdas/tabular_preview/CHANGELOG.md
@@ -17,7 +17,7 @@ where verb is one of
 
 ## Changes
 
-- [Fixed] A preview with no rows is now a loadable Arrow file: a 0-row table yields no record batches, and a batch-less IPC file cannot be loaded, so a header-only file or one whose every data row was skipped as invalid failed to render instead of showing an empty table (PR-NUMBER)
+- [Fixed] A preview with no rows is now a loadable Arrow file: a 0-row table yields no record batches, and a batch-less IPC file cannot be loaded, so a header-only file or one whose every data row was skipped as invalid failed to render instead of showing an empty table ([#5214](https://github.com/quiltdata/quilt/pull/5214))
 - [Added] Preview h5ad (anndata) files ([#4636](https://github.com/quiltdata/quilt/pull/4636))
 - [Changed] Switch to uv ([#4654](https://github.com/quiltdata/quilt/pull/4654))
 - [Changed] Upgrade to Python 3.13 ([#4654](https://github.com/quiltdata/quilt/pull/4654))

--- a/lambdas/tabular_preview/CHANGELOG.md
+++ b/lambdas/tabular_preview/CHANGELOG.md
@@ -17,7 +17,7 @@ where verb is one of
 
 ## Changes
 
-- [Fixed] A zero-row preview now carries an empty record batch, without which the catalog cannot load it ([#5214](https://github.com/quiltdata/quilt/pull/5214))
+- [Fixed] A zero-row preview now carries an empty record batch instead of none, which the catalog could not load ([#5214](https://github.com/quiltdata/quilt/pull/5214))
 - [Added] Preview h5ad (anndata) files ([#4636](https://github.com/quiltdata/quilt/pull/4636))
 - [Changed] Switch to uv ([#4654](https://github.com/quiltdata/quilt/pull/4654))
 - [Changed] Upgrade to Python 3.13 ([#4654](https://github.com/quiltdata/quilt/pull/4654))

--- a/lambdas/tabular_preview/src/t4_lambda_tabular_preview/__init__.py
+++ b/lambdas/tabular_preview/src/t4_lambda_tabular_preview/__init__.py
@@ -121,7 +121,7 @@ def write_data_as_arrow(data, schema, max_size):
             if not writer.stats.num_record_batches:
                 # perspective's arrow_loader.cpp calls Table::FromRecordBatches
                 # without a schema, so it rejects a batch-less file. Fixed in
-                # 3.2.0 by finos/perspective#2854; the catalog pins 1.9.4.
+                # 3.2.0 by finos/perspective#2854.
                 writer.write(pyarrow.RecordBatch.from_pylist([], schema=schema))
 
     return memoryview(buf.getvalue()), truncated

--- a/lambdas/tabular_preview/src/t4_lambda_tabular_preview/__init__.py
+++ b/lambdas/tabular_preview/src/t4_lambda_tabular_preview/__init__.py
@@ -104,6 +104,7 @@ def write_data_as_arrow(data, schema, max_size):
         data = data.to_batches(OUT_BATCH_SIZE)
 
     truncated = False
+    written = False
     buf = pyarrow.BufferOutputStream()
     with pyarrow.CompressedOutputStream(buf, "gzip") as sink:
         with pyarrow.ipc.new_file(sink, schema) as writer:
@@ -117,6 +118,18 @@ def write_data_as_arrow(data, schema, max_size):
                     truncated = True
                     break
                 writer.write(batch)
+                written = True
+
+            if not written:
+                # A file carrying a schema and no record batches is not loadable by
+                # the consumer: perspective builds its table from the batches and
+                # rejects a batch-less file outright ("Must pass at least one record
+                # batch or an explicit Schema"), so the preview fails instead of
+                # showing an empty table. Reachable whenever nothing gets written --
+                # a header-only CSV, one whose every data row was skipped as invalid,
+                # or a first batch already too large for max_size. Emit one empty
+                # batch so the schema arrives in a form that loads.
+                writer.write(pyarrow.RecordBatch.from_pylist([], schema=schema))
 
     return memoryview(buf.getvalue()), truncated
 

--- a/lambdas/tabular_preview/src/t4_lambda_tabular_preview/__init__.py
+++ b/lambdas/tabular_preview/src/t4_lambda_tabular_preview/__init__.py
@@ -119,12 +119,7 @@ def write_data_as_arrow(data, schema, max_size):
                 writer.write(batch)
 
             if not writer.stats.num_record_batches:
-                # A file carrying a schema and no record batches is not loadable:
-                # perspective builds its table from the batches and rejects one with
-                # none ("Must pass at least one record batch or an explicit Schema"),
-                # so the preview fails instead of showing an empty table. Reached by
-                # a header-only file, one whose every data row was skipped as
-                # invalid, or a first batch already too large for max_size.
+                # perspective rejects an IPC file with a schema and no batches
                 writer.write(pyarrow.RecordBatch.from_pylist([], schema=schema))
 
     return memoryview(buf.getvalue()), truncated

--- a/lambdas/tabular_preview/src/t4_lambda_tabular_preview/__init__.py
+++ b/lambdas/tabular_preview/src/t4_lambda_tabular_preview/__init__.py
@@ -104,7 +104,6 @@ def write_data_as_arrow(data, schema, max_size):
         data = data.to_batches(OUT_BATCH_SIZE)
 
     truncated = False
-    written = False
     buf = pyarrow.BufferOutputStream()
     with pyarrow.CompressedOutputStream(buf, "gzip") as sink:
         with pyarrow.ipc.new_file(sink, schema) as writer:
@@ -118,17 +117,14 @@ def write_data_as_arrow(data, schema, max_size):
                     truncated = True
                     break
                 writer.write(batch)
-                written = True
 
-            if not written:
-                # A file carrying a schema and no record batches is not loadable by
-                # the consumer: perspective builds its table from the batches and
-                # rejects a batch-less file outright ("Must pass at least one record
-                # batch or an explicit Schema"), so the preview fails instead of
-                # showing an empty table. Reachable whenever nothing gets written --
-                # a header-only CSV, one whose every data row was skipped as invalid,
-                # or a first batch already too large for max_size. Emit one empty
-                # batch so the schema arrives in a form that loads.
+            if not writer.stats.num_record_batches:
+                # A file carrying a schema and no record batches is not loadable:
+                # perspective builds its table from the batches and rejects one with
+                # none ("Must pass at least one record batch or an explicit Schema"),
+                # so the preview fails instead of showing an empty table. Reached by
+                # a header-only file, one whose every data row was skipped as
+                # invalid, or a first batch already too large for max_size.
                 writer.write(pyarrow.RecordBatch.from_pylist([], schema=schema))
 
     return memoryview(buf.getvalue()), truncated

--- a/lambdas/tabular_preview/src/t4_lambda_tabular_preview/__init__.py
+++ b/lambdas/tabular_preview/src/t4_lambda_tabular_preview/__init__.py
@@ -119,7 +119,9 @@ def write_data_as_arrow(data, schema, max_size):
                 writer.write(batch)
 
             if not writer.stats.num_record_batches:
-                # perspective rejects an IPC file with a schema and no batches
+                # perspective rejects an IPC file with a schema and no batches. Fixed
+                # in the v3 Rust engine, still broken in v2, so this goes when the
+                # catalog reaches v3 -- not on a v2 upgrade.
                 writer.write(pyarrow.RecordBatch.from_pylist([], schema=schema))
 
     return memoryview(buf.getvalue()), truncated

--- a/lambdas/tabular_preview/src/t4_lambda_tabular_preview/__init__.py
+++ b/lambdas/tabular_preview/src/t4_lambda_tabular_preview/__init__.py
@@ -119,9 +119,9 @@ def write_data_as_arrow(data, schema, max_size):
                 writer.write(batch)
 
             if not writer.stats.num_record_batches:
-                # perspective rejects an IPC file with a schema and no batches. Fixed
-                # in the v3 Rust engine, still broken in v2, so this goes when the
-                # catalog reaches v3 -- not on a v2 upgrade.
+                # perspective's arrow_loader.cpp calls Table::FromRecordBatches
+                # without a schema, so it rejects a batch-less file. Fixed in v3,
+                # not v2.
                 writer.write(pyarrow.RecordBatch.from_pylist([], schema=schema))
 
     return memoryview(buf.getvalue()), truncated

--- a/lambdas/tabular_preview/src/t4_lambda_tabular_preview/__init__.py
+++ b/lambdas/tabular_preview/src/t4_lambda_tabular_preview/__init__.py
@@ -120,8 +120,8 @@ def write_data_as_arrow(data, schema, max_size):
 
             if not writer.stats.num_record_batches:
                 # perspective's arrow_loader.cpp calls Table::FromRecordBatches
-                # without a schema, so it rejects a batch-less file. Fixed in v3,
-                # not v2.
+                # without a schema, so it rejects a batch-less file. Fixed in
+                # 3.2.0 by finos/perspective#2854; the catalog pins 1.9.4.
                 writer.write(pyarrow.RecordBatch.from_pylist([], schema=schema))
 
     return memoryview(buf.getvalue()), truncated

--- a/lambdas/tabular_preview/tests/test_index.py
+++ b/lambdas/tabular_preview/tests/test_index.py
@@ -65,6 +65,44 @@ def test_preview_csv(handler_name, data):
 
 
 @pytest.mark.parametrize(
+    "data, rows_skipped",
+    [
+        # nothing but a header: an empty query export, a filter that matched nothing
+        (b"a,b\n", 0),
+        # every data row malformed, so invalid_row_handler skips them all
+        (b"a,b\n1,2,3\n4\n", 2),
+    ]
+)
+def test_preview_csv_no_rows(data, rows_skipped):
+    """A preview with no rows must still be a loadable Arrow file.
+
+    pyarrow yields no record batches for a 0-row table, and a batch-less IPC file
+    is rejected outright by perspective, so without an explicit empty batch the
+    catalog shows "Could not render tabular data" instead of an empty table.
+    """
+    with patch_urlopen(data):
+        code, body, headers = t4_lambda_tabular_preview.handlers["csv"](
+            url=mock.sentinel.URL,
+            compression=mock.sentinel.COMPRESSION,
+            max_out_size=None,
+        )
+
+    assert code == 200
+    assert json.loads(headers[QUILT_INFO_HEADER]) == {
+        "truncated": False,
+        "rows_skipped": rows_skipped,
+    }
+
+    with pyarrow.ipc.open_file(io.BytesIO(gzip.decompress(body))) as reader:
+        # the point of the fix: a consumer that reads batches finds one to read
+        assert reader.num_record_batches == 1
+        t = reader.read_all()
+
+    assert t.column_names == ["a", "b"]
+    assert t.num_rows == 0
+
+
+@pytest.mark.parametrize(
     "filename, handler_name",
     [
         ("simple/test.xls", "excel"),


### PR DESCRIPTION
# Description

A tabular preview with no rows fails to render — the catalog shows "Could not
render tabular data" where an empty table belongs.

`write_data_as_arrow` iterates `table.to_batches(...)`, which yields nothing for
a 0-row table, so it writes an IPC file carrying a schema and no record batches.
That file is valid — pyarrow reads it back as a 0-row table — but perspective's
`arrow_loader.cpp` calls `Table::FromRecordBatches` without a schema, so Arrow
has nothing to infer from and rejects it. Fixed upstream in perspective 3.2.0
([finos/perspective#2854](https://github.com/finos/perspective/pull/2854)); we
are below that.

Reached by a header-only file (an empty query export, a filter that matched
nothing), a file whose every data row was skipped as invalid, or a first batch
already too large for `max_size`. The fix writes one empty batch when nothing
else was written.

Surfaced while building preview test samples for #4671.

# TODO

- [x] Unit tests — `test_preview_csv_no_rows`; both cases fail without the fix
- [x] Security: no new surface — no new input handling, no new dependency
- [x] Open and Embed: server-side change
- [x] [Changelog](../tree/master/lambdas/tabular_preview/CHANGELOG.md) entry


<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR makes zero-row tabular previews loadable by emitting one schema-bearing empty Arrow record batch when no data batches were written.
- Adds the empty-batch fallback to Arrow serialization.
- Covers header-only and entirely malformed CSV inputs.
- Documents the Catalog rendering fix in the changelog.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge.

No blocking failure remains.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| lambdas/tabular_preview/src/t4_lambda_tabular_preview/__init__.py | Adds a schema-preserving empty record batch when Arrow serialization otherwise produces no batches. |
| lambdas/tabular_preview/tests/test_index.py | Adds coverage for header-only CSV and inputs where every malformed row is skipped. |
| lambdas/tabular_preview/CHANGELOG.md | Records the zero-row preview compatibility fix. |


<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart LR
  A[Tabular input] --> B[Convert table to record batches]
  B --> C{Any batch written?}
  C -->|Yes| D[Finish Arrow IPC file]
  C -->|No| E[Write schema-bearing empty batch]
  E --> D
  D --> F[Compress response]
  F --> G[Catalog renders table]
```

<sub>Reviews (2): Last reviewed commit: ["Drop the pinned version from the comment"](https://github.com/quiltdata/quilt/commit/eb778beda0cfad3262399f19b8cf88f7a5e0d347) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=56643061)</sub>

**Context used:**

- Knowledge Base — [Data preview processing](https://app.greptile.com/quilt-bio/-/custom-context/knowledge-base/quiltdata/quilt/-/docs/data-preview-processing.md)

<!-- /greptile_comment -->