### PR TITLE
Fix: surface swallowed hash-computation errors in calculate_pkg_hashes

### DIFF
--- a/lambdas/pkgpush/CHANGELOG.md
+++ b/lambdas/pkgpush/CHANGELOG.md
@@ -17,7 +17,7 @@ where verb is one of
 
 ## Changes
 
-- [Fixed] Surface exceptions raised while hashing package entries (e.g. an AccessDenied writing to a cross-region scratch bucket) instead of silently swallowing them and falling back to download-and-hash ([#PR](https://github.com/quiltdata/quilt/pull/PR))
+- [Fixed] Surface exceptions raised while hashing package entries (e.g. an AccessDenied writing to a cross-region scratch bucket) instead of silently swallowing them and falling back to download-and-hash ([#5249](https://github.com/quiltdata/quilt/pull/5249))
 - [Fixed] Read the published revision off the package `_push()` returns instead of its private `_origin` bookkeeping, which quilt3 8 removes ([#5180](https://github.com/quiltdata/quilt/pull/5180))
 - [Changed] Switch to uv ([#4649](https://github.com/quiltdata/quilt/pull/4649))
 - [Changed] Upgrade to Python 3.13 ([#4649](https://github.com/quiltdata/quilt/pull/4649))

--- a/lambdas/pkgpush/CHANGELOG.md
+++ b/lambdas/pkgpush/CHANGELOG.md
@@ -17,6 +17,7 @@ where verb is one of
 
 ## Changes
 
+- [Fixed] Surface exceptions raised while hashing package entries (e.g. an AccessDenied writing to a cross-region scratch bucket) instead of silently swallowing them and falling back to download-and-hash ([#PR](https://github.com/quiltdata/quilt/pull/PR))
 - [Fixed] Read the published revision off the package `_push()` returns instead of its private `_origin` bookkeeping, which quilt3 8 removes ([#5180](https://github.com/quiltdata/quilt/pull/5180))
 - [Changed] Switch to uv ([#4649](https://github.com/quiltdata/quilt/pull/4649))
 - [Changed] Upgrade to Python 3.13 ([#4649](https://github.com/quiltdata/quilt/pull/4649))

--- a/lambdas/pkgpush/src/t4_lambda_pkgpush/__init__.py
+++ b/lambdas/pkgpush/src/t4_lambda_pkgpush/__init__.py
@@ -460,8 +460,13 @@ def calculate_pkg_hashes(
                 else local_pool.submit(compute_via_copy, entry)
             )
 
-        # Wait for all computations to complete
-        concurrent.futures.wait(comp_futures)
+        # Wait for all computations to complete, surfacing any exception.
+        # wait() alone silently retains exceptions on the futures, leaving entry.hash
+        # unset (e.g. an AccessDenied writing to a cross-region scratch bucket) and
+        # falling back to an expensive download-and-hash with no signal. result()
+        # re-raises so the failure is loud.
+        for f in concurrent.futures.as_completed(comp_futures):
+            f.result()  # Raises exception if any occurred
 
     # Summary
     precomputed = len(entries_to_hash) - len(comp_futures)

--- a/lambdas/pkgpush/tests/test_hash_calc.py
+++ b/lambdas/pkgpush/tests/test_hash_calc.py
@@ -101,8 +101,14 @@ def test_calculate_pkg_hashes(
     assert entry_without_hash_large.hash is not None
 
 
+class _ScratchAccessDenied(Exception):
+    """Distinct exception type so the regression test binds to the intended failure path,
+    not any incidental Exception with a matching message."""
+
+
 def test_calculate_pkg_hashes_propagates_compute_error(
     pkg: Package,
+    entry_without_hash: PackageEntry,
     mocker: MockerFixture,
 ):
     """A failure inside a per-entry hash computation must propagate, not be swallowed.
@@ -119,15 +125,22 @@ def test_calculate_pkg_hashes_propagates_compute_error(
     mocker.patch.object(t4_lambda_pkgpush, "try_get_compliant_sha256_chunked", return_value=None)
 
     # The small-file copy path raises (mirrors an S3 AccessDenied on the scratch bucket).
-    boom = Exception("AccessDenied")
+    boom = _ScratchAccessDenied("AccessDenied")
     mocker.patch.object(t4_lambda_pkgpush, "compute_checksum_via_copy", side_effect=boom)
     # Keep the large-file path succeeding so only the copy path is the failure.
     invoke_hash_lambda_mock = mocker.patch.object(t4_lambda_pkgpush, "invoke_hash_lambda")
     invoke_hash_lambda_mock.return_value = Checksum.sha256_chunked(b"large_hash")
 
     with t4_lambda_pkgpush.setup_user_boto_session(session_mock):
-        with pytest.raises(Exception, match="AccessDenied"):
+        with pytest.raises(_ScratchAccessDenied):
             t4_lambda_pkgpush.calculate_pkg_hashes(pkg, SCRATCH_BUCKETS, checksum_algorithms)
+
+    # The core regression symptom: the failed entry's hash must NOT have been quietly
+    # left set/unset-and-ignored. The small (copy-path) entry never got a hash, and the
+    # bug's damage was that this silently triggered a download-and-hash fallback. Asserting
+    # the hash stayed None guards that the failure surfaces instead of masquerading as
+    # "just recompute later".
+    assert entry_without_hash.hash is None
 
 
 def test_calculate_pkg_hashes_too_large_file_error(pkg: Package, mocker: MockerFixture):

--- a/lambdas/pkgpush/tests/test_hash_calc.py
+++ b/lambdas/pkgpush/tests/test_hash_calc.py
@@ -101,6 +101,35 @@ def test_calculate_pkg_hashes(
     assert entry_without_hash_large.hash is not None
 
 
+def test_calculate_pkg_hashes_propagates_compute_error(
+    pkg: Package,
+    mocker: MockerFixture,
+):
+    """A failure inside a per-entry hash computation must propagate, not be swallowed.
+
+    Regression: calculate_pkg_hashes used concurrent.futures.wait() without reading
+    the futures' results, so an exception (e.g. an AccessDenied writing to a scratch
+    bucket) was silently discarded, entry.hash stayed None, and package creation fell
+    back to an expensive download-and-hash with no signal.
+    """
+    checksum_algorithms = [ChecksumAlgorithm.SHA256_CHUNKED]
+
+    session_mock = boto3.Session(**CREDENTIALS.boto_args)
+
+    mocker.patch.object(t4_lambda_pkgpush, "try_get_compliant_sha256_chunked", return_value=None)
+
+    # The small-file copy path raises (mirrors an S3 AccessDenied on the scratch bucket).
+    boom = Exception("AccessDenied")
+    mocker.patch.object(t4_lambda_pkgpush, "compute_checksum_via_copy", side_effect=boom)
+    # Keep the large-file path succeeding so only the copy path is the failure.
+    invoke_hash_lambda_mock = mocker.patch.object(t4_lambda_pkgpush, "invoke_hash_lambda")
+    invoke_hash_lambda_mock.return_value = Checksum.sha256_chunked(b"large_hash")
+
+    with t4_lambda_pkgpush.setup_user_boto_session(session_mock):
+        with pytest.raises(Exception, match="AccessDenied"):
+            t4_lambda_pkgpush.calculate_pkg_hashes(pkg, SCRATCH_BUCKETS, checksum_algorithms)
+
+
 def test_calculate_pkg_hashes_too_large_file_error(pkg: Package, mocker: MockerFixture):
     """Test that files exceeding max size raise error"""
     checksum_algorithms = [ChecksumAlgorithm.SHA256_CHUNKED]


### PR DESCRIPTION
## Problem

`calculate_pkg_hashes` submits per-entry hash computations to a thread pool, then calls `concurrent.futures.wait(comp_futures)`. `wait()` blocks until every future is done but **never reads their results**, so any exception raised inside a computation is silently retained on the future and discarded. The observable damage:

- An `AccessDenied` writing to a **cross-region scratch bucket** (or any per-entry failure) is swallowed.
- `entry.hash` is left unset, and package creation falls back to an expensive download-and-hash — with **no signal** that anything went wrong.

This is item 4.5 of the alias-roles 26.8.0 remediation (the swallowed-error half of the cross-region scratch finding). It is filed and reviewed as a **standalone PR**, separate from the cross-region scratch **grant** fix (item 4), which is an IAM/template change in the deployment repo.

## Fix

Replace `wait()` with an `as_completed()` + `f.result()` loop, re-raising the first exception so the failure is loud. This mirrors the pattern already used for `precomp_futures` a few lines above.

## Test

Added `test_calculate_pkg_hashes_propagates_compute_error`: mocks `compute_checksum_via_copy` to raise a dedicated `_ScratchAccessDenied`, asserts the exception propagates, and asserts the failed entry's `hash` stays `None` (the actual regression symptom). Verified it **fails** (`DID NOT RAISE`) against the pre-fix `wait()` code before the fix was applied.

A `/code-review` pass ran on the branch's final head; the two test-quality findings it raised (bare-`Exception` assertion; missing symptom assertion) are folded into the test above.

## Test environment note

The pkgpush lambda suite runs standalone (no Postgres/Docker needed). Run locally with `uv run pytest` under `lambdas/pkgpush/` — **58 passed** including the new regression test. This differs from the registry suite, which needs Postgres + Docker.

## Follow-up

- The CHANGELOG entry currently carries a `#PR` placeholder link; it will be backfilled with this PR's number.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR makes package hash computation fail loudly when a worker future raises, rather than silently proceeding with an unset entry hash.
- Replaces passive waiting with `as_completed()` and `result()` so worker exceptions propagate.
- Adds a regression test covering the scratch-copy failure path and its unset-hash symptom.
- Documents the behavior change in the pkgpush changelog.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge because it surfaces worker failures as intended without introducing a concrete correctness, security, or lifecycle defect.

The executor context still waits for all submitted work during unwinding, while calling each completed future's result closes the existing exception-swallowing path and the regression test covers the intended failure behavior.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| lambdas/pkgpush/src/t4_lambda_pkgpush/__init__.py | Replaces exception-swallowing future waiting with explicit result retrieval while preserving executor shutdown behavior. |
| lambdas/pkgpush/tests/test_hash_calc.py | Adds focused regression coverage proving copy-path exceptions propagate and do not set the failed entry's hash. |
| lambdas/pkgpush/CHANGELOG.md | Records the corrected package-hashing error behavior, with the acknowledged PR-link placeholder pending replacement. |


<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant Push as Package push
    participant Pool as Hash worker pool
    participant Worker as Entry hash computation
    Push->>Pool: Submit entry computations
    Pool->>Worker: Compute checksum
    alt computation succeeds
        Worker-->>Pool: Checksum
        Pool-->>Push: Future completes
        Push->>Push: result() returns
    else computation fails
        Worker-->>Pool: Exception
        Pool-->>Push: Future completes
        Push->>Push: result() re-raises exception
    end
```

<sub>Reviews (1): Last reviewed commit: ["Tighten swallowed-hash-error regression ..."](https://github.com/quiltdata/quilt/commit/fc1632d0f3f5f7e747aade475a542bae164e5ffb) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=57790137)</sub>

**Context used:**

- Knowledge Base — [Operational event services](https://app.greptile.com/quilt-bio/-/custom-context/knowledge-base/quiltdata/quilt/-/docs/operational-event-services.md)

<!-- /greptile_comment -->