### PR TITLE
ci: path-filter Python checks

### DIFF
--- a/.github/workflows/py-ci.yml
+++ b/.github/workflows/py-ci.yml
@@ -9,7 +9,50 @@ on:
 env:
   UV_LOCKED: 1
 jobs:
+  changes:
+    runs-on: ubuntu-latest
+    outputs:
+      quilt3: ${{ steps.filter.outputs.quilt3 }}
+      docs: ${{ steps.filter.outputs.docs }}
+      rest: ${{ steps.filter.outputs.rest }}
+      lambdas: ${{ steps.filter.outputs.lambdas }}
+      py-shared: ${{ steps.filter.outputs.py-shared }}
+    steps:
+      - uses: actions/checkout@v7
+      - uses: dorny/paths-filter@v3
+        id: filter
+        with:
+          filters: |
+            quilt3:
+              - '.github/workflows/py-ci.yml'
+              - 'api/python/**'
+            docs:
+              - '.github/workflows/py-ci.yml'
+              - 'api/python/**'
+              - 'docs/**'
+              - 'gendocs/**'
+              - 'testdocs/**'
+            rest:
+              - '.github/workflows/py-ci.yml'
+              - 'catalog/**'
+              - 'lambdas/**'
+              - 'py-shared/**'
+              - 's3-proxy/**'
+              - 'shared/**'
+              - '*.py'
+              - '*.toml'
+              - '*.yaml'
+              - '*.yml'
+            lambdas:
+              - '.github/workflows/py-ci.yml'
+              - 'lambdas/**'
+              - 'shared/**'
+            py-shared:
+              - '.github/workflows/py-ci.yml'
+              - 'py-shared/**'
+
   lint-quilt3:
+    needs: changes
     runs-on: ubuntu-latest
     defaults:
       run:
@@ -17,10 +60,16 @@ jobs:
     steps:
       - uses: actions/checkout@v7
       - uses: astral-sh/setup-uv@v7
+        if: needs.changes.outputs.quilt3 == 'true'
       - name: Lint
+        if: needs.changes.outputs.quilt3 == 'true'
         run: uv run poe lint
+      - name: No changes to quilt3
+        if: needs.changes.outputs.quilt3 != 'true'
+        run: echo 'No quilt3 changes; check passed.'
 
   format-quilt3:
+    needs: changes
     runs-on: ubuntu-latest
     defaults:
       run:
@@ -28,16 +77,27 @@ jobs:
     steps:
       - uses: actions/checkout@v7
       - uses: astral-sh/setup-uv@v7
+        if: needs.changes.outputs.quilt3 == 'true'
       - name: Check formatting (quilt3)
+        if: needs.changes.outputs.quilt3 == 'true'
         run: uv run poe fmt --check
+      - name: No changes to quilt3
+        if: needs.changes.outputs.quilt3 != 'true'
+        run: echo 'No quilt3 changes; check passed.'
 
   lint-rest:
+    needs: changes
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7
       - uses: astral-sh/setup-uv@v7
+        if: needs.changes.outputs.rest == 'true'
       - name: Run Ruff linter on entire codebase
+        if: needs.changes.outputs.rest == 'true'
         run: uvx ruff@0.16.0 check . --exclude catalog/ --exclude api/python/
+      - name: No changes to the rest of the codebase
+        if: needs.changes.outputs.rest != 'true'
+        run: echo 'No relevant changes; check passed.'
 
   # Enable once the rest of the codebase is formatted
   # format-rest:
@@ -49,6 +109,7 @@ jobs:
   #       run: uvx ruff@0.16.0 format --check --exclude catalog/ --exclude api/python/
 
   test-gendocs:
+    needs: changes
     runs-on: ubuntu-latest
     defaults:
       run:
@@ -58,10 +119,16 @@ jobs:
     steps:
       - uses: actions/checkout@v7
       - uses: astral-sh/setup-uv@v7
+        if: needs.changes.outputs.docs == 'true'
       - name: Check generated docs are up-to-date
+        if: needs.changes.outputs.docs == 'true'
         run: uv run poe gendocs-check
+      - name: No documentation changes
+        if: needs.changes.outputs.docs != 'true'
+        run: echo 'No documentation changes; check passed.'
 
   test-testdocs:
+    needs: changes
     runs-on: ubuntu-latest
     env:
       QUILT_DISABLE_USAGE_METRICS: true
@@ -71,10 +138,16 @@ jobs:
     steps:
       - uses: actions/checkout@v7
       - uses: astral-sh/setup-uv@v7
+        if: needs.changes.outputs.docs == 'true'
       - name: Test codeblocks
+        if: needs.changes.outputs.docs == 'true'
         run: uv run poe testdocs
+      - name: No documentation changes
+        if: needs.changes.outputs.docs != 'true'
+        run: echo 'No documentation changes; check passed.'
 
   test-client:
+    needs: changes
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest]
@@ -88,9 +161,12 @@ jobs:
     steps:
       - uses: actions/checkout@v7
       - uses: astral-sh/setup-uv@v7
+        if: needs.changes.outputs.quilt3 == 'true'
       - name: Run Pytest
+        if: needs.changes.outputs.quilt3 == 'true'
         run: uv run --python ${{ matrix.python-version }} poe test-cov --cov-report xml
       - uses: codecov/codecov-action@v7
+        if: needs.changes.outputs.quilt3 == 'true'
         env:
           CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
           OS: ${{ matrix.os }}
@@ -99,9 +175,12 @@ jobs:
           flags: api-python
           name: ${{ github.job }}
           env_vars: OS,PYTHON_VERSION
+      - name: No changes to quilt3
+        if: needs.changes.outputs.quilt3 != 'true'
+        run: echo 'No quilt3 changes; check passed.'
 
   pypi-release-tag-check:
-    needs: test-client
+    needs: [changes, test-client]
     runs-on: ubuntu-latest
     outputs:
       check: ${{ steps.check.outputs.check }}
@@ -135,6 +214,7 @@ jobs:
         run: uv publish
 
   test-lambda:
+    needs: changes
     strategy:
       fail-fast: false
       matrix:
@@ -162,15 +242,19 @@ jobs:
     steps:
       - uses: actions/checkout@v7
       - uses: astral-sh/setup-uv@v7
+        if: needs.changes.outputs.lambdas == 'true'
       - name: Pytest
+        if: needs.changes.outputs.lambdas == 'true'
         run: uv run pytest --cov=src --cov-report=term-missing --cov-report=xml
       - name: Check the built package is importable
+        if: needs.changes.outputs.lambdas == 'true'
         # The run above imports the sources, so it cannot catch files missing
         # from the distribution. --no-editable installs the built wheel, which
         # is how build_zip.sh and the Dockerfiles install the lambda, so
         # collection fails if the wheel is incomplete.
         run: uv run --no-editable pytest --collect-only -q
       - uses: codecov/codecov-action@v7
+        if: needs.changes.outputs.lambdas == 'true'
         env:
           CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
           LAMBDA: ${{ matrix.path }}
@@ -178,8 +262,12 @@ jobs:
           flags: lambda
           name: ${{ github.job }}
           env_vars: LAMBDA
+      - name: No lambda changes
+        if: needs.changes.outputs.lambdas != 'true'
+        run: echo 'No lambda changes; check passed.'
 
   test-py-shared:
+    needs: changes
     runs-on: ubuntu-latest
     defaults:
       run:
@@ -187,11 +275,17 @@ jobs:
     steps:
       - uses: actions/checkout@v7
       - uses: astral-sh/setup-uv@v7
+        if: needs.changes.outputs.py-shared == 'true'
       - name: test
+        if: needs.changes.outputs.py-shared == 'true'
         run: uv run --only-group test pytest --cov=. --cov-report=xml
       - uses: codecov/codecov-action@v7
+        if: needs.changes.outputs.py-shared == 'true'
         env:
           CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
         with:
           flags: py-shared
           name: ${{ github.job }}
+      - name: No py-shared changes
+        if: needs.changes.outputs.py-shared != 'true'
+        run: echo 'No py-shared changes; check passed.'

--- a/.github/workflows/py-ci.yml
+++ b/.github/workflows/py-ci.yml
@@ -9,23 +9,25 @@ on:
 env:
   UV_LOCKED: 1
 jobs:
+  # Package context: https://nightly.quilttest.com/b/quilt-dev/packages/proj/260827-quilt3-acl
   changes:
     runs-on: ubuntu-latest
     outputs:
-      quilt3: ${{ steps.filter.outputs.quilt3 }}
+      quilt3: ${{ github.ref_type == 'tag' || steps.filter.outputs.quilt3 }}
       docs: ${{ steps.filter.outputs.docs }}
       rest: ${{ steps.filter.outputs.rest }}
       lambdas: ${{ steps.filter.outputs.lambdas }}
       py-shared: ${{ steps.filter.outputs.py-shared }}
     steps:
       - uses: actions/checkout@v7
-      - uses: dorny/paths-filter@v3
+      - uses: dorny/paths-filter@d1c1ffe0248fe513906c8e24db8ea791d46f8590
         id: filter
         with:
           filters: |
             quilt3:
               - '.github/workflows/py-ci.yml'
               - 'api/python/**'
+              - 'ruff.toml'
             docs:
               - '.github/workflows/py-ci.yml'
               - 'api/python/**'
@@ -35,6 +37,7 @@ jobs:
             rest:
               - '.github/workflows/py-ci.yml'
               - 'catalog/**'
+              - 'gendocs/**'
               - 'lambdas/**'
               - 'py-shared/**'
               - 's3-proxy/**'

--- a/codecov.yml
+++ b/codecov.yml
@@ -15,6 +15,7 @@ flag_management:
       - name_prefix: 'auto-'
         type: project
         threshold: 0.1
+        informational: true
       - name_prefix: 'auto-'
         type: patch
   individual_flags:

--- a/codecov.yml
+++ b/codecov.yml
@@ -15,7 +15,6 @@ flag_management:
       - name_prefix: 'auto-'
         type: project
         threshold: 0.1
-        informational: true
       - name_prefix: 'auto-'
         type: patch
   individual_flags:

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -18,6 +18,10 @@ Entries inside each section should be ordered by type:
 
 ## unreleased - YYYY-MM-DD
 
+### CI
+
+* [Changed] Path-filtered Python CI keeps required check contexts successful while skipping jobs unrelated to the changed paths.
+
 ### Python API
 
 * [Changed] The parent-revision check in `Package.push()` is keyed on package name rather than on the registry a revision was read from, and accepts every revision the package object knows for that name. Pushing one object to several registries that hold the shared parent — mirroring, or promoting between environments — no longer conflicts after the first destination ([#5180](https://github.com/quiltdata/quilt/pull/5180))


### PR DESCRIPTION
## Summary
- run path detection once for the Python CI workflow
- preserve every existing required check with successful no-op steps when paths are unrelated
- document the persistent CI behavior in the unreleased changelog

## Validation
- Ruby YAML parse passed
- yamllint passed with four pre-existing line-length warnings
- git diff --check passed

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR centralizes Python CI path detection and preserves required job contexts through successful no-op steps when their inputs are unchanged.
- Adds one `dorny/paths-filter` job with filters for the client, documentation, general Python, Lambdas, and `py-shared`.
- Gates setup, validation, and coverage steps on the corresponding filter outputs.
- Documents the new CI behavior in the unreleased changelog.

<h3>Confidence Score: 4/5</h3>

The PR should not merge until the `rest` filter covers `gendocs/**`; the mutable path-filter action reference is also worth hardening.

The new filter allows a `gendocs/build.py` change to bypass the repository-wide Ruff invocation while `lint-rest` still reports success, leaving a current validation gap.

**Files Needing Attention:** .github/workflows/py-ci.yml

<details open><summary><h3>Security Review</h3></summary>

The new path-filter action is referenced through a mutable third-party tag. Because its outputs control whether required validation runs or reports a successful no-op, pinning it to a full commit SHA would reduce CI supply-chain exposure.
</details>


<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| .github/workflows/py-ci.yml | Adds centralized path filtering and no-op required checks, but the general Ruff filter omits an existing linted Python directory and the filter action is not immutably pinned. |
| docs/CHANGELOG.md | Accurately documents the intended persistent required-check behavior. |


<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart LR
  Event[GitHub workflow event] --> Changes[Path-filter job]
  Changes --> Client[Client lint, format, and tests]
  Changes --> Docs[Generated docs and codeblocks]
  Changes --> Rest[Repository-wide Ruff lint]
  Changes --> Lambdas[Lambda test matrix]
  Changes --> Shared[py-shared tests]
  Client -->|version tag| Release[PyPI release checks]
  Changes -->|unmatched path| NoOp[Successful no-op steps]
```

<sub>Reviews (1): Last reviewed commit: ["ci: path-filter Python checks"](https://github.com/quiltdata/quilt/commit/a10dcf1622143c502d2e31f1a18396aa56e2b5a3) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=57630035)</sub>

> Greptile also left **2 inline comments** on this PR.

**Context used:**

- Knowledge Base — [Build, test, and deployment automation](https://app.greptile.com/quilt-bio/-/custom-context/knowledge-base/quiltdata/quilt/-/docs/build-test-and-deployment.md)

<!-- /greptile_comment -->