### PR TITLE
catalog: stop the volume row's access readout from covering its tags

### DIFF
--- a/catalog/CHANGELOG.md
+++ b/catalog/CHANGELOG.md
@@ -21,6 +21,7 @@ complete sentence without it.
 
 ## Changes
 
+- [Fixed] Volumes list: the "Shared with" readout no longer overlaps a bucket's tags, and the extra space inside it is gone ([#5220](https://github.com/quiltdata/quilt/pull/5220))
 - [Fixed] Front door: the example-query chips show real package handles, a mix of prompts rather than five recent packages, and icons that match the rest of the app ([#5219](https://github.com/quiltdata/quilt/pull/5219))
 - [Changed] Bucket identity tints go from six to fifteen, so a wall of same-prefix volumes reads as distinct objects rather than a few colors repeating. Same scheme — a pale ground with a dark ink of its own hue, initials clearing AA — in two tiers so a hue family can contribute twice; the accent, semantic and error hues stay excluded ([#5210](https://github.com/quiltdata/quilt/pull/5210))
 - [Fixed] Admin Buckets and role bucket-permission lists show the same per-bucket mark the volumes landing does — a bucket with no custom icon wears its tinted initials disc instead of an anonymous glyph stub, so one bucket reads as one object on every screen ([#5210](https://github.com/quiltdata/quilt/pull/5210))

--- a/catalog/app/containers/Home/BucketGrid/BucketRows.spec.tsx
+++ b/catalog/app/containers/Home/BucketGrid/BucketRows.spec.tsx
@@ -1,0 +1,69 @@
+import * as React from 'react'
+import { MemoryRouter } from 'react-router-dom'
+import { render, cleanup } from '@testing-library/react'
+import { describe, expect, it, vi, afterEach } from 'vitest'
+import * as M from '@material-ui/core'
+
+import * as style from 'constants/style'
+
+import BucketRows from './BucketRows'
+import type { VolumeEntry } from './entries'
+
+// PRODUCT mode so the collaborator readout renders at all.
+vi.mock('constants/config', () => ({ default: { mode: 'PRODUCT' } }))
+
+vi.mock('utils/NamedRoutes', async () => ({
+  ...(await vi.importActual('utils/NamedRoutes')),
+  use: () => ({
+    urls: {
+      bucketRoot: (b: string) => `/b/${b}`,
+      dataProduct: (id: string) => `/p/${id}`,
+    },
+  }),
+}))
+
+vi.mock('components/BucketIcon', () => ({
+  default: () => <div data-testid="bucket-icon" />,
+}))
+
+vi.mock('./Collaborators', () => ({
+  default: () => <button type="button">Shared with 15+</button>,
+}))
+
+const BUCKET = {
+  name: 'quilt-bio-production',
+  title: 'Production datasets',
+  iconUrl: null,
+  description: null,
+  tags: ['prod', 'bio', 'flow'],
+}
+
+const renderRows = (entries: ReadonlyArray<VolumeEntry>) =>
+  render(
+    <MemoryRouter>
+      <M.MuiThemeProvider theme={style.appTheme}>
+        <BucketRows entries={entries} />
+      </M.MuiThemeProvider>
+    </MemoryRouter>,
+  )
+
+describe('containers/Home/BucketGrid/BucketRows', () => {
+  afterEach(cleanup)
+
+  // jsdom does no layout, so the overlap itself is not observable; what keeps
+  // the readout and the tags apart is that neither is positioned out of flow.
+  it('keeps the access readout in flow, not in the absolute secondary slot', () => {
+    const { container, getByText } = renderRows([
+      {
+        kind: 'bucket',
+        label: BUCKET.title,
+        sortKey: BUCKET.name,
+        relevance: 0,
+        bucket: BUCKET,
+      },
+    ])
+    expect(getByText('Shared with 15+')).toBeTruthy()
+    expect(getByText('prod')).toBeTruthy()
+    expect(container.querySelector('.MuiListItemSecondaryAction-root')).toBeNull()
+  })
+})

--- a/catalog/app/containers/Home/BucketGrid/BucketRows.tsx
+++ b/catalog/app/containers/Home/BucketGrid/BucketRows.tsx
@@ -27,10 +27,10 @@ const useStyles = M.makeStyles((t) => ({
       backgroundColor: t.palette.action.hover,
     },
   },
-  // Only rows that actually render the access readout reserve the right
-  // gutter ListItemSecondaryAction needs; the rest keep their full width.
-  rowWithSecondary: {
-    paddingRight: t.spacing(14),
+  access: {
+    flexShrink: 0,
+    marginLeft: t.spacing(2),
+    whiteSpace: 'nowrap',
   },
   avatar: {
     minWidth: t.spacing(6),
@@ -126,7 +126,7 @@ function BucketRow({ bucket, divider, tagIsMatching, onTagClick }: BucketRowProp
 
   return (
     <M.ListItem
-      className={cx(classes.row, hasCollaborators && classes.rowWithSecondary)}
+      className={classes.row}
       divider={divider}
       data-testid="bucket-grid--bucket"
       data-bucket={bucket.name}
@@ -186,12 +186,12 @@ function BucketRow({ bucket, divider, tagIsMatching, onTagClick }: BucketRowProp
         </div>
       )}
       {hasCollaborators && (
-        <M.ListItemSecondaryAction>
+        <div className={classes.access}>
           <Collaborators
             bucket={bucket.name}
             collaborators={bucket.collaborators ?? null}
           />
-        </M.ListItemSecondaryAction>
+        </div>
       )}
     </M.ListItem>
   )
@@ -214,7 +214,7 @@ function DataProductRow({ product, divider }: DataProductRowProps) {
 
   return (
     <M.ListItem
-      className={cx(classes.row, classes.rowWithSecondary)}
+      className={classes.row}
       divider={divider}
       data-testid="bucket-grid--data-product"
       data-data-product={product.id}
@@ -252,11 +252,11 @@ function DataProductRow({ product, divider }: DataProductRowProps) {
           ) : null
         }
       />
-      <M.ListItemSecondaryAction>
+      <div className={classes.access}>
         <M.Typography variant="caption" color="textSecondary">
           {DP.accessSummary(product)}
         </M.Typography>
-      </M.ListItemSecondaryAction>
+      </div>
     </M.ListItem>
   )
 }

--- a/catalog/app/containers/Home/BucketGrid/Collaborators.tsx
+++ b/catalog/app/containers/Home/BucketGrid/Collaborators.tsx
@@ -43,10 +43,10 @@ const useStyles = M.makeStyles((t) => ({
   },
   label: {
     ...t.typography.caption,
+    whiteSpace: 'nowrap',
   },
   // Tabular figures so counts line up down a column of cards.
   count: {
-    ...t.typography.caption,
     fontVariantNumeric: 'tabular-nums',
     fontWeight: 500,
   },
@@ -110,10 +110,12 @@ export default function Collaborators({ bucket, collaborators }: CollaboratorsPr
         <M.Icon className={classes.icon} fontSize="inherit">
           group
         </M.Icon>
-        <span className={classes.label}>Shared with&nbsp;</span>
-        <span className={classes.count}>
-          {knownNumber}
-          {hasUnmanagedRole ? '+' : ''}
+        <span className={classes.label}>
+          Shared with{' '}
+          <span className={classes.count}>
+            {knownNumber}
+            {hasUnmanagedRole ? '+' : ''}
+          </span>
         </span>
       </M.ButtonBase>
     </>


### PR DESCRIPTION
On the volumes list, a bucket's tag chips are drawn over by the "Shared with <n>+" readout on the right of the row. It hits every tagged row, not just heavily tagged ones.

`ListItemSecondaryAction` is absolutely positioned, so the row can only make room for it by reserving a fixed right-hand gutter — `paddingRight: t.spacing(14)`, 112px. The readout is `Shared with ` plus a count plus an optional `+`, which is wider than that, so it hangs left over whatever is at the row's content edge. The tags are what's there.

The readout now sits in the row's flow as an ordinary flex child, so the two cannot overlap whatever the count reads, and the reserved gutter is gone. `DataProductRow` had the same slot with the same fixed gutter and gets the same treatment.

While in there: the readout was spacing itself twice. `root` is a flex row with `gap: t.spacing(0.5)`, and the label *also* ended in `&nbsp;` — so the glyph sat 4px from "Shared with" while the count sat ~8px from it. Label and count are now one text run separated by the sentence's own word space, with the flex gap left to do only what it is for. `whiteSpace: nowrap` moves onto the readout itself so it cannot break between the words in either consumer; both wrappers are `flexShrink: 0`, so it will not be squeezed.

### Test plan

- `npm run typecheck`, `npm run lint:app` — clean
- `npx vitest run app/containers/Home` — 38 passed
- New `BucketRows.spec.tsx` (the file had no coverage): asserts the row renders no `.MuiListItemSecondaryAction-root` while both the readout and the tags are present. Confirmed it fails against the pre-fix component and passes after — jsdom does no layout, so the mechanism is what can be pinned, not the overlap itself.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Before:
<img width="1431" height="922" alt="Screenshot_2026-08-26_14-32-24" src="https://github.com/user-attachments/assets/0855eb5b-8a2b-4150-8821-8b886a210d9d" />

After:
<img width="1431" height="922" alt="Screenshot_2026-08-26_14-31-52" src="https://github.com/user-attachments/assets/95d532ab-734f-4ab0-ba3e-20a4fd53c22e" />





<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR moves bucket collaborator and data-product access readouts into normal flex flow so they no longer overlap adjacent tags, and consolidates collaborator label/count spacing. It also adds a regression test that verifies the bucket readout no longer uses Material UI’s absolutely positioned secondary-action slot.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge.

No blocking failure remains.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| catalog/app/containers/Home/BucketGrid/BucketRows.tsx | Replaces fixed-gutter secondary actions with non-shrinking in-flow access elements for bucket and data-product rows. |
| catalog/app/containers/Home/BucketGrid/Collaborators.tsx | Consolidates the collaborator label and count into one non-wrapping text run while preserving count emphasis. |
| catalog/app/containers/Home/BucketGrid/BucketRows.spec.tsx | Adds coverage confirming that tags and the access readout render without the absolute secondary-action wrapper. |
| catalog/CHANGELOG.md | Documents the corrected volume-row overlap and spacing behavior. |

<sub>Reviews (2): Last reviewed commit: ["catalog: stop the volume row&#39;s access re..."](https://github.com/quiltdata/quilt/commit/36b8a790f5bd4f738650c3d44e7f255d1da79025) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=57046413)</sub>

<!-- /greptile_comment -->