### PR TITLE
Block a revise that would replace a different package's contents

### DIFF
--- a/catalog/CHANGELOG.md
+++ b/catalog/CHANGELOG.md
@@ -21,6 +21,7 @@ complete sentence without it.
 
 ## Changes
 
+- [Fixed] Revise package: renaming the destination to a different existing package no longer replaces that package's contents with the loaded ones ([#PRNUM](https://github.com/quiltdata/quilt/pull/PRNUM))
 - [Changed] Search: error states are separate, more strictly typed components, safer to extend than one component behind a `kind` prop ([#5238](https://github.com/quiltdata/quilt/pull/5238))
 - [Fixed] Search: a malformed filter value in the URL no longer breaks the page ([#5233](https://github.com/quiltdata/quilt/pull/5233))
 - [Fixed] Search results table: a package with no commit message shows the no-value marker instead of the literal text `None` ([#5232](https://github.com/quiltdata/quilt/pull/5232))

--- a/catalog/app/containers/Bucket/PackageDialog/State/State.tsx
+++ b/catalog/app/containers/Bucket/PackageDialog/State/State.tsx
@@ -120,6 +120,7 @@ export function useState(
     meta,
     metadataSchema,
     name,
+    src,
     workflow,
   })
 

--- a/catalog/app/containers/Bucket/PackageDialog/State/params.spec.ts
+++ b/catalog/app/containers/Bucket/PackageDialog/State/params.spec.ts
@@ -305,6 +305,104 @@ describe('containers/Bucket/PackageDialog/State/params', () => {
     })
   })
 
+  describe('destination the loaded manifest does not describe', () => {
+    const src = { bucket: 'test-bucket', name: 'test-package' }
+    // What useNameExistence reports for a name that resolves to some other package.
+    const existsElsewhere = {
+      ...name,
+      status: { _tag: 'exists' as const, dst: { bucket: 'test-bucket', name: 'other' } },
+    }
+
+    it('is invalid when the destination is a different package that exists', () => {
+      const { result } = renderHook(() =>
+        useParamsWith({
+          dst: { bucket: 'test-bucket', name: 'other' },
+          name: existsElsewhere,
+          src,
+        }),
+      )
+
+      expect(result.current._tag).toBe('invalid')
+      if (result.current._tag === 'invalid') {
+        expect(result.current.error).toBeInstanceOf(ERRORS.DestinationManifestMismatch)
+      }
+    })
+
+    it('is invalid when only the bucket differs', () => {
+      const { result } = renderHook(() =>
+        useParamsWith({
+          dst: { bucket: 'other-bucket', name: 'test-package' },
+          name: {
+            ...name,
+            status: {
+              _tag: 'exists' as const,
+              dst: { bucket: 'other-bucket', name: 'test-package' },
+            },
+          },
+          src,
+        }),
+      )
+
+      expect(result.current._tag).toBe('invalid')
+      if (result.current._tag === 'invalid') {
+        expect(result.current.error).toBeInstanceOf(ERRORS.DestinationManifestMismatch)
+      }
+    })
+
+    it('permits the plain revise, where dst and src name the same package', () => {
+      const { result } = renderHook(() =>
+        useParamsWith({
+          dst: src,
+          name: { ...name, status: { _tag: 'new-revision' as const } },
+          src,
+        }),
+      )
+
+      expect(result.current._tag).toBe('ok')
+    })
+
+    it('permits a destination that does not exist yet', () => {
+      const { result } = renderHook(() =>
+        useParamsWith({
+          dst: { bucket: 'test-bucket', name: 'brand-new' },
+          name: { ...name, status: { _tag: 'new' as const } },
+          src,
+        }),
+      )
+
+      expect(result.current._tag).toBe('ok')
+    })
+
+    it('reports the unloaded manifest, not the mismatch, when both apply', () => {
+      // Ordering matters: the manifest never loaded, so nothing is known about `src` to
+      // describe a mismatch against.
+      const { result } = renderHook(() =>
+        useParamsWith({
+          dst: { bucket: 'test-bucket', name: 'other' },
+          manifest: { _tag: 'error' as const, error: new Error('failed to fetch') },
+          name: existsElsewhere,
+          src,
+        }),
+      )
+
+      expect(result.current._tag).toBe('invalid')
+      if (result.current._tag === 'invalid') {
+        expect(result.current.error).toBeInstanceOf(ERRORS.SourceManifestNotLoaded)
+      }
+    })
+
+    it('permits an existing destination when there is no source to mismatch', () => {
+      // Plain creation passes no `src`: the ready manifest is the empty one from
+      // useManifestRequest, so there are no loaded entries to publish over the
+      // destination. Guards against gating on 'exists' alone.
+      const { result } = renderHook(() =>
+        useParamsWith({ name: existsElsewhere, src: undefined }),
+      )
+
+      expect(result.current._tag).toBe('ok')
+    })
+  })
+
   describe('memoization', () => {
     it('should recompute when dependencies change', () => {
       const { result, rerender } = renderHook(

--- a/catalog/app/containers/Bucket/PackageDialog/State/params.ts
+++ b/catalog/app/containers/Bucket/PackageDialog/State/params.ts
@@ -7,7 +7,7 @@ import * as ERRORS from '../../errors'
 import { getMetaValue } from '../../requests'
 
 import { WorkflowState } from './workflow'
-import { ManifestStatus } from './manifest'
+import { ManifestStatus, PackageSrc } from './manifest'
 import { NameState } from './name'
 import { MessageState } from './message'
 import { MetaState } from './meta'
@@ -54,6 +54,7 @@ export interface FormInputs {
   meta: MetaState
   metadataSchema: SchemaStatus
   name: NameState
+  src?: PackageSrc
   workflow: WorkflowState
 }
 
@@ -64,6 +65,7 @@ export function useParams({
   meta,
   metadataSchema,
   name,
+  src,
   workflow,
 }: FormInputs): FormParams {
   return React.useMemo(() => {
@@ -74,6 +76,16 @@ export function useParams({
     // prefill, and reporting that instead would call an existing destination safe.
     if (manifest._tag !== 'ready' && name.status._tag !== 'new') {
       return Invalid(new ERRORS.SourceManifestNotLoaded())
+    }
+    // The loaded manifest describes `src`, so a `dst` naming a different package that
+    // already exists would get this one's entries as its complete replacement list.
+    // Compared against `src` rather than trusting 'exists' to imply the mismatch.
+    if (
+      src &&
+      name.status._tag === 'exists' &&
+      (dst.bucket !== src.bucket || dst.name !== src.name)
+    ) {
+      return Invalid(new ERRORS.DestinationManifestMismatch())
     }
     if (!workflow.value || workflow.status._tag === 'error') {
       return Invalid(new Error('Valid workflow required'))
@@ -99,5 +111,5 @@ export function useParams({
       userMeta: getMetaValue(meta.value, metadataSchema.schema) ?? null,
       workflow: workflowSelectionToWorkflow(workflow.value),
     })
-  }, [dst, workflow, name, message, metadataSchema, meta, manifest])
+  }, [dst, src, workflow, name, message, metadataSchema, meta, manifest])
 }

--- a/catalog/app/containers/Bucket/errors.tsx
+++ b/catalog/app/containers/Bucket/errors.tsx
@@ -83,6 +83,17 @@ export class SourceManifestNotLoaded extends BucketError {
   }
 }
 
+/** The loaded manifest describes a package other than the one being published to. */
+export class DestinationManifestMismatch extends BucketError {
+  static displayName = 'DestinationManifestMismatch'
+
+  constructor() {
+    super(
+      'The loaded contents belong to a different package, so pushing is disabled to keep the existing contents of this one from being replaced. Use "load and revise it" beside the name to load this package instead, or enter a name that does not exist yet to create a new package.',
+    )
+  }
+}
+
 interface WhenAuthCases {
   true: () => React.ReactElement
   false: () => React.ReactElement


### PR DESCRIPTION
Found reviewing the 26.8.0 candidate. Pre-existing, and adjacent to #5165's fix rather than caused by it.

`useParams` gates publishing with `manifest._tag !== 'ready' && name.status._tag !== 'new'`. But `manifest` is keyed on `src`, while `params.name` comes from `dst`. So: open the revise dialog on `alice/p` — its manifest loads `ready` — then edit the Name field to `bob/q`, a *different* existing package. `name.status` becomes `exists`, `manifest` is still `ready` for `alice/p`, and the gate passes.

Entries are sent as a complete replacement list, so this publishes `alice/p`'s entry list over `bob/q`'s latest revision. Same class of silent data loss #5165 closed, one condition short.

## The fix

`useParams` now takes `src` (threaded from `State.tsx`, which already owns it) and blocks when a loaded manifest does not describe the destination:

```ts
if (src && name.status._tag === 'exists' && (dst.bucket !== src.bucket || dst.name !== src.name))
  return Invalid(new ERRORS.DestinationManifestMismatch())
```

Design notes:
- **Placed after the manifest gate.** If the manifest never loaded there is nothing known about `src` to describe a mismatch against, and `SourceManifestNotLoaded` is the truthful report. A test pins the ordering.
- **Guarded on `src &&`** because plain package creation passes no `src`; gating on `name.status === 'exists'` alone would have broken creating into an existing name. A test pins this too.
- **Compared against `src` explicitly** rather than treating `exists` as implying a mismatch. Both are true today, but the comparison states the invariant honestly instead of relying on that coincidence.
- **Bucket compared as well as name** — a same-name/different-bucket destination is the same loss.

New `DestinationManifestMismatch` error beside `SourceManifestNotLoaded`, matching its shape. The message points at "load and revise it" — the exact link text `Inputs/Name.tsx` already renders for the `exists` state, which calls `setSrc` and is the real recovery path.

## Tests

Six new cases in `params.spec.ts`. Two are the blocking cases; four guard the permissive side (src===dst revise, dst 'new', manifest-not-ready still reported as `SourceManifestNotLoaded`, no-src plain creation) so a later widening of the gate fails.

- `TZ=UTC npx vitest run app/containers/Bucket/PackageDialog app/containers/Bucket/errors.tsx` — 125 passed (119 on master)
- `npx tsc --noEmit -p .` — clean
- `npx oxfmt --check` — clean

Regression-verified: restoring master's `params.ts` fails exactly the two new blocking cases and nothing else.

## Known caveat

The new error's message is currently unreachable UI. `Create.tsx:129` returns null when `manifest._tag !== 'error'`, and the manifest is `ready` in this scenario — so the push button is correctly disabled and `Inputs/Name.tsx` still offers the recovery link, but this specific copy never renders. Wiring `StatusMessage` to surface it is a separate conceptual unit; flagging rather than folding it in.

The Copy dialog cannot reach this gate at all (`disableRestore: true` maps `exists` to `new-revision`), so Copy behavior is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR threads the package source into publish-parameter validation and adds a destination-manifest mismatch error intended to prevent one package's loaded entries from replacing another package. It also adds regression tests and documents the fix.
- Compares the revise source and destination when the destination is known to exist.
- Adds permissive and blocking parameter-validation cases.
- Adds the new bucket error and changelog entry.

<h3>Confidence Score: 4/5</h3>

This PR should not merge until publishing remains disabled during destination-existence and source-manifest transitions, which currently leave the destructive replacement path reachable.

The new guard blocks the settled mismatch case but skips `loading` and `new-revision`; retained ready manifest data can therefore still be submitted to a different existing destination.

**Files Needing Attention:** catalog/app/containers/Bucket/PackageDialog/State/params.ts, catalog/app/containers/Bucket/PackageDialog/State/params.spec.ts

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| catalog/app/containers/Bucket/PackageDialog/State/params.ts | Adds the central mismatch guard, but its `exists`-only condition leaves destructive asynchronous transition paths reachable. |
| catalog/app/containers/Bucket/PackageDialog/State/State.tsx | Correctly threads `src` into parameter validation, although `src` and the asynchronously loaded manifest are not an atomic identity pair. |
| catalog/app/containers/Bucket/PackageDialog/State/params.spec.ts | Covers settled mismatch states and permissive cases but omits pending existence and stale-manifest source transitions. |
| catalog/app/containers/Bucket/errors.tsx | Adds a specific mismatch error with appropriate recovery guidance. |
| catalog/CHANGELOG.md | Documents the intended prevention of cross-package content replacement. |


<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
  A[Manifest for package A is ready] --> B[Destination changes to existing package B]
  B --> C{Asynchronous state}
  C -->|Existence query pending| D[name status: loading]
  C -->|Load and revise clicked| E[src becomes B; status: new-revision]
  D --> F[exists-only mismatch guard skipped]
  E --> G[Old A query data retained while B fetches]
  G --> F
  F --> H[useParams returns Ok]
  H --> I[A entries submitted to destination B]
```

<sub>Reviews (1): Last reviewed commit: ["catalog: block a push whose destination ..."](https://github.com/quiltdata/quilt/commit/ca1e41e0401ce1a35b45475f1670dabfdbdf0512) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=57692768)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->