### PR TITLE
catalog: contain a malformed search URL on the search page, and name the filter

### DIFF
--- a/catalog/CHANGELOG.md
+++ b/catalog/CHANGELOG.md
@@ -21,6 +21,7 @@ complete sentence without it.
 
 ## Changes
 
+- [Fixed] Search: a malformed filter value in a search URL reports which filter could not be read, rather than a raw JSON parser offset ([#5233](https://github.com/quiltdata/quilt/pull/5233))
 - [Fixed] Admin buckets: the sticky Cancel/Add bar lines up with the form above it ([#5224](https://github.com/quiltdata/quilt/pull/5224))
 - [Fixed] Volumes grid: a card's description no longer touches its tags ([#5225](https://github.com/quiltdata/quilt/pull/5225))
 - [Changed] Volumes: tag chips are outlined, and a volume's description is set at the body step rather than as fine print ([#5225](https://github.com/quiltdata/quilt/pull/5225))

--- a/catalog/CHANGELOG.md
+++ b/catalog/CHANGELOG.md
@@ -21,7 +21,7 @@ complete sentence without it.
 
 ## Changes
 
-- [Fixed] Search: a malformed filter value in a search URL reports which filter could not be read, rather than a raw JSON parser offset ([#5233](https://github.com/quiltdata/quilt/pull/5233))
+- [Changed] Search: a malformed filter value in a search URL raises an error naming that filter, and logs the offending value, instead of only a raw JSON parser offset. Not yet visible on screen — the app-wide error boundary shows fixed text — but the console is diagnosable and the message is in place for search's own boundary ([#5233](https://github.com/quiltdata/quilt/pull/5233))
 - [Fixed] Admin buckets: the sticky Cancel/Add bar lines up with the form above it ([#5224](https://github.com/quiltdata/quilt/pull/5224))
 - [Fixed] Volumes grid: a card's description no longer touches its tags ([#5225](https://github.com/quiltdata/quilt/pull/5225))
 - [Changed] Volumes: tag chips are outlined, and a volume's description is set at the body step rather than as fine print ([#5225](https://github.com/quiltdata/quilt/pull/5225))

--- a/catalog/CHANGELOG.md
+++ b/catalog/CHANGELOG.md
@@ -21,7 +21,7 @@ complete sentence without it.
 
 ## Changes
 
-- [Fixed] Search: a malformed filter value in a search URL no longer replaces the whole catalog with the app-level error screen. Both the search page and a bucket's package list keep their chrome and show which filter could not be read, with reload and start-a-new-search as the ways out ([#5233](https://github.com/quiltdata/quilt/pull/5233))
+- [Fixed] Search: a malformed filter value in the URL no longer breaks the page ([#5233](https://github.com/quiltdata/quilt/pull/5233))
 - [Fixed] Admin buckets: the sticky Cancel/Add bar lines up with the form above it ([#5224](https://github.com/quiltdata/quilt/pull/5224))
 - [Fixed] Volumes grid: a card's description no longer touches its tags ([#5225](https://github.com/quiltdata/quilt/pull/5225))
 - [Changed] Volumes: tag chips are outlined, and a volume's description is set at the body step rather than as fine print ([#5225](https://github.com/quiltdata/quilt/pull/5225))

--- a/catalog/CHANGELOG.md
+++ b/catalog/CHANGELOG.md
@@ -21,7 +21,7 @@ complete sentence without it.
 
 ## Changes
 
-- [Changed] Search: a malformed filter value in a search URL raises an error naming that filter, and logs the offending value, instead of only a raw JSON parser offset. Not yet visible on screen — the app-wide error boundary shows fixed text — but the console is diagnosable and the message is in place for search's own boundary ([#5233](https://github.com/quiltdata/quilt/pull/5233))
+- [Fixed] Search: a malformed filter value in a search URL no longer replaces the whole catalog with the app-level error screen. Both the search page and a bucket's package list keep their chrome and show which filter could not be read, with reload and start-a-new-search as the ways out ([#5233](https://github.com/quiltdata/quilt/pull/5233))
 - [Fixed] Admin buckets: the sticky Cancel/Add bar lines up with the form above it ([#5224](https://github.com/quiltdata/quilt/pull/5224))
 - [Fixed] Volumes grid: a card's description no longer touches its tags ([#5225](https://github.com/quiltdata/quilt/pull/5225))
 - [Changed] Volumes: tag chips are outlined, and a volume's description is set at the body step rather than as fine print ([#5225](https://github.com/quiltdata/quilt/pull/5225))

--- a/catalog/app/containers/Bucket/PackageList.tsx
+++ b/catalog/app/containers/Bucket/PackageList.tsx
@@ -116,13 +116,8 @@ const useErrorFallbackStyles = M.makeStyles((t) => ({
   },
 }))
 
-// Same containment as the global search page: the model parses the URL in its
-// own render, so a filter param that won't parse escapes every boundary below
-// and takes the whole catalog down with it. See Search/Search.tsx.
-//
-// Deliberately not wrapped in `Search/Layout/Main` the way the loaded page is:
-// Main reads the search model, so it would throw here -- and a boundary does
-// not catch what its own fallback throws.
+// Not wrapped in Search/Layout/Main like the loaded page: Main reads the model,
+// and a boundary does not catch what its own fallback throws.
 function PackageListErrorFallback({ error }: FallbackProps) {
   const classes = useErrorFallbackStyles()
   const bucket = useBucketStrict()

--- a/catalog/app/containers/Bucket/PackageList.tsx
+++ b/catalog/app/containers/Bucket/PackageList.tsx
@@ -1,5 +1,8 @@
 import * as React from 'react'
+import { ErrorBoundary, type FallbackProps } from 'react-error-boundary'
 import * as RR from 'react-router-dom'
+import * as M from '@material-ui/core'
+import * as Sentry from '@sentry/react'
 
 import { useSearchInput } from 'components/Layout'
 import * as SearchUIModel from 'containers/Search/model'
@@ -9,7 +12,7 @@ import assertNever from 'utils/assertNever'
 
 import { useBucketStrict } from 'containers/Bucket/Routes'
 import Main from 'containers/Search/Layout/Main'
-import { Refine } from 'containers/Search/NoResults'
+import { Error as SearchErrorScreen, Refine } from 'containers/Search/NoResults'
 import ListResults from 'containers/Search/List'
 import TableResults from 'containers/Search/Table'
 
@@ -103,8 +106,49 @@ function PackageList({ bucket }: PackageListProps) {
   )
 }
 
+const useErrorFallbackStyles = M.makeStyles((t) => ({
+  root: {
+    margin: t.spacing(3, 0),
+  },
+}))
+
+// Same containment as the global search page: the model parses the URL in its
+// own render, so a filter param that won't parse escapes every boundary below
+// and takes the whole catalog down with it. See Search/Search.tsx.
+//
+// Deliberately not wrapped in `Search/Layout/Main` the way the loaded page is:
+// Main reads the search model, so it would throw here -- and a boundary does
+// not catch what its own fallback throws.
+function PackageListErrorFallback({ error }: FallbackProps) {
+  const classes = useErrorFallbackStyles()
+  const bucket = useBucketStrict()
+  const { urls } = NamedRoutes.use<RouteMap>()
+  const history = RR.useHistory()
+  // The bad state lives in the location, i.e. *above* this boundary, so
+  // `resetErrorBoundary` would re-render the same throw. Navigating is the
+  // reset -- `resetKeys` below clears the boundary when the URL changes.
+  const handleRefine = React.useCallback(
+    (action: Refine) => {
+      if (action === Refine.Network) {
+        window.location.reload()
+        return
+      }
+      history.push(urls.bucketPackageList(bucket))
+    },
+    [bucket, history, urls],
+  )
+  return (
+    <SearchErrorScreen className={classes.root} onRefine={handleRefine}>
+      {error.message}
+    </SearchErrorScreen>
+  )
+}
+
+const onError = (error: Error) => Sentry.captureException(error)
+
 export default function PackageListWrapper() {
   const bucket = useBucketStrict()
+  const { search } = RR.useLocation()
   const { urls } = NamedRoutes.use<RouteMap>()
   const defaults = React.useMemo(
     () => ({
@@ -115,8 +159,14 @@ export default function PackageListWrapper() {
     [bucket],
   )
   return (
-    <SearchUIModel.Provider base={urls.bucketPackageList(bucket)} defaults={defaults}>
-      <PackageList bucket={bucket} />
-    </SearchUIModel.Provider>
+    <ErrorBoundary
+      FallbackComponent={PackageListErrorFallback}
+      onError={onError}
+      resetKeys={[search]}
+    >
+      <SearchUIModel.Provider base={urls.bucketPackageList(bucket)} defaults={defaults}>
+        <PackageList bucket={bucket} />
+      </SearchUIModel.Provider>
+    </ErrorBoundary>
   )
 }

--- a/catalog/app/containers/Bucket/PackageList.tsx
+++ b/catalog/app/containers/Bucket/PackageList.tsx
@@ -12,7 +12,11 @@ import assertNever from 'utils/assertNever'
 
 import { useBucketStrict } from 'containers/Bucket/Routes'
 import Main from 'containers/Search/Layout/Main'
-import { Error as SearchErrorScreen, Refine } from 'containers/Search/NoResults'
+import {
+  Error as SearchErrorScreen,
+  Refine,
+  useErrorRefine,
+} from 'containers/Search/NoResults'
 import ListResults from 'containers/Search/List'
 import TableResults from 'containers/Search/Table'
 
@@ -123,22 +127,9 @@ function PackageListErrorFallback({ error }: FallbackProps) {
   const classes = useErrorFallbackStyles()
   const bucket = useBucketStrict()
   const { urls } = NamedRoutes.use<RouteMap>()
-  const history = RR.useHistory()
-  // The bad state lives in the location, i.e. *above* this boundary, so
-  // `resetErrorBoundary` would re-render the same throw. Navigating is the
-  // reset -- `resetKeys` below clears the boundary when the URL changes.
-  const handleRefine = React.useCallback(
-    (action: Refine) => {
-      if (action === Refine.Network) {
-        window.location.reload()
-        return
-      }
-      history.push(urls.bucketPackageList(bucket))
-    },
-    [bucket, history, urls],
-  )
+  const onRefine = useErrorRefine(urls.bucketPackageList(bucket))
   return (
-    <SearchErrorScreen className={classes.root} onRefine={handleRefine}>
+    <SearchErrorScreen className={classes.root} onRefine={onRefine}>
       {error.message}
     </SearchErrorScreen>
   )

--- a/catalog/app/containers/Search/NoResults.boundary.spec.tsx
+++ b/catalog/app/containers/Search/NoResults.boundary.spec.tsx
@@ -9,8 +9,7 @@ import * as NamedRoutes from 'utils/NamedRoutes'
 
 vi.mock('constants/config', () => ({ default: {}, registryUrl: '' }))
 
-// Skeletons only, and they drag in notebook CSS through the renderer tree.
-// Irrelevant to what this spec guards.
+// Unrelated to this spec, and they drag in notebook CSS.
 vi.mock('./List/Hit', () => ({
   PackageSkeleton: () => null,
   ObjectSkeleton: () => null,
@@ -19,11 +18,8 @@ vi.mock('./Table/Skeleton', () => ({ Table: () => null }))
 
 import * as NoResults from './NoResults'
 
-// What the search error boundaries in Search/Search.tsx and
-// Bucket/PackageList.tsx depend on: their fallback renders *outside*
-// SearchUIModel.Provider, because the Provider is what threw. A boundary does
-// not catch what its own fallback throws, so the moment this screen reads the
-// model the containment silently becomes a blank page again.
+// The search boundaries' fallbacks render outside SearchUIModel.Provider. If
+// this screen ever reads the model, containment silently becomes a blank page.
 const Boundary = ({ children }: React.PropsWithChildren<{}>) => (
   <ErrorBoundary
     FallbackComponent={({ error }: FallbackProps) => (

--- a/catalog/app/containers/Search/NoResults.boundary.spec.tsx
+++ b/catalog/app/containers/Search/NoResults.boundary.spec.tsx
@@ -1,0 +1,59 @@
+import * as React from 'react'
+import { MemoryRouter } from 'react-router-dom'
+import { ErrorBoundary, type FallbackProps } from 'react-error-boundary'
+import { render, cleanup } from '@testing-library/react'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+import { search } from 'constants/routes'
+import * as NamedRoutes from 'utils/NamedRoutes'
+
+vi.mock('constants/config', () => ({ default: {}, registryUrl: '' }))
+
+// Skeletons only, and they drag in notebook CSS through the renderer tree.
+// Irrelevant to what this spec guards.
+vi.mock('./List/Hit', () => ({
+  PackageSkeleton: () => null,
+  ObjectSkeleton: () => null,
+}))
+vi.mock('./Table/Skeleton', () => ({ Table: () => null }))
+
+import * as NoResults from './NoResults'
+
+// What the search error boundaries in Search/Search.tsx and
+// Bucket/PackageList.tsx depend on: their fallback renders *outside*
+// SearchUIModel.Provider, because the Provider is what threw. A boundary does
+// not catch what its own fallback throws, so the moment this screen reads the
+// model the containment silently becomes a blank page again.
+const Boundary = ({ children }: React.PropsWithChildren<{}>) => (
+  <ErrorBoundary
+    FallbackComponent={({ error }: FallbackProps) => (
+      <span>ESCAPED: {error.message}</span>
+    )}
+  >
+    {children}
+  </ErrorBoundary>
+)
+
+describe('containers/Search/NoResults.Error outside the model provider', () => {
+  afterEach(cleanup)
+
+  it('renders with no SearchUIModel.Provider above it', () => {
+    const { getByText, queryByText } = render(
+      <MemoryRouter>
+        <NamedRoutes.Provider routes={{ search }}>
+          <Boundary>
+            <NoResults.Error onRefine={() => {}}>
+              Invalid date range in the search URL
+            </NoResults.Error>
+          </Boundary>
+        </NamedRoutes.Provider>
+      </MemoryRouter>,
+    )
+
+    expect(getByText('Unexpected error')).toBeTruthy()
+    // the thrown message reaches the screen, which is the whole point
+    expect(getByText('Invalid date range in the search URL')).toBeTruthy()
+    // and it got there without tripping the boundary
+    expect(queryByText(/^ESCAPED:/)).toBeNull()
+  })
+})

--- a/catalog/app/containers/Search/NoResults.tsx
+++ b/catalog/app/containers/Search/NoResults.tsx
@@ -1,5 +1,6 @@
 import cx from 'classnames'
 import * as React from 'react'
+import * as RRDom from 'react-router-dom'
 import * as M from '@material-ui/core'
 
 import Empty from 'components/Empty'
@@ -53,6 +54,29 @@ export enum Refine {
   Search,
   New,
   Network,
+}
+
+// Shared by the error boundaries that wrap SearchUIModel.Provider (the search
+// page, a bucket's package list). Their fallbacks render *above* the model,
+// because the model is what threw, so the two exits this offers are the only
+// ones available: reload, or leave for a URL that parses.
+//
+// `base` is that clean URL. Navigating is the reset rather than
+// `resetErrorBoundary`, because the bad state lives in the location -- above
+// the boundary -- so clearing the error alone re-renders the same throw. Pair
+// this with `resetKeys` on the location's search string.
+export function useErrorRefine(base: string) {
+  const history = RRDom.useHistory()
+  return React.useCallback(
+    (action: Refine) => {
+      if (action === Refine.Network) {
+        window.location.reload()
+        return
+      }
+      history.push(base)
+    },
+    [base, history],
+  )
 }
 
 interface EmptyWrapperProps {

--- a/catalog/app/containers/Search/NoResults.tsx
+++ b/catalog/app/containers/Search/NoResults.tsx
@@ -56,15 +56,9 @@ export enum Refine {
   Network,
 }
 
-// Shared by the error boundaries that wrap SearchUIModel.Provider (the search
-// page, a bucket's package list). Their fallbacks render *above* the model,
-// because the model is what threw, so the two exits this offers are the only
-// ones available: reload, or leave for a URL that parses.
-//
-// `base` is that clean URL. Navigating is the reset rather than
-// `resetErrorBoundary`, because the bad state lives in the location -- above
-// the boundary -- so clearing the error alone re-renders the same throw. Pair
-// this with `resetKeys` on the location's search string.
+// For fallbacks rendering above SearchUIModel.Provider, where the model's own
+// refine actions don't exist. Navigating to `base` is the reset: the bad state
+// is the location, above the boundary, so clearing the error alone re-throws.
 export function useErrorRefine(base: string) {
   const history = RRDom.useHistory()
   return React.useCallback(

--- a/catalog/app/containers/Search/Search.tsx
+++ b/catalog/app/containers/Search/Search.tsx
@@ -82,12 +82,8 @@ function SearchLayout() {
   )
 }
 
-// The URL is parsed in `SearchUIModel.Provider`'s own render, so a filter param
-// that won't parse throws above every boundary search has -- all the way to
-// `Errors.ErrorBoundary` in app.tsx, which replaces the whole catalog with the
-// app-level error screen. The search UI is entirely reconstructable from the
-// URL, so that page is recoverable in place: keep the chrome and offer the two
-// exits that work.
+// The provider parses the URL in its own render, so a filter param that won't
+// parse escapes every boundary below and unwinds to app.tsx.
 function SearchErrorFallback({ error }: FallbackProps) {
   const { urls } = NamedRoutes.use()
   const onRefine = NoResults.useErrorRefine(urls.search({}))

--- a/catalog/app/containers/Search/Search.tsx
+++ b/catalog/app/containers/Search/Search.tsx
@@ -90,23 +90,10 @@ function SearchLayout() {
 // exits that work.
 function SearchErrorFallback({ error }: FallbackProps) {
   const { urls } = NamedRoutes.use()
-  const history = RRDom.useHistory()
-  // The bad state lives in the location, i.e. *above* this boundary, so
-  // `resetErrorBoundary` would re-render the same throw. Navigating is the
-  // reset -- `resetKeys` below clears the boundary when the URL changes.
-  const handleRefine = React.useCallback(
-    (action: NoResults.Refine) => {
-      if (action === NoResults.Refine.Network) {
-        window.location.reload()
-        return
-      }
-      history.push(urls.search({}))
-    },
-    [history, urls],
-  )
+  const onRefine = NoResults.useErrorRefine(urls.search({}))
   return (
     <Layout>
-      <NoResults.Error onRefine={handleRefine}>{error.message}</NoResults.Error>
+      <NoResults.Error onRefine={onRefine}>{error.message}</NoResults.Error>
     </Layout>
   )
 }

--- a/catalog/app/containers/Search/Search.tsx
+++ b/catalog/app/containers/Search/Search.tsx
@@ -1,8 +1,12 @@
 import * as React from 'react'
+import { ErrorBoundary, type FallbackProps } from 'react-error-boundary'
+import * as RRDom from 'react-router-dom'
+import * as Sentry from '@sentry/react'
 
 import Layout, { Container, useSearchInput } from 'components/Layout'
 import assertNever from 'utils/assertNever'
 import MetaTitle from 'utils/MetaTitle'
+import * as NamedRoutes from 'utils/NamedRoutes'
 
 import * as SearchUIModel from './model'
 import AssistantContext from './AssistantContext'
@@ -78,11 +82,49 @@ function SearchLayout() {
   )
 }
 
-export default function Search() {
+// The URL is parsed in `SearchUIModel.Provider`'s own render, so a filter param
+// that won't parse throws above every boundary search has -- all the way to
+// `Errors.ErrorBoundary` in app.tsx, which replaces the whole catalog with the
+// app-level error screen. The search UI is entirely reconstructable from the
+// URL, so that page is recoverable in place: keep the chrome and offer the two
+// exits that work.
+function SearchErrorFallback({ error }: FallbackProps) {
+  const { urls } = NamedRoutes.use()
+  const history = RRDom.useHistory()
+  // The bad state lives in the location, i.e. *above* this boundary, so
+  // `resetErrorBoundary` would re-render the same throw. Navigating is the
+  // reset -- `resetKeys` below clears the boundary when the URL changes.
+  const handleRefine = React.useCallback(
+    (action: NoResults.Refine) => {
+      if (action === NoResults.Refine.Network) {
+        window.location.reload()
+        return
+      }
+      history.push(urls.search({}))
+    },
+    [history, urls],
+  )
   return (
-    <SearchUIModel.Provider>
-      <AssistantContext />
-      <Layout pre={<SearchLayout />} />
-    </SearchUIModel.Provider>
+    <Layout>
+      <NoResults.Error onRefine={handleRefine}>{error.message}</NoResults.Error>
+    </Layout>
+  )
+}
+
+const onError = (error: Error) => Sentry.captureException(error)
+
+export default function Search() {
+  const { search } = RRDom.useLocation()
+  return (
+    <ErrorBoundary
+      FallbackComponent={SearchErrorFallback}
+      onError={onError}
+      resetKeys={[search]}
+    >
+      <SearchUIModel.Provider>
+        <AssistantContext />
+        <Layout pre={<SearchLayout />} />
+      </SearchUIModel.Provider>
+    </ErrorBoundary>
   )
 }

--- a/catalog/app/containers/Search/model.spec.ts
+++ b/catalog/app/containers/Search/model.spec.ts
@@ -370,6 +370,24 @@ describe('containers/Search/model', () => {
       })
     })
 
+    // The character offset in the original SyntaxError is meaningless without
+    // the string it indexes into, so the log has to carry that string.
+    it('logs the value that failed to parse, not just the SyntaxError', () => {
+      const level = Log.getLevel()
+      Log.setLevel('error')
+      const spy = vi.spyOn(Log, 'error').mockImplementation(() => {})
+      try {
+        expect(() => model.parseSearchParams('modified={')).toThrow()
+        expect(spy).toHaveBeenCalledWith(
+          expect.stringContaining('JSON.parse failed on "{"'),
+          expect.any(SyntaxError),
+        )
+      } finally {
+        spy.mockRestore()
+        Log.setLevel(level)
+      }
+    })
+
     it('leaves well-formed filter params parsing as before', () => {
       expect(
         model.Predicates.Datetime.fromString('{"gte":"2020-01-02T00:00:00.000Z"}'),

--- a/catalog/app/containers/Search/model.spec.ts
+++ b/catalog/app/containers/Search/model.spec.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it, vi } from 'vitest'
 
 import * as KTree from 'utils/KeyedTree'
+import Log from 'utils/Logging'
 
 import * as model from './model'
 
@@ -312,6 +313,57 @@ describe('containers/Search/model', () => {
         expect(model.orderingToResultOrder('sys:size:asc')).toBe(
           model.GQLResultOrder.BEST_MATCH,
         )
+      })
+    })
+  })
+
+  // A filter param comes off a URL anyone can hand-edit, so the JSON in it is
+  // not trustworthy input.
+  describe('Predicates: malformed filter JSON', () => {
+    const silenced = (f: () => void) => {
+      const level = Log.getLevel()
+      Log.setLevel('silent')
+      try {
+        f()
+      } finally {
+        Log.setLevel(level)
+      }
+    }
+
+    it('names the filter when a date range will not parse', () => {
+      silenced(() =>
+        expect(() => model.Predicates.Datetime.fromString('{"gte":')).toThrow(
+          'Invalid date range in the search URL',
+        ),
+      )
+    })
+
+    it('names the filter when a number range will not parse', () => {
+      silenced(() =>
+        expect(() => model.Predicates.Number.fromString('{oops}')).toThrow(
+          'Invalid number range in the search URL',
+        ),
+      )
+    })
+
+    it('names the filter when a keyword list will not parse', () => {
+      silenced(() =>
+        expect(() => model.Predicates.KeywordEnum.fromString('"a",,')).toThrow(
+          'Invalid keyword list in the search URL',
+        ),
+      )
+    })
+
+    it('leaves well-formed filter params parsing as before', () => {
+      expect(
+        model.Predicates.Datetime.fromString('{"gte":"2020-01-02T00:00:00.000Z"}'),
+      ).toMatchObject({ gte: new Date('2020-01-02T00:00:00.000Z'), lte: null })
+      expect(model.Predicates.Number.fromString('{"gte":1,"lte":5}')).toMatchObject({
+        gte: 1,
+        lte: 5,
+      })
+      expect(model.Predicates.KeywordEnum.fromString('"a","b"')).toMatchObject({
+        terms: ['a', 'b'],
       })
     })
   })

--- a/catalog/app/containers/Search/model.spec.ts
+++ b/catalog/app/containers/Search/model.spec.ts
@@ -317,8 +317,6 @@ describe('containers/Search/model', () => {
     })
   })
 
-  // A filter param comes off a URL anyone can hand-edit, so the JSON in it is
-  // not trustworthy input.
   describe('Predicates: malformed filter JSON', () => {
     const silenced = (f: () => void) => {
       const level = Log.getLevel()
@@ -354,8 +352,7 @@ describe('containers/Search/model', () => {
       )
     })
 
-    // The filter's URL param is its key, unprefixed, so these are the strings
-    // that actually reach JSON.parse from a real link.
+    // The filter's URL param is its key, unprefixed.
     it('reports the filter when parsing a whole search URL', () => {
       silenced(() => {
         expect(() => model.parseSearchParams('modified={')).toThrow(
@@ -370,8 +367,6 @@ describe('containers/Search/model', () => {
       })
     })
 
-    // The character offset in the original SyntaxError is meaningless without
-    // the string it indexes into, so the log has to carry that string.
     it('logs the value that failed to parse, not just the SyntaxError', () => {
       const level = Log.getLevel()
       Log.setLevel('error')

--- a/catalog/app/containers/Search/model.spec.ts
+++ b/catalog/app/containers/Search/model.spec.ts
@@ -354,6 +354,22 @@ describe('containers/Search/model', () => {
       )
     })
 
+    // The filter's URL param is its key, unprefixed, so these are the strings
+    // that actually reach JSON.parse from a real link.
+    it('reports the filter when parsing a whole search URL', () => {
+      silenced(() => {
+        expect(() => model.parseSearchParams('modified={')).toThrow(
+          'Invalid date range in the search URL',
+        )
+        expect(() => model.parseSearchParams('size={oops}')).toThrow(
+          'Invalid number range in the search URL',
+        )
+        expect(() => model.parseSearchParams('workflow="a",,')).toThrow(
+          'Invalid keyword list in the search URL',
+        )
+      })
+    })
+
     it('leaves well-formed filter params parsing as before', () => {
       expect(
         model.Predicates.Datetime.fromString('{"gte":"2020-01-02T00:00:00.000Z"}'),

--- a/catalog/app/containers/Search/model.ts
+++ b/catalog/app/containers/Search/model.ts
@@ -342,11 +342,8 @@ function Predicate<Tag extends string, State, GQLType>(input: {
   }
 }
 
-// A filter's URL param is user-editable, so JSON.parse can throw on anything a
-// hand-edited or truncated link carries. The raw SyntaxError names a character
-// offset in a string the reader never sees, so the throw carries a message
-// naming the filter instead, and the console gets the offending value verbatim
-// alongside the original error -- the offset means nothing without it.
+// The SyntaxError names an offset into a string nobody printed, so the throw
+// names the filter and the log carries the value.
 function parseFilterJson(input: string, message: string) {
   try {
     return JSON.parse(input)

--- a/catalog/app/containers/Search/model.ts
+++ b/catalog/app/containers/Search/model.ts
@@ -10,6 +10,7 @@ import * as Model from 'model'
 import * as GQL from 'utils/GraphQL'
 import * as JSONPointer from 'utils/JSONPointer'
 import * as KTree from 'utils/KeyedTree'
+import Log from 'utils/Logging'
 import * as NamedRoutes from 'utils/NamedRoutes'
 import assertNever from 'utils/assertNever'
 import * as tagged from 'utils/taggedV2'
@@ -341,6 +342,19 @@ function Predicate<Tag extends string, State, GQLType>(input: {
   }
 }
 
+// A filter's URL param is user-editable, so JSON.parse can throw on anything a
+// hand-edited or truncated link carries. The raw SyntaxError names a character
+// offset in a string the reader never sees, so it goes to the console and the
+// throw carries a message naming the filter that could not be read.
+function parseFilterJson(input: string, message: string) {
+  try {
+    return JSON.parse(input)
+  } catch (e) {
+    Log.error(e)
+    throw new Error(message)
+  }
+}
+
 const STRICT_MARKER = '$s$:'
 
 export const Predicates = {
@@ -351,7 +365,7 @@ export const Predicates = {
       lte: null as Date | null,
     },
     fromString: (input: string) => {
-      const json = JSON.parse(input)
+      const json = parseFilterJson(input, 'Invalid date range in the search URL')
       return {
         gte: parseDate(json.gte),
         lte: parseDate(json.lte),
@@ -371,7 +385,7 @@ export const Predicates = {
       lte: null as number | null,
     },
     fromString: (input: string) => {
-      const json = JSON.parse(input)
+      const json = parseFilterJson(input, 'Invalid number range in the search URL')
       return {
         gte: (json.gte as number) ?? null,
         lte: (json.lte as number) ?? null,
@@ -398,7 +412,12 @@ export const Predicates = {
   KeywordEnum: Predicate({
     tag: 'KeywordEnum',
     init: { terms: [] as string[] },
-    fromString: (input: string) => ({ terms: JSON.parse(`[${input}]`) as string[] }),
+    fromString: (input: string) => ({
+      terms: parseFilterJson(
+        `[${input}]`,
+        'Invalid keyword list in the search URL',
+      ) as string[],
+    }),
     toString: ({ terms }) => JSON.stringify(terms).slice(1, -1),
     toGQL: ({ terms }) =>
       terms.length

--- a/catalog/app/containers/Search/model.ts
+++ b/catalog/app/containers/Search/model.ts
@@ -344,13 +344,14 @@ function Predicate<Tag extends string, State, GQLType>(input: {
 
 // A filter's URL param is user-editable, so JSON.parse can throw on anything a
 // hand-edited or truncated link carries. The raw SyntaxError names a character
-// offset in a string the reader never sees, so it goes to the console and the
-// throw carries a message naming the filter that could not be read.
+// offset in a string the reader never sees, so the throw carries a message
+// naming the filter instead, and the console gets the offending value verbatim
+// alongside the original error -- the offset means nothing without it.
 function parseFilterJson(input: string, message: string) {
   try {
     return JSON.parse(input)
   } catch (e) {
-    Log.error(e)
+    Log.error(`${message}; JSON.parse failed on ${JSON.stringify(input)}`, e)
     throw new Error(message)
   }
 }


### PR DESCRIPTION
# Description

Split out of #4463. Independent of #5232.

A malformed filter value in a search URL currently takes down the entire catalog. This contains it to the search page and says what went wrong.

## The failure

`Predicates.Datetime`, `Predicates.Number` and `Predicates.KeywordEnum` call `JSON.parse` on a raw filter value taken off the URL. `Filter.fromURLSearchParams` (`model.ts:522`) calls them with no guard, and that runs inside the `useMemo` in `useUrlState` — i.e. in `SearchUIModel.Provider`'s own render pass, which is *above* every error boundary search has. So the throw unwinds to `Errors.ErrorBoundary` in `app.tsx` and replaces the whole catalog with the app-level screen.

That screen renders a fixed `'Something went wrong'` for any non-credentials error — it never shows `error.message`. So the user gets a blank-slate failure page, and the only description of the real fault is a `SyntaxError` in the console naming a character offset into a string nobody printed.

The realistic trigger is not adversarial input. A valid date filter serializes to `modified={"gte":"2020-01-01T00:00:00.000Z","lte":null}`; paste that into Slack or an email, let it line-wrap, and the recipient clicks a URL truncated mid-value.

## What this changes

**Containment.** Both pages that mount the model — `Search/Search.tsx` and `Bucket/PackageList.tsx` — wrap the provider in an `ErrorBoundary`. The search UI is wholly reconstructable from the URL, so the failure is recoverable in place: keep the page chrome, show the error, offer reload or a clean search.

Two things the implementation is deliberate about, both learned from `Bucket/PanelBoundary.tsx`'s notes:

- The bad state lives in the **location**, above the boundary, so `resetErrorBoundary` alone would re-render the same throw. Navigating is the reset; `resetKeys={[location.search]}` clears the boundary when the URL actually changes. A retry that cannot succeed would be a dead affordance.
- Neither fallback uses `Search/Layout/Main`, because `Main` reads the search model — and a boundary does not catch what its own fallback throws. `NoResults.Error` is model-free, which is what makes it usable here; `NoResults.boundary.spec.tsx` pins that, and fails with `ESCAPED:` the moment the screen starts reading the model.

**The message.** The three parses go through one helper that throws a message naming the filter, and logs that message, the offending value verbatim, and the original `SyntaxError`. The offset is meaningless without the string it indexes into, so the console needed the value as much as the user needed the name.

| Param | Message |
|---|---|
| `modified` | `Invalid date range in the search URL` |
| `size`, `entries` | `Invalid number range in the search URL` |
| `workflow` | `Invalid keyword list in the search URL` |
| `comment`, `name`, `hash` | cannot throw — Text/KeywordWildcard never parse JSON |

The filter's URL param is the predicate key, unprefixed. Objects search shares `modified` and `size`, so `t=o&modified={` behaves the same.

## Reproducing

```
/search?modified={
/search?size={oops}
/search?workflow="a",,
/b/<bucket>/packages?modified={
```

Before: full-page app-level error screen reading `'Something went wrong'`. After: the search page, with `Unexpected error` / `Invalid date range in the search URL` and both exits live.

Before:
<img width="1002" height="816" alt="Screenshot_2026-08-27_18-23-11" src="https://github.com/user-attachments/assets/2c132e82-7169-412c-85d9-3ba0fd608747" />

After:
<img width="1001" height="507" alt="Screenshot_2026-08-27_18-22-59" src="https://github.com/user-attachments/assets/77f5f7a4-7eea-401a-a602-02e14b9ebced" />


## Tests

`model.spec.ts` — one case per filter at the predicate level, one driving `parseSearchParams` over whole query strings (pinning the param names above), one asserting the log carries the failing value, one asserting well-formed params parse as before. `NoResults.boundary.spec.tsx` — the error screen renders with no provider above it.

Every one was checked against a reverted implementation: the naming cases fail, the well-formed case stays green, and the boundary spec reports `ESCAPED:` when the screen reads the model.

Verified: `Search/` + `Bucket/` suites 443 passed / 5 skipped, `npm run typecheck` clean, `oxfmt` + `oxlint` clean. `Bucket/File/File.boundary.spec.tsx` fails as an import timeout under the full parallel run and passes in isolation — reproduced identically on unmodified `master`, so it is pre-existing flake, not this change.

# TODO

- [x] Unit tests
- [x] Security: Confirm that this change meets security best practices and does not violate the security model
- [x] Open: Confirm that this change doesn't break the Open variant
- [x] [Changelog](../tree/master/catalog/CHANGELOG.md) entry




<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR contains malformed search-filter URLs within the affected search surface and provides filter-specific error messages and recovery actions.
- Adds page-level error boundaries around the global and bucket package search models.
- Adds model-independent fallback UI that can reload or navigate to a clean search URL.
- Wraps JSON parsing for date, number, and keyword filters with named errors and diagnostic logging.
- Adds parser and boundary regression coverage plus a changelog entry.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge.

No blocking failure remains.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| catalog/app/containers/Search/model.ts | Centralizes malformed filter JSON handling into named errors while preserving valid filter parsing. |
| catalog/app/containers/Search/Search.tsx | Places an error boundary above the global search model and supplies model-independent recovery UI. |
| catalog/app/containers/Bucket/PackageList.tsx | Adds equivalent malformed-URL containment and recovery around the bucket package-list model. |
| catalog/app/containers/Search/NoResults.tsx | Adds fallback recovery behavior that reloads network failures or navigates to a clean base URL. |
| catalog/app/containers/Search/model.spec.ts | Covers named parser failures, diagnostics, whole-query parameter mapping, and valid inputs. |
| catalog/app/containers/Search/NoResults.boundary.spec.tsx | Verifies that the fallback error screen renders without the search model provider. |


<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
  URL[Search URL] --> Provider[Search model provider]
  Provider --> Parse[Parse filter parameters]
  Parse -->|Valid| Results[Render search results]
  Parse -->|Malformed JSON| Error[Throw named filter error]
  Error --> Boundary[Page-level error boundary]
  Boundary --> Fallback[Model-independent error screen]
  Fallback -->|Clean search| Navigate[Navigate without bad filters]
  Fallback -->|Reload| Reload[Reload current page]
```

<sub>Reviews (3): Last reviewed commit: ["catalog: say the changelog entry plainly"](https://github.com/quiltdata/quilt/commit/2d0a10c72b0e0192e8e07917c0daed9d4d7defa8) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=57513753)</sub>

**Context used:**

- Knowledge Base — [Catalog client features](https://app.greptile.com/quilt-bio/-/custom-context/knowledge-base/quiltdata/quilt/-/docs/catalog-client.md)
- Knowledge Base — [Catalog web application](https://app.greptile.com/quilt-bio/-/custom-context/knowledge-base/quiltdata/quilt/-/docs/catalog-application.md)

<!-- /greptile_comment -->