### PR TITLE
Docs: distinguish catalog and registry URLs for API keys

### DIFF
--- a/docs/Quickstart.md
+++ b/docs/Quickstart.md
@@ -42,10 +42,10 @@ quilt3.login()  # Opens browser for OAuth/SSO
 # OR use an API key (for automation, CI/CD, scripts)
 import os
 
-# QUILT_CATALOG_URL is your catalog homepage, for example https://example.quiltdata.com
+# QUILT_REGISTRY_URL is the `registryUrl` from your catalog's /config.json
 quilt3.login_with_api_key(
     os.environ["QUILT_API_KEY"],
-    registry_url=os.environ["QUILT_CATALOG_URL"],
+    registry_url=os.environ["QUILT_REGISTRY_URL"],
 )
 ```
 

--- a/docs/api-reference/authentication.md
+++ b/docs/api-reference/authentication.md
@@ -112,9 +112,12 @@ Create a `.env` file in your project directory:
 
 ```bash
 # .env
-QUILT_CATALOG_URL=https://example.quiltdata.com
+QUILT_REGISTRY_URL=https://example-registry.quiltdata.com
 QUILT_API_KEY=qk_your_secret_here
 ```
+
+Use the `registryUrl` value from your catalog's `/config.json`, not the catalog
+homepage URL. These URLs can differ.
 
 Load it in your Python code:
 
@@ -140,8 +143,8 @@ import quilt3
 
 # Load from environment
 api_key = os.environ["QUILT_API_KEY"]
-catalog_url = os.environ["QUILT_CATALOG_URL"]
-quilt3.login_with_api_key(api_key, registry_url=catalog_url)
+registry_url = os.environ["QUILT_REGISTRY_URL"]
+quilt3.login_with_api_key(api_key, registry_url=registry_url)
 
 # Now use Quilt normally
 pkg = quilt3.Package.browse("mypackage", "s3://mybucket")
@@ -412,9 +415,9 @@ import os
 import quilt3
 
 api_key = os.environ["QUILT_API_KEY"]
-catalog_url = os.environ["QUILT_CATALOG_URL"]
+registry_url = os.environ["QUILT_REGISTRY_URL"]
 quilt3.logout()  # Clear all credentials
-quilt3.login_with_api_key(api_key, registry_url=catalog_url)  # Try again
+quilt3.login_with_api_key(api_key, registry_url=registry_url)  # Try again
 ```
 
 ### API Key Prefix Error
@@ -532,7 +535,7 @@ if not api_key:
 
 quilt3.login_with_api_key(
     api_key,
-    registry_url=os.environ["QUILT_CATALOG_URL"],
+    registry_url=os.environ["QUILT_REGISTRY_URL"],
 )
 
 pkg = quilt3.Package.browse("data/latest", "s3://mybucket")


### PR DESCRIPTION
## Summary

- Use `QUILT_REGISTRY_URL` when passing `registry_url=` to `login_with_api_key()`.
- Explain that the value is `registryUrl` from the catalog `/config.json`, not the catalog homepage.
- Update the Quickstart, authentication walkthrough, troubleshooting example, and migration example consistently.

The previous examples stored the API key under the catalog homepage. On deployments with distinct catalog and registry URLs, `get_session()` then looked under the configured registry URL and missed the key.

Follow-up to #5248 and the review finding on #5250.

## Validation

- `uv run poe testdocs` — 42 passed, 66 skipped
- `npx --yes markdownlint-cli docs/Quickstart.md docs/api-reference/authentication.md`
- `git diff --check`

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR corrects API-key authentication documentation so `login_with_api_key()` receives the registry URL rather than the catalog homepage.
- Renames the documented environment variable from `QUILT_CATALOG_URL` to `QUILT_REGISTRY_URL`.
- Explains that the value comes from `registryUrl` in the catalog’s `/config.json`.
- Applies the correction consistently across quickstart, authentication, troubleshooting, and migration examples.

<h3>Confidence Score: 5/5</h3>

The documentation-only change appears safe to merge.

The updated examples consistently pass the registry URL expected by API-key session lookup, and no concrete regression remains.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| docs/Quickstart.md | Correctly updates the API-key quickstart to pass the deployment’s registry URL. |
| docs/api-reference/authentication.md | Consistently distinguishes catalog and registry URLs throughout the authentication examples. |

<sub>Reviews (1): Last reviewed commit: ["Fix API key registry URL examples"](https://github.com/quiltdata/quilt/commit/9ce70cf4327cb96718fa3faf08f9735298c7e5d8) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=57996788)</sub>

<!-- /greptile_comment -->