### PR TITLE
catalog: sort the package metadata list from one control, next to the list

### DIFF
--- a/catalog/CHANGELOG.md
+++ b/catalog/CHANGELOG.md
@@ -21,6 +21,7 @@ complete sentence without it.
 
 ## Changes
 
+- [Changed] Search sidebar: the package metadata list is sorted from one "Sort by" control, sitting directly above the list ([#5222](https://github.com/quiltdata/quilt/pull/5222))
 - [Fixed] Volumes list: the "Shared with" readout no longer overlaps a bucket's tags, and the extra space inside it is gone ([#5220](https://github.com/quiltdata/quilt/pull/5220))
 - [Fixed] Front door: the example-query chips show real package handles, a mix of prompts rather than five recent packages, and icons that match the rest of the app ([#5219](https://github.com/quiltdata/quilt/pull/5219))
 - [Changed] Bucket identity tints go from six to fifteen, so a wall of same-prefix volumes reads as distinct objects rather than a few colors repeating. Same scheme — a pale ground with a dark ink of its own hue, initials clearing AA — in two tiers so a hue family can contribute twice; the accent, semantic and error hues stay excluded ([#5210](https://github.com/quiltdata/quilt/pull/5210))

--- a/catalog/app/components/Filters/Select.tsx
+++ b/catalog/app/components/Filters/Select.tsx
@@ -1,12 +1,5 @@
-import cx from 'classnames'
 import * as React from 'react'
 import * as M from '@material-ui/core'
-
-const useStyles = M.makeStyles((t) => ({
-  root: {
-    background: t.palette.background.paper,
-  },
-}))
 
 interface SelectFilterProps<T> {
   className?: string
@@ -27,10 +20,9 @@ export default function Select<T extends string>({
   value,
   ...props
 }: SelectProps<T>) {
-  const classes = useStyles()
   return (
     <M.Select
-      className={cx(classes.root, className)}
+      className={className}
       value={value}
       onChange={(event) => onChange(event.target.value as T)}
       {...props}

--- a/catalog/app/containers/Search/Layout/PackageFilters.tsx
+++ b/catalog/app/containers/Search/Layout/PackageFilters.tsx
@@ -127,6 +127,17 @@ function FilterGroup({ disabled, path, items }: FilterGroupProps) {
   )
 }
 
+const FACET_ORDERING_VALUES = SearchUIModel.FACET_ORDERINGS.map((o) =>
+  SearchUIModel.serializeFacetOrdering(o.ordering),
+)
+
+const FACET_ORDERING_LABELS: Record<string, string> = Object.fromEntries(
+  SearchUIModel.FACET_ORDERINGS.map((o) => [
+    SearchUIModel.serializeFacetOrdering(o.ordering),
+    o.label,
+  ]),
+)
+
 const useAvailablePackagesMetaFiltersStyles = M.makeStyles((t) => ({
   list: {
     background: 'inherit',
@@ -150,7 +161,6 @@ const useAvailablePackagesMetaFiltersStyles = M.makeStyles((t) => ({
     alignItems: 'baseline',
     display: 'flex',
     gap: t.spacing(0.5),
-    justifyContent: 'flex-end',
     marginBottom: t.spacing(0.5),
   },
   orderLabel: {
@@ -193,36 +203,6 @@ function AvailablePackagesMetaFilters({
 
   return (
     <div className={className}>
-      {/* `offered` rather than a count taken here: withholding it turns on how many
-          fields exist, and `facets.available` is already narrowed by the filter box
-          on the client-filter path. */}
-      {ordering.offered && (
-        <div className={classes.order}>
-          <span className={classes.orderLabel} id="meta-order-label">
-            Order by
-          </span>
-          <FiltersUI.Select<SearchUIModel.FacetOrderBy>
-            className={classes.orderSelect}
-            disableUnderline
-            disabled={fetching}
-            extents={[...SearchUIModel.FACET_ORDER_BY]}
-            getOptionLabel={(o) => SearchUIModel.FACET_ORDER_BY_LABELS[o]}
-            inputProps={{ 'aria-labelledby': 'meta-order-label' }}
-            onChange={(by) => ordering.set({ ...ordering.value, by })}
-            value={ordering.value.by}
-          />
-          <FiltersUI.Select<SearchUIModel.FacetOrderDirection>
-            className={classes.orderSelect}
-            disableUnderline
-            disabled={fetching}
-            extents={[...SearchUIModel.FACET_ORDER_DIRECTIONS]}
-            getOptionLabel={(d) => SearchUIModel.FACET_ORDER_DIRECTION_LABELS[d]}
-            inputProps={{ 'aria-label': 'Order direction' }}
-            onChange={(direction) => ordering.set({ ...ordering.value, direction })}
-            value={ordering.value.direction}
-          />
-        </div>
-      )}
       {SearchUIModel.FacetsFilteringState.match({
         Enabled: ({ value, set }) => (
           <FiltersUI.TinyTextField
@@ -252,6 +232,28 @@ function AvailablePackagesMetaFilters({
         },
         Disabled: () => null,
       })(filtering)}
+      {/* `offered` rather than a count taken here: withholding it turns on how many
+          fields exist, and `facets.available` is already narrowed by the filter box
+          on the client-filter path. */}
+      {ordering.offered && (
+        <div className={classes.order}>
+          <span className={classes.orderLabel} id="meta-order-label">
+            Sort by:
+          </span>
+          <FiltersUI.Select<string>
+            className={classes.orderSelect}
+            disableUnderline
+            disabled={fetching}
+            extents={FACET_ORDERING_VALUES}
+            getOptionLabel={(value) => FACET_ORDERING_LABELS[value]}
+            inputProps={{ 'aria-labelledby': 'meta-order-label' }}
+            onChange={(value) =>
+              ordering.set(SearchUIModel.parseFacetOrdering(value, ordering.value))
+            }
+            value={SearchUIModel.serializeFacetOrdering(ordering.value)}
+          />
+        </div>
+      )}
       <M.List dense disablePadding className={classes.list}>
         <FilterGroup disabled={fetching} items={facets.visible.children} />
         <M.Collapse in={expanded}>

--- a/catalog/app/containers/Search/model.spec.ts
+++ b/catalog/app/containers/Search/model.spec.ts
@@ -209,19 +209,28 @@ describe('containers/Search/model', () => {
         ])
       })
 
-      it('offers exactly the options the two controls render', () => {
-        // Each control maps over its own list, so every entry needs a label and the
-        // default has to name a real option on both axes.
-        expect(model.FACET_ORDER_BY).toContain(model.DEFAULT_FACET_ORDERING.by)
-        expect(model.FACET_ORDER_DIRECTIONS).toContain(
-          model.DEFAULT_FACET_ORDERING.direction,
+      it('offers every combination of the two axes, exactly once', () => {
+        const combinations = model.FACET_ORDER_BY.flatMap((by) =>
+          model.FACET_ORDER_DIRECTIONS.map((direction) => `${by}:${direction}`),
         )
-        model.FACET_ORDER_BY.forEach((by) => {
-          expect(model.FACET_ORDER_BY_LABELS[by]).toBeTruthy()
-        })
-        model.FACET_ORDER_DIRECTIONS.forEach((d) => {
-          expect(model.FACET_ORDER_DIRECTION_LABELS[d]).toBeTruthy()
-        })
+        const offered = model.FACET_ORDERINGS.map((o) =>
+          model.serializeFacetOrdering(o.ordering),
+        )
+        expect(offered.slice().sort()).toEqual(combinations.slice().sort())
+        expect(new Set(offered).size).toBe(offered.length)
+      })
+
+      it('names every option, and the default is one of them', () => {
+        model.FACET_ORDERINGS.forEach((o) => expect(o.label).toBeTruthy())
+        expect(model.FACET_ORDERINGS.map((o) => o.label)).toEqual([
+          'Name A → Z',
+          'Name Z → A',
+          'Type A → Z',
+          'Type Z → A',
+        ])
+        expect(
+          model.FACET_ORDERINGS.map((o) => model.serializeFacetOrdering(o.ordering)),
+        ).toContain(model.serializeFacetOrdering(model.DEFAULT_FACET_ORDERING))
       })
     })
   })

--- a/catalog/app/containers/Search/model.ts
+++ b/catalog/app/containers/Search/model.ts
@@ -38,28 +38,16 @@ export const DEFAULT_RESULT_TYPE = ResultType.QuiltPackage
 
 export const DEFAULT_VIEW = View.List
 
-// What the list is ordered by, and which way: two axes, so two controls. Folded
-// into one four-entry list they read as four unrelated modes rather than a choice
-// plus a direction.
+// The two axes the `mo` param carries. They stay separate here because the param
+// falls back per axis; the panel offers their combinations as one list
+// (FACET_ORDERINGS).
 export const FACET_ORDER_BY = ['name', 'type'] as const
 
 export type FacetOrderBy = (typeof FACET_ORDER_BY)[number]
 
-export const FACET_ORDER_BY_LABELS: Record<FacetOrderBy, string> = {
-  name: 'Name',
-  type: 'Type',
-}
-
 export const FACET_ORDER_DIRECTIONS = ['asc', 'desc'] as const
 
 export type FacetOrderDirection = (typeof FACET_ORDER_DIRECTIONS)[number]
-
-// The result list's "Sort by" already names these directions this way
-// (PRESET_ORDERINGS), so the same arrows mean the same thing in both places.
-export const FACET_ORDER_DIRECTION_LABELS: Record<FacetOrderDirection, string> = {
-  asc: 'A → Z',
-  desc: 'Z → A',
-}
 
 export interface FacetOrdering {
   by: FacetOrderBy
@@ -67,6 +55,16 @@ export interface FacetOrdering {
 }
 
 export const DEFAULT_FACET_ORDERING: FacetOrdering = { by: 'name', direction: 'asc' }
+
+// One control, the way the result list's "Sort by" is one control -- and named
+// with its arrows (PRESET_ORDERINGS), so a direction means the same thing in
+// both places.
+export const FACET_ORDERINGS: { label: string; ordering: FacetOrdering }[] = [
+  { label: 'Name A → Z', ordering: { by: 'name', direction: 'asc' } },
+  { label: 'Name Z → A', ordering: { by: 'name', direction: 'desc' } },
+  { label: 'Type A → Z', ordering: { by: 'type', direction: 'asc' } },
+  { label: 'Type Z → A', ordering: { by: 'type', direction: 'desc' } },
+]
 
 /** `<by>:<direction>` in the querystring: one param for two axes. */
 export function serializeFacetOrdering(ordering: FacetOrdering): string {


### PR DESCRIPTION
The search sidebar offered the metadata ordering as two selects — `Order by [Name ▾] [A → Z ▾]` — right-aligned above the "Find metadata" field. Three things came out of that: the control that orders the list sat apart from the list, behind a text field and the "Some metadata not displayed" paragraph; it was the only right-aligned element in a left-aligned panel; and at caption size with `disableUnderline` the pair read as grey text with chevrons rather than as a control.

It is now a single `Sort by:` select carrying the four combinations — `Name A → Z`, `Name Z → A`, `Type A → Z`, `Type Z → A` — in the panel's own alignment, directly above the list it orders.

`Filters/Select` also painted `background: t.palette.background.paper` on its root, so the control sat on a white patch rather than the panel's ground. These two are its only callers, so the rule goes with the component — **this supersedes #5221**, which did only that; close it in favour of this one, since both touch the same lines and would conflict.

### On folding the two axes

`model.ts` argued against exactly this:

> `// What the list is ordered by, and which way: two axes, so two controls. Folded`
> `// into one four-entry list they read as four unrelated modes rather than a choice`
> `// plus a direction.`

The counter-argument is on the same page. The result list's own "Sort by" is `PRESET_ORDERINGS` — `Best match`, `Most recent first`, `Least recent first`, `A → Z`, `Z → A` — which is field and direction folded into one flat list of five, and reads fine. The volumes list does the same. DESIGN.md asks for one control vocabulary ("a control means one thing on every screen"), and the facet panel was the exception. Four options is one fewer than the control it now matches.

The direction labels keep their arrows, which the old comment noted are shared with `PRESET_ORDERINGS` on purpose.

### Unchanged

The `mo` param still serializes as `<by>:<direction>` and still falls back per axis, so existing links keep working and `mo=type:sideways` still orders by type. `FACET_ORDER_BY` / `FACET_ORDER_DIRECTIONS` stay as the two axes the param validates against; `FACET_ORDERINGS` is the panel's view of their combinations.

### Test plan

- `npm run typecheck`, `npm run lint:app` — clean
- `npx vitest run app/containers/Search app/components/Filters` — 113 passed
- The model spec's ordering test now pins that the offered list is exactly every combination of the two axes, each once, and that the default is among them — so adding an axis without extending the list fails.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Before:
<img width="361" height="403" alt="Screenshot_2026-08-26_15-26-27" src="https://github.com/user-attachments/assets/cb4d4ea1-81d1-4d09-948b-fa6143e4c5f7" />

After:
<img width="361" height="403" alt="Screenshot_2026-08-26_15-26-32" src="https://github.com/user-attachments/assets/f8cb25d0-70d4-4a4e-b259-2a4694c1b2f4" />





<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR consolidates package-metadata ordering into one adjacent “Sort by” control while preserving the existing URL representation and per-axis fallback behavior.
- Adds four explicit metadata-ordering combinations to the search model.
- Replaces the separate field and direction controls with one combined select.
- Removes the shared select’s paper-colored background and updates ordering tests and the changelog.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge.

No blocking failure remains.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| catalog/app/components/Filters/Select.tsx | Removes the paper background from the shared select root; no eligible blocking regression was established. |
| catalog/app/containers/Search/Layout/PackageFilters.tsx | Replaces two metadata-ordering selects with one combined control whose values remain aligned with model parsing and serialization. |
| catalog/app/containers/Search/model.ts | Adds the complete four-entry ordering preset list without changing the URL format or fallback semantics. |
| catalog/app/containers/Search/model.spec.ts | Verifies that presets cover every ordering-axis combination exactly once and include the default. |
| catalog/CHANGELOG.md | Documents the consolidated metadata sorting control. |

<sub>Reviews (2): Last reviewed commit: ["catalog: sort the package metadata list ..."](https://github.com/quiltdata/quilt/commit/bc5c5484ea0199c7f104bd55ec1e9154a009dfba) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=57070845)</sub>

<!-- /greptile_comment -->