### PR TITLE
catalog: pin the admin form's actions with position: sticky

### DIFF
--- a/catalog/CHANGELOG.md
+++ b/catalog/CHANGELOG.md
@@ -21,6 +21,7 @@ complete sentence without it.
 
 ## Changes
 
+- [Fixed] Admin buckets: the sticky Cancel/Add bar lines up with the form above it ([#5224](https://github.com/quiltdata/quilt/pull/5224))
 - [Removed] The unbaked data-products GraphQL contract (added in [#5203](https://github.com/quiltdata/quilt/pull/5203), never served by a registry) is out of the schema; the `data-products` preview UI is unaffected and keeps reading fixture data ([#5223](https://github.com/quiltdata/quilt/pull/5223))
 - [Changed] Search sidebar: the package metadata list is sorted from one "Sort by" control, sitting directly above the list ([#5222](https://github.com/quiltdata/quilt/pull/5222))
 - [Fixed] Volumes list: the "Shared with" readout no longer overlaps a bucket's tags, and the extra space inside it is gone ([#5220](https://github.com/quiltdata/quilt/pull/5220))

--- a/catalog/app/containers/Admin/Buckets/Buckets.tsx
+++ b/catalog/app/containers/Admin/Buckets/Buckets.tsx
@@ -6,8 +6,6 @@ import * as R from 'ramda'
 import * as React from 'react'
 import * as RF from 'react-final-form'
 import * as RRDom from 'react-router-dom'
-import { useDebounce } from 'use-debounce'
-import useResizeObserver from 'use-resize-observer'
 import * as M from '@material-ui/core'
 import * as Lab from '@material-ui/lab'
 
@@ -79,104 +77,62 @@ const bucketToFormValues = (bucket: BucketConfig) => ({
 
 const useStickyActionsStyles = M.makeStyles((t) => ({
   actions: {
-    animation: `$show 150ms ease-out`,
-    padding: t.spacing(3, 0, 0),
     alignItems: 'center',
+    bottom: 0,
     display: 'flex',
     justifyContent: 'flex-end',
+    position: 'sticky',
+    transition: t.transitions.create(['box-shadow', 'padding'], { duration: 150 }),
     '& > * + *': {
       // Spacing between direct children
       marginLeft: t.spacing(2),
     },
   },
-  sticky: {
-    animation: `$sticking 150ms ease-out`,
-    bottom: 0,
-    left: '50%',
-    position: 'fixed',
-    transform: `translateX(-50%)`,
-    '& $actions': {
-      padding: t.spacing(2),
-    },
+  floating: {
+    backgroundColor: t.palette.background.paper,
+    borderRadius: t.shape.borderRadius,
+    boxShadow: t.shadows[8],
+    padding: t.spacing(2),
   },
-  '@keyframes show': {
-    '0%': {
-      opacity: 0.3,
-    },
-    '100%': {
-      opacity: '1',
-    },
+  resting: {
+    padding: t.spacing(3, 0, 0),
   },
-  '@keyframes sticking': {
-    '0%': {
-      transform: 'translate(-50%, 10%)',
-    },
-    '100%': {
-      transform: 'translate(-50%, 0)',
-    },
+  sentinel: {
+    height: 1,
+    marginTop: -1,
   },
 }))
 
 interface StickyActionsProps {
   children: React.ReactNode
-  parentRef: React.RefObject<HTMLElement>
 }
 
-function StickyActions({ children, parentRef }: StickyActionsProps) {
+function StickyActions({ children }: StickyActionsProps) {
   const classes = useStickyActionsStyles()
 
-  const [size, setSize] = React.useState<DOMRect | null>(null)
-  const [parentSize, setParentSize] = React.useState<DOMRect | null>(null)
-  const ref = React.useRef<HTMLDivElement>(null)
-  const handleScroll = React.useCallback(() => {
-    const rect = ref.current?.getBoundingClientRect()
-    if (!rect || !rect.height) return
-    setSize(rect)
-    const parent = parentRef.current?.getBoundingClientRect()
-    if (!parent || !parent.height) return
-    setParentSize(parent)
-  }, [parentRef])
+  const sentinelRef = React.useRef<HTMLDivElement>(null)
+  const [pinned, setPinned] = React.useState(false)
+
+  // The sentinel sits just past the bar's resting place, so it is out of view
+  // for exactly as long as the bar is pinned. 1px, not 0: a zero-area target's
+  // intersection is unreliable.
   React.useEffect(() => {
-    window.addEventListener('scroll', handleScroll)
-    return () => window.removeEventListener('scroll', handleScroll)
-  }, [handleScroll])
-  const { height: parentHeight } = useResizeObserver({ ref: parentRef })
-  React.useEffect(() => handleScroll(), [handleScroll, parentHeight])
-
-  const DEBOUNCE_TIMEOUT = 50
-  const [debouncedSize] = useDebounce(size, DEBOUNCE_TIMEOUT)
-  const [debouncedParentSize] = useDebounce(parentSize, DEBOUNCE_TIMEOUT)
-  const sticky = React.useMemo(() => {
-    const winHeight = window.innerHeight || document.documentElement.clientHeight
-
-    const containerBottom = debouncedSize?.bottom || 0
-    const containerHeight = debouncedSize?.height || 0
-    const parentTop = debouncedParentSize?.top || 0
-
-    return (
-      // Container's bottom (relative to viewport) is below the viewport's bottom
-      containerBottom >= winHeight + containerHeight &&
-      // Parent's top is inside the viewport
-      parentTop >= 0 &&
-      parentTop <= winHeight - containerHeight
+    const sentinel = sentinelRef.current
+    if (!sentinel) return undefined
+    const observer = new IntersectionObserver(([entry]) =>
+      setPinned(!entry.isIntersecting),
     )
-  }, [debouncedSize, debouncedParentSize])
+    observer.observe(sentinel)
+    return () => observer.disconnect()
+  }, [])
 
   return (
-    <div ref={ref}>
-      {sticky ? (
-        <>
-          <M.Container className={classes.sticky} maxWidth="lg">
-            <M.Paper className={classes.actions} elevation={8}>
-              {children}
-            </M.Paper>
-          </M.Container>
-          <div style={{ height: debouncedSize?.height }}>{/* height placeholder */}</div>
-        </>
-      ) : (
-        <div className={classes.actions}>{children}</div>
-      )}
-    </div>
+    <>
+      <div className={cx(classes.actions, pinned ? classes.floating : classes.resting)}>
+        {children}
+      </div>
+      <div className={classes.sentinel} ref={sentinelRef} />
+    </>
   )
 }
 
@@ -759,7 +715,6 @@ interface PrimaryCardProps {
 
 function PrimaryCard({ bucket, className, disabled, onSubmit }: PrimaryCardProps) {
   const initialValues = bucketToPrimaryValues(bucket)
-  const ref = React.useRef<HTMLElement>(null)
   const { urls } = NamedRoutes.use()
   const configPath = quiltConfigs.bucketPreferences[0]
   const configHref = urls.bucketFile(bucket.name, configPath, {
@@ -772,13 +727,12 @@ function PrimaryCard({ bucket, className, disabled, onSubmit }: PrimaryCardProps
           className={className}
           disabled={disabled}
           error={submitFailed}
-          ref={ref}
           title="Display settings"
         >
           <form onSubmit={handleSubmit}>
             <PrimaryForm bucket={bucket} />
           </form>
-          <StickyActions parentRef={ref}>
+          <StickyActions>
             <CardActions<PrimaryFormValues>
               action={<StyledLink to={configHref}>Configure Bucket UI</StyledLink>}
               disabled={disabled}
@@ -836,7 +790,6 @@ interface MetadataCardProps {
 
 function MetadataCard({ bucket, className, disabled, onSubmit }: MetadataCardProps) {
   const initialValues = bucketToMetadataValues(bucket)
-  const ref = React.useRef<HTMLElement>(null)
   return (
     <RF.Form<MetadataFormValues> onSubmit={onSubmit} initialValues={initialValues}>
       {({ handleSubmit, form, submitFailed }) => (
@@ -844,13 +797,12 @@ function MetadataCard({ bucket, className, disabled, onSubmit }: MetadataCardPro
           className={className}
           disabled={disabled}
           error={submitFailed}
-          ref={ref}
           title="Metadata"
         >
           <form onSubmit={handleSubmit}>
             <MetadataForm />
           </form>
-          <StickyActions parentRef={ref}>
+          <StickyActions>
             <CardActions<MetadataFormValues> disabled={disabled} form={form} />
           </StickyActions>
         </Card>
@@ -1065,7 +1017,6 @@ function IndexingAndNotificationsCard({
   const settings = data.config.contentIndexingSettings
 
   const initialValues = bucketToIndexingAndNotificationsValues(bucket)
-  const ref = React.useRef<HTMLFormElement>(null)
 
   return (
     <RF.Form<IndexingAndNotificationsFormValues>
@@ -1077,13 +1028,12 @@ function IndexingAndNotificationsCard({
           className={className}
           disabled={disabled}
           error={submitFailed}
-          ref={ref}
           title="Indexing and notifications"
         >
           <form onSubmit={handleSubmit}>
             <IndexingAndNotificationsForm bucket={bucket} settings={settings} />
           </form>
-          <StickyActions parentRef={ref}>
+          <StickyActions>
             <CardActions<IndexingAndNotificationsFormValues>
               action={
                 <M.Button
@@ -1200,12 +1150,11 @@ interface AddPageSkeletonProps {
 
 function AddPageSkeleton({ back }: AddPageSkeletonProps) {
   const classes = useStyles()
-  const formRef = React.useRef<HTMLDivElement>(null)
   return (
-    <div ref={formRef}>
+    <div>
       <SubPageHeader back={back}>Add a bucket</SubPageHeader>
       <CardsPlaceholder className={classes.fields} />
-      <StickyActions parentRef={formRef}>
+      <StickyActions>
         <Buttons.Skeleton />
         <Buttons.Skeleton />
       </StickyActions>
@@ -1286,7 +1235,6 @@ function Add({ back, settings, submit }: AddProps) {
     },
     [back, submit],
   )
-  const scrollingRef = React.useRef<HTMLFormElement>(null)
   const guardNavigation = React.useCallback(
     () => 'You have unsaved changes. Discard changes and leave the page?',
     [],
@@ -1307,7 +1255,7 @@ function Add({ back, settings, submit }: AddProps) {
           <SubPageHeader back={back} disabled={submitting}>
             Add a bucket
           </SubPageHeader>
-          <form className={classes.fields} onSubmit={handleSubmit} ref={scrollingRef}>
+          <form className={classes.fields} onSubmit={handleSubmit}>
             <Card className={classes.card} title="Display settings">
               <PrimaryForm />
             </Card>
@@ -1327,7 +1275,7 @@ function Add({ back, settings, submit }: AddProps) {
             </Card>
             <input type="submit" style={{ display: 'none' }} />
           </form>
-          <StickyActions parentRef={scrollingRef}>
+          <StickyActions>
             {submitFailed && (
               <Form.FormError
                 className={classes.error}


### PR DESCRIPTION
On Admin → Buckets, the sticky Cancel/Add bar ends short of the cards above it.

`StickyActions` wrapped itself in its own `M.Container maxWidth="lg"`, centred on the viewport with `left: 50%` + `translateX(-50%)`. The app's shared container is `maxWidth={false}` with `disableGutters` — "every view is effectively full-width now" (`components/Layout/Container.tsx`) — so on any viewport wider than `lg` the bar sat in a 1280px box while the cards ran to the page edge.

### Why `position: sticky` and not a wider box

Holding the bar in place took a scroll listener, a resize observer, two debounced `DOMRect`s, a viewport-geometry predicate and a height placeholder — about ninety lines to reproduce what `position: sticky; bottom: 0` does in one declaration. It also travels within its own container, so it takes that container's width without being told it.

The alternative of hardcoding the inset (`calc(100% - 280px - 24px)`) doesn't hold: the rail is not always a column. Per `Layout.tsx`, "under 960px there is no room for a 256px column beside the content, so the rail becomes an overlay". That needs a media query mirroring the shell's breakpoint, and pins three constants this component doesn't own — the rail's width, that breakpoint, and Admin's `spacing(0, 3)`. Sticky needs none of them.

### The one thing CSS can't express

Whether the bar is *currently* pinned, which decides the shadow — a shadow means "this floats above the plane and will leave" (the Overlay-Only Rule), and once it lands it shouldn't have one. An `IntersectionObserver` on a 1px marker just past the bar's resting place answers exactly that: out of view for as long as the bar is pinned. 1px rather than 0 because a zero-area target's intersection is unreliable; pulled back with `marginTop: -1` so it occupies nothing.

### Also gone

The anchor refs the measurement needed (`parentRef` and its five call sites), and `use-debounce` / `use-resize-observer` from this module. The pinned state was an `M.Paper elevation={8}`; it's now the same shadow and radius on the bar itself, so there's one element instead of two swapping places. The slide-in keyframes are dropped — shadow and padding transition instead.

Net: **-92 / +47**.

### Test plan

- `npm run typecheck`, `npm run lint:app` — clean
- `npx vitest run app/containers/Admin` — 30 passed

**Needs an eyeball.** None of this is testable in jsdom, which computes no geometry and has no `IntersectionObserver`. Worth checking on Add a bucket and on the edit page's per-card bars:

- the bar spans the cards' width, at a wide viewport and below 960px
- it pins while scrolling and lands at the end of the form without jumping
- the shadow appears while pinned and goes when it lands
- the per-card bars on the edit page still pin within their own card

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR replaces JavaScript-driven fixed positioning for Admin bucket form actions with CSS sticky positioning and uses a sentinel to control the floating visual treatment.
- Makes action bars inherit the width of their form or card container.
- Removes scroll, resize, and geometry-measurement state.
- Adds a changelog entry for the alignment fix.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge.

No blocking failure remains.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| catalog/app/containers/Admin/Buckets/Buckets.tsx | Reworks Admin bucket action bars around CSS sticky positioning and IntersectionObserver-based presentation state; no follow-up-eligible blocking issue was established. |
| catalog/CHANGELOG.md | Documents the corrected alignment of the Admin bucket action bar. |

<sub>Reviews (2): Last reviewed commit: ["Merge branch &#39;master&#39; into dx/sticky-act..."](https://github.com/quiltdata/quilt/commit/1d890714954b191315baf9992fd0baa18451206b) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=57097269)</sub>

<!-- /greptile_comment -->