### PR TITLE
catalog: read a "None" package commit message as absent in search results

### DIFF
--- a/catalog/CHANGELOG.md
+++ b/catalog/CHANGELOG.md
@@ -21,6 +21,7 @@ complete sentence without it.
 
 ## Changes
 
+- [Fixed] Search results table: a package with no commit message shows the no-value marker instead of the literal text `None` ([#5232](https://github.com/quiltdata/quilt/pull/5232))
 - [Fixed] Admin buckets: the sticky Cancel/Add bar lines up with the form above it ([#5224](https://github.com/quiltdata/quilt/pull/5224))
 - [Fixed] Volumes grid: a card's description no longer touches its tags ([#5225](https://github.com/quiltdata/quilt/pull/5225))
 - [Changed] Volumes: tag chips are outlined, and a volume's description is set at the body step rather than as fine print ([#5225](https://github.com/quiltdata/quilt/pull/5225))

--- a/catalog/app/containers/Search/Table/CellValue.spec.tsx
+++ b/catalog/app/containers/Search/Table/CellValue.spec.tsx
@@ -28,6 +28,28 @@ const column = {
   // ...mock the rest of the data if necessary
 } as ColumnSystemMeta
 
+const commentColumn = {
+  tag: ColumnTag.SystemMeta as const,
+  filter: 'comment' as const,
+  // ...mock the rest of the data if necessary
+} as ColumnSystemMeta
+
+const renderComment = (comment: string) => {
+  const hit = {
+    ...hitBase,
+    pointer: 'latest',
+    comment,
+    matchLocations: { ...hitBase.matchLocations, comment: false },
+  } as Hit
+  return render(
+    <MemoryRouter>
+      <NamedRoutes.Provider routes={{ bucketPackageTree }}>
+        <CellValue column={commentColumn} hit={hit} />
+      </NamedRoutes.Provider>
+    </MemoryRouter>,
+  )
+}
+
 describe('containers/Search/Table/CellValue', () => {
   afterEach(cleanup)
 
@@ -43,6 +65,26 @@ describe('containers/Search/Table/CellValue', () => {
     )
 
     expect(getByRole('link').getAttribute('href')).toBe('/b/foo/packages/pkg/name')
+  })
+
+  it('renders a commit message', () => {
+    const { container } = renderComment('a real commit message')
+
+    expect(container.textContent).toBe('a real commit message')
+  })
+
+  // The registry serializes a package with no commit message as the string
+  // 'None', which must read as absent rather than as that literal text.
+  it('renders a "None" commit message as no value', () => {
+    const { container } = renderComment('None')
+
+    expect(container.textContent).toBe('')
+  })
+
+  it('renders an empty commit message as no value', () => {
+    const { container } = renderComment('')
+
+    expect(container.textContent).toBe('')
   })
 
   it('renders with pointer "123456"', () => {

--- a/catalog/app/containers/Search/Table/CellValue.spec.tsx
+++ b/catalog/app/containers/Search/Table/CellValue.spec.tsx
@@ -73,8 +73,6 @@ describe('containers/Search/Table/CellValue', () => {
     expect(container.textContent).toBe('a real commit message')
   })
 
-  // The registry serializes a package with no commit message as the string
-  // 'None', which must read as absent rather than as that literal text.
   it('renders a "None" commit message as no value', () => {
     const { container } = renderComment('None')
 

--- a/catalog/app/containers/Search/Table/CellValue.tsx
+++ b/catalog/app/containers/Search/Table/CellValue.tsx
@@ -152,7 +152,9 @@ function SystemMetaValue({ hit, filter }: SystemMetaValueProps) {
         </StyledLink>
       )
     case 'comment':
-      return hit.comment ? (
+      // The registry serializes a package with no commit message as the string
+      // 'None', not null. FIXME: drop the check once the backend sends null.
+      return hit.comment && hit.comment !== 'None' ? (
         <OverflowTextTooltip title={hit.comment}>
           <Match on={hit.matchLocations.comment}>{hit.comment}</Match>
         </OverflowTextTooltip>

--- a/catalog/app/containers/Search/Table/CellValue.tsx
+++ b/catalog/app/containers/Search/Table/CellValue.tsx
@@ -152,8 +152,7 @@ function SystemMetaValue({ hit, filter }: SystemMetaValueProps) {
         </StyledLink>
       )
     case 'comment':
-      // The registry serializes a package with no commit message as the string
-      // 'None', not null. FIXME: drop the check once the backend sends null.
+      // FIXME: the registry sends 'None', not null, for no commit message.
       return hit.comment && hit.comment !== 'None' ? (
         <OverflowTextTooltip title={hit.comment}>
           <Match on={hit.matchLocations.comment}>{hit.comment}</Match>


### PR DESCRIPTION
# Description

Split out of #4463, which bundled several unrelated search-UI changes on a branch that has since gone stale. This is the smallest of the pieces and stands alone.

The registry serializes a package with no commit message as the string `"None"` rather than `null`. The search results table checked only for falsiness, so the Comment column printed that literal instead of the no-value marker every other empty system-meta cell gets.

The check carries a `FIXME` to drop it once the backend sends `null`.

`CellValue.spec.tsx` had no coverage of the comment column at all; it now has three cases (a real message renders, `"None"` renders as no value, `""` renders as no value). Reverting the implementation fails exactly the `"None"` case, so the test gates the fix rather than restating the fixture.

Verified: `npm run test:only` 5/5, `npm run typecheck` clean, `oxfmt` + `oxlint` clean.

# TODO

- [x] Unit tests
- [x] Security: Confirm that this change meets security best practices and does not violate the security model
- [x] Open: Confirm that this change doesn't break the Open variant
- [x] [Changelog](../tree/master/catalog/CHANGELOG.md) entry

Before:
<img width="712" height="327" alt="Screenshot_2026-08-27_15-57-48" src="https://github.com/user-attachments/assets/e3e23195-4222-4202-9427-38053bc6a646" />

After:
<img width="712" height="327" alt="Screenshot_2026-08-27_15-57-51" src="https://github.com/user-attachments/assets/2e5b3596-6b4b-4d70-ae8f-5264e531e529" />





<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR makes search-table comment cells treat the registry’s `"None"` sentinel as an absent commit message.
- Adds the sentinel check to the system-metadata comment renderer.
- Adds tests for real, sentinel, and empty commit messages.
- Documents the correction in the Catalog changelog.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge.

No blocking failure remains.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| catalog/app/containers/Search/Table/CellValue.tsx | Treats the registry’s `"None"` commit-message sentinel as an absent value in search-table results. |
| catalog/app/containers/Search/Table/CellValue.spec.tsx | Adds focused coverage for real, sentinel, and empty comment values. |
| catalog/CHANGELOG.md | Records the corrected rendering of absent package commit messages. |

<sub>Reviews (2): Last reviewed commit: ["catalog: cut the commentary to the FIXME"](https://github.com/quiltdata/quilt/commit/d9df7b6e1af3f9f1aa2ed8e6f3af96d87f214e64) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=57501180)</sub>

<!-- /greptile_comment -->