### PR TITLE
catalog: tidy the volume card's body -- spacing, tag chips, description type

### DIFF
--- a/catalog/CHANGELOG.md
+++ b/catalog/CHANGELOG.md
@@ -22,6 +22,7 @@ complete sentence without it.
 ## Changes
 
 - [Fixed] Volumes grid: a card's description no longer touches its tags ([#5225](https://github.com/quiltdata/quilt/pull/5225))
+- [Changed] Volumes: tag chips are outlined, and a volume's description is set at the body step rather than as fine print ([#5225](https://github.com/quiltdata/quilt/pull/5225))
 - [Removed] The unbaked data-products GraphQL contract (added in [#5203](https://github.com/quiltdata/quilt/pull/5203), never served by a registry) is out of the schema; the `data-products` preview UI is unaffected and keeps reading fixture data ([#5223](https://github.com/quiltdata/quilt/pull/5223))
 - [Changed] Search sidebar: the package metadata list is sorted from one "Sort by" control, sitting directly above the list ([#5222](https://github.com/quiltdata/quilt/pull/5222))
 - [Fixed] Volumes list: the "Shared with" readout no longer overlaps a bucket's tags, and the extra space inside it is gone ([#5220](https://github.com/quiltdata/quilt/pull/5220))

--- a/catalog/CHANGELOG.md
+++ b/catalog/CHANGELOG.md
@@ -21,6 +21,7 @@ complete sentence without it.
 
 ## Changes
 
+- [Fixed] Volumes grid: a card's description no longer touches its tags ([#5225](https://github.com/quiltdata/quilt/pull/5225))
 - [Removed] The unbaked data-products GraphQL contract (added in [#5203](https://github.com/quiltdata/quilt/pull/5203), never served by a registry) is out of the schema; the `data-products` preview UI is unaffected and keeps reading fixture data ([#5223](https://github.com/quiltdata/quilt/pull/5223))
 - [Changed] Search sidebar: the package metadata list is sorted from one "Sort by" control, sitting directly above the list ([#5222](https://github.com/quiltdata/quilt/pull/5222))
 - [Fixed] Volumes list: the "Shared with" readout no longer overlaps a bucket's tags, and the extra space inside it is gone ([#5220](https://github.com/quiltdata/quilt/pull/5220))

--- a/catalog/app/containers/Home/BucketGrid/BucketCard.tsx
+++ b/catalog/app/containers/Home/BucketGrid/BucketCard.tsx
@@ -104,10 +104,8 @@ const useStyles = M.makeStyles((t) => ({
     display: 'flex',
     flexDirection: 'column',
     flexGrow: 1,
+    gap: t.spacing(1),
     padding: t.spacing(2),
-  },
-  bodySpacer: {
-    flexGrow: 1,
   },
   // Not raised above the navigation overlay: raising the row lifts its
   // `space-between` gap too, and clicks in that whitespace stop navigating. Only
@@ -117,6 +115,9 @@ const useStyles = M.makeStyles((t) => ({
     display: 'flex',
     gap: t.spacing(1),
     justifyContent: 'space-between',
+    // Absorbs the slack that row-height equalization leaves; `body`'s gap is
+    // the floor when there is none.
+    marginTop: 'auto',
   },
   // The icon is a fixed-size disc: without this it inherits `flex-shrink: 1`
   // and a long title squashes the circle into an ellipse.
@@ -256,7 +257,6 @@ export default function BucketCard({
             {bucket.description}
           </M.Typography>
         )}
-        <div className={classes.bodySpacer} />
         <div className={classes.bottomRow}>
           <div className={classes.tags}>
             {visibleTags.map((tg) => (

--- a/catalog/app/containers/Home/BucketGrid/BucketCard.tsx
+++ b/catalog/app/containers/Home/BucketGrid/BucketCard.tsx
@@ -172,9 +172,9 @@ const useStyles = M.makeStyles((t) => ({
       outlineOffset: -2,
     },
   },
-  // A matching tag reads as "selected" via the Indicator Rule's amber, never
-  // a solid fill: a wash + a matching border, layered on top of the chip's
-  // own `color="default"` ground rather than replacing it with a fill.
+  // A matching tag reads as "selected" via the Indicator Rule's amber, never a
+  // solid fill: an amber wash and border on the outlined chip. Both states
+  // carry a border, so selecting a tag does not resize it.
   matching: {
     backgroundColor: fade(t.palette.secondary.main, 0.15),
     border: `1px solid ${t.palette.secondary.main}`,
@@ -253,7 +253,7 @@ export default function BucketCard({
       </Link>
       <div className={classes.body}>
         {!!bucket.description && (
-          <M.Typography className={classes.description} component="p" variant="caption">
+          <M.Typography className={classes.description} component="p" variant="body2">
             {bucket.description}
           </M.Typography>
         )}
@@ -265,6 +265,7 @@ export default function BucketCard({
                 className={cx(classes.tag, { [classes.matching]: tagIsMatching(tg) })}
                 label={tg}
                 size="small"
+                variant="outlined"
                 clickable
                 color="default"
                 onClick={handleTagClick(tg)}

--- a/catalog/app/containers/Home/BucketGrid/BucketRows.tsx
+++ b/catalog/app/containers/Home/BucketGrid/BucketRows.tsx
@@ -78,9 +78,8 @@ const useStyles = M.makeStyles((t) => ({
     gap: t.spacing(0.5),
     marginLeft: t.spacing(2),
   },
-  // Mirrors BucketCard's chip vocabulary (focus ring on the hashed
-  // `Mui-focusVisible` hook; a matching chip washed in the Indicator amber
-  // rather than filled) so a tag reads the same in either view.
+  // Mirrors BucketCard's chip vocabulary -- outlined, focus ring on the hashed
+  // `Mui-focusVisible` hook -- so a tag reads the same in either view.
   tag: {
     '&.Mui-focusVisible': {
       outline: `2px solid ${t.palette.primary.main}`,
@@ -178,6 +177,7 @@ function BucketRow({ bucket, divider, tagIsMatching, onTagClick }: BucketRowProp
               className={cx(classes.tag, { [classes.matching]: tagIsMatching(tg) })}
               label={tg}
               size="small"
+              variant="outlined"
               clickable
               color="default"
               onClick={handleTagClick(tg)}

--- a/catalog/app/containers/Home/BucketGrid/DataProductCard.tsx
+++ b/catalog/app/containers/Home/BucketGrid/DataProductCard.tsx
@@ -54,16 +54,17 @@ const useStyles = M.makeStyles((t) => ({
     display: 'flex',
     flexDirection: 'column',
     flexGrow: 1,
+    gap: t.spacing(1),
     padding: t.spacing(2),
-  },
-  bodySpacer: {
-    flexGrow: 1,
   },
   bottomRow: {
     alignItems: 'center',
     display: 'flex',
     gap: t.spacing(1),
     justifyContent: 'space-between',
+    // Absorbs the slack that row-height equalization leaves; `body`'s gap is
+    // the floor when there is none.
+    marginTop: 'auto',
   },
   // Matches BucketIcon's footprint so a DP card's identity block aligns with a
   // bucket card's in the same grid row.
@@ -142,7 +143,6 @@ export default function DataProductCard({ product }: DataProductCardProps) {
             {product.description}
           </M.Typography>
         )}
-        <div className={classes.bodySpacer} />
         <div className={classes.bottomRow}>
           {/* Curation is capability-gated: only Unity has the primitive, so
               elsewhere the chip is absent rather than empty. An unconditional

--- a/catalog/app/containers/Home/BucketGrid/DataProductCard.tsx
+++ b/catalog/app/containers/Home/BucketGrid/DataProductCard.tsx
@@ -139,7 +139,7 @@ export default function DataProductCard({ product }: DataProductCardProps) {
       </Link>
       <div className={classes.body}>
         {!!product.description && (
-          <M.Typography className={classes.description} component="p" variant="caption">
+          <M.Typography className={classes.description} component="p" variant="body2">
             {product.description}
           </M.Typography>
         )}


### PR DESCRIPTION
Three small fixes to the volume grid, found on nightly.

- **Description touched the tags.** The grid equalizes row heights, and a flex spacer was the only thing between the two — so the gap was whatever equalization left over, and the fullest card in a row got none. `margin-top: auto` on the bottom row absorbs the slack; `gap` on the body is the floor. The spacer div is gone.
- **Tag chips are outlined**, in the card and the row view. A matching tag already carried a 1px border and a filled one did not, so selecting a tag resized it by 2px and nudged its neighbours.
- **Descriptions are set at the body step.** They were Caption — smaller than the `s3://` address above them. DESIGN.md:266 names Body as the step for descriptions.

Before:
<img width="1436" height="1070" alt="Screenshot_2026-08-26_18-34-40" src="https://github.com/user-attachments/assets/a3f50fb6-f2de-4950-955a-8d1964ac8b2c" />

After:
<img width="1436" height="1070" alt="Screenshot_2026-08-26_18-34-46" src="https://github.com/user-attachments/assets/0fc20075-129d-4d1a-9568-8e2560ee1e97" />


<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR tidies volume-card presentation and keeps card and row tag styling consistent.
- Adds a minimum gap between descriptions and card footers while preserving equalized grid spacing.
- Uses outlined tag chips in card and row views to prevent selection-related resizing.
- Promotes bucket and data-product descriptions from caption to body typography.
- Documents the presentation changes in the Catalog changelog.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge, with no concrete functional or accessibility regression identified.

The changed flex layout retains bounded descriptions and equalized card behavior, while outlined chips preserve border dimensions across matching states and no repository rule violations were found.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| catalog/app/containers/Home/BucketGrid/BucketCard.tsx | Replaces the flexible spacer with explicit flex spacing, promotes description typography, and outlines tag chips without an identified functional regression. |
| catalog/app/containers/Home/BucketGrid/BucketRows.tsx | Applies the outlined tag-chip treatment consistently to the row view. |
| catalog/app/containers/Home/BucketGrid/DataProductCard.tsx | Mirrors the card-body spacing and description typography changes for data products without an identified failure. |
| catalog/CHANGELOG.md | Accurately records the user-visible spacing, chip, and typography changes. |

<sub>Reviews (1): Last reviewed commit: ["catalog: outline the volume tag chips, s..."](https://github.com/quiltdata/quilt/commit/d6ba1001fa0420ede2dc19fdea76c502d08cefc1) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=57144919)</sub>

<!-- /greptile_comment -->