### PR TITLE
catalog: mainline the beta surfaces behind a legacy-ui opt-out

### DIFF
--- a/catalog/CHANGELOG.md
+++ b/catalog/CHANGELOG.md
@@ -21,7 +21,7 @@ complete sentence without it.
 
 ## Changes
 
-- [Changed] The bucket header above the tabs, the current bucket Overview, and Athena's Tabulator tables are on for everyone, no longer behind the global `beta` switch. A new `legacy-ui` preview feature (Admin > Settings) restores the previous Overview and its full-bleed header for a catalog that needs it; the `beta` switch stays in place, now gating nothing ([#PRNUM](https://github.com/quiltdata/quilt/pull/PRNUM))
+- [Changed] The bucket header above the tabs, the current bucket Overview, and Athena's Tabulator tables are on for everyone, no longer behind the global `beta` switch. A new `legacy-ui` preview feature (Admin > Settings) restores the previous Overview and its full-bleed header for a catalog that needs it; the `beta` switch stays in place, now gating nothing ([#5243](https://github.com/quiltdata/quilt/pull/5243))
 - [Changed] Search: error states are separate, more strictly typed components, safer to extend than one component behind a `kind` prop ([#5238](https://github.com/quiltdata/quilt/pull/5238))
 - [Fixed] Search: a malformed filter value in the URL no longer breaks the page ([#5233](https://github.com/quiltdata/quilt/pull/5233))
 - [Fixed] Search results table: a package with no commit message shows the no-value marker instead of the literal text `None` ([#5232](https://github.com/quiltdata/quilt/pull/5232))

--- a/catalog/CHANGELOG.md
+++ b/catalog/CHANGELOG.md
@@ -21,6 +21,7 @@ complete sentence without it.
 
 ## Changes
 
+- [Changed] The bucket header above the tabs, the current bucket Overview, and Athena's Tabulator tables are on for everyone, no longer behind the global `beta` switch. A new `legacy-ui` preview feature (Admin > Settings) restores the previous Overview and its full-bleed header for a catalog that needs it; the `beta` switch stays in place, now gating nothing ([#PRNUM](https://github.com/quiltdata/quilt/pull/PRNUM))
 - [Changed] Search: error states are separate, more strictly typed components, safer to extend than one component behind a `kind` prop ([#5238](https://github.com/quiltdata/quilt/pull/5238))
 - [Fixed] Search: a malformed filter value in the URL no longer breaks the page ([#5233](https://github.com/quiltdata/quilt/pull/5233))
 - [Fixed] Search results table: a package with no commit message shows the no-value marker instead of the literal text `None` ([#5232](https://github.com/quiltdata/quilt/pull/5232))

--- a/catalog/app/containers/Bucket/Bucket.tsx
+++ b/catalog/app/containers/Bucket/Bucket.tsx
@@ -8,7 +8,7 @@ import * as BucketNav from 'containers/Bucket/Nav'
 import { useBucketStrict } from 'containers/Bucket/Routes'
 import { NotFoundInTabs } from 'containers/NotFound'
 import { useBucketExistence } from 'utils/BucketCache'
-import * as CatalogSettings from 'utils/CatalogSettings'
+import { useFeature } from 'utils/features'
 import * as NamedRoutes from 'utils/NamedRoutes'
 import * as BucketPreferences from 'utils/BucketPreferences'
 import MetaTitle from 'utils/MetaTitle'
@@ -62,14 +62,16 @@ interface BucketLayoutProps {
 
 function BucketLayout({ bucket, children }: BucketLayoutProps) {
   const classes = useStyles()
-  const settings = CatalogSettings.use()
+  // The legacy Overview carries its own full-bleed header, so this one stands
+  // down for it rather than stacking a second bucket name above the tabs.
+  const legacy = useFeature('legacy-ui')
   const bucketExistenceData = useBucketExistence(bucket)
   return (
     <Layout
       pre={
         <Container className={classes.content}>
           <M.Paper className={classes.headerCard}>
-            {settings?.beta && (
+            {!legacy && (
               <>
                 <div className={classes.headerTop}>
                   <Header bucket={bucket} />

--- a/catalog/app/containers/Bucket/Overview/index.spec.tsx
+++ b/catalog/app/containers/Bucket/Overview/index.spec.tsx
@@ -2,8 +2,6 @@ import * as React from 'react'
 import { describe, it, expect, vi, afterEach, type Mock } from 'vitest'
 import { render, cleanup } from '@testing-library/react'
 
-import type * as CatalogSettings from 'utils/CatalogSettings'
-
 import Overview from './index'
 
 vi.mock('constants/config', () => ({ default: {} }))
@@ -16,31 +14,24 @@ vi.mock('./v2/Overview', () => ({
   default: () => <div>V2</div>,
 }))
 
-const settingsHook: Mock<() => CatalogSettings.CatalogSettings | null> = vi.fn(() => null)
+const useFeature: Mock<() => boolean> = vi.fn(() => false)
 
-vi.mock('utils/CatalogSettings', () => ({
-  use: () => settingsHook(),
+vi.mock('utils/features', () => ({
+  useFeature: () => useFeature(),
 }))
 
 describe('Bucket/Overview', () => {
   afterEach(cleanup)
 
-  it('renders v2 Overview when the beta flag is on', () => {
-    settingsHook.mockReturnValue({ beta: true })
+  it('renders the current Overview by default', () => {
+    useFeature.mockReturnValue(false)
     const { queryByText } = render(<Overview />)
     expect(queryByText('V2')).toBeTruthy()
     expect(queryByText('LEGACY')).toBeFalsy()
   })
 
-  it('renders legacy Overview when the beta flag is off', () => {
-    settingsHook.mockReturnValue({ beta: false })
-    const { queryByText } = render(<Overview />)
-    expect(queryByText('LEGACY')).toBeTruthy()
-    expect(queryByText('V2')).toBeFalsy()
-  })
-
-  it('renders legacy Overview when there are no catalog settings', () => {
-    settingsHook.mockReturnValue(null)
+  it('renders the legacy Overview when the legacy-ui feature is on', () => {
+    useFeature.mockReturnValue(true)
     const { queryByText } = render(<Overview />)
     expect(queryByText('LEGACY')).toBeTruthy()
     expect(queryByText('V2')).toBeFalsy()

--- a/catalog/app/containers/Bucket/Overview/index.tsx
+++ b/catalog/app/containers/Bucket/Overview/index.tsx
@@ -1,11 +1,11 @@
 import * as React from 'react'
 
-import * as CatalogSettings from 'utils/CatalogSettings'
+import { useFeature } from 'utils/features'
 
 import Overview from './Overview'
 import OverviewV2 from './v2/Overview'
 
 export default function OverviewSelector() {
-  const settings = CatalogSettings.use()
-  return settings?.beta ? <OverviewV2 /> : <Overview />
+  const legacy = useFeature('legacy-ui')
+  return legacy ? <Overview /> : <OverviewV2 />
 }

--- a/catalog/app/containers/Queries/Athena/Athena.tsx
+++ b/catalog/app/containers/Queries/Athena/Athena.tsx
@@ -6,7 +6,6 @@ import * as M from '@material-ui/core'
 
 import Code from 'components/Code'
 import Skeleton from 'components/Skeleton'
-import * as CatalogSettings from 'utils/CatalogSettings'
 import * as NamedRoutes from 'utils/NamedRoutes'
 
 import QuerySelect from '../QuerySelect'
@@ -372,7 +371,6 @@ const useStyles = M.makeStyles((t) => ({
 
 function AthenaContainer() {
   const { queryExecutionId, workgroup } = Model.use()
-  const settings = CatalogSettings.use()
 
   const classes = useStyles()
   return (
@@ -398,7 +396,7 @@ function AthenaContainer() {
       {Model.hasData(workgroup.data) && (
         <div className={classes.content}>
           <div className={classes.section}>
-            {settings?.beta && <TabulatorTables />}
+            <TabulatorTables />
             <QueryEditor.Form className={classes.form} />
           </div>
           {queryExecutionId ? (

--- a/catalog/app/utils/features.ts
+++ b/catalog/app/utils/features.ts
@@ -43,6 +43,11 @@ export const FEATURES = {
     description:
       'Browse data products defined in an enterprise catalog (AWS DataZone, Databricks Unity, Snowflake). Off, no data-product route or nav entry exists. Reads fixture data until catalog adapters land.',
   },
+  'legacy-ui': {
+    label: 'Legacy UI',
+    description:
+      "Restore the previous bucket Overview and its full-bleed header. Off, buckets use the current Overview and the header above the tabs. Doesn't affect any other surface.",
+  },
 } satisfies Record<string, Feature>
 
 export type FeatureId = keyof typeof FEATURES


### PR DESCRIPTION
## What

The global `beta` switch gated three unrelated capabilities at once — so no catalog could adopt one without all three:

| Was gated by `beta` | Now |
|---|---|
| Bucket header above the tabs (`Bucket.tsx`) | on by default; stands down under `legacy-ui` |
| Current bucket Overview vs legacy (`Overview/index.tsx`) | current by default; legacy under `legacy-ui` |
| Athena Tabulator tables (`Athena.tsx`) | on unconditionally |

A new **`legacy-ui`** entry in the `FEATURES` registry restores the previous Overview **and** its full-bleed header for a catalog that needs it. The bucket header hides when it's on, rather than stacking a second bucket name above the tabs — the legacy Overview carries its own header.

Tabulator tables have no legacy counterpart, so they mainline with no flag.

`beta` itself stays in place — schema field and admin switch — gating nothing, kept for future use.

## Why

`features.ts` already documents the problem in its own header comment: `beta` is *"a single global switch already wired to four unrelated consumers … so it cannot enable one capability without enabling all of them. A slice that needs to be evaluated on its own merits needs its own switch."* This moves the surfaces out from behind that switch and puts the one real rollback path in the per-feature registry, where the admin panel renders it with no panel edit.

Worth noting for release context: on `rc.quilttest.com` the `beta` flag reads false (its `catalog/settings.json` 403s), so the RC currently serves the **old** dark-hero bucket header and legacy Overview. After this change those surfaces are what a catalog gets by default.

## Verified

- `npm run typecheck` clean
- 49/49 tests green across the affected specs (`Overview/index.spec.tsx` rewritten for the new flag, `features.spec.ts`, all four `Admin/Settings` specs)
- Confirmed the switch reaches Admin > Settings with no panel edit — `FeatureSettings` renders straight off `FEATURE_IDS`
- Confirmed no `settings?.beta` gates remain outside the admin toggle itself (one comment reference in `BucketPreferences/Provider.tsx` left as-is)

## Not in scope

The legacy `Overview.tsx`, its `Header.tsx`, and `Overview-bg.jpg` are retained and reachable via `legacy-ui` — deliberately not deleted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR makes the current bucket header, Overview, and Athena Tabulator tables the defaults while adding a `legacy-ui` feature that restores the previous bucket Overview and header treatment.
- Replaces the global `beta` checks in bucket surfaces with a dedicated legacy opt-out.
- Mainlines Athena Tabulator table selection without a feature gate.
- Adds coverage for both Overview-selection states.
- Adds the new feature to the registry consumed by Admin Settings.

<h3>Confidence Score: 4/5</h3>

The implementation appears safe to merge after correcting the non-blocking broken pull-request reference in the changelog.

The feature-selection and Athena changes retain guarded behavior, while the only accepted issue is the changelog entry’s unresolved `PRNUM` placeholder.

**Files Needing Attention:** catalog/CHANGELOG.md

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| catalog/app/utils/features.ts | Registers the `legacy-ui` opt-out using the existing generic feature persistence mechanism. |
| catalog/app/containers/Bucket/Bucket.tsx | Shows the shared bucket header by default and suppresses it when the legacy UI is selected. |
| catalog/app/containers/Bucket/Overview/index.tsx | Selects the current Overview by default and the legacy Overview under `legacy-ui`. |
| catalog/app/containers/Queries/Athena/Athena.tsx | Removes the beta gate from the locally guarded Tabulator table selector. |
| catalog/app/containers/Bucket/Overview/index.spec.tsx | Updates selector tests to cover default-current and legacy-opt-out behavior. |
| catalog/CHANGELOG.md | Documents the rollout but leaves the pull-request number placeholder unresolved. |


<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    Settings[Catalog feature settings] --> Legacy{legacy-ui enabled?}
    Legacy -->|No| Current[Shared bucket header and current Overview]
    Legacy -->|Yes| Previous[Legacy Overview with full-bleed header]
    Athena[Athena with selected workgroup] --> Tables[Tabulator tables available unconditionally]
```

<sub>Reviews (1): Last reviewed commit: ["catalog: mainline the beta surfaces behi..."](https://github.com/quiltdata/quilt/commit/420130ac56ffbcce830e8be47a6d3b79f2f3b770) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=57660634)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->