### PR TITLE
Test the bucket header's beta gate

### DIFF
--- a/catalog/CHANGELOG.md
+++ b/catalog/CHANGELOG.md
@@ -21,6 +21,7 @@ complete sentence without it.
 
 ## Changes
 
+- [Added] Bucket: the header card's beta gate is covered by tests, so the bucket name cannot silently disappear from the tabs again ([#PRNUM](https://github.com/quiltdata/quilt/pull/PRNUM))
 - [Changed] Search: error states are separate, more strictly typed components, safer to extend than one component behind a `kind` prop ([#5238](https://github.com/quiltdata/quilt/pull/5238))
 - [Fixed] Search: a malformed filter value in the URL no longer breaks the page ([#5233](https://github.com/quiltdata/quilt/pull/5233))
 - [Fixed] Search results table: a package with no commit message shows the no-value marker instead of the literal text `None` ([#5232](https://github.com/quiltdata/quilt/pull/5232))

--- a/catalog/app/containers/Bucket/Bucket.spec.tsx
+++ b/catalog/app/containers/Bucket/Bucket.spec.tsx
@@ -1,0 +1,197 @@
+import * as React from 'react'
+import { MemoryRouter, Route } from 'react-router-dom'
+import { render, cleanup } from '@testing-library/react'
+import { describe, it, expect, vi, afterEach, type Mock } from 'vitest'
+
+import * as NamedRoutes from 'utils/NamedRoutes'
+import AsyncResult from 'utils/AsyncResult'
+import type * as CatalogSettings from 'utils/CatalogSettings'
+import * as BucketPreferences from 'utils/BucketPreferences'
+
+import Bucket from './Bucket'
+
+vi.mock('constants/config', () => ({ default: {} }))
+
+// The real shell pulls the sidebar, search bar and theme roots; only its `pre`
+// slot and children carry the header card under test.
+vi.mock('components/Layout', () => ({
+  default: ({ pre }: { pre?: React.ReactNode }) => <>{pre}</>,
+  Container: ({ children }: { children?: React.ReactNode }) => <>{children}</>,
+}))
+
+vi.mock('containers/Bucket/Nav', () => ({
+  Tabs: () => <div data-testid="tabs" />,
+}))
+
+vi.mock('containers/NotFound', () => ({
+  NotFoundInTabs: () => <div data-testid="not-found" />,
+}))
+
+vi.mock('utils/MetaTitle', () => ({
+  default: () => null,
+}))
+
+vi.mock('./AssistantContext', () => ({
+  BucketContext: () => null,
+}))
+
+vi.mock('utils/BucketCache', () => ({
+  useBucketExistence: () => ({
+    case: ({ Ok }: { Ok: () => React.ReactNode }) => Ok(),
+  }),
+}))
+
+const settingsHook: Mock<() => CatalogSettings.CatalogSettings | null> = vi.fn(() => null)
+
+vi.mock('utils/CatalogSettings', () => ({
+  use: () => settingsHook(),
+}))
+
+vi.mock('utils/BucketPreferences', async () => ({
+  ...(await vi.importActual<typeof BucketPreferences>('utils/BucketPreferences')),
+  Provider: ({ children }: { children?: React.ReactNode }) => <>{children}</>,
+  use: () => ({
+    prefs: BucketPreferences.Result.Ok({
+      ui: { nav: { queries: false } },
+    } as unknown as BucketPreferences.BucketPreferences),
+  }),
+}))
+
+// Header's stats plumbing, mocked to resolve immediately so the stats row is
+// either fully present or absent — never mid-flight.
+vi.mock('components/Skeleton', () => ({
+  default: () => <div data-testid="skeleton" />,
+}))
+
+vi.mock('./PackageDialog', () => ({
+  useCreateDialog: () => ({ open: vi.fn(), render: () => null }),
+}))
+
+vi.mock('react-redux', () => ({
+  useSelector: () => false,
+}))
+
+vi.mock('utils/AWS', () => ({
+  S3: { use: () => ({}) },
+}))
+
+vi.mock('utils/APIConnector', () => ({
+  use: () => vi.fn(),
+}))
+
+vi.mock('utils/Data', () => ({
+  useData: () => ({
+    result: AsyncResult.Ok({ totalBytes: 1024, totalObjects: 42, exts: [] }),
+  }),
+}))
+
+type FoldResult = { fetching?: boolean; error?: unknown; data?: unknown }
+type FoldHandlers = {
+  data: (d: unknown, r: FoldResult) => unknown
+  fetching: (r: FoldResult) => unknown
+  error?: (e: unknown, r: FoldResult) => unknown
+}
+vi.mock('utils/GraphQL', () => ({
+  useQuery: () => ({
+    data: { searchPackages: { __typename: 'PackagesSearchResultSet', total: 7 } },
+  }),
+  fold: (result: FoldResult, handlers: FoldHandlers) => {
+    if (result?.fetching) return handlers.fetching(result)
+    if (result?.error) return handlers.error?.(result.error, result)
+    return handlers.data(result?.data, result)
+  },
+}))
+
+vi.mock('./Tabulator/requests', () => ({
+  useTabulatorTables: () => ({ _tag: 'ready', tables: [] }),
+}))
+
+// Every tab path is unreachable from the rendered location, so the Switch lands
+// on the catch-all and no `RT.mkLazy` route is imported.
+const mkRoute = (name: string) => ({
+  path: `/never/${name}`,
+  url: (bucket: string) => `/${name}/${bucket}`,
+})
+
+const routes = {
+  bucketFile: mkRoute('file'),
+  bucketDir: { path: '/never/dir', url: (bucket: string) => `/dir/${bucket}` },
+  bucketOverview: mkRoute('overview'),
+  bucketPackageList: {
+    path: '/never/packages',
+    url: (bucket: string) => `/packages/${bucket}`,
+  },
+  bucketPackageAddFiles: mkRoute('add-files'),
+  bucketPackageDetail: mkRoute('detail'),
+  bucketPackageTree: mkRoute('tree'),
+  bucketPackageRevisions: mkRoute('revisions'),
+  bucketPackageCompare: mkRoute('compare'),
+  bucketWorkflowList: mkRoute('workflows'),
+  bucketWorkflowDetail: mkRoute('workflow'),
+  adminBucketEdit: mkRoute('admin'),
+  queriesAthena: {
+    path: '/never/athena',
+    url: ({ bucket }: { bucket?: string } = {}) => `/queries/athena?bucket=${bucket}`,
+  },
+}
+
+function renderBucket() {
+  return render(
+    <MemoryRouter initialEntries={['/b/test-bucket']}>
+      <NamedRoutes.Provider routes={routes}>
+        <Route path="/b/:bucket">
+          <Bucket />
+        </Route>
+      </NamedRoutes.Provider>
+    </MemoryRouter>,
+  )
+}
+
+describe('containers/Bucket: header card gate', () => {
+  afterEach(() => {
+    cleanup()
+    settingsHook.mockReturnValue(null)
+  })
+
+  it('names the bucket when the beta flag is on', () => {
+    settingsHook.mockReturnValue({ beta: true })
+    const { queryByText } = renderBucket()
+    expect(queryByText('test-bucket')).toBeTruthy()
+  })
+
+  it('shows the stats row when the beta flag is on', () => {
+    settingsHook.mockReturnValue({ beta: true })
+    const { queryByText } = renderBucket()
+    expect(queryByText(/objects/)).toBeTruthy()
+    expect(queryByText('Create package')).toBeTruthy()
+  })
+
+  it('hides the stats row when the beta flag is off', () => {
+    settingsHook.mockReturnValue({ beta: false })
+    const { queryByText } = renderBucket()
+    expect(queryByText(/objects/)).toBeNull()
+    expect(queryByText('Create package')).toBeNull()
+  })
+
+  it('hides the stats row when there are no catalog settings', () => {
+    settingsHook.mockReturnValue(null)
+    const { queryByText } = renderBucket()
+    expect(queryByText(/objects/)).toBeNull()
+    expect(queryByText('Create package')).toBeNull()
+  })
+
+  // The bucket name is not a beta feature: the tabs below it are the only other
+  // place a tab could name its bucket, and they don't. Asserted as the desired
+  // behavior via `it.fails` so each flips red once the gate covers stats only.
+  it.fails('names the bucket when the beta flag is off', () => {
+    settingsHook.mockReturnValue({ beta: false })
+    const { queryByText } = renderBucket()
+    expect(queryByText('test-bucket')).toBeTruthy()
+  })
+
+  it.fails('names the bucket when there are no catalog settings', () => {
+    settingsHook.mockReturnValue(null)
+    const { queryByText } = renderBucket()
+    expect(queryByText('test-bucket')).toBeTruthy()
+  })
+})


### PR DESCRIPTION
The catalog shell moved the bucket name into a header card gated behind `settings?.beta`, so on a default stack the Packages and Workflows tabs name the bucket nowhere. #5235 fixes that — but every test in it exercises `Header` directly. **None exercises `BucketLayout`'s gate, which is the line that actually regressed.**

This adds that test. There is no `Bucket.spec.tsx`; the template followed is `Overview/index.spec.tsx`, which mocks `utils/CatalogSettings` with a mutable settings object and asserts the beta/non-beta/null branches.

## Written against master's shape, not #5235's

#5235 is still open, so this branches off master and targets the gate master actually has (the whole header card behind `beta`). Consequence: **"beta off → bucket name present" is false today — that is the bug** — so those two assertions are written as `it.fails`, following the `Routes.spec.ts` precedent already in this repo.

When #5235 lands, those two flip to plain `it`. The spec says so in a comment, and the transition was verified in both directions:

- master shape: 6 passed
- with #5235's fix applied locally: 4 passed / 2 failed — i.e. the `it.fails` cases now fail *because they pass*

The four stats-gate assertions (beta on → stats present; beta off and null → stats absent) stay green under both shapes, so they pin the surviving half of the gate under either spelling.

If you'd rather this land only after #5235, it rebases to a two-line change.

## Harness notes

`BucketLayout` is not exported, so the spec renders the default `Bucket` export inside `MemoryRouter` + a `Route path="/b/:bucket"` (what feeds `useBucketStrict`). Two things keep it fast: `components/Layout` is mocked down to its `pre` slot, and every route path in the `NamedRoutes` stub is set to an unreachable `/never/*` so the `Switch` lands on the catch-all and no `RT.mkLazy` chunk is ever imported. `useBucketExistence` is mocked to its tagged-union shape.

- `TZ=UTC npx vitest run app/containers/Bucket` — 350 passed / 49 files (was 344 / 48)
- `Bucket.spec.tsx` alone: 39ms, well inside the 5s budget
- `npx tsc --noEmit -p .` and `npx oxfmt --check` — clean

Also verified the `it.fails` cases fail on the assertion rather than a broken harness: flipping one to plain `it` gives `AssertionError: expected null to be truthy`, so the harness mounts and `queryByText` genuinely returns null.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds coverage for the bucket header’s beta and missing-settings branches, including expected-failure assertions that document the existing bucket-name regression.

- Adds a routed `Bucket` test harness with focused mocks for layout, settings, preferences, stats, and lazy routes.
- Covers bucket-name and stats visibility with beta enabled, disabled, and settings absent.
- Adds a Catalog changelog entry for the new coverage.

<h3>Confidence Score: 4/5</h3>

The PR appears safe to merge after replacing the malformed changelog pull-request placeholder.

The test harness matches the currently exercised Bucket and Header contracts, while the only accepted issue is a broken changelog label and link.

**Files Needing Attention:** catalog/CHANGELOG.md

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| catalog/app/containers/Bucket/Bucket.spec.tsx | Adds focused coverage of the Bucket-level beta gate; the expected-failure cases intentionally record the known non-beta bucket-name defect. |
| catalog/CHANGELOG.md | Documents the added coverage, but leaves the pull-request number and URL as unresolved placeholders. |

<sub>Reviews (1): Last reviewed commit: ["Test the bucket header card&#39;s beta gate ..."](https://github.com/quiltdata/quilt/commit/33aa4828c381706ce50501b88f7c86daa2dfab97) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=57692905)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->