### PR TITLE
Stop reporting success while dev drifts behind master

### DIFF
--- a/.github/workflows/back-merge-dev.yaml
+++ b/.github/workflows/back-merge-dev.yaml
@@ -43,6 +43,10 @@ jobs:
       - name: Merge master into dev
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # How far dev may fall behind while a back-merge PR sits open before this
+          # workflow starts failing instead of warning. Low enough that the drift is
+          # still cheap to resolve by hand.
+          MAX_BEHIND: 5
         run: |
           set -euo pipefail
 
@@ -90,8 +94,25 @@ jobs:
             exit 1
           fi
 
-          if [ -n "$(gh pr list --base dev --head master --state open --json number --jq '.[].number')" ]; then
-            echo "A master->dev PR is already open; leaving it to the existing one."
+          # An already-open PR is the idempotent case, but exiting 0 silently makes
+          # this workflow report success on every later landing while dev keeps
+          # drifting — a green check that means "someone else's problem", not "done".
+          # Escalate to a failure once dev is far enough behind that the next
+          # promotion is going to hurt.
+          # Guarded because `set -e` aborts on a failing assignment: a transient API
+          # error would otherwise kill the run here rather than at `gh pr create`
+          # below, which is where an outage should surface.
+          open_pr="$(gh pr list --base dev --head master --state open --json number --jq '.[].number')" || open_pr=''
+          if [ -n "$open_pr" ]; then
+            behind="$(git rev-list --count origin/dev..origin/master)"
+            if [ "$behind" -ge "$MAX_BEHIND" ]; then
+              echo "::error::dev is $behind commits behind master and PR #$open_pr has been" \
+                   "open since before this landing. The next dev->master promotion will" \
+                   "conflict on every file both branches touched. Resolve #$open_pr."
+              exit 1
+            fi
+            echo "::warning::dev is $behind commits behind master; PR #$open_pr is already" \
+                 "open to resolve it. Not opening another."
             exit 0
           fi
 


### PR DESCRIPTION
Found reviewing the 26.8.0 candidate, and it is live right now.

`back-merge-dev.yaml` (#5204) merges master into dev after every landing so squash-merges cannot freeze the merge base. When the merge conflicts it opens a PR — correct. But on every *subsequent* landing it finds that PR already open, prints a line, and `exit 0`. So the workflow reports **success** while doing nothing, and the green check reads as "done" when it means "someone else's problem".

Current state: PR #5213 has been open and `CONFLICTING` since 2026-08-25. Every run since took the exit-0 path, including the run for the catalog commit this release pins. `dev` is now **10 commits behind master, and master is not an ancestor of it** — it was 7 when I started this review a couple of hours ago, so the drift is still growing. The next dev→master promotion will conflict on every file both branches have touched.

## Change

The already-open branch keeps its idempotence but stops being silent:

- `::warning::` with the current distance while the drift is small.
- `::error::` and a non-zero exit once dev is `MAX_BEHIND` (5) or more commits behind. At that point the next promotion is going to hurt, which is worth a red check rather than a note in a log nobody opens.

`MAX_BEHIND` is a step env var so the threshold is one edit, and low enough that the drift is still cheap to resolve by hand when it fires.

One incidental fix: the `gh pr list` result is now assigned to a variable, and `set -euo pipefail` aborts on a failing assignment — so it is guarded with `|| open_pr=''`. Without that, a transient API error would kill the run here instead of surfacing at `gh pr create`, which is where an outage should show up. (The original was inside an `if [ -n "$(...)" ]` condition, where `set -e` does not apply.)

## Verification

No test harness exists for workflow shell, so this was checked directly rather than by eye:

- `yaml.safe_load` parses; `MAX_BEHIND` resolves to 5 in the step env.
- `bash -n` on the extracted `run` body — syntax clean.
- Ran the escalation logic standalone at `behind=3/5/10` against `MAX_BEHIND=5`: warn+exit 0, error+exit 1, error+exit 1.
- Confirmed the `set -e` assignment-abort behavior empirically (`out="$(false)"` aborts; the `|| open_pr=''` form does not), which is what motivated the guard.

**Not verified:** the workflow has not run. The first real execution is its next push to master, and the expected outcome given today's state is a **red check** with the escalation message — that is the fix working, not a new failure.

## Notes

- Does not resolve #5213. That is a real conflict needing a person, and this PR is only about the workflow no longer hiding it.
- No changelog entry: `catalog/CHANGELOG.md` is the catalog's, and this is a CI workflow with no catalog-visible effect. Say so if the convention here is otherwise.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR makes unresolved `master`-to-`dev` drift visible when a conflict pull request is already open.
- Adds a configurable five-commit escalation threshold.
- Reports smaller drift as a workflow warning and larger drift as a failing error.
- Preserves the existing pull-request lookup fallback during transient GitHub API failures.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge, with no actionable defects identified in the changed workflow behavior.

The workflow refreshes complete `master` and `dev` refs before counting commits, uses the intended Git range for divergent branch drift, and preserves the pre-existing API-failure control flow.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| .github/workflows/back-merge-dev.yaml | Adds correctly sourced branch-distance reporting and threshold-based escalation without introducing a concrete failure in the workflow paths reviewed. |

<sub>Reviews (1): Last reviewed commit: ["Stop reporting success while dev drifts ..."](https://github.com/quiltdata/quilt/commit/d1514f9815341a8b4d15ec8444dcd3715edeb02a) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=57565930)</sub>

**Context used:**

- Knowledge Base — [Build, test, and deployment automation](https://app.greptile.com/quilt-bio/-/custom-context/knowledge-base/quiltdata/quilt/-/docs/build-test-and-deployment.md)

<!-- /greptile_comment -->