### PR TITLE
Catalog: stop the facet "Sort by" control vanishing as you type (5217 stack 4/9)

### DIFF
--- a/catalog/CHANGELOG.md
+++ b/catalog/CHANGELOG.md
@@ -21,6 +21,7 @@ complete sentence without it.
 
 ## Changes
 
+- [Fixed] Search sidebar: the facet "Sort by" control no longer disappears while you type in "Find metadata" on stacks with truncated facet lists, and it is withheld when the query matches nothing rather than offering to sort an empty list ([#5262](https://github.com/quiltdata/quilt/pull/5262))
 - [Fixed] Search sidebar: the facet "Sort by" control announces what it is — its label used to land on a hidden input, leaving assistive tech to read the control as its current ordering and nothing more ([#5261](https://github.com/quiltdata/quilt/pull/5261))
 - [Fixed] Queries: the query selector announces its label to assistive tech, and no longer claims "Custom" is loaded while its helper text reports the query failed to load ([#5260](https://github.com/quiltdata/quilt/pull/5260))
 - [Changed] The `data-products` demo fixture data no longer ships in the bundles a browser downloads on the volumes landing; it loads only when the preview is on ([#5259](https://github.com/quiltdata/quilt/pull/5259))

--- a/catalog/app/containers/Search/Layout/PackageFilters.tsx
+++ b/catalog/app/containers/Search/Layout/PackageFilters.tsx
@@ -237,9 +237,10 @@ export function AvailablePackagesMetaFilters({
         },
         Disabled: () => null,
       })(filtering)}
-      {/* `offered` rather than a count taken here: withholding it turns on how many
+      {/* `offered` rather than a count taken here: the threshold turns on how many
           fields exist, and `facets.available` is already narrowed by the filter box
-          on the client-filter path. */}
+          on the filtering paths. The model also withholds it when nothing is
+          displayed, so this is the whole rule. */}
       {ordering.offered && (
         <div className={classes.order}>
           <span className={classes.orderLabel} id={orderLabelId}>

--- a/catalog/app/containers/Search/model.spec.ts
+++ b/catalog/app/containers/Search/model.spec.ts
@@ -1,7 +1,7 @@
+import { renderHook } from '@testing-library/react-hooks'
 import { describe, expect, it, vi } from 'vitest'
 
 import * as KTree from 'utils/KeyedTree'
-import Log from 'utils/Logging'
 
 import * as model from './model'
 
@@ -317,86 +317,6 @@ describe('containers/Search/model', () => {
     })
   })
 
-  describe('Predicates: malformed filter JSON', () => {
-    const silenced = (f: () => void) => {
-      const level = Log.getLevel()
-      Log.setLevel('silent')
-      try {
-        f()
-      } finally {
-        Log.setLevel(level)
-      }
-    }
-
-    it('names the filter when a date range will not parse', () => {
-      silenced(() =>
-        expect(() => model.Predicates.Datetime.fromString('{"gte":')).toThrow(
-          'Invalid date range in the search URL',
-        ),
-      )
-    })
-
-    it('names the filter when a number range will not parse', () => {
-      silenced(() =>
-        expect(() => model.Predicates.Number.fromString('{oops}')).toThrow(
-          'Invalid number range in the search URL',
-        ),
-      )
-    })
-
-    it('names the filter when a keyword list will not parse', () => {
-      silenced(() =>
-        expect(() => model.Predicates.KeywordEnum.fromString('"a",,')).toThrow(
-          'Invalid keyword list in the search URL',
-        ),
-      )
-    })
-
-    // The filter's URL param is its key, unprefixed.
-    it('reports the filter when parsing a whole search URL', () => {
-      silenced(() => {
-        expect(() => model.parseSearchParams('modified={')).toThrow(
-          'Invalid date range in the search URL',
-        )
-        expect(() => model.parseSearchParams('size={oops}')).toThrow(
-          'Invalid number range in the search URL',
-        )
-        expect(() => model.parseSearchParams('workflow="a",,')).toThrow(
-          'Invalid keyword list in the search URL',
-        )
-      })
-    })
-
-    it('logs the value that failed to parse, not just the SyntaxError', () => {
-      const level = Log.getLevel()
-      Log.setLevel('error')
-      const spy = vi.spyOn(Log, 'error').mockImplementation(() => {})
-      try {
-        expect(() => model.parseSearchParams('modified={')).toThrow()
-        expect(spy).toHaveBeenCalledWith(
-          expect.stringContaining('JSON.parse failed on "{"'),
-          expect.any(SyntaxError),
-        )
-      } finally {
-        spy.mockRestore()
-        Log.setLevel(level)
-      }
-    })
-
-    it('leaves well-formed filter params parsing as before', () => {
-      expect(
-        model.Predicates.Datetime.fromString('{"gte":"2020-01-02T00:00:00.000Z"}'),
-      ).toMatchObject({ gte: new Date('2020-01-02T00:00:00.000Z'), lte: null })
-      expect(model.Predicates.Number.fromString('{"gte":1,"lte":5}')).toMatchObject({
-        gte: 1,
-        lte: 5,
-      })
-      expect(model.Predicates.KeywordEnum.fromString('"a","b"')).toMatchObject({
-        terms: ['a', 'b'],
-      })
-    })
-  })
-
   // The URL is the contract catalog, registry and MCP share: a search link
   // pasted into chat, a bookmark, or an MCP-built URL must reconstruct the
   // exact state that produced it.
@@ -493,6 +413,50 @@ describe('containers/Search/model', () => {
       expect(model.serializeSearchUrlState(fromLegacyS).get('s')).toBe(
         'sys:modified:desc',
       )
+    })
+  })
+
+  describe('useOrderingOffered', () => {
+    const T = model.FACET_ORDERING_THRESHOLD
+
+    it('withholds the control below the threshold', () => {
+      const { result } = renderHook(() => model.useOrderingOffered(T - 1, T - 1))
+      expect(result.current).toBe(false)
+    })
+
+    it('offers the control at the threshold', () => {
+      const { result } = renderHook(() => model.useOrderingOffered(T, T))
+      expect(result.current).toBe(true)
+    })
+
+    it('keeps the control once offered, however far the list narrows', () => {
+      // The flicker: typing in "Find metadata" narrows the list, and a control
+      // that reappraised every keystroke would vanish mid-word.
+      const { result, rerender } = renderHook(
+        ({ total, shown }) => model.useOrderingOffered(total, shown),
+        { initialProps: { total: T, shown: T } },
+      )
+      expect(result.current).toBe(true)
+      rerender({ total: 1, shown: 1 })
+      expect(result.current).toBe(true)
+    })
+
+    it('withholds the control while nothing is displayed', () => {
+      // A live "Sort by" above "No metadata found" sorts nothing.
+      const { result, rerender } = renderHook(
+        ({ total, shown }) => model.useOrderingOffered(total, shown),
+        { initialProps: { total: T, shown: T } },
+      )
+      expect(result.current).toBe(true)
+      rerender({ total: T, shown: 0 })
+      expect(result.current).toBe(false)
+    })
+
+    it('does not carry the offer across mounts', () => {
+      const { result: first } = renderHook(() => model.useOrderingOffered(T, T))
+      expect(first.current).toBe(true)
+      const { result: second } = renderHook(() => model.useOrderingOffered(1, 1))
+      expect(second.current).toBe(false)
     })
   })
 })

--- a/catalog/app/containers/Search/model.spec.ts
+++ b/catalog/app/containers/Search/model.spec.ts
@@ -508,10 +508,8 @@ describe('containers/Search/model', () => {
     })
 
     it('keeps the control while the reader narrows the list', () => {
-      // The flicker this replaces: typing in "Find metadata" narrows what is
-      // displayed, and the control used to be reappraised against the narrowed
-      // count and vanish mid-word. The threshold reads the pre-filter total,
-      // which does not move while the filter box is typed in.
+      // The threshold reads the pre-filter total, which does not move while the
+      // filter box is typed in, so narrowing cannot retract the control.
       expect(model.orderingOffered(T, T)).toBe(true)
       expect(model.orderingOffered(T, 3)).toBe(true)
       expect(model.orderingOffered(T, 1)).toBe(true)
@@ -523,9 +521,7 @@ describe('containers/Search/model', () => {
     })
 
     it('carries no state between calls', () => {
-      // The predicate is pure: an earlier version latched the highest total it
-      // had seen in a ref, which made the answer depend on call order and on
-      // which mount asked.
+      // The answer must not depend on call order or on which mount asked.
       expect(model.orderingOffered(T, T)).toBe(true)
       expect(model.orderingOffered(1, 1)).toBe(false)
       expect(model.orderingOffered(T, T)).toBe(true)

--- a/catalog/app/containers/Search/model.spec.ts
+++ b/catalog/app/containers/Search/model.spec.ts
@@ -1,4 +1,3 @@
-import { renderHook } from '@testing-library/react-hooks'
 import { describe, expect, it, vi } from 'vitest'
 
 import * as KTree from 'utils/KeyedTree'
@@ -416,47 +415,39 @@ describe('containers/Search/model', () => {
     })
   })
 
-  describe('useOrderingOffered', () => {
+  describe('orderingOffered', () => {
     const T = model.FACET_ORDERING_THRESHOLD
 
     it('withholds the control below the threshold', () => {
-      const { result } = renderHook(() => model.useOrderingOffered(T - 1, T - 1))
-      expect(result.current).toBe(false)
+      expect(model.orderingOffered(T - 1, T - 1)).toBe(false)
     })
 
     it('offers the control at the threshold', () => {
-      const { result } = renderHook(() => model.useOrderingOffered(T, T))
-      expect(result.current).toBe(true)
+      expect(model.orderingOffered(T, T)).toBe(true)
     })
 
-    it('keeps the control once offered, however far the list narrows', () => {
-      // The flicker: typing in "Find metadata" narrows the list, and a control
-      // that reappraised every keystroke would vanish mid-word.
-      const { result, rerender } = renderHook(
-        ({ total, shown }) => model.useOrderingOffered(total, shown),
-        { initialProps: { total: T, shown: T } },
-      )
-      expect(result.current).toBe(true)
-      rerender({ total: 1, shown: 1 })
-      expect(result.current).toBe(true)
+    it('keeps the control while the reader narrows the list', () => {
+      // The flicker this replaces: typing in "Find metadata" narrows what is
+      // displayed, and the control used to be reappraised against the narrowed
+      // count and vanish mid-word. The threshold reads the pre-filter total,
+      // which does not move while the filter box is typed in.
+      expect(model.orderingOffered(T, T)).toBe(true)
+      expect(model.orderingOffered(T, 3)).toBe(true)
+      expect(model.orderingOffered(T, 1)).toBe(true)
     })
 
     it('withholds the control while nothing is displayed', () => {
-      // A live "Sort by" above "No metadata found" sorts nothing.
-      const { result, rerender } = renderHook(
-        ({ total, shown }) => model.useOrderingOffered(total, shown),
-        { initialProps: { total: T, shown: T } },
-      )
-      expect(result.current).toBe(true)
-      rerender({ total: T, shown: 0 })
-      expect(result.current).toBe(false)
+      // A live "Sort by" above "No metadata found" offers to sort nothing.
+      expect(model.orderingOffered(T, 0)).toBe(false)
     })
 
-    it('does not carry the offer across mounts', () => {
-      const { result: first } = renderHook(() => model.useOrderingOffered(T, T))
-      expect(first.current).toBe(true)
-      const { result: second } = renderHook(() => model.useOrderingOffered(1, 1))
-      expect(second.current).toBe(false)
+    it('carries no state between calls', () => {
+      // The predicate is pure: an earlier version latched the highest total it
+      // had seen in a ref, which made the answer depend on call order and on
+      // which mount asked.
+      expect(model.orderingOffered(T, T)).toBe(true)
+      expect(model.orderingOffered(1, 1)).toBe(false)
+      expect(model.orderingOffered(T, T)).toBe(true)
     })
   })
 })

--- a/catalog/app/containers/Search/model.spec.ts
+++ b/catalog/app/containers/Search/model.spec.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it, vi } from 'vitest'
 
 import * as KTree from 'utils/KeyedTree'
+import Log from 'utils/Logging'
 
 import * as model from './model'
 
@@ -312,6 +313,86 @@ describe('containers/Search/model', () => {
         expect(model.orderingToResultOrder('sys:size:asc')).toBe(
           model.GQLResultOrder.BEST_MATCH,
         )
+      })
+    })
+  })
+
+  describe('Predicates: malformed filter JSON', () => {
+    const silenced = (f: () => void) => {
+      const level = Log.getLevel()
+      Log.setLevel('silent')
+      try {
+        f()
+      } finally {
+        Log.setLevel(level)
+      }
+    }
+
+    it('names the filter when a date range will not parse', () => {
+      silenced(() =>
+        expect(() => model.Predicates.Datetime.fromString('{"gte":')).toThrow(
+          'Invalid date range in the search URL',
+        ),
+      )
+    })
+
+    it('names the filter when a number range will not parse', () => {
+      silenced(() =>
+        expect(() => model.Predicates.Number.fromString('{oops}')).toThrow(
+          'Invalid number range in the search URL',
+        ),
+      )
+    })
+
+    it('names the filter when a keyword list will not parse', () => {
+      silenced(() =>
+        expect(() => model.Predicates.KeywordEnum.fromString('"a",,')).toThrow(
+          'Invalid keyword list in the search URL',
+        ),
+      )
+    })
+
+    // The filter's URL param is its key, unprefixed.
+    it('reports the filter when parsing a whole search URL', () => {
+      silenced(() => {
+        expect(() => model.parseSearchParams('modified={')).toThrow(
+          'Invalid date range in the search URL',
+        )
+        expect(() => model.parseSearchParams('size={oops}')).toThrow(
+          'Invalid number range in the search URL',
+        )
+        expect(() => model.parseSearchParams('workflow="a",,')).toThrow(
+          'Invalid keyword list in the search URL',
+        )
+      })
+    })
+
+    it('logs the value that failed to parse, not just the SyntaxError', () => {
+      const level = Log.getLevel()
+      Log.setLevel('error')
+      const spy = vi.spyOn(Log, 'error').mockImplementation(() => {})
+      try {
+        expect(() => model.parseSearchParams('modified={')).toThrow()
+        expect(spy).toHaveBeenCalledWith(
+          expect.stringContaining('JSON.parse failed on "{"'),
+          expect.any(SyntaxError),
+        )
+      } finally {
+        spy.mockRestore()
+        Log.setLevel(level)
+      }
+    })
+
+    it('leaves well-formed filter params parsing as before', () => {
+      expect(
+        model.Predicates.Datetime.fromString('{"gte":"2020-01-02T00:00:00.000Z"}'),
+      ).toMatchObject({ gte: new Date('2020-01-02T00:00:00.000Z'), lte: null })
+      expect(model.Predicates.Number.fromString('{"gte":1,"lte":5}')).toMatchObject({
+        gte: 1,
+        lte: 5,
+      })
+      expect(model.Predicates.KeywordEnum.fromString('"a","b"')).toMatchObject({
+        terms: ['a', 'b'],
       })
     })
   })

--- a/catalog/app/containers/Search/model.ts
+++ b/catalog/app/containers/Search/model.ts
@@ -10,6 +10,7 @@ import * as Model from 'model'
 import * as GQL from 'utils/GraphQL'
 import * as JSONPointer from 'utils/JSONPointer'
 import * as KTree from 'utils/KeyedTree'
+import Log from 'utils/Logging'
 import * as NamedRoutes from 'utils/NamedRoutes'
 import assertNever from 'utils/assertNever'
 import * as tagged from 'utils/taggedV2'
@@ -341,6 +342,17 @@ function Predicate<Tag extends string, State, GQLType>(input: {
   }
 }
 
+// The SyntaxError names an offset into a string nobody printed, so the throw
+// names the filter and the log carries the value.
+function parseFilterJson(input: string, message: string) {
+  try {
+    return JSON.parse(input)
+  } catch (e) {
+    Log.error(`${message}; JSON.parse failed on ${JSON.stringify(input)}`, e)
+    throw new Error(message)
+  }
+}
+
 const STRICT_MARKER = '$s$:'
 
 export const Predicates = {
@@ -351,7 +363,7 @@ export const Predicates = {
       lte: null as Date | null,
     },
     fromString: (input: string) => {
-      const json = JSON.parse(input)
+      const json = parseFilterJson(input, 'Invalid date range in the search URL')
       return {
         gte: parseDate(json.gte),
         lte: parseDate(json.lte),
@@ -371,7 +383,7 @@ export const Predicates = {
       lte: null as number | null,
     },
     fromString: (input: string) => {
-      const json = JSON.parse(input)
+      const json = parseFilterJson(input, 'Invalid number range in the search URL')
       return {
         gte: (json.gte as number) ?? null,
         lte: (json.lte as number) ?? null,
@@ -398,7 +410,12 @@ export const Predicates = {
   KeywordEnum: Predicate({
     tag: 'KeywordEnum',
     init: { terms: [] as string[] },
-    fromString: (input: string) => ({ terms: JSON.parse(`[${input}]`) as string[] }),
+    fromString: (input: string) => ({
+      terms: parseFilterJson(
+        `[${input}]`,
+        'Invalid keyword list in the search URL',
+      ) as string[],
+    }),
     toString: ({ terms }) => JSON.stringify(terms).slice(1, -1),
     toGQL: ({ terms }) =>
       terms.length

--- a/catalog/app/containers/Search/model.ts
+++ b/catalog/app/containers/Search/model.ts
@@ -10,7 +10,6 @@ import * as Model from 'model'
 import * as GQL from 'utils/GraphQL'
 import * as JSONPointer from 'utils/JSONPointer'
 import * as KTree from 'utils/KeyedTree'
-import Log from 'utils/Logging'
 import * as NamedRoutes from 'utils/NamedRoutes'
 import assertNever from 'utils/assertNever'
 import * as tagged from 'utils/taggedV2'
@@ -342,17 +341,6 @@ function Predicate<Tag extends string, State, GQLType>(input: {
   }
 }
 
-// The SyntaxError names an offset into a string nobody printed, so the throw
-// names the filter and the log carries the value.
-function parseFilterJson(input: string, message: string) {
-  try {
-    return JSON.parse(input)
-  } catch (e) {
-    Log.error(`${message}; JSON.parse failed on ${JSON.stringify(input)}`, e)
-    throw new Error(message)
-  }
-}
-
 const STRICT_MARKER = '$s$:'
 
 export const Predicates = {
@@ -363,7 +351,7 @@ export const Predicates = {
       lte: null as Date | null,
     },
     fromString: (input: string) => {
-      const json = parseFilterJson(input, 'Invalid date range in the search URL')
+      const json = JSON.parse(input)
       return {
         gte: parseDate(json.gte),
         lte: parseDate(json.lte),
@@ -383,7 +371,7 @@ export const Predicates = {
       lte: null as number | null,
     },
     fromString: (input: string) => {
-      const json = parseFilterJson(input, 'Invalid number range in the search URL')
+      const json = JSON.parse(input)
       return {
         gte: (json.gte as number) ?? null,
         lte: (json.lte as number) ?? null,
@@ -410,12 +398,7 @@ export const Predicates = {
   KeywordEnum: Predicate({
     tag: 'KeywordEnum',
     init: { terms: [] as string[] },
-    fromString: (input: string) => ({
-      terms: parseFilterJson(
-        `[${input}]`,
-        'Invalid keyword list in the search URL',
-      ) as string[],
-    }),
+    fromString: (input: string) => ({ terms: JSON.parse(`[${input}]`) as string[] }),
     toString: ({ terms }) => JSON.stringify(terms).slice(1, -1),
     toGQL: ({ terms }) =>
       terms.length
@@ -1316,7 +1299,11 @@ function AvailablePackagesMetaFiltersServerFilterQuery({
   return React.createElement(AvailablePackagesMetaFiltersGroup, {
     state,
     children,
-    totalAvailable: available.length,
+    // Neither count alone is the pre-filter total on this path: `available` is
+    // the server-filtered result, and `initial` is the truncated list minus
+    // applied filters — which understates it when a text query matches far more
+    // than the truncated list held. Take whichever is larger.
+    totalAvailable: Math.max(initial.length, available.length),
   })
 }
 
@@ -1364,6 +1351,23 @@ function AvailablePackagesMetaFiltersClientFilter({
   })
 }
 
+/**
+ * Whether to offer the ordering switcher.
+ *
+ * Monotonic per mount: once enough fields have been seen the control stays, so
+ * narrowing the list by typing cannot make it flicker away mid-keystroke. It is
+ * withheld while nothing is displayed at all, because a live "Sort by" above "No
+ * metadata found" sorts nothing.
+ *
+ * Exported for testing: every visibility rule is here, so the hook is the only
+ * place the question can be answered.
+ */
+export function useOrderingOffered(totalAvailable: number, displayed: number): boolean {
+  const maxSeen = React.useRef(0)
+  maxSeen.current = Math.max(maxSeen.current, totalAvailable)
+  return displayed > 0 && maxSeen.current >= FACET_ORDERING_THRESHOLD
+}
+
 // Every `Ready` path funnels through here before the tree reaches the panel, so
 // this is the one place the ordering can own both the sort and the split.
 function AvailablePackagesMetaFiltersGroup({
@@ -1392,7 +1396,7 @@ function AvailablePackagesMetaFiltersGroup({
     [available, ordering],
   )
 
-  const offered = totalAvailable >= FACET_ORDERING_THRESHOLD
+  const offered = useOrderingOffered(totalAvailable, available?.length ?? 0)
 
   const orderingState = React.useMemo(
     () => ({ value: ordering, set: setOrdering, offered }),

--- a/catalog/app/containers/Search/model.ts
+++ b/catalog/app/containers/Search/model.ts
@@ -1318,11 +1318,10 @@ function AvailablePackagesMetaFiltersServerFilterQuery({
     state,
     children,
     // `initial`, not `available`: `available` is this query's own result and
-    // shrinks with every keystroke, which is what used to unmount the control
-    // mid-word. `initial` is the list as it stood before the reader started
-    // typing, so it is stable across the search — and it is a genuine lower
-    // bound on the total, because the list reaching this path is truncated, so
-    // the server holds at least this many.
+    // shrinks with every keystroke. `initial` is the list as it stood before the
+    // reader started typing, so it is stable across the search — and it is a
+    // genuine lower bound on the total, because the list reaching this path is
+    // truncated, so the server holds at least this many.
     totalAvailable: initial.length,
   })
 }
@@ -1382,13 +1381,8 @@ function AvailablePackagesMetaFiltersClientFilter({
  * - the control is **withheld** while `displayed` is zero, because a live "Sort
  *   by" above "No metadata found" offers to sort nothing.
  *
- * A plain function, not a hook: nothing here is per-mount state. An earlier
- * version latched the highest count it had seen in a ref to paper over a caller
- * that passed a moving total; fixing the caller removed the need, and with it a
- * ref written during render.
- *
- * Exported for testing: every visibility rule is here, so this is the only place
- * the question is answered.
+ * Pure, and a plain function rather than a hook: the answer must not depend on
+ * call order or on which mount asked.
  */
 export function orderingOffered(totalAvailable: number, displayed: number): boolean {
   return displayed > 0 && totalAvailable >= FACET_ORDERING_THRESHOLD

--- a/catalog/app/containers/Search/model.ts
+++ b/catalog/app/containers/Search/model.ts
@@ -1076,11 +1076,12 @@ export const AvailableFiltersState = tagged.create(
       ordering: {
         value: FacetOrdering
         set: (value: FacetOrdering) => void
-        // Whether to offer the control at all. Decided here because it turns on how
-        // many fields *exist*, not how many currently match the filter box --
-        // `facets.available` is the post-filter list on the client-filter path, so
-        // gating on it would unmount the control mid-search, exactly while a reader
-        // is hunting for a field.
+        // Whether to offer the control at all. Decided here because the threshold
+        // turns on how many fields *exist*, not how many currently match the filter
+        // box — `facets.available` is the post-filter list on the filtering paths,
+        // so gating the threshold on it would unmount the control mid-search,
+        // exactly while a reader is hunting for a field. It is additionally
+        // withheld when nothing is displayed at all: see `orderingOffered`.
         offered: boolean
       }
       fetching: boolean
@@ -1299,11 +1300,13 @@ function AvailablePackagesMetaFiltersServerFilterQuery({
   return React.createElement(AvailablePackagesMetaFiltersGroup, {
     state,
     children,
-    // Neither count alone is the pre-filter total on this path: `available` is
-    // the server-filtered result, and `initial` is the truncated list minus
-    // applied filters — which understates it when a text query matches far more
-    // than the truncated list held. Take whichever is larger.
-    totalAvailable: Math.max(initial.length, available.length),
+    // `initial`, not `available`: `available` is this query's own result and
+    // shrinks with every keystroke, which is what used to unmount the control
+    // mid-word. `initial` is the list as it stood before the reader started
+    // typing, so it is stable across the search — and it is a genuine lower
+    // bound on the total, because the list reaching this path is truncated, so
+    // the server holds at least this many.
+    totalAvailable: initial.length,
   })
 }
 
@@ -1354,18 +1357,24 @@ function AvailablePackagesMetaFiltersClientFilter({
 /**
  * Whether to offer the ordering switcher.
  *
- * Monotonic per mount: once enough fields have been seen the control stays, so
- * narrowing the list by typing cannot make it flicker away mid-keystroke. It is
- * withheld while nothing is displayed at all, because a live "Sort by" above "No
- * metadata found" sorts nothing.
+ * Two rules, and they read different counts on purpose:
  *
- * Exported for testing: every visibility rule is here, so the hook is the only
- * place the question can be answered.
+ * - the **threshold** turns on `totalAvailable`, the size of the list before the
+ *   reader narrows it. Every caller passes a count that does not move while the
+ *   filter box is typed in, so narrowing cannot retract the control mid-word.
+ * - the control is **withheld** while `displayed` is zero, because a live "Sort
+ *   by" above "No metadata found" offers to sort nothing.
+ *
+ * A plain function, not a hook: nothing here is per-mount state. An earlier
+ * version latched the highest count it had seen in a ref to paper over a caller
+ * that passed a moving total; fixing the caller removed the need, and with it a
+ * ref written during render.
+ *
+ * Exported for testing: every visibility rule is here, so this is the only place
+ * the question is answered.
  */
-export function useOrderingOffered(totalAvailable: number, displayed: number): boolean {
-  const maxSeen = React.useRef(0)
-  maxSeen.current = Math.max(maxSeen.current, totalAvailable)
-  return displayed > 0 && maxSeen.current >= FACET_ORDERING_THRESHOLD
+export function orderingOffered(totalAvailable: number, displayed: number): boolean {
+  return displayed > 0 && totalAvailable >= FACET_ORDERING_THRESHOLD
 }
 
 // Every `Ready` path funnels through here before the tree reaches the panel, so
@@ -1396,7 +1405,7 @@ function AvailablePackagesMetaFiltersGroup({
     [available, ordering],
   )
 
-  const offered = useOrderingOffered(totalAvailable, available?.length ?? 0)
+  const offered = orderingOffered(totalAvailable, available?.length ?? 0)
 
   const orderingState = React.useMemo(
     () => ({ value: ordering, set: setOrdering, offered }),

--- a/catalog/app/containers/Search/model.ts
+++ b/catalog/app/containers/Search/model.ts
@@ -1385,8 +1385,15 @@ function AvailablePackagesMetaFiltersGroup({
   totalAvailable,
 }: RenderProps<AvailableFiltersStateInstance> & {
   state: AvailableFiltersStateInstance
-  // The count *before* any filtering, which the caller still has. `state.facets
-  // .available` is already narrowed on the client-filter path.
+  // How many fields the list held before the reader started narrowing it with
+  // the filter box — which only the caller still has, because `state.facets
+  // .available` is already narrowed on every filtering path.
+  //
+  // "Before any filtering" is *not* what this is, and the difference matters:
+  // facet filters the reader has already applied are excluded, and on the
+  // truncated paths the server returned only part of the list. It is a lower
+  // bound on the total that does not move while the filter box is typed in,
+  // which is exactly what the threshold needs and no more than that.
   totalAvailable: number
 }) {
   // From the URL, not local state, so a shared link reproduces the panel the


### PR DESCRIPTION
# Description

The search sidebar's "Sort by" control disappeared while you typed in "Find
metadata". On a stack whose facet list the server truncates, narrowing the list
dropped the count the control gates on below its threshold, and the control
unmounted mid-word — while the reader was using it to hunt for a field. It was
also offered above an empty list, where it has nothing to sort.

This is the visibility half of the "Sort by" work. The control's accessible name
is [PR 3](https://github.com/quiltdata/quilt/pull/5261), a different file and a
different concern.

## Review findings addressed

This unit drew most of the review's attention, and the approach here is the one
[f5](https://github.com/quiltdata/quilt/pull/5217#pullrequestreview-5060578213)
asked for: fix the count, rather than patch the symptom twice.

- **f5** — visibility was patched in two places at once: a `Math.max` guess at
  the total *and* a monotonic per-mount ref that latched the highest count it had
  ever seen. Only one of the four call sites was actually passing a total that
  moved. Fixing that one caller made both patches unnecessary.
- **f36** ([thread](https://github.com/quiltdata/quilt/pull/5217#discussion_r3889140893))
  — the latch wrote `maxSeen.current` in the render body, which React's
  "Referencing values with refs" documents as something not to do, and it was not
  scoped to the narrowing it was written for: *any* drop in the total made it
  stick for the life of the mount. The ref is gone; `useOrderingOffered` is now
  `orderingOffered`, a pure predicate.
- **f6** — the count change was itself an untested behaviour change. Five tests
  now drive the predicate directly, including the narrowing case that used to
  flicker and the withhold-on-empty case.
- **f47** — the gate's contract was documented in three places (the state
  declaration, the `totalAvailable` prop, the consumer in `PackageFilters.tsx`)
  and all three had gone stale against the implementation. They describe it
  correctly again, and the withhold-on-empty rule — which was never written down
  anywhere — is now stated.
- **f3** — the old description claimed the code "passes the pre-filter count"
  while shipping `Math.max(initial.length, available.length)`, whose own comment
  conceded neither operand is the pre-filter total. It now passes `initial.length`,
  and the claim is true as stated.
- **f4** — and to state it plainly rather than let it be inferred: this changes
  the visibility rule on **all four** paths through
  `AvailablePackagesMetaFiltersGroup`, not the one path the old description named.
  Three of them already passed a stable pre-filter count and are unaffected by the
  count change, but all four now go through the same predicate and all four gain
  the withhold-on-empty rule.
- **f7** — the `totalAvailable` prop doc said "the count before any filtering",
  which was offered as the substitute for a test and which the diff falsified. It
  now says what the value is: a lower bound that excludes already-applied facet
  filters and understates a truncated list, whose one load-bearing property is
  that it does not move while the filter box is typed in.

## On f5, and what was not available

f5 recommended gating on "the count the server already answers". **It does not
answer one.** `PackagesSearchStats` exposes `userMeta` (the possibly-truncated
list) and `userMetaTruncated` (a boolean) — there is no facet total in the schema;
`PackagesSearchResultSet.total` counts packages, not fields. So the fallback f5
allowed for applies, and `initial.length` is the strongest sound stand-in the
client can compute: stable across the search, and a genuine lower bound because
the list reaching that path is truncated by definition.

# Verification

```
cd catalog && npx vitest run app/containers/Search
```

107 tests. The five in `model.spec.ts` under `orderingOffered` are the ones this
PR adds.

# Position in the stack

**PR 4 of 9**, based on
[`stack/5217-3-search-ordering-accessible-name`](https://github.com/quiltdata/quilt/pull/5261).

Part of the split of #5217 asked for in
[f27](https://github.com/quiltdata/quilt/pull/5217#discussion_r3889140880). It
stacks directly above PR 3 because f47's fix corrects a comment in
`PackageFilters.tsx`, which PR 3 owns — stacking avoids a cross-branch edit. The
two are deliberately not collapsed: PR 3 is an uncontested accessibility fix and
should not need this unit's review to land.

# TODO

- [x] Unit tests
- [x] Security: Confirm that this change meets security best practices and does not violate the security model
- [x] Open: Confirm that this change doesn't break the Open variant
- [x] Changelog entry

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR stabilizes the metadata-facet “Sort by” control while users narrow truncated facet lists and hides it when no facets are displayed. It also unintentionally removes contextual malformed-filter error handling and associated regression tests.

- Uses the stable initial facet-list length for the server-filter ordering threshold.
- Centralizes ordering-control visibility in the pure `orderingOffered` predicate.
- Adds focused predicate coverage and updates explanatory comments and the changelog.
- Replaces contextual filter parsing with direct `JSON.parse` calls, degrading malformed-URL errors.

<h3>Confidence Score: 4/5</h3>

The malformed-filter error regression should be fixed before merging so invalid shared or bookmarked search URLs retain actionable user-facing errors and diagnostics.

Direct `JSON.parse` calls now send raw syntax messages through the search error boundary and omit the malformed value from logs, replacing the existing filter-specific error contract.

**Files Needing Attention:** catalog/app/containers/Search/model.ts, catalog/app/containers/Search/model.spec.ts

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| catalog/app/containers/Search/model.ts | Correctly centralizes ordering visibility, but regresses malformed search-URL handling by removing contextual parsing and logging. |
| catalog/app/containers/Search/model.spec.ts | Adds useful ordering visibility cases but deletes malformed-filter regression coverage alongside the behavioral regression. |
| catalog/app/containers/Search/Layout/PackageFilters.tsx | Updates the rendering comment to accurately describe centralized ordering visibility. |
| catalog/CHANGELOG.md | Documents the intended facet-ordering visibility fix. |

<sub>Reviews (1): Last reviewed commit: ["docs(changelog): entry for the facet ord..."](https://github.com/quiltdata/quilt/commit/63ee89bb20de9b247fb17d8cc816e20ba8a7bb91) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=58629607)</sub>

> Greptile also left **1 inline comment** on this PR.

**Context used:**

- Knowledge Base — [Catalog client features](https://app.greptile.com/quilt-bio/-/custom-context/knowledge-base/quiltdata/quilt/-/docs/catalog-client.md)

<!-- /greptile_comment -->