### PR TITLE
docs: catch docs up to the 26.8.0 catalog shell (sidebar, global Queries, Files tab, ES sunset)

### DIFF
--- a/docs/Catalog/Admin.md
+++ b/docs/Catalog/Admin.md
@@ -1,7 +1,8 @@
 <!-- markdownlint-disable -->
 The Quilt catalog includes an admin panel that allows you to manage
 users and buckets in Quilt, as well as customize the Quilt catalog. You can access
-the panel via a dropdown menu under username in the navbar.
+the panel via **Admin** in the catalog's left sidebar, which is shown only to
+administrators.
 
 ![](../imgs/admin-dropdown.png)
 
@@ -30,8 +31,9 @@ You can edit existing users' attributes by clicking on underlined cells.
 
 ![](../imgs/admin-users-invite.png)
 
-Users can switch between assigned roles via the dropdown menu in the navbar
-(if assigned more than one).
+Users assigned more than one role can switch between them from the
+**Workspace** row at the top of the left sidebar, which shows the role they are
+currently using. Clicking it opens the **Switch workspace** dialog.
 
 ![](../imgs/switch-role-menu.png)
 
@@ -120,8 +122,8 @@ break indexing or event delivery.
 
 ## Settings
 
-This section allows you to customize your Quilt catalog, including custom links
-in the navbar, custom logo, and default search mode. The Theme editor accepts
+This section allows you to customize your Quilt catalog, including a custom
+navigation link, custom logo, and default search mode. The Theme editor accepts
 a logo as either a direct file upload (PNG, JPEG, WebP, or GIF) or a URL
 (all of those plus SVG).
 

--- a/docs/Catalog/FileBrowser.md
+++ b/docs/Catalog/FileBrowser.md
@@ -1,5 +1,5 @@
 <!-- markdownlint-disable-next-line first-line-h1 -->
-Every S3 bucket attached to Quilt has a "Bucket" tab in the Catalog
+Every S3 bucket attached to Quilt has a "Files" tab in the Catalog
 that displays all files in the bucket.
 
 ![Files browser tab](../imgs/catalog-filesbrowser-tab.png)
@@ -51,7 +51,7 @@ an individual file by clicking "Add to bookmarks".
 
 ![Add selected files to bookmarks](../imgs/catalog-filesbrowser-addtobookmarks.png)
 
-Open the Bookmarks pane (listed in the User account menu) and
+Open the Bookmarks pane (**Bookmarks** in the left sidebar) and
 optionally create a new package from the bookmarked files.
 
 ![Open bookmarks](../imgs/catalog-filesbrowser-bookmarksmenu.png)
@@ -92,7 +92,7 @@ There are currently three types of S3 object archive storage class that
 work differently with the Quilt Catalog, `quilt3` CLI and Python API.
 
 1. **S3 Glacier Instant Retrieval:** Objects in this storage class are
-available as normal in the Bucket and Packages tabs in the Quilt
+available as normal in the Files and Packages tabs in the Quilt
 Catalog.
 1. **S3 Glacier Flexible Retrieval (formerly S3 Glacier):** Objects are
 not immediately available and appear "grayed out" in the Catalog.

--- a/docs/Catalog/Preferences.md
+++ b/docs/Catalog/Preferences.md
@@ -52,7 +52,11 @@ ui:
 * `ui.nav.files: False` - hide Files tab
 * `ui.nav.workflows: False` - hide Workflows tab
 * `ui.nav.packages: False` - hide Packages tab
-* `ui.nav.queries: False` - hide Queries tab
+* `ui.nav.queries: False` - hide this bucket's entry points into the
+workspace-global Queries page: the tables stat in the bucket header and the
+Tabulator tables section on the Overview tab. Queries is no longer a bucket
+tab, so this does not hide the Queries page itself
+([learn more](./Query.md))
 * `ui.actions: False` - hide all buttons used to create and edit packages and files
 (make the catalog "read-only")
 * `ui.actions.copyPackage: False` - hide buttons to push packages across buckets
@@ -61,17 +65,18 @@ drag-and-drop or from folders in S3
 * `ui.actions.deleteObject: True` - show buttons to delete files and
   directories (off by default since 1.66 to prevent accidental deletions)
 * `ui.actions.deleteRevision: True` - show buttons to delete package revision
-* `ui.actions.downloadObject: False` - hide download buttons under "Bucket" tab
+* `ui.actions.downloadObject: False` - hide download buttons under "Files" tab
 * `ui.actions.downloadPackage: False` - hide download buttons under "Packages" tab
 * `ui.actions.restore: False` - hide the button to restore (rehydrate) archived
   S3 Glacier / Deep Archive objects
 * `ui.actions.revisePackage: False` - hide the button to revise packages
 * `ui.actions.writeFile: False` - hide buttons to create or edit files
 * `ui.blocks.analytics: False` - hide Analytics block on file page
-* `ui.blocks.browser: False` - hide files browser on both Bucket and Packages tab
+* `ui.blocks.browser: False` - hide files browser on both the Files and
+Packages tabs
 * `ui.blocks.code: False` - hide Code block with quilt3 code boilerplate
 * `ui.blocks.gallery: False` - hide all galleries (see below for list of galleries)
-* `ui.blocks.gallery.files: False` - hide gallery in Bucket tab;
+* `ui.blocks.gallery.files: False` - hide gallery in Files tab;
 this gallery lists all images in the current directory
 * `ui.blocks.gallery.packages: False` - hide gallery in Packages tab;
 this gallery lists all images in the current directory in package
@@ -96,7 +101,7 @@ in the package list view.
 * `ui.package_description_multiline: True` - expands package metadata's root key/values
 * `ui.athena.defaultWorkgroup` - default workgroup to select on the Athena page
 
-![Alongside text editor users can use visual form to modify the config](../imgs/bucket-preferences-editor.png)
+![Alongside text editor users can use visual form to modify the config](../imgs/buckets-preferences-editor.png)
 
 #### `ui.sourceBuckets` example
 

--- a/docs/Catalog/Query.md
+++ b/docs/Catalog/Query.md
@@ -4,10 +4,22 @@ that makes it easy to analyze data in Amazon S3 using standard SQL. Athena is
 serverless, so there is no infrastructure to manage, and you pay only for the
 queries that you run.
 
-The Catalog's Queries tab allows you to run Athena queries against your S3
-buckets, and any other data sources your users have access to. There are
-prebuilt tables for packages and objects, and you can create your own tables and
-views. See, for example, [Tabulator](../advanced-features/tabulator.md).
+The Catalog's Queries page — **Queries** in the left sidebar, at `/queries` —
+allows you to run Athena queries against your S3 buckets, and any other data
+sources your users have access to. There are prebuilt tables for packages and
+objects, and you can create your own tables and views. See, for example,
+[Tabulator](../advanced-features/tabulator.md).
+
+The page is workspace-global rather than per-bucket: there is no longer a
+Queries tab on a bucket. Old `/b/<BUCKET>/queries` links redirect here,
+carrying the bucket along as a `?bucket=` scope parameter, which is what
+surfaces that bucket's Tabulator tables as one-click chips.
+
+Queries is Athena-only by default. The legacy [ElasticSearch query
+console](Search.md#elasticsearch-query-console-legacy) is no longer enabled by
+default; an administrator can keep it available by turning on the
+**ElasticSearch query console** toggle under **Admin > Settings > Preview
+features**, which adds an **ElasticSearch** tab alongside Athena.
 
 NOTE: This page describes how to use Athena for precise querying of specific
 tables and fields. For full-text searching using Elasticsearch, see the
@@ -15,13 +27,11 @@ tables and fields. For full-text searching using Elasticsearch, see the
 
 ## Basics
 
-"Run query" executes the selected query and waits for the result.
+"Run query" executes the selected query and waits for the result. Individual
+users also see their past queries under "Query executions", and can easily
+re-run them.
 
 ![ui](../imgs/athena-ui.png)
-
- Individual users will also see their past queries, and easily re-run them.
-
-![history](../imgs/athena-history.png)
 
 ## Example: query package-level metadata
 
@@ -61,5 +71,9 @@ AND json_array_contains(json_extract(metadata, '$.user_meta.cellindex'), '5');
 Athena queries saved from the AWS Console for a given workgroup will be
 available in the Quilt Catalog for all users to run.
 
-Administrators can hide the "Queries" tab by setting `ui > nav > queries: false`
-([learn more](./Preferences.md)).
+The Queries page is workspace-global and always reachable from the left
+sidebar; there is no per-bucket toggle that hides it. Setting `ui > nav >
+queries: false` for a bucket ([learn more](./Preferences.md)) hides that
+bucket's own entry points into this page — the tables stat in the bucket header
+and the Tabulator tables section on the bucket's Overview tab — but not the
+page itself.

--- a/docs/Catalog/Qurator.md
+++ b/docs/Catalog/Qurator.md
@@ -85,8 +85,8 @@ To enable Qurator Omni:
 3. **Start Using Qurator**:  
    - Once activated, the Qurator chatbot will appear in the Quilt web catalog
      interface.
-   - Click the Qurator icon on the
-     bottom right of the screen to open the chat interface. ![qurator icon](../imgs/qurator-icon.png)
+   - Click **Ask Qurator** in the catalog's left sidebar to open the chat
+     interface. ![qurator icon](../imgs/qurator-icon.png)
    - You can begin by typing questions into the chat interface. For example,
      queries like _“What are the key findings on small molecule delivery?”_ will
      prompt Qurator to search for relevant data and present a summarized

--- a/docs/Catalog/Search.md
+++ b/docs/Catalog/Search.md
@@ -29,7 +29,9 @@ indexing for the following file extensions:
 
 ### Search page
 
-The search page in the catalog, accessible from the search button in the top menu bar, provides a convenient
+The search page in the catalog, reachable from **Search** in the left sidebar
+or by submitting a query in the always-on search bar at the top of every page
+(`/` or Cmd/Ctrl+K focuses it), provides a convenient
 way for searching objects and packages in an Amazon S3
 bucket.
 
@@ -109,14 +111,27 @@ match the search query.
 | `?` | Exactly one character | `ext:React.?sx` |
 | `//` | Regular expression (slows performance) | `content:/lmnb[12]/` |
 
-### ELASTICSEARCH tab
+### ElasticSearch query console (legacy)
 
-When you click into a specific bucket, you can access the Elasticsearch tab to
-run more complex queries. The Elasticsearch tab provides a more powerful search
-interface than the search bar, allowing you to specify the Elasticsearch index
-and query parameters.
+The ElasticSearch query console exposes the raw Elasticsearch Search API,
+letting you specify the Elasticsearch index and query parameters directly
+rather than going through the search page above.
 
-![catalog-es-queries-default](../imgs/catalog-es-queries-default.png)
+**The console is no longer enabled by default.** It is retained for existing
+workflows: an administrator can keep it available by turning on the
+**ElasticSearch query console** toggle under **Admin > Settings > Preview
+features**. With that toggle off, the [Queries](Query.md) page is Athena-only
+and `/queries/es` redirects to the Athena console. For new work, prefer the
+search page above or Athena on the [Queries](Query.md) page.
+
+Once enabled, the console appears as an **ElasticSearch** tab on the
+[Queries](Query.md) page. It offers a **Bucket (index scope)** selector — a
+single bucket, or *All readable indexes* — and a **Select query** drop-down
+listing the [saved
+queries](../walkthrough/working-with-elasticsearch.md#configuring-saved-queries)
+configured for the selected bucket.
+
+![ElasticSearch query console](../imgs/catalog-es-queries-default.png)
 
 Quilt Elasticsearch queries support the following keys:
 

--- a/docs/Catalog/URI.md
+++ b/docs/Catalog/URI.md
@@ -1,5 +1,5 @@
 <!-- markdownlint-disable-next-line first-line-h1 -->
-Every package and object in the Bucket and Packages views has a "CODE" pane,
+Every package and object in the Files and Packages views has a "CODE" pane,
 which contains code snippets that can be used to download and upload a package
 or object via either:
 
@@ -33,10 +33,10 @@ the `akarve/cord19` package of the `quilt-example` bucket.
 ### Catalog Usage
 
 URIs can be used to quickly navigate to a specific package or object from the
-Catalog. If your window is wide enough, there will be a "URI" button to the
-right of the search bar. Clicking this button will display a dialog where you
-can paste a URI and "Resolve" it to navigate to the package or object it
-references.
+Catalog. At the right end of the header bar, past the search field, there is a
+chain-link icon button tooltipped "Resolve a Quilt URI". Clicking it opens a
+page where you can paste a URI and "Resolve" it to navigate to the package or
+object it references.
 
 ![Resolving URIs](../imgs/uri-resolve.png)
 

--- a/docs/Catalog/VisualizationDashboards.md
+++ b/docs/Catalog/VisualizationDashboards.md
@@ -25,7 +25,7 @@ The above systems provide you with hundreds of charts out of the box.
 
 ## `quilt_summarize.json`
 `quilt_summarize.json` is a configuration file that renders one or more dashboard
-elements in both Bucket view and Packages view. The contents of `quilt_summarize.json`
+elements in both Files view and Packages view. The contents of `quilt_summarize.json`
 are a JSON array of files that you wish to preview in the catalog. Each file may
 be represented as a string or, if you wish to provide more configuration, as an
 object.
@@ -119,7 +119,7 @@ all [supported image types](../Catalog/Preview.md#binary-and-special-file-format
 > To hide this block, use the `gallery` field in
 your [bucket preferences](./Preferences.md) file.
 
-In the **Bucket** tab, the Catalog displays thumbnail image 
+In the **Files** tab, the Catalog displays thumbnail image 
 previews in a similarly paginated grid but _only from the current 
 directory viewed_.
 

--- a/docs/FAQ.md
+++ b/docs/FAQ.md
@@ -251,5 +251,5 @@ additional IPs.
 ## The "Last Modified" column in the Quilt catalog is empty
 
 Amazon S3 is a key-value store with prefixes but no true "folders".
-In the Quilt Catalog Bucket view, as in AWS Console, only objects have
+In the Quilt Catalog Files view, as in AWS Console, only objects have
 a "Last modified" value, whereas package entries and prefixes do not.

--- a/docs/advanced-features/iceberg-tables.md
+++ b/docs/advanced-features/iceberg-tables.md
@@ -42,11 +42,11 @@ have stack-wide access by design.
 > other things) breaks. Leave the parameter off only on accounts that do not
 > enforce Lake Formation.
 
-## Finding the tables in the Queries tab
+## Finding the tables on the Queries page
 
 As of Quilt Platform 1.71.0, managed users can select the Iceberg package-index
-database directly from the **Database** dropdown in the catalog's **Queries**
-tab, instead of typing its fully-qualified name.
+database directly from the **Database** dropdown on the catalog's **Queries**
+page, instead of typing its fully-qualified name.
 
 ## Example: Get entries and metadata for the latest version of a package
 
@@ -94,6 +94,6 @@ WHERE tag_name = 'latest'
 
 ## See also
 
-- [Query](../Catalog/Query.md): Use the Catalog's Queries tab
+- [Query](../Catalog/Query.md): Use the Catalog's Queries page
 - [Athena](athena.md): Query package manifests using AWS Athena
 - [Tabulator](tabulator.md): Query tabular data within packages

--- a/docs/advanced-features/s3-prefix-permissions.md
+++ b/docs/advanced-features/s3-prefix-permissions.md
@@ -22,12 +22,12 @@ search results.
 
 ## Limitations and workarounds
 
-* Roles for users of the Quilt Catalog's Bucket tab must have
+* Roles for users of the Quilt Catalog's Files tab must have
 **full ListBucket permissions**, whether or not they are allowed to access all
 folders and objects. Catalog users who click on a prefix or object that they
 are not permitted to access will see an _Access Denied_ message.
-  * Alternatively, you can [hide the Bucket tab completely](../Catalog/Admin.md#show-and-hide-features-in-the-quilt-catalog)
-  and leave users access to the Package tab.
+  * Alternatively, you can [hide the Files tab completely](../Catalog/Preferences.md#show-and-hide-features-in-the-quilt-catalog)
+  and leave users access to the Packages tab.
 
   > IAM is not designed as a filter for browsing S3.
   ListBucket will return a 403 error for the root of bucket

--- a/docs/advanced-features/tabulator.md
+++ b/docs/advanced-features/tabulator.md
@@ -90,8 +90,9 @@ In addition to the columns defined in the schema, Tabulator will add:
 ### Using Athena to Access Tabulator
 
 The primary way of accessing Tabulator is using the Quilt stack to query those
-tables. This can be done by users via the per-bucket "Queries" tab in the Quilt
-Catalog, or programmatically via `quilt3`. See "Usage" below for more details.
+tables. This can be done by users via the Queries page in the Quilt Catalog
+(**Queries** in the left sidebar), or programmatically via `quilt3`. See "Usage"
+below for more details.
 
 As of Quilt Platform version 1.57, admins can enable [open query](#open-query)
 (below) to allow external users to access Tabulator tables directly from the AWS
@@ -143,8 +144,9 @@ returns an error. As of Quilt Platform version 1.58:
 
 ## Usage
 
-Once the configuration is set, users can query the tables using the Athena tab
-from the Quilt Catalog. Note that because Tabulator runs with elevated
+Once the configuration is set, users can query the tables using the Athena
+console on the Quilt Catalog's [Queries page](../Catalog/Query.md), which is
+Athena-only by default. Note that because Tabulator runs with elevated
 permissions, it cannot be accessed from the AWS Console by default
 (unless [open query](#open-query) is enabled).
 
@@ -181,7 +183,7 @@ JOIN "<IcebergDatabase>"."udp-spec_package_manifest" m
 
 ### From Outside the Quilt Catalog
 
-To call Tabulator from outside the Queries tab, you must use `quilt3` to
+To call Tabulator from outside the Queries page, you must use `quilt3` to
 authenticate against the stack using `config()` and `login()`, which opens a web
 page from which you must paste in the appropriate access token. Use
 `get_boto3_session()` to get a session with the same permissions as your Quilt

--- a/docs/walkthrough/working-with-elasticsearch.md
+++ b/docs/walkthrough/working-with-elasticsearch.md
@@ -29,7 +29,12 @@ queries:
 ```
 
 The Quilt catalog displays your saved queries in a drop-down for your users to
-select, edit, and execute.
+select, edit, and execute. That drop-down lives on the legacy [ElasticSearch
+query console](../Catalog/Search.md#elasticsearch-query-console-legacy), which
+is no longer enabled by default: an administrator must turn on the
+**ElasticSearch query console** toggle under **Admin > Settings > Preview
+features**, and the user must pick this bucket in the console's **Bucket (index
+scope)** selector before its saved queries load.
 
 ## Managing Elasticsearch
 

--- a/docs/walkthrough/working-with-the-catalog.md
+++ b/docs/walkthrough/working-with-the-catalog.md
@@ -10,24 +10,37 @@ but they are designed to work together.
 
 ## Brief tour
 
-The Quilt Catalog provides a homepage for your data catalog, based on a `README.md`
-file that you can optionally create at the top of your bucket.
+The Catalog opens on **Volumes**: the list of S3 buckets attached to your
+stack, with a text filter and a cards/list toggle. A persistent left sidebar
+carries Volumes, Search, Queries, Bookmarks, Ask Qurator and — for
+administrators — Admin, and an always-on search bar runs across the top of
+every page.
 
 ### Browse
 
+Clicking a volume opens its **Overview** tab, which renders a `README.md` file
+that you can optionally create at the top of the bucket.
+
 ![Homepage](../imgs/catalog_homepage.png)
+
+Each volume has four tabs: **Overview**, **Files**, **Packages** and
+**Workflows**. Queries are not among them — the Athena console (and the legacy
+ElasticSearch console, where an administrator has kept it enabled) lives on the
+workspace-global [Queries](../Catalog/Query.md) page, reachable from the
+sidebar.
 
 The Catalog lets you navigate packages in the registry using the "Packages" tab.
 
 ![Packages tab](../imgs/catalog_packages_tab.png)
 
-You can also browse the underlying S3 objects using the "Bucket" tab.
+You can also browse the underlying S3 objects using the "Files" tab.
 
 ![Files tab](../imgs/catalog_bucket_tab.png)
 
 ### Search
 
-Catalogs also enable you to search the contents of your bucket. We support both
+Catalogs also enable you to search the contents of your bucket, from the search
+bar at the top of the page or from **Search** in the sidebar. We support both
 unstructured (e.g. "`San Francisco`") and structured with
 [Query String Queries](https://www.elastic.co/guide/en/elasticsearch/reference/7.10/query-dsl-query-string-query.html#query-string-syntax)
 (e.g. "`metadata_key: metadata_value`") search. Hits are previewed right in the


### PR DESCRIPTION
Docs-only fast-follow for the 26.8.0 catalog shell change. Fixes every P1 from
the 26.8.0 docs sweep plus the mechanical P2s (nav language, tab/page naming).
No `catalog/` code touched.

Every behavior claim below was re-verified against `origin/master` catalog
source rather than the audit's paraphrase — `constants/routes.ts`,
`containers/Sidebar/Sidebar.tsx`, `containers/Sidebar/RoleSwitcher.tsx`,
`containers/Bucket/Nav/Nav.tsx`, `containers/Queries/{Queries,ElasticSearch}.tsx`,
`containers/App/queryRedirects.jsx`, `containers/Admin/Settings/Settings.tsx`,
`utils/features.ts`, `utils/BucketPreferences`. Three places where the real UI
strings contradicted the audit are called out under **UI strings** below.

## The ElasticSearch console is sunset, not a preview

`docs/Catalog/Search.md`'s ES section is now **"ElasticSearch query console
(legacy)"**, framed as *retained for existing workflows* — not as a new preview
feature and with no removal timeline invented. The wording throughout is "no
longer enabled by default; an administrator can keep it available by turning on
the **ElasticSearch query console** toggle under **Admin > Settings > Preview
features**."

The panel in Admin Settings is genuinely titled "Preview features"
(`containers/Admin/Settings/Settings.tsx:409`), and the switch inside it is
labelled "ElasticSearch query console" (`utils/features.ts`), so the click-path
names the real UI while the surrounding prose carries the sunset framing. The
`front-door` and `data-products` flags in that same panel *are* real previews
and are deliberately left undocumented here.

## What changed, by page

### `docs/Catalog/Search.md`
- Search page is reached from **Search** in the left sidebar or the always-on
  header search bar (`/` or Cmd/Ctrl+K focuses it) — not "the search button in
  the top menu bar".
- "### ELASTICSEARCH tab" → "### ElasticSearch query console (legacy)", with
  the sunset framing, the admin click-path, and the console's actual controls:
  a **Bucket (index scope)** selector (single bucket or *All readable indexes*)
  and a **Select query** drop-down. The old prose described a per-bucket tab
  and did not mention the index-scope selector at all.
- Notes that with the toggle off, Queries is Athena-only and `/queries/es`
  redirects to the Athena console.

### `docs/Catalog/Query.md`
- "Queries tab" → the Queries page, **Queries** in the left sidebar, at
  `/queries`.
- Documents that the page is workspace-global and that old
  `/b/<BUCKET>/queries` links redirect there, carrying the bucket as a
  `?bucket=` scope parameter (which is what surfaces that bucket's Tabulator
  tables as chips). Verified in `containers/App/queryRedirects.jsx` and
  `containers/Queries/Athena/TabulatorTables.tsx`.
- Adds the Athena-only-by-default note and links to the legacy ES section.
- **Rewrote the `ui > nav > queries` claim.** The old text said admins can
  "hide the Queries tab" with it. There is no Queries tab. The flag is still
  read, but for two other things: the tables stat in the bucket header
  (`containers/Bucket/Header.tsx:126`) and the Tabulator tables section on the
  bucket Overview (`Bucket/Overview/v2/TabulatorTables.tsx:221`). The docs now
  say that.
- Dropped a dead `athena-history.png` reference (see **Bonus fixes**).

### `docs/Catalog/Preferences.md`
- `ui.nav.queries: False` — same rewrite as above, since this is the reference
  admins actually configure from.
- `ui.actions.downloadObject`, `ui.blocks.browser`, `ui.blocks.gallery.files`:
  "Bucket" tab → "Files" tab. (`ui.nav.files` already said "Files tab" and
  `gallery.overview` already said "Overview tab" — the file was internally
  inconsistent.)
- Fixed a dead image link (see **Bonus fixes**).

### `docs/Catalog/Admin.md`
- Admin is reached from **Admin** in the left sidebar (shown only to admins) —
  not "a dropdown menu under username in the navbar".
- Role switching is the **Workspace** row at the top of the sidebar, showing
  the current role; clicking it opens the **Switch workspace** dialog.
- Settings section: "custom links in the navbar" → "a custom navigation link"
  (see **UI strings** — the placement claim was the unsafe part).

### `docs/Catalog/FileBrowser.md`
- "Bucket" tab → "Files" tab (reconciles with the image alt text, which
  already said "Files browser tab").
- Bookmarks: "listed in the User account menu" → **Bookmarks** in the left
  sidebar. The account menu at the bottom of the sidebar now holds only Sign
  Out (`containers/Sidebar/Sidebar.tsx:310`).
- Glacier Instant Retrieval: "Bucket and Packages tabs" → "Files and Packages
  tabs".

### `docs/Catalog/Qurator.md`
- "Click the Qurator icon on the bottom right of the screen" → "Click **Ask
  Qurator** in the catalog's left sidebar". The sidebar item's label is
  literally "Ask Qurator", not "Qurator".

### `docs/Catalog/URI.md`
- "Bucket and Packages views" → "Files and Packages views".
- The resolver entry point: the old "if your window is wide enough, there will
  be a 'URI' button" is wrong on both counts. It is now an unconditional
  chain-link icon button at the right end of the header bar, tooltipped
  "Resolve a Quilt URI" (`components/Layout/ContentBar.tsx:250`).

### `docs/Catalog/VisualizationDashboards.md`
- "**Bucket** tab" → "**Files** tab" (line 122; Overview/Packages nearby were
  already correct).
- Also "both Bucket view and Packages view" → "Files view" (line 28). Not in
  the audit; same rename class, same page.

### `docs/advanced-features/tabulator.md`
- "per-bucket 'Queries' tab" → the Queries page (**Queries** in the sidebar).
- "using the Athena tab from the Quilt Catalog" → the Athena console on the
  Queries page, Athena-only by default. There has never been an "Athena tab"
  at top level; it is a subsection tab of Queries, and with the ES flag off the
  tab strip is not rendered at all (`containers/Queries/Queries.tsx:75`).
- "outside the Queries tab" → "outside the Queries page".

### `docs/advanced-features/iceberg-tables.md`
- Heading "Finding the tables in the Queries tab" → "...on the Queries page".
  No inbound links to the old anchor (checked repo-wide).
- "Database dropdown in the catalog's Queries tab" → "...on the Queries page".
  The **Database** label is confirmed at `Queries/Athena/Database.tsx:182`.
- "See also" line: "Queries tab" → "Queries page".

### `docs/advanced-features/s3-prefix-permissions.md`
- "Bucket tab" → "Files tab", "Package tab" → "Packages tab".

### `docs/FAQ.md`
- "Quilt Catalog Bucket view" → "Files view".

### `docs/walkthrough/working-with-the-catalog.md`
- The tour now opens where the catalog opens: **Volumes**, the volume list with
  a text filter and a cards/list toggle, and names the sidebar contents and the
  header search bar.
- Separates the two things the old page conflated: the catalog home (Volumes)
  and the bucket's README-backed landing page (the **Overview** tab).
- Names the current tab set (Overview, Files, Packages, Workflows) and states
  that Queries is not among them.
- "Bucket" tab → "Files" tab; Search now says where the search entry points
  are.

### `docs/walkthrough/working-with-elasticsearch.md`
- The saved-queries drop-down claim now carries its two preconditions: the
  `elasticsearch-queries` toggle must be on, *and* the user must select this
  bucket in the console's **Bucket (index scope)** selector. Saved queries load
  only for a selected bucket — `queriesConfig.ts:50` returns `[]` for no
  bucket scope, which the old text did not hint at.

## Bonus fixes (not in the audit — found while verifying)

Both are dead links that a link checker would flag:

- `docs/Catalog/Query.md:24` referenced `../imgs/athena-history.png`, deleted
  in #4217 (Nov 2024). Reference removed; `athena-ui.png` on the same page
  already shows the "Query executions" list, so the prose was folded into it.
- `docs/Catalog/Preferences.md:99` referenced
  `../imgs/bucket-preferences-editor.png`; the file is
  `buckets-preferences-editor.png`. Retargeted.
- `docs/advanced-features/s3-prefix-permissions.md:29` linked to
  `../Catalog/Admin.md#show-and-hide-features-in-the-quilt-catalog`; that
  heading is in `Preferences.md`. Retargeted.

## UI strings that contradicted the audit or the brief

1. **The role-switch dialog is titled "Switch workspace", not "Switch role".**
   `containers/Sidebar/RoleSwitcher.tsx:100` (and "Could not switch workspace"
   on error). The audit proposed only changing the *location* description;
   the dialog title in `switch-role-dialog.png` is itself wrong now. Docs use
   "Switch workspace".
2. **The custom navigation link is configurable but no longer rendered
   anywhere.** `customNavLink` appears only in `utils/CatalogSettings.tsx` (the
   type) and `containers/Admin/Settings/Settings.tsx` (the editor) — there is
   no read site in the new shell. The audit asked to "verify custom links still
   render there"; they do not. Rather than move the claim from the navbar to the
   sidebar (which would be a new false statement), the docs now describe the
   Settings section's contents without asserting where the link appears. **This
   looks like a shell-migration regression worth a catalog-side issue.**
3. **The Admin Settings panel really is titled "Preview features"** — named
   accurately, sunset framing kept in the prose, per the brief.

Two more catalog-side string mismatches, out of scope for a docs PR but worth
filing:

4. The BucketPreferences visual config editor still labels `ui.nav.files` as
   `"BUCKET"` and still offers `ui.nav.queries` as a navigation item called
   `"QUERIES"` —
   `catalog/app/components/FileEditor/QuiltConfigEditor/BucketPreferences/BucketPreferences.tsx:197-200`.
   The prose is now right and the editor is wrong. This also blocks one
   screenshot recapture (flagged below).
5. `catalog-es-queries-default.png` footnotes "Quilt uses ElasticSearch 6.7
   Search API" while the docs say 7.10 throughout.

## Screenshot recapture checklist

**Not done in this PR** — no images were recaptured, renamed, or deleted; all
references still resolve. Recapture needs the new shell live. Every image below
was opened and described from what it actually shows, not inferred from its
filename.

Unless stated otherwise, recapture with **`front-door` OFF, `data-products`
OFF** (both are real previews, off by default), so the shell shown is what a
26.8.0 customer sees.

### Group A — old shell chrome visible, recapture required (18)

`docs/walkthrough/working-with-the-catalog.md`

- [ ] `imgs/catalog_homepage.png` — **Currently:** despite the filename, this
  is the *bucket* Overview page for `s3://quilt-example`: old dark top bar
  (bucket selector, Search field, URI/Docs/Jobs/Blog, ADMIN menu), old tab
  strip OVERVIEW·BUCKET·PACKAGES·QUERIES, stats header, "Objects by File
  Extension" + Downloads charts, README.md block. **Should show:** the bucket
  **Overview** tab under the new shell (left sidebar visible, header search
  bar, tab strip reading Overview·Files·Packages·Workflows). Consider a second
  shot of the actual home — the **Volumes** list with its `h1` — since the page
  now describes both.
- [ ] `imgs/catalog_packages_tab.png` — **Currently:** old top bar + old tab
  strip, PACKAGES active; package list with Filter/Create Package/Sort by.
  **Should show:** same page, new shell, tab strip reading
  Overview·Files·Packages·Workflows.
- [ ] `imgs/catalog_bucket_tab.png` — **Currently:** old top bar + old tab
  strip with **BUCKET** active; `quilt-example` root listing. **Should show:**
  the same listing with the tab reading **Files**. (Filename now
  misleading; leave as-is or rename in the recapture batch, but update the
  reference in the same commit if renamed.)
- [ ] `imgs/catalog_search.png` — **Currently:** old top bar with the query in
  the *top-bar* field, and a per-bucket **SEARCH** tab in the bucket tab strip.
  Both are gone: `/b/:bucket/search` now redirects to global search
  (`App.jsx:204`) and the query field lives in the header bar. **Should show:**
  the global `/search` page under the new shell, query in the header bar,
  filter sidebar, no per-bucket SEARCH tab.
- [ ] `imgs/catalog_package_landing_page.png` — **Currently:** old top bar +
  old tab strip, PACKAGES active; package landing page with CODE/METADATA
  panes and a summarized `description.md`. **Should show:** same, new shell.

`docs/Catalog/Search.md`

- [ ] `imgs/catalog-es-queries-default.png` — **Currently:** old top bar; old
  tab strip OVERVIEW·BUCKET·PACKAGES·QUERIES·**ELASTICSEARCH** with
  ELASTICSEARCH active; "ElasticSearch queries" panel with "Select query"
  (Custom) and a Query body editor; footnote "Quilt uses ElasticSearch 6.7
  Search API"; RUN QUERY; Intercom bubble bottom-right. **Should show:**
  `/queries/es` with **`elasticsearch-queries` ON** — new shell, the Queries
  header card with an **Athena | ElasticSearch** tab strip (ElasticSearch
  active), and crucially the **Bucket (index scope)** selector, which this shot
  does not contain at all. Filename asserts "default", which is now false;
  rename in the recapture batch and update the reference.

`docs/Catalog/Query.md`

- [ ] `imgs/athena-ui.png` — **Currently:** old tab strip
  OVERVIEW·BUCKET·PACKAGES·QUERIES·ELASTICSEARCH with QUERIES active; "Athena
  SQL" panel (Select workgroup, Select a query → "My awesome query", Query body
  `SHOW TABLES;`, Data catalog + Database, RUN QUERY) and a "Query executions"
  table. **Should show:** `/queries/athena` with **`elasticsearch-queries`
  OFF** — new shell, "Queries" header card with **no** tab strip (a lone tab is
  deliberately not rendered, `Queries.tsx:75`), the Athena panel, and the Query
  executions list. The history rows in the current shot query
  `*_objects-view`, replaced by the Iceberg `package_entry` table since 1.70 —
  prefer fresher example SQL.
- [x] `imgs/athena-history.png` — **no longer referenced.** File was deleted in
  #4217; this PR removes the dangling reference. Nothing to recapture.

`docs/Catalog/Admin.md`

- [ ] `imgs/admin-dropdown.png` — **Currently:** fragment of the old dark top
  bar (Search field, URI, Docs) with an open white dropdown: "admin –
  ReadWriteQuiltBucket" header, Bookmarks, **Admin settings** (highlighted),
  Sign Out. **Should show:** the left sidebar as an admin, with the **Admin**
  item visible (and ideally selected). Note the new account menu at the bottom
  of the sidebar holds only Sign Out — Bookmarks and Admin are now top-level
  sidebar items.
- [ ] `imgs/switch-role-menu.png` — **Currently:** the same old dropdown, with
  a "Switch role – 3 available" row plus a red arrow annotation. **Should
  show:** the sidebar's **Workspace** box — briefcase icon, current role name,
  chevron — which is what opens the switcher now.
- [ ] `imgs/switch-role-dialog.png` — **Currently:** dialog titled **"Switch
  role"** with radios Empty / ReadWriteQuiltBucket (current) / ReadQuiltBucket
  and CANCEL/SWITCH. **Should show:** the same dialog titled **"Switch
  workspace"**. The title, not just the surrounding chrome, is stale.
- [ ] `imgs/admin-settings.png` — **Currently:** old top bar ("Go to bucket",
  Search, Example/URI/Docs, ADMIN); Admin tab strip USERS AND
  ROLES·BUCKETS·STATUS·SETTINGS; "Catalog Customization" with four cards:
  **Navbar link**, Theme (logo and color), Default search mode, Enable beta
  features. **Stale three ways:** the first card is now titled **"Navigation
  link"**; a fifth card **"Preview features"** is missing; and the page now
  also carries **Packaging Engine Settings**, **Tabulator Settings** and
  **Support Diagnostics** sections below the grid. **Should show:** full Admin
  > Settings under the new shell, tall enough to include the Preview features
  card (with all three flags listed) and the Support Diagnostics section.
- [ ] `imgs/admin-buckets.png` — **Currently:** old top bar; Admin tab strip
  with only USERS AND ROLES·BUCKETS·SETTINGS — it predates the **STATUS** tab;
  Buckets table with the old circular Q placeholder icons. **Should show:** new
  shell, four-tab Admin strip, and the new tinted-initials discs for buckets
  without a custom icon (26.8.0 change). *Not flagged by the audit.*
- [ ] `imgs/admin-users-roles.png` — **Currently:** no shell chrome (cropped
  below the top bar); four-tab Admin strip; Users / Roles / Policies panels.
  The Users row for `_canary` shows an Enabled toggle, an Admin toggle and a
  delete icon. **Stale for a non-shell reason:** 26.8.0 removes those controls
  for the stack-managed `_canary` account, and gives SSO/service accounts a
  real "Last login". **Should show:** the Users table with `_canary`'s
  controls absent. *Not flagged by the audit.*

`docs/Catalog/FileBrowser.md` — every crop on this page includes the bucket tab
strip reading **BUCKET**; all need the strip to read **Files**.

- [ ] `imgs/catalog-filesbrowser-tab.png` — **Currently:** tab strip
  OVERVIEW·**BUCKET**·PACKAGES·QUERIES; `allencell` root listing with CREATE
  PACKAGE FROM DIRECTORY / DOWNLOAD DIRECTORY / kebab. **Should show:** the
  same with **Files** active and no QUERIES tab (Workflows may appear
  depending on `ui.nav.workflows`).
- [ ] `imgs/catalog-filesbrowser-bookmarksmenu.png` — **Currently:** old dark
  top bar with the account dropdown open showing Bookmarks / Admin settings /
  Sign Out, over an `allencell / aics` listing. **Should show:** the sidebar
  **Bookmarks** item being clicked (badge dot if there are updates).
- [ ] `imgs/catalog-filesbrowser-bookmarkspane.png` — **Currently:** the
  Bookmarks drawer (two s3:// entries, CLEAR BOOKMARKS / CREATE PACKAGE) over
  the old top bar and BUCKET tab. **Should show:** the same drawer over the new
  shell.
- [ ] `imgs/catalog-filesbrowser-select.png` and
  `imgs/catalog-filesbrowser-addtobookmarks.png` — **Currently:** tab strip
  with **BUCKET** active; `allencell / aics` listing with two rows checked and
  the SELECTED ITEMS / CREATE PACKAGE actions. **Should show:** same, tab
  reading **Files**.
- [ ] `imgs/catalog-filesbrowser-create-package.png`,
  `imgs/catalog-texteditor-edit.png`, `-create.png`, `-name.png`, `-main.png` —
  same family, same viewport; `catalog-texteditor-edit.png` verified to show
  the **BUCKET** tab strip over a `config.yaml` file page. **Should show:**
  same flows with the tab reading **Files**.
- [ ] `imgs/catalog-filesbrowser-glacier-listview.png` — **Currently:** old
  dark top bar (`s3://quilt-rob-glacier-test`, Search, URI/Docs, ROBERT@…) plus
  the **BUCKET** tab strip. **Should show:** same listing, new shell, **Files**
  tab. Companion crops `-glacier-rehydrate.png` and
  `-glacier-rehydrate-dialog.png` are panel/dialog-sized; check whether they
  include the strip before recapturing.

`docs/Catalog/Qurator.md`

- [ ] `imgs/qurator-icon.png` — **Currently:** just the old floating
  bottom-right circular chat button (dark disc, sparkle-in-speech-bubble
  glyph). That affordance is gone. **Should show:** the **Ask Qurator** row in
  the left sidebar (assistant icon + label), or be dropped in favour of a shot
  of the opened assistant drawer.

`docs/Catalog/URI.md`

- [ ] `imgs/uri-resolve.png` — **Currently:** old dark top bar with Search /
  URI / Docs text links, over the "Resolve a Quilt+ URI" page with a filled URI
  field and RESOLVE button. **Should show:** the same page under the new shell,
  with the resolver's header-bar entry point being the chain-link icon button
  rather than a "URI" text link.

`docs/Catalog/Preferences.md`

- [ ] `imgs/buckets-preferences-editor.png` — **BLOCKED on a catalog fix, do
  not recapture yet.** **Currently:** old top bar + old tab strip
  (OVERVIEW·BUCKET·PACKAGES·QUERIES) over the BucketPreferences visual editor;
  inside the editor, the "Navigation items" section lists `"BUCKET"`,
  `"PACKAGES"`, `"QUERIES"` (no `"WORKFLOWS"`), and Actions says "Download
  buttons under the 'BUCKET' tab". **Should show:** the editor with navigation
  items matching the real tabs. But those labels are hardcoded stale in
  `BucketPreferences.tsx:197-200` — recapturing now would just re-photograph
  the wrong strings and contradict this PR's prose. Fix the editor labels
  first (see **UI strings** #4), then recapture.

### Group B — verified clean, no recapture needed

Panel- and dialog-only crops on touched pages, with no shell chrome:
`admin-users-invite.png`, `default-role.png`, `admin-role-managed-create.png`
(verified: bare "Create a role" dialog), `admin-role-managed-attach-policy.png`,
`admin-role-unmanaged-create.png`, `admin-policy-managed-create.png`,
`admin-policy-managed-bucket-access{,-add,-change}.png`,
`admin-policy-attach-to-role.png`, `admin-policy-unmanaged-create.png`,
`admin-buckets-add.png` (spot-check recommended — 2560x1600 may include the top
bar), `package-list-selective-metadata.png`, `qurator-tools.png`,
`uri-python.png`, `uri-cli.png`, `uri-uri.png`, the `tabulator.md` admin-panel
shots, the `VisualizationDashboards.md` chart/perspective shots, and
`working-with-elasticsearch.md`'s two AWS-console shots.

**Checklist total: 18 recapture items** (1 of them blocked on a catalog fix),
plus 1 already resolved by this PR.

## Deliberately deferred

- **All P3s** (cosmetic / stale-screenshot-only items), including
  `technical-reference.md:404`'s "Users and Buckets"→"Buckets" naming and
  `api-reference/cli.md:13`'s "catalog landing page" phrasing.
- **P2s that need new prose about new features**, none of which are
  contradictions today — just gaps: the search "Sort by" control and `mo=` URL
  param (#15); alias IAM roles and their Lake Formation / DataZone implications
  (#21, #28, #31); new Admin Settings subsections for Support Diagnostics and
  Preview features as their own reference sections (#22). These want a writer
  with the feature in front of them, not a find-and-replace.
- **The front door and data products preview features** — genuinely off by
  default and correctly absent from `docs/` today.
- **All screenshot recapture**, per the checklist above.

## Verification

- `npx --package=markdownlint-cli markdownlint .` — clean, matching the
  `lint-docs` job in `.github/workflows/js-ci.yml`. Baseline was also clean, so
  no new violations.
- Every relative image reference in `docs/` resolves (0 broken, down from 2).
- Every relative markdown link + anchor in `docs/` re-checked; the two anchors
  this PR touches (`Search.md#elasticsearch-query-console-legacy`,
  `Preferences.md#show-and-hide-features-in-the-quilt-catalog`) resolve, and no
  pre-existing breakage was introduced.
- Pre-commit hook bypassed: `catalog/.husky/pre-commit` runs `npx lint-staged`,
  whose only pattern is `app/**/*.[jt]s?(x)` — a no-op for a docs-only diff,
  and the husky shim isn't installed in this worktree.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This docs-only PR updates Catalog documentation for the 26.8.0 shell, including sidebar navigation, global Queries, Files naming, and the legacy ElasticSearch console.

- Replaces obsolete top-navbar and bucket-tab terminology with current sidebar and workspace-global navigation.
- Documents current Queries routing, feature gating, and bucket-scoped Tabulator behavior.
- Repairs stale image and documentation links while retaining a screenshot-recapture checklist outside this diff.

<h3>Confidence Score: 4/5</h3>

The PR appears safe to merge, with two non-blocking documentation inaccuracies around legacy query redirects and configurable bucket tabs.

The main shell and ElasticSearch documentation matches the implementation, while the accepted issues can mislead users only in legacy deep-link or customized bucket-navigation scenarios.

**Files Needing Attention:** docs/Catalog/Query.md; docs/walkthrough/working-with-the-catalog.md

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| docs/Catalog/Query.md | Accurately describes global Queries and preference behavior overall, but overgeneralizes bucket preservation across legacy deep-link redirects. |
| docs/walkthrough/working-with-the-catalog.md | Updates the tour for the new shell, but states a preference-dependent four-tab volume layout unconditionally. |
| docs/Catalog/Search.md | Correctly reframes the ElasticSearch console as legacy and documents its feature gate, scope selector, and redirect behavior. |
| docs/Catalog/Preferences.md | Aligns preference descriptions with current Files naming and the actual consumers of `ui.nav.queries`. |
| docs/Catalog/Admin.md | Correctly updates Admin and workspace-switching entry points for the sidebar shell. |

<sub>Reviews (1): Last reviewed commit: ["docs: rename the bucket &quot;Bucket&quot; tab to ..."](https://github.com/quiltdata/quilt/commit/b65dc3bfde33d44d1262b2fc7ff0d5c6dc942034) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=57495262)</sub>

> Greptile also left **2 inline comments** on this PR.

**Context used:**

- Knowledge Base — [Catalog client features](https://app.greptile.com/quilt-bio/-/custom-context/knowledge-base/quiltdata/quilt/-/docs/catalog-client.md)

<!-- /greptile_comment -->