### PR TITLE
Catalog: give the query selector an accessible name

### DIFF
--- a/catalog/CHANGELOG.md
+++ b/catalog/CHANGELOG.md
@@ -21,6 +21,7 @@ complete sentence without it.
 
 ## Changes
 
+- [Fixed] Queries: the query selector announces its label to assistive tech, and no longer claims "Custom" is loaded while its helper text reports the query failed to load ([#5260](https://github.com/quiltdata/quilt/pull/5260))
 - [Changed] The `data-products` demo fixture data no longer ships in the bundles a browser downloads on the volumes landing; it loads only when the preview is on ([#5259](https://github.com/quiltdata/quilt/pull/5259))
 - [Fixed] Quilt+ URI parsing retains the informational `catalog` field, reads a raw `+` in an unencoded path as a `+` rather than a space, and shares its compatibility corpus with quilt3 ([#5255](https://github.com/quiltdata/quilt/pull/5255))
 - [Fixed] Quilt+ URIs: a package path containing a literal `%` no longer breaks the URI, and one containing a literal `%20` no longer decodes to a space and points at the wrong entry. Paths from producers that do not percent-encode now resolve instead of failing, and a path that genuinely cannot be decoded reports a real error rather than the literal text `unknown error: ${e}` ([#5256](https://github.com/quiltdata/quilt/pull/5256))

--- a/catalog/app/containers/Queries/QuerySelect.spec.tsx
+++ b/catalog/app/containers/Queries/QuerySelect.spec.tsx
@@ -86,9 +86,7 @@ describe('containers/Queries/QuerySelect', () => {
     afterEach(cleanup)
 
     it('names the focusable node after the label', () => {
-      // The label must reach the role="button" display div through
-      // labelId/aria-labelledby -- InputLabel next to a Select names nothing by
-      // itself, which reads as "Custom, button" to a screen reader.
+      // Without `labelId` this reads as "Custom, button" to a screen reader.
       const { getByRole } = render(
         <QuerySelect label="Select a query" queries={[]} onChange={noop} value={null} />,
       )
@@ -116,9 +114,8 @@ describe('containers/Queries/QuerySelect', () => {
     afterEach(cleanup)
 
     it('does not claim "Custom" when the load failed', () => {
-      // Athena passes value=null for the error state too. "Custom" asserts a
-      // hand-written query is loaded, directly beside a helper saying the load
-      // failed -- the field must stay blank instead.
+      // Athena passes value=null for the error state too, so the blank has to
+      // come from `error` rather than from the value being absent.
       const { container } = render(
         <QuerySelect
           label="Select a query"

--- a/catalog/app/containers/Queries/QuerySelect.spec.tsx
+++ b/catalog/app/containers/Queries/QuerySelect.spec.tsx
@@ -6,10 +6,15 @@ import noop from 'utils/noop'
 
 import QuerySelect from './QuerySelect'
 
-// The label id now renders unconditionally, and the real useId is
-// Math.random-based -- snapshots need it deterministic.
+// `useId` is Math.random-based and its ids reach the snapshots, so generation
+// has to be deterministic. Delegate to the real hook through its `makeId` seam
+// instead of replacing it: an id has to stay stable across re-renders, and a
+// bare counter hands out a fresh one on every render.
 const ids = vi.hoisted(() => ({ n: 0 }))
-vi.mock('utils/useId', () => ({ default: () => `test-id-${(ids.n += 1)}` }))
+vi.mock('utils/useId', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('utils/useId')>()
+  return { default: () => actual.default(() => `test-id-${(ids.n += 1)}`) }
+})
 beforeEach(() => {
   ids.n = 0
 })

--- a/catalog/app/containers/Queries/QuerySelect.spec.tsx
+++ b/catalog/app/containers/Queries/QuerySelect.spec.tsx
@@ -89,6 +89,22 @@ describe('containers/Queries/QuerySelect', () => {
       )
       expect(getByRole('button', { name: /Select a query/ })).toBeDefined()
     })
+
+    it('keeps the selected query in the name, next to the label', () => {
+      // `aria-labelledby` overrides the display div's contents, so pointing it
+      // at the label alone drops the selection a sighted user can read.
+      const queries = [{ key: 'key1', name: 'name1', url: 'url1' }]
+      const { getByRole } = render(
+        <QuerySelect
+          label="Select a query"
+          queries={queries}
+          onChange={noop}
+          value={queries[0]}
+        />,
+      )
+      expect(getByRole('button', { name: /Select a query/ })).toBeDefined()
+      expect(getByRole('button', { name: /name1/ })).toBeDefined()
+    })
   })
 
   describe('the display value under error', () => {

--- a/catalog/app/containers/Queries/QuerySelect.spec.tsx
+++ b/catalog/app/containers/Queries/QuerySelect.spec.tsx
@@ -1,10 +1,18 @@
 import * as React from 'react'
 import { render, cleanup } from '@testing-library/react'
-import { describe, it, expect, afterEach } from 'vitest'
+import { describe, it, expect, afterEach, beforeEach, vi } from 'vitest'
 
 import noop from 'utils/noop'
 
 import QuerySelect from './QuerySelect'
+
+// The label id now renders unconditionally, and the real useId is
+// Math.random-based -- snapshots need it deterministic.
+const ids = vi.hoisted(() => ({ n: 0 }))
+vi.mock('utils/useId', () => ({ default: () => `test-id-${(ids.n += 1)}` }))
+beforeEach(() => {
+  ids.n = 0
+})
 
 describe('containers/Queries/QuerySelect', () => {
   it('should render', () => {
@@ -66,6 +74,50 @@ describe('containers/Queries/QuerySelect', () => {
       expect(
         container.querySelector('[role="button"]')?.getAttribute('aria-describedby'),
       ).toBeNull()
+    })
+  })
+
+  describe('the accessible name', () => {
+    afterEach(cleanup)
+
+    it('names the focusable node after the label', () => {
+      // The label must reach the role="button" display div through
+      // labelId/aria-labelledby -- InputLabel next to a Select names nothing by
+      // itself, which reads as "Custom, button" to a screen reader.
+      const { getByRole } = render(
+        <QuerySelect label="Select a query" queries={[]} onChange={noop} value={null} />,
+      )
+      expect(getByRole('button', { name: /Select a query/ })).toBeDefined()
+    })
+  })
+
+  describe('the display value under error', () => {
+    afterEach(cleanup)
+
+    it('does not claim "Custom" when the load failed', () => {
+      // Athena passes value=null for the error state too. "Custom" asserts a
+      // hand-written query is loaded, directly beside a helper saying the load
+      // failed -- the field must stay blank instead.
+      const { container } = render(
+        <QuerySelect
+          label="Select a query"
+          error
+          helperText="Failed to load"
+          queries={[]}
+          onChange={noop}
+          value={null}
+        />,
+      )
+      expect(container.querySelector('[role="button"]')?.textContent).not.toContain(
+        'Custom',
+      )
+    })
+
+    it('still reads "Custom" for a genuine no-selection state', () => {
+      const { container } = render(
+        <QuerySelect label="Select a query" queries={[]} onChange={noop} value={null} />,
+      )
+      expect(container.querySelector('[role="button"]')?.textContent).toContain('Custom')
     })
   })
 })

--- a/catalog/app/containers/Queries/QuerySelect.tsx
+++ b/catalog/app/containers/Queries/QuerySelect.tsx
@@ -35,6 +35,7 @@ export default function QuerySelect<T>({
   value,
 }: QuerySelectProps<T & AbstractQuery>) {
   const helperId = useId()
+  const labelId = useId()
   const handleChange = React.useCallback(
     (event) => {
       if (event.target.value === LOAD_MORE && onLoadMore) {
@@ -56,8 +57,11 @@ export default function QuerySelect<T>({
       error={error}
       fullWidth
     >
-      <M.InputLabel>{label}</M.InputLabel>
+      <M.InputLabel id={labelId}>{label}</M.InputLabel>
       <M.Select
+        // `labelId` is what actually names the focusable display div -- an
+        // InputLabel sitting next to a Select names nothing by itself.
+        labelId={labelId}
         onChange={handleChange}
         // The menu rows need `ListItemText` for the name + description pair, but
         // `Select` reuses the selected row's children as the field's display
@@ -65,7 +69,10 @@ export default function QuerySelect<T>({
         // line-height and renders 5px taller than a plain-text Select beside it,
         // leaving the two underlines misaligned. Same trap `Workgroups` avoids by
         // using bare text in its rows.
-        renderValue={() => value?.name ?? 'Custom'}
+        // Blank under error: callers null the value on a failed load, and
+        // "Custom" would assert a hand-written query is loaded right beside a
+        // helper saying the load failed.
+        renderValue={() => value?.name ?? (error ? '' : 'Custom')}
         // Not `aria-describedby` on the Select: that lands on the hidden native
         // input. The focusable node is the `role="button"` display div, which is
         // only reachable through `SelectDisplayProps`.

--- a/catalog/app/containers/Queries/QuerySelect.tsx
+++ b/catalog/app/containers/Queries/QuerySelect.tsx
@@ -36,6 +36,7 @@ export default function QuerySelect<T>({
 }: QuerySelectProps<T & AbstractQuery>) {
   const helperId = useId()
   const labelId = useId()
+  const buttonId = useId()
   const handleChange = React.useCallback(
     (event) => {
       if (event.target.value === LOAD_MORE && onLoadMore) {
@@ -59,9 +60,13 @@ export default function QuerySelect<T>({
     >
       <M.InputLabel id={labelId}>{label}</M.InputLabel>
       <M.Select
-        // `labelId` is what actually names the focusable display div -- an
-        // InputLabel sitting next to a Select names nothing by itself.
+        // An InputLabel next to a Select names nothing by itself -- only
+        // `labelId` reaches the focusable display div. `id` must come with it:
+        // MUI joins the two into `aria-labelledby="labelId buttonId"`, and with
+        // `labelId` alone the label overrides the div's contents, dropping the
+        // selected query from the accessible name.
         labelId={labelId}
+        id={buttonId}
         onChange={handleChange}
         // The menu rows need `ListItemText` for the name + description pair, but
         // `Select` reuses the selected row's children as the field's display

--- a/catalog/app/containers/Queries/QuerySelect.tsx
+++ b/catalog/app/containers/Queries/QuerySelect.tsx
@@ -74,9 +74,8 @@ export default function QuerySelect<T>({
         // line-height and renders 5px taller than a plain-text Select beside it,
         // leaving the two underlines misaligned. Same trap `Workgroups` avoids by
         // using bare text in its rows.
-        // Blank under error: callers null the value on a failed load, and
-        // "Custom" would assert a hand-written query is loaded right beside a
-        // helper saying the load failed.
+        // Callers null the value on a failed load, where "Custom" would assert
+        // a hand-written query is loaded right beside a helper saying it failed.
         renderValue={() => value?.name ?? (error ? '' : 'Custom')}
         // Not `aria-describedby` on the Select: that lands on the hidden native
         // input. The focusable node is the `role="button"` display div, which is

--- a/catalog/app/containers/Queries/__snapshots__/QuerySelect.spec.tsx.snap
+++ b/catalog/app/containers/Queries/__snapshots__/QuerySelect.spec.tsx.snap
@@ -7,6 +7,7 @@ exports[`containers/Queries/QuerySelect > should render 1`] = `
   <label
     class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink Mui-disabled Mui-disabled MuiFormLabel-filled"
     data-shrink="true"
+    id="test-id-2"
   >
     Label
   </label>
@@ -16,6 +17,7 @@ exports[`containers/Queries/QuerySelect > should render 1`] = `
     <div
       aria-disabled="true"
       aria-haspopup="listbox"
+      aria-labelledby="test-id-2"
       class="MuiSelect-root MuiSelect-select MuiSelect-selectMenu MuiInputBase-input MuiInput-input Mui-disabled Mui-disabled Mui-disabled"
       role="button"
     >
@@ -48,6 +50,7 @@ exports[`containers/Queries/QuerySelect > should render with selected value 1`] 
   <label
     class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiFormLabel-filled"
     data-shrink="true"
+    id="test-id-2"
   >
     Label
   </label>
@@ -56,6 +59,7 @@ exports[`containers/Queries/QuerySelect > should render with selected value 1`] 
   >
     <div
       aria-haspopup="listbox"
+      aria-labelledby="test-id-2"
       class="MuiSelect-root MuiSelect-select MuiSelect-selectMenu MuiInputBase-input MuiInput-input"
       role="button"
       tabindex="0"

--- a/catalog/app/containers/Queries/__snapshots__/QuerySelect.spec.tsx.snap
+++ b/catalog/app/containers/Queries/__snapshots__/QuerySelect.spec.tsx.snap
@@ -17,8 +17,9 @@ exports[`containers/Queries/QuerySelect > should render 1`] = `
     <div
       aria-disabled="true"
       aria-haspopup="listbox"
-      aria-labelledby="test-id-2"
+      aria-labelledby="test-id-2 test-id-3"
       class="MuiSelect-root MuiSelect-select MuiSelect-selectMenu MuiInputBase-input MuiInput-input Mui-disabled Mui-disabled Mui-disabled"
+      id="test-id-3"
       role="button"
     >
       Custom
@@ -59,8 +60,9 @@ exports[`containers/Queries/QuerySelect > should render with selected value 1`] 
   >
     <div
       aria-haspopup="listbox"
-      aria-labelledby="test-id-2"
+      aria-labelledby="test-id-2 test-id-3"
       class="MuiSelect-root MuiSelect-select MuiSelect-selectMenu MuiInputBase-input MuiInput-input"
+      id="test-id-3"
       role="button"
       tabindex="0"
     >


### PR DESCRIPTION
# Description

Two defects in the shared query selector used by the Athena and ElasticSearch
query screens.

**It has no accessible name.** Its `InputLabel` sits beside the `Select` rather
than naming it. In MUI v4 the focusable node is the `role="button"` display div,
which takes its name from `labelId` — so a keyboard or screen-reader user hears
an unnamed button where a sighted user reads "Select query".

**It claims a query is loaded when the load failed.** `renderValue` fell back to
`"Custom"` — the label for a hand-written query — whenever `value` was null.
Callers null the value on a failed load, so the field asserted "Custom" directly
beside its own helper text saying the query list could not be loaded. It now
renders blank on the error path and keeps "Custom" for the case it was written
for.

## Review findings addressed

None folded in; the review raised nothing against this unit's code. Recorded:

- **f42** — the compensation for a caller's lossy null encoding sits inside the
  shared `QuerySelect` rather than at the caller. Left as is deliberately: the
  trigger does not exist yet (`ElasticSearch.tsx` passes no `error` prop), so
  there is no second call site to disagree with.
- **f18** — worth naming across two PRs in this stack rather than in neither.
  The same MUI v4 accessible-name problem is fixed **twice, in two different
  ways**: `labelId` here, `SelectDisplayProps` in the Search sidebar (PR 3).
  Both are correct for their call site; the inconsistency is the finding. A third
  case is still unfixed at `Queries/Athena/Workgroups.tsx:64-66`. Unifying this
  in the shared `Select` wrapper is a follow-up, not something either PR should
  reach across into.

# Verification

```
cd catalog && npx vitest run app/containers/Queries/QuerySelect.spec.tsx
```

8 tests, including the accessible name and the blank-under-error branch.

# Position in the stack

**PR 2 of 9**, based on
[`stack/5217-1-data-products-lazy-adapter`](https://github.com/quiltdata/quilt/pull/5259).

This is part of the split of #5217 asked for in
[f27](https://github.com/quiltdata/quilt/pull/5217#discussion_r3889140880). PRs 2
and 3 are the two smallest, uncontested accessibility fixes in that set and share
no symbol with anything above them — they are early in the stack so a release
gets them even if the contested units above stall.

# TODO

- [x] Unit tests
- [x] Security: Confirm that this change meets security best practices and does not violate the security model
- [x] Open: Confirm that this change doesn't break the Open variant
- [x] Changelog entry

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR gives the shared query selector an accessible name and changes its null display during errors.
- Connects `InputLabel` to the MUI Select display node through `labelId`.
- Blanks the selector for an error with no selected query, while retaining “Custom” for ordinary null selections.
- Adds focused accessibility and error-display tests plus updated snapshots and changelog text.

<h3>Confidence Score: 4/5</h3>

The ElasticSearch custom-query regression should be fixed before merging because validation errors now blank a selector whose active mode is still “Custom.”

The accessible-name change is sound, but the shared display condition conflates Athena’s query-list load failure with ElasticSearch’s query-body validation error and hides a reachable active selection.

**Files Needing Attention:** catalog/app/containers/Queries/QuerySelect.tsx and catalog/app/containers/Queries/QuerySelect.spec.tsx

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| catalog/app/containers/Queries/QuerySelect.tsx | Correctly adds accessible labeling, but the broad error-based blanking also hides ElasticSearch’s active custom-query state during validation errors. |
| catalog/app/containers/Queries/QuerySelect.spec.tsx | Adds useful accessible-name and display-state coverage, but does not exercise the existing ElasticSearch meaning of the error prop. |
| catalog/app/containers/Queries/__snapshots__/QuerySelect.spec.tsx.snap | Records the expected label ID and `aria-labelledby` relationship. |
| catalog/CHANGELOG.md | Documents the intended accessibility and failed-load display fixes. |

<sub>Reviews (1): Last reviewed commit: ["docs(changelog): entry for the query sel..."](https://github.com/quiltdata/quilt/commit/e5eb0a233160e8ee4ed5171ba2543d5f6160fbfd) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=58629592)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->