### PR TITLE
catalog: drop the white ground behind the metadata order selectors

### DIFF
--- a/catalog/CHANGELOG.md
+++ b/catalog/CHANGELOG.md
@@ -21,6 +21,7 @@ complete sentence without it.
 
 ## Changes
 
+- [Fixed] Search sidebar: the metadata "Order by" selectors no longer sit on a white patch of their own ([#5221](https://github.com/quiltdata/quilt/pull/5221))
 - [Fixed] Volumes list: the "Shared with" readout no longer overlaps a bucket's tags, and the extra space inside it is gone ([#5220](https://github.com/quiltdata/quilt/pull/5220))
 - [Fixed] Front door: the example-query chips show real package handles, a mix of prompts rather than five recent packages, and icons that match the rest of the app ([#5219](https://github.com/quiltdata/quilt/pull/5219))
 - [Changed] Bucket identity tints go from six to fifteen, so a wall of same-prefix volumes reads as distinct objects rather than a few colors repeating. Same scheme — a pale ground with a dark ink of its own hue, initials clearing AA — in two tiers so a hue family can contribute twice; the accent, semantic and error hues stay excluded ([#5210](https://github.com/quiltdata/quilt/pull/5210))

--- a/catalog/app/components/Filters/Select.tsx
+++ b/catalog/app/components/Filters/Select.tsx
@@ -1,12 +1,5 @@
-import cx from 'classnames'
 import * as React from 'react'
 import * as M from '@material-ui/core'
-
-const useStyles = M.makeStyles((t) => ({
-  root: {
-    background: t.palette.background.paper,
-  },
-}))
 
 interface SelectFilterProps<T> {
   className?: string
@@ -27,10 +20,9 @@ export default function Select<T extends string>({
   value,
   ...props
 }: SelectProps<T>) {
-  const classes = useStyles()
   return (
     <M.Select
-      className={cx(classes.root, className)}
+      className={className}
       value={value}
       onChange={(event) => onChange(event.target.value as T)}
       {...props}


### PR DESCRIPTION
In the search sidebar's package-level metadata section, the two "Order by" controls sit on white patches of their own rather than on the panel's ground.

`Filters/Select` paints `background: t.palette.background.paper` on its root. Those two controls are its only callers, so the rule goes with the component rather than being overridden at the call site — which also takes the now-empty `useStyles` and the `cx` import with it.

### Test plan

- `npm run typecheck`, `npm run lint:app` — clean
- `npx vitest run app/containers/Search app/components/Filters` — 112 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR removes the Material UI paper background from the metadata-order selectors so they inherit the search sidebar panel ground.
- Removes the component-local `makeStyles` background rule.
- Removes the now-unused `classnames` dependency and forwards the caller’s `className` directly.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge with no actionable defects identified.

The change is limited to removing an unwanted component background and redundant class merging while preserving caller classes and all selection behavior.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| catalog/app/components/Filters/Select.tsx | Removes the root background style and obsolete class merging without changing the selector’s value or event behavior. |

<sub>Reviews (1): Last reviewed commit: [aabd8c7](https://github.com/quiltdata/quilt/commit/aabd8c729c364ccae8c2215038f5279f349294da) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=57067406)</sub>

<!-- /greptile_comment -->