### PR TITLE
catalog: package revision line joins the responsive tier system

### DIFF
--- a/catalog/CHANGELOG.md
+++ b/catalog/CHANGELOG.md
@@ -21,7 +21,7 @@ complete sentence without it.
 
 ## Changes
 
-- [Changed] Package top bar: the breadcrumbs and action cluster lay out on two explicit tiers — one row when wide (crumbs truncate first, actions never squash), and at medium widths the whole action cluster moves onto its own right-anchored row below full-width crumbs, wrapping with even gaps instead of crushing ([#PRNUM](https://github.com/quiltdata/quilt/pull/PRNUM))
+- [Changed] Package top bar: the breadcrumbs and action cluster lay out on two explicit tiers — one row when wide (crumbs truncate first, actions never squash), and at medium widths the whole action cluster moves onto its own right-anchored row below full-width crumbs, wrapping with even gaps instead of crushing ([#5227](https://github.com/quiltdata/quilt/pull/5227))
 - [Removed] The unbaked data-products GraphQL contract (added in [#5203](https://github.com/quiltdata/quilt/pull/5203), never served by a registry) is out of the schema; the `data-products` preview UI is unaffected and keeps reading fixture data ([#5223](https://github.com/quiltdata/quilt/pull/5223))
 - [Changed] Search sidebar: the package metadata list is sorted from one "Sort by" control, sitting directly above the list ([#5222](https://github.com/quiltdata/quilt/pull/5222))
 - [Fixed] Volumes list: the "Shared with" readout no longer overlaps a bucket's tags, and the extra space inside it is gone ([#5220](https://github.com/quiltdata/quilt/pull/5220))

--- a/catalog/CHANGELOG.md
+++ b/catalog/CHANGELOG.md
@@ -21,6 +21,7 @@ complete sentence without it.
 
 ## Changes
 
+- [Changed] Package revision line: the package name, "@ revision" selector and its shortcuts lay out on two explicit tiers — one line when wide (the name truncates first; the revision control and shortcuts never separate), and at narrow widths the name takes its own wrapping line with the revision cluster grouped beneath, instead of arbitrary inline wrapping ([#5228](https://github.com/quiltdata/quilt/pull/5228))
 - [Changed] Package top bar: the breadcrumbs and action cluster lay out on two explicit tiers — one row when wide (crumbs truncate first, actions never squash), and at medium widths the whole action cluster moves onto its own right-anchored row below full-width crumbs, wrapping with even gaps instead of crushing ([#5227](https://github.com/quiltdata/quilt/pull/5227))
 - [Removed] The unbaked data-products GraphQL contract (added in [#5203](https://github.com/quiltdata/quilt/pull/5203), never served by a registry) is out of the schema; the `data-products` preview UI is unaffected and keeps reading fixture data ([#5223](https://github.com/quiltdata/quilt/pull/5223))
 - [Changed] Search sidebar: the package metadata list is sorted from one "Sort by" control, sitting directly above the list ([#5222](https://github.com/quiltdata/quilt/pull/5222))

--- a/catalog/CHANGELOG.md
+++ b/catalog/CHANGELOG.md
@@ -21,6 +21,7 @@ complete sentence without it.
 
 ## Changes
 
+- [Changed] Package top bar: the breadcrumbs and action cluster lay out on two explicit tiers — one row when wide (crumbs truncate first, actions never squash), and at medium widths the whole action cluster moves onto its own right-anchored row below full-width crumbs, wrapping with even gaps instead of crushing ([#PRNUM](https://github.com/quiltdata/quilt/pull/PRNUM))
 - [Removed] The unbaked data-products GraphQL contract (added in [#5203](https://github.com/quiltdata/quilt/pull/5203), never served by a registry) is out of the schema; the `data-products` preview UI is unaffected and keeps reading fixture data ([#5223](https://github.com/quiltdata/quilt/pull/5223))
 - [Changed] Search sidebar: the package metadata list is sorted from one "Sort by" control, sitting directly above the list ([#5222](https://github.com/quiltdata/quilt/pull/5222))
 - [Fixed] Volumes list: the "Shared with" readout no longer overlaps a bucket's tags, and the extra space inside it is gone ([#5220](https://github.com/quiltdata/quilt/pull/5220))

--- a/catalog/app/containers/Bucket/PackageTree/PackageTree.tsx
+++ b/catalog/app/containers/Bucket/PackageTree/PackageTree.tsx
@@ -1007,37 +1007,42 @@ const useStyles = M.makeStyles((t) => ({
     textOverflow: 'ellipsis',
     whiteSpace: 'nowrap',
   },
-  // Two explicit tiers instead of emergent inline wrapping. Wide: one line
-  // (name @ revision + shortcuts) where the package name truncates first and
-  // the revision control never separates from its shortcuts. Stacked (≤640px):
-  // the name gets its own full-width line — wrapping instead of truncating, so
-  // identity stays readable — with the revision cluster grouped beneath.
   revisionLine: {
     ...t.typography.body1,
     alignItems: 'baseline',
-    columnGap: t.spacing(0.5),
     display: 'grid',
     gridTemplateAreas: '"name revision"',
     gridTemplateColumns: 'minmax(0, max-content) max-content',
     justifyContent: 'start',
-    '@media (max-width: 640px)': {
+    [t.breakpoints.down(640)]: {
       gridTemplateAreas: '"name" "revision"',
       gridTemplateColumns: 'minmax(0, 1fr)',
+      rowGap: t.spacing(0.5),
     },
   },
+  // Truncation's escape hatches: the title tooltip for the mouse, and
+  // keyboard focus landing inside unfolds the name for the sighted
+  // keyboard user (the links inside stay tabbable when clipped).
   packageName: {
     gridArea: 'name',
     minWidth: 0,
     overflow: 'hidden',
     textOverflow: 'ellipsis',
     whiteSpace: 'nowrap',
-    '@media (max-width: 640px)': {
+    '&:focus-within': {
+      overflowWrap: 'anywhere',
+      whiteSpace: 'normal',
+    },
+    [t.breakpoints.down(640)]: {
+      overflowWrap: 'anywhere',
       whiteSpace: 'normal',
     },
   },
+  // `pre` keeps the leading " @ " separator rendered and copyable, so
+  // selecting the line still yields "name @ revision" like the old markup.
   revision: {
     gridArea: 'revision',
-    whiteSpace: 'nowrap',
+    whiteSpace: 'pre',
   },
 }))
 
@@ -1182,7 +1187,7 @@ function PackageTree({
           <PackageLink {...{ bucket, name }} />
         </span>
         <span className={classes.revision}>
-          {'@ '}
+          {' @ '}
           <RevisionInfo {...{ hash, hashOrTag, bucket, name, path, revisionListQuery }} />
         </span>
       </div>

--- a/catalog/app/containers/Bucket/PackageTree/PackageTree.tsx
+++ b/catalog/app/containers/Bucket/PackageTree/PackageTree.tsx
@@ -122,13 +122,8 @@ const isStillBrowsingPackage = (
 }
 
 const useTopBarStyles = M.makeStyles((t) => ({
-  // Two explicit tiers instead of emergent flex crush. Wide: one grid row
-  // (crumbs | actions) — crumbs truncate/wrap first, the action cluster never
-  // squashes. Stacked (≤1100px viewport): the cluster moves to its own
-  // full-width row below the crumbs, keeping the wide tier's right anchor so
-  // the (often icon-collapsed) strip doesn't sit parked at the left edge; it
-  // wraps with even 8px gaps so it never overflows, and crumbs get the full
-  // width.
+  // The stacked tier keeps the wide tier's right anchor so the (often
+  // icon-collapsed) action strip doesn't sit parked at the left edge.
   topBar: {
     alignItems: 'end',
     columnGap: t.spacing(2),
@@ -137,7 +132,7 @@ const useTopBarStyles = M.makeStyles((t) => ({
     gridTemplateColumns: 'minmax(0, 1fr) auto',
     marginBottom: t.spacing(2),
     marginTop: t.spacing(0.5),
-    '@media (max-width: 1100px)': {
+    [t.breakpoints.down(1100)]: {
       gridTemplateAreas: '"crumbs" "actions"',
       gridTemplateColumns: 'minmax(0, 1fr)',
     },
@@ -158,13 +153,20 @@ const useTopBarStyles = M.makeStyles((t) => ({
     '&:empty': {
       display: 'none',
     },
-    '@media (max-width: 1100px)': {
+    // Children carry their own marginLeft for intra-cluster gaps; the grid's
+    // columnGap already provides the crumbs seam, so the first child's margin
+    // is zeroed. Doubled selectors (&&) outrank the children's single-class
+    // margin rules regardless of JSS sheet insertion order.
+    '&& > :first-child': {
+      marginLeft: 0,
+    },
+    [t.breakpoints.down(1100)]: {
       flexWrap: 'wrap',
       gap: t.spacing(1),
       justifyContent: 'flex-end',
       marginBottom: 0,
       marginTop: t.spacing(1),
-      '& > *': {
+      '&& > *': {
         margin: 0,
       },
     },

--- a/catalog/app/containers/Bucket/PackageTree/PackageTree.tsx
+++ b/catalog/app/containers/Bucket/PackageTree/PackageTree.tsx
@@ -999,13 +999,45 @@ type RevisionData = NonNullable<
   GQL.DataForDoc<typeof REVISION_QUERY>['package']
 >['revision']
 
-const useStyles = M.makeStyles({
+const useStyles = M.makeStyles((t) => ({
   alertMsg: {
     overflow: 'hidden',
     textOverflow: 'ellipsis',
     whiteSpace: 'nowrap',
   },
-})
+  // Two explicit tiers instead of emergent inline wrapping. Wide: one line
+  // (name @ revision + shortcuts) where the package name truncates first and
+  // the revision control never separates from its shortcuts. Stacked (≤640px):
+  // the name gets its own full-width line — wrapping instead of truncating, so
+  // identity stays readable — with the revision cluster grouped beneath.
+  revisionLine: {
+    ...t.typography.body1,
+    alignItems: 'baseline',
+    columnGap: t.spacing(0.5),
+    display: 'grid',
+    gridTemplateAreas: '"name revision"',
+    gridTemplateColumns: 'minmax(0, max-content) max-content',
+    justifyContent: 'start',
+    '@media (max-width: 640px)': {
+      gridTemplateAreas: '"name" "revision"',
+      gridTemplateColumns: 'minmax(0, 1fr)',
+    },
+  },
+  packageName: {
+    gridArea: 'name',
+    minWidth: 0,
+    overflow: 'hidden',
+    textOverflow: 'ellipsis',
+    whiteSpace: 'nowrap',
+    '@media (max-width: 640px)': {
+      whiteSpace: 'normal',
+    },
+  },
+  revision: {
+    gridArea: 'revision',
+    whiteSpace: 'nowrap',
+  },
+}))
 
 interface PackageRevisionProps {
   packageHandle: PackageHandle
@@ -1143,11 +1175,15 @@ function PackageTree({
           </Lab.Alert>
         </M.Box>
       )}
-      <M.Typography variant="body1">
-        <PackageLink {...{ bucket, name }} />
-        {' @ '}
-        <RevisionInfo {...{ hash, hashOrTag, bucket, name, path, revisionListQuery }} />
-      </M.Typography>
+      <div className={classes.revisionLine}>
+        <span className={classes.packageName} title={name}>
+          <PackageLink {...{ bucket, name }} />
+        </span>
+        <span className={classes.revision}>
+          {'@ '}
+          <RevisionInfo {...{ hash, hashOrTag, bucket, name, path, revisionListQuery }} />
+        </span>
+      </div>
       {packageHandle ? (
         <PackageRevision
           packageHandle={packageHandle}

--- a/catalog/app/containers/Bucket/PackageTree/PackageTree.tsx
+++ b/catalog/app/containers/Bucket/PackageTree/PackageTree.tsx
@@ -122,27 +122,52 @@ const isStillBrowsingPackage = (
 }
 
 const useTopBarStyles = M.makeStyles((t) => ({
+  // Two explicit tiers instead of emergent flex crush. Wide: one grid row
+  // (crumbs | actions) — crumbs truncate/wrap first, the action cluster never
+  // squashes. Stacked (≤1100px viewport): the cluster moves to its own
+  // full-width row below the crumbs, keeping the wide tier's right anchor so
+  // the (often icon-collapsed) strip doesn't sit parked at the left edge; it
+  // wraps with even 8px gaps so it never overflows, and crumbs get the full
+  // width.
   topBar: {
-    alignItems: 'flex-end',
-    display: 'flex',
+    alignItems: 'end',
+    columnGap: t.spacing(2),
+    display: 'grid',
+    gridTemplateAreas: '"crumbs actions"',
+    gridTemplateColumns: 'minmax(0, 1fr) auto',
     marginBottom: t.spacing(2),
     marginTop: t.spacing(0.5),
+    '@media (max-width: 1100px)': {
+      gridTemplateAreas: '"crumbs" "actions"',
+      gridTemplateColumns: 'minmax(0, 1fr)',
+    },
   },
   crumbs: {
     ...t.typography.body1,
-    maxWidth: 'calc(100% - 160px)',
+    gridArea: 'crumbs',
+    minWidth: 0,
     overflowWrap: 'break-word',
-    [t.breakpoints.down('xs')]: {
-      maxWidth: 'calc(100% - 40px)',
-    },
   },
   content: {
     alignItems: 'center',
     display: 'flex',
-    flexShrink: 0,
+    flexWrap: 'nowrap',
+    gridArea: 'actions',
     marginBottom: -3,
-    marginLeft: 'auto',
     marginTop: -3,
+    '&:empty': {
+      display: 'none',
+    },
+    '@media (max-width: 1100px)': {
+      flexWrap: 'wrap',
+      gap: t.spacing(1),
+      justifyContent: 'flex-end',
+      marginBottom: 0,
+      marginTop: t.spacing(1),
+      '& > *': {
+        margin: 0,
+      },
+    },
   },
 }))
 

--- a/catalog/app/containers/Bucket/Toolbar/Assist.tsx
+++ b/catalog/app/containers/Bucket/Toolbar/Assist.tsx
@@ -1,21 +1,37 @@
+import cx from 'classnames'
 import * as React from 'react'
 import * as M from '@material-ui/core'
 
 import * as Assistant from 'components/Assistant'
+
+// A class, not an inline style: toolbars neutralize their children's margins
+// at stacked breakpoints, and inline styles are unreachable from a stylesheet.
+const useStyles = M.makeStyles({
+  root: {
+    marginBottom: -12,
+    marginTop: -12,
+  },
+})
 
 interface AssistButtonProps extends M.IconButtonProps {
   title?: string
   message?: string
 }
 
-export default function AssistButton({ message, title, ...props }: AssistButtonProps) {
+export default function AssistButton({
+  className,
+  message,
+  title,
+  ...props
+}: AssistButtonProps) {
+  const classes = useStyles()
   const assist = Assistant.use()
   if (!assist) return null
   return (
     <M.IconButton
+      className={cx(classes.root, className)}
       color="primary"
       onClick={() => assist(message || 'Summarize this document')}
-      style={{ marginTop: '-12px', marginBottom: '-12px' }}
       edge="end"
       {...props}
     >


### PR DESCRIPTION
Stacked on #5227 — merge that first; this PR's real diff is the last commit(s).

Siblings in the tier series: #5226 (bucket header), #5227 (package top bar).

## What

The package revision line — the package-name crumb links, the `@ latest` revision selector, and the two shortcut icons (what's-changed, copy-link) rendered above the package top bar — now degrades on two explicit tiers instead of wrapping arbitrarily:

- **Wide**: one line. The package name is the flexible element and truncates first (ellipsis, full handle on hover via `title`); the revision control and its shortcuts never separate from each other.
- **Narrow (≤640px)**: the name takes its own full-width line — wrapping instead of truncating, so identity stays readable — with the `@ revision` cluster grouped beneath.

## Why

The header (#5226) and top bar (#5227) already follow the deliberate-tier philosophy (grid-template-areas + explicit media queries). The revision line sat outside it: at narrow widths the `@`, the revision word, and each shortcut icon could land on their own line — emergent wrap points, not chosen ones. This uses the same house pattern (`useTopBarStyles` in the same file, `Header.tsx` on the sibling branch) and the accepted 640px narrow breakpoint.

Crumb link behavior, the RevisionInfo popover trigger, and both shortcut tooltips/hrefs are untouched — the change is layout-only, wrapping the existing elements in grid areas.

## Verified

- `npm run typecheck` clean
- `npm run test:only -- app/containers/Bucket/PackageTree` — 2 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR moves the package revision line and package top bar onto explicit responsive layout tiers.
- Uses grid areas to keep package identity and revision actions grouped predictably.
- Truncates long package names on wide screens and restores wrapping at the narrow breakpoint.
- Stacks package breadcrumbs and actions at intermediate widths.
- Adds the corresponding package top-bar changelog entry.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge, with no concrete functional, accessibility, or responsive-layout defect identified.

The changes are limited to responsive markup and styling, and the existing package navigation, revision controls, shortcut actions, and popover behavior remain reachable across the defined tiers.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| catalog/app/containers/Bucket/PackageTree/PackageTree.tsx | Replaces emergent wrapping with explicit responsive grid tiers while preserving existing links, revision controls, shortcuts, and popovers. |
| catalog/CHANGELOG.md | Adds the package top-bar responsive-layout entry for the stacked prerequisite change. |

<sub>Reviews (1): Last reviewed commit: ["catalog: package revision line joins the..."](https://github.com/quiltdata/quilt/commit/87c5c2086e0ab467befc2e1a0ad2d134e142834c) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=57300099)</sub>

<!-- /greptile_comment -->