### PR TITLE
Catalog: decode a Quilt+ URI path exactly once

### DIFF
--- a/catalog/CHANGELOG.md
+++ b/catalog/CHANGELOG.md
@@ -21,7 +21,7 @@ complete sentence without it.
 
 ## Changes
 
-- [Fixed] Quilt+ URIs: a package path containing a literal `%` no longer breaks the URI, and one containing a literal `%20` no longer decodes to a space and points at the wrong entry ([#5256](https://github.com/quiltdata/quilt/pull/5256))
+- [Fixed] Quilt+ URIs: a package path containing a literal `%` no longer breaks the URI, and one containing a literal `%20` no longer decodes to a space and points at the wrong entry. Paths from producers that do not percent-encode now resolve instead of failing, and a path that genuinely cannot be decoded reports a real error rather than the literal text `unknown error: ${e}` ([#5256](https://github.com/quiltdata/quilt/pull/5256))
 - [Changed] Search: error states are separate, more strictly typed components, safer to extend than one component behind a `kind` prop ([#5238](https://github.com/quiltdata/quilt/pull/5238))
 - [Fixed] Search: a malformed filter value in the URL no longer breaks the page ([#5233](https://github.com/quiltdata/quilt/pull/5233))
 - [Fixed] Search results table: a package with no commit message shows the no-value marker instead of the literal text `None` ([#5232](https://github.com/quiltdata/quilt/pull/5232))

--- a/catalog/CHANGELOG.md
+++ b/catalog/CHANGELOG.md
@@ -21,6 +21,7 @@ complete sentence without it.
 
 ## Changes
 
+- [Fixed] Quilt+ URIs: a package path containing a literal `%` no longer breaks the URI, and one containing a literal `%20` no longer decodes to a space and points at the wrong entry ([#5256](https://github.com/quiltdata/quilt/pull/5256))
 - [Changed] Search: error states are separate, more strictly typed components, safer to extend than one component behind a `kind` prop ([#5238](https://github.com/quiltdata/quilt/pull/5238))
 - [Fixed] Search: a malformed filter value in the URL no longer breaks the page ([#5233](https://github.com/quiltdata/quilt/pull/5233))
 - [Fixed] Search results table: a package with no commit message shows the no-value marker instead of the literal text `None` ([#5232](https://github.com/quiltdata/quilt/pull/5232))

--- a/catalog/app/containers/UriResolver/parsePackageUriSafe.spec.ts
+++ b/catalog/app/containers/UriResolver/parsePackageUriSafe.spec.ts
@@ -1,0 +1,36 @@
+import { describe, it, expect, vi } from 'vitest'
+
+import * as PackageUri from 'utils/PackageUri'
+
+import parsePackageUriSafe from './parsePackageUriSafe'
+
+vi.mock('utils/PackageUri', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('utils/PackageUri')>()
+  return { ...actual, parse: vi.fn(actual.parse) }
+})
+
+describe('containers/UriResolver/parsePackageUriSafe', () => {
+  it('should return the parsed URI when it is valid', () => {
+    expect(parsePackageUriSafe('quilt+s3://bucket-name#package=quilt/test')).toEqual({
+      bucket: 'bucket-name',
+      name: 'quilt/test',
+    })
+  })
+
+  it('should return, not throw, a PackageUriError when the URI is invalid', () => {
+    const result = parsePackageUriSafe('quilt+http://bucket-name#package=quilt/test')
+    expect(result).toBeInstanceOf(PackageUri.PackageUriError)
+    expect((result as PackageUri.PackageUriError).msg).toMatch(/unsupported protocol/)
+  })
+
+  it('should interpolate the underlying error for a non-PackageUriError throw', () => {
+    vi.mocked(PackageUri.parse).mockImplementationOnce(() => {
+      throw new Error('boom')
+    })
+    const result = parsePackageUriSafe('quilt+s3://bucket-name#package=quilt/test')
+    expect(result).toBeInstanceOf(PackageUri.PackageUriError)
+    const { msg } = result as PackageUri.PackageUriError
+    expect(msg).not.toContain('${e}')
+    expect(msg).toContain('boom')
+  })
+})

--- a/catalog/app/containers/UriResolver/parsePackageUriSafe.ts
+++ b/catalog/app/containers/UriResolver/parsePackageUriSafe.ts
@@ -5,6 +5,6 @@ export default function parsePackageUriSafe(decoded: string) {
     return PackageUri.parse(decoded)
   } catch (e) {
     if (e instanceof PackageUri.PackageUriError) return e
-    return new PackageUri.PackageUriError('unknown error: ${e}', decoded)
+    return new PackageUri.PackageUriError(`unknown error: ${e}`, decoded)
   }
 }

--- a/catalog/app/utils/PackageUri.spec.ts
+++ b/catalog/app/utils/PackageUri.spec.ts
@@ -34,24 +34,32 @@ describe('utils/PackageUri', () => {
       })
     })
 
-    it('should decode a path containing a literal "%" exactly once', () => {
-      expect(
-        PackageUri.parse('quilt+s3://bucket-name#package=quilt/test&path=50%25_sample'),
-      ).toEqual({
-        bucket: 'bucket-name',
-        name: 'quilt/test',
-        path: '50%_sample',
+    // These mirror `urllib.parse.unquote`, so that quilt3's parser can agree with
+    // this one on paths the producers actually emit.
+    const lenientCases = [
+      ['an unencoded "%"', '50%_sample.csv', '50%_sample.csv'],
+      ['an encoded "%"', '50%25_sample.csv', '50%_sample.csv'],
+      ['a truncated escape', 'abc%', 'abc%'],
+      ['a non-hex escape', 'a%2zb', 'a%2zb'],
+      ['an encoded space', 'a%20b', 'a b'],
+      ['an encoded "%20"', 'a%2520b', 'a%20b'],
+    ]
+    lenientCases.forEach(([label, raw, expected]) => {
+      it(`should decode a path with ${label} the way unquote does`, () => {
+        expect(
+          PackageUri.parse(`quilt+s3://bucket-name#package=quilt/test&path=${raw}`),
+        ).toEqual({
+          bucket: 'bucket-name',
+          name: 'quilt/test',
+          path: expected,
+        })
       })
     })
 
-    it('should decode a path containing a literal "%20" exactly once', () => {
-      expect(
-        PackageUri.parse('quilt+s3://bucket-name#package=quilt/test&path=a%2520b'),
-      ).toEqual({
-        bucket: 'bucket-name',
-        name: 'quilt/test',
-        path: 'a%20b',
-      })
+    it('should raise PackageUriError, not URIError, on undecodable input', () => {
+      expect(() =>
+        PackageUri.parse('quilt+s3://bucket-name#package=quilt/test&path=%FF'),
+      ).toThrowError(PackageUri.PackageUriError)
     })
 
     it('should throw on invalid protocol', () => {

--- a/catalog/app/utils/PackageUri.spec.ts
+++ b/catalog/app/utils/PackageUri.spec.ts
@@ -34,6 +34,26 @@ describe('utils/PackageUri', () => {
       })
     })
 
+    it('should decode a path containing a literal "%" exactly once', () => {
+      expect(
+        PackageUri.parse('quilt+s3://bucket-name#package=quilt/test&path=50%25_sample'),
+      ).toEqual({
+        bucket: 'bucket-name',
+        name: 'quilt/test',
+        path: '50%_sample',
+      })
+    })
+
+    it('should decode a path containing a literal "%20" exactly once', () => {
+      expect(
+        PackageUri.parse('quilt+s3://bucket-name#package=quilt/test&path=a%2520b'),
+      ).toEqual({
+        bucket: 'bucket-name',
+        name: 'quilt/test',
+        path: 'a%20b',
+      })
+    })
+
     it('should throw on invalid protocol', () => {
       expect(() =>
         PackageUri.parse('quilt+http://bucket-name#package=quilt/test'),
@@ -192,6 +212,25 @@ describe('utils/PackageUri', () => {
       ).toBe(
         'quilt+s3://bucket-name#package=quilt/test@abc1&path=sub%2Fpath&catalog=quilt-test',
       )
+    })
+  })
+
+  describe('parse(stringify(x))', () => {
+    const paths = [
+      'sub/path',
+      'sub/dir/',
+      '50%_sample.csv',
+      'a%20b',
+      'a b',
+      'a+b',
+      'a&b=c',
+      'ünïcödé.csv',
+    ]
+    paths.forEach((path) => {
+      it(`should round-trip the path ${JSON.stringify(path)}`, () => {
+        const uri = { bucket: 'bucket-name', name: 'quilt/test', path }
+        expect(PackageUri.parse(PackageUri.stringify(uri))).toEqual(uri)
+      })
     })
   })
 })

--- a/catalog/app/utils/PackageUri.ts
+++ b/catalog/app/utils/PackageUri.ts
@@ -61,6 +61,24 @@ function parsePackageSpec(spec: string, uri: string) {
   return { name: spec }
 }
 
+// `querystring.parse` percent-decodes via `decodeURIComponent`, which throws on a
+// "%" not followed by two hex digits. Producers emit unencoded paths (quilt_uri.py
+// builds `&path=${logicalKey}` verbatim), so a key like "50%_sample.csv" would
+// otherwise blow up the whole parse. Re-escaping the stray "%" lets it survive
+// decoding as a literal, matching `urllib.parse.unquote`, which leaves malformed
+// escapes alone.
+const escapeStrayPercents = (qs: string) => qs.replace(/%(?![0-9A-Fa-f]{2})/g, '%25')
+
+function parseFragment(hash: string, uri: string) {
+  try {
+    return parseQs(escapeStrayPercents(hash))
+  } catch {
+    // `decodeURIComponent` still rejects well-formed escapes that aren't valid
+    // UTF-8 (e.g. "%FF"). Surface a PackageUriError rather than a raw URIError.
+    throw new PackageUriError('malformed percent-encoding.', uri)
+  }
+}
+
 // TODO: do we need strict parsing here (throw on extra parameters)?
 // TODO: do we need extra validation for each part (package name, path, registry, etc)?
 export function parse(uri: string): PackageUri {
@@ -81,7 +99,7 @@ export function parse(uri: string): PackageUri {
     )
   }
   const bucket = url.host
-  const params = parseQs((url.hash || '').replace('#', ''))
+  const params = parseFragment((url.hash || '').replace('#', ''), uri)
   if (!params.package) {
     throw new PackageUriError('missing "package=" part.', uri)
   }

--- a/catalog/app/utils/PackageUri.ts
+++ b/catalog/app/utils/PackageUri.ts
@@ -92,7 +92,9 @@ export function parse(uri: string): PackageUri {
   if (Array.isArray(params.path)) {
     throw new PackageUriError('"path=" specified multiple times.', uri)
   }
-  const path = params.path ? decodeURIComponent(params.path) : undefined
+  // `parseQs` has already percent-decoded the value; decoding it a second time
+  // would throw on a literal "%" and silently mangle a literal "%20".
+  const path = params.path || undefined
   return R.reject(R.isNil, { bucket, name, hash, tag, path }) as unknown as PackageUri
 }
 

--- a/docs/Catalog/URI.md
+++ b/docs/Catalog/URI.md
@@ -67,3 +67,32 @@ A Quilt+ URI contains the following components:
 - `&catalog=<catalog>`: An optional fragment specifying the DNS name of the
   catalog that generated the URI. This is used to help clients generate the
   human-readable URL for that package.
+
+#### Percent-encoding
+
+Fragment values are percent-encoded **exactly once**. A producer encodes the
+value once (`50%_sample.csv` is written as `path=50%25_sample.csv`), and a
+consumer decodes it once. Encoding is required for any character that would
+otherwise be read as structure — `&`, `=`, `#` — and recommended for `%` and
+any character outside the unreserved set.
+
+Consumers are lenient about malformed input, following the same rules as
+Python's `urllib.parse.unquote`: a `%` that is not followed by two hexadecimal
+digits is treated as a literal `%` rather than an error. This keeps URIs from
+producers that do not encode their paths readable:
+
+| `path=` value       | decodes to       |
+| ------------------- | ---------------- |
+| `50%25_sample.csv`  | `50%_sample.csv` |
+| `50%_sample.csv`    | `50%_sample.csv` |
+| `a%2zb`             | `a%2zb`          |
+| `a%20b`             | `a b`            |
+| `a%2520b`           | `a%20b`          |
+
+A directory path may carry a trailing slash (`path=subdir%2F`); consumers must
+accept it.
+
+Note that leniency covers malformed escapes, not undecodable ones: a
+well-formed escape that is not valid UTF-8 (e.g. `%FF`) is currently a decode
+error in the catalog, while Python substitutes the Unicode replacement
+character.


### PR DESCRIPTION
## Problem

`PackageUri.parse` percent-decodes the `path=` value twice: `querystring.parse` decodes it, and then the result is passed through `decodeURIComponent` again.

```js
parseQs('path=50%25_sample.csv').path  // '50%_sample.csv'
decodeURIComponent('50%_sample.csv')   // URIError: URI malformed
```

So for a package entry whose key contains a literal `%`, `PackageUri.stringify` produces a URI that `PackageUri.parse` cannot read back — the round trip throws. A key containing a literal `%20` is worse: it round-trips silently to a space, pointing at the wrong entry.

The existing tests only cover `path=sub%2Fpath`, where one decode and two decodes happen to agree, so the bug was invisible.

## Fix

Drop the second decode. `querystring.parse` already returns the decoded value, and `stringify`'s `encodeURIComponent` is its exact inverse.

## Tests

Two parse cases (literal `%`, literal `%20`) plus a round-trip suite over paths with `%`, `%20`, a space, `+`, `&`/`=`, non-ASCII, and a trailing slash. Four of them fail on `master` and pass with the fix.

## Notes

Found while reviewing #5255, which ports this parser to Python (`quilt3/uri.py`) and pins the behavior in a shared JSON corpus. Fixing it here first means that PR can rebase onto the corrected semantics rather than reproducing the double-decode. The Python half of the fix belongs to #5255 — it does not exist on `master`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR fixes Quilt+ URI path parsing so query-string values are decoded exactly once.
- Removes the redundant `decodeURIComponent` call after `querystring.parse`.
- Adds direct coverage for literal `%` and `%20` path content.
- Adds round-trip tests for reserved characters, Unicode, spaces, and trailing slashes.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge because it restores correct path round-tripping and no actionable regression was identified.

The query-string parser already decodes the path value, so removing the redundant decode prevents literal percent content from throwing or being silently transformed while preserving normal encoded-path behavior.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| catalog/app/utils/PackageUri.ts | Removes the second path-decoding operation, restoring symmetry with `stringify` without introducing a concrete regression. |
| catalog/app/utils/PackageUri.spec.ts | Adds focused regression and round-trip coverage for paths containing percent sequences, reserved characters, Unicode, spaces, and trailing slashes. |

<sub>Reviews (1): Last reviewed commit: ["Catalog: decode a Quilt+ URI path exactl..."](https://github.com/quiltdata/quilt/commit/6c983007607d36b49f149d2672ee953b916a235d) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=58257527)</sub>

<!-- /greptile_comment -->