### PR TITLE
Catalog: say why a disabled Admin Users switch is disabled (5217 stack 5/9)

### DIFF
--- a/catalog/CHANGELOG.md
+++ b/catalog/CHANGELOG.md
@@ -21,7 +21,7 @@ complete sentence without it.
 
 ## Changes
 
-- [Fixed] Admin Users: a disabled Enabled or Admin switch explains why on hover or keyboard focus — "you can't deactivate yourself" and "managed by the stack" used to render as the same mute, dead control ([#5263](https://github.com/quiltdata/quilt/pull/5263))
+- [Fixed] Admin Users: a disabled Enabled or Admin switch says why on hover and on keyboard focus — your own account, a service user managed by the stack, or admin capabilities managed by the SSO configuration — instead of rendering as the same unexplained dead control; the Admin switch now also refuses service users ([#5263](https://github.com/quiltdata/quilt/pull/5263))
 - [Fixed] Search sidebar: the facet "Sort by" control no longer disappears while you type in "Find metadata" on stacks with truncated facet lists, and it is withheld when the query matches nothing rather than offering to sort an empty list ([#5262](https://github.com/quiltdata/quilt/pull/5262))
 - [Fixed] Search sidebar: the facet "Sort by" control announces what it is — its label used to land on a hidden input, leaving assistive tech to read the control as its current ordering and nothing more ([#5261](https://github.com/quiltdata/quilt/pull/5261))
 - [Fixed] Queries: the query selector announces its label to assistive tech, and no longer claims "Custom" is loaded while its helper text reports the query failed to load ([#5260](https://github.com/quiltdata/quilt/pull/5260))

--- a/catalog/CHANGELOG.md
+++ b/catalog/CHANGELOG.md
@@ -21,6 +21,7 @@ complete sentence without it.
 
 ## Changes
 
+- [Fixed] Admin Users: a disabled Enabled or Admin switch explains why on hover or keyboard focus — "you can't deactivate yourself" and "managed by the stack" used to render as the same mute, dead control ([#5263](https://github.com/quiltdata/quilt/pull/5263))
 - [Fixed] Search sidebar: the facet "Sort by" control no longer disappears while you type in "Find metadata" on stacks with truncated facet lists, and it is withheld when the query matches nothing rather than offering to sort an empty list ([#5262](https://github.com/quiltdata/quilt/pull/5262))
 - [Fixed] Search sidebar: the facet "Sort by" control announces what it is — its label used to land on a hidden input, leaving assistive tech to read the control as its current ordering and nothing more ([#5261](https://github.com/quiltdata/quilt/pull/5261))
 - [Fixed] Queries: the query selector announces its label to assistive tech, and no longer claims "Custom" is loaded while its helper text reports the query failed to load ([#5260](https://github.com/quiltdata/quilt/pull/5260))

--- a/catalog/app/containers/Admin/UsersAndRoles/Users.spec.tsx
+++ b/catalog/app/containers/Admin/UsersAndRoles/Users.spec.tsx
@@ -1,0 +1,172 @@
+import * as React from 'react'
+import { render, cleanup, fireEvent, screen } from '@testing-library/react'
+import { describe, it, expect, vi, afterEach } from 'vitest'
+
+import { EditableSwitch, columns } from './Users'
+
+vi.mock('constants/config', () => ({ default: {} }))
+
+describe('containers/Admin/UsersAndRoles/Users', () => {
+  describe('EditableSwitch', () => {
+    afterEach(cleanup)
+
+    it('explains why it is disabled', async () => {
+      // A dead control with no cause is indistinguishable from a rendering
+      // bug -- and two causes (self, service user) share this column.
+      const { container } = render(
+        <EditableSwitch
+          hint="Deactivated users can't sign in"
+          disabled
+          disabledReason="This service user is managed by the stack"
+          checked
+          onChange={vi.fn()}
+        />,
+      )
+      expect(container.querySelector('input')?.disabled).toBe(true)
+      fireEvent.mouseOver(container.querySelector('span')!)
+      expect(
+        await screen.findByText('This service user is managed by the stack'),
+      ).toBeDefined()
+    })
+
+    it('carries the reason to keyboard and screen-reader users', async () => {
+      // The switch is disabled, so it is out of the tab order and fires no
+      // events: without a focusable, named wrapper the reason is mouse-only.
+      render(
+        <EditableSwitch
+          hint="Deactivated users can't sign in"
+          disabled
+          disabledReason="This service user is managed by the stack"
+          checked
+          onChange={vi.fn()}
+        />,
+      )
+      const wrapper = screen.getByLabelText('This service user is managed by the stack')
+      expect(wrapper.getAttribute('tabindex')).toBe('0')
+
+      fireEvent.focus(wrapper)
+      expect(
+        await screen.findByText('This service user is managed by the stack'),
+      ).toBeDefined()
+    })
+
+    it('keeps the hint on the enabled control', async () => {
+      const { container } = render(
+        <EditableSwitch
+          hint="Deactivated users can't sign in"
+          checked
+          onChange={vi.fn()}
+        />,
+      )
+      // MUI seeds the tooltip as a `title` before opening the popper; hover the
+      // node that actually carries it.
+      const titled = container.querySelector('[title]')!
+      expect(titled.getAttribute('title')).toBe("Deactivated users can't sign in")
+      fireEvent.mouseOver(titled)
+      expect(await screen.findByText("Deactivated users can't sign in")).toBeDefined()
+    })
+
+    it('renders a plain disabled switch when no reason is given', () => {
+      const { container } = render(
+        <EditableSwitch
+          hint="Deactivated users can't sign in"
+          disabled
+          checked
+          onChange={vi.fn()}
+        />,
+      )
+      expect(container.querySelector('input')?.disabled).toBe(true)
+    })
+  })
+
+  describe('the Admin column switch', () => {
+    afterEach(cleanup)
+
+    const column = columns.find((c) => c.id === 'isAdmin')!
+
+    function renderSwitch(user: object, isSelf = false) {
+      return render(
+        <>
+          {column.getDisplay!(undefined, user as never, { isSelf, openDialog: vi.fn() })}
+        </>,
+      )
+    }
+
+    it.each([
+      [
+        'a service user',
+        { isAdminAssignmentDisabled: true, isService: true },
+        false,
+        'This service user is managed by the stack',
+      ],
+      [
+        'an SSO-managed user',
+        { isAdminAssignmentDisabled: true, isService: false },
+        false,
+        'Admin capabilities for this user are managed by the SSO configuration',
+      ],
+      [
+        'yourself',
+        { isAdminAssignmentDisabled: false, isService: false },
+        true,
+        'You cannot change your own admin status',
+      ],
+    ])('says why it is disabled for %s', async (_label, user, isSelf, reason) => {
+      const { container } = renderSwitch({ name: 'u', isAdmin: false, ...user }, isSelf)
+      expect(container.querySelector('input')?.disabled).toBe(true)
+      fireEvent.mouseOver(container.querySelector('span')!)
+      expect(await screen.findByText(reason)).toBeDefined()
+    })
+
+    it('stays editable for an ordinary user', () => {
+      const { container } = renderSwitch({
+        name: 'u',
+        isAdmin: false,
+        isAdminAssignmentDisabled: false,
+        isService: false,
+      })
+      expect(container.querySelector('input')?.disabled).toBe(false)
+    })
+  })
+
+  describe('the Enabled column switch', () => {
+    afterEach(cleanup)
+
+    const column = columns.find((c) => c.id === 'isActive')!
+
+    function renderSwitch(user: object, isSelf = false) {
+      return render(
+        <>
+          {column.getDisplay!(
+            undefined,
+            user as never,
+            {
+              isSelf,
+              setActive: vi.fn(),
+            } as never,
+          )}
+        </>,
+      )
+    }
+
+    it.each([
+      [
+        'a service user',
+        { isService: true },
+        false,
+        'This service user is managed by the stack',
+      ],
+      ['yourself', { isService: false }, true, 'You cannot deactivate your own account'],
+    ])('says why it is disabled for %s', async (_label, user, isSelf, reason) => {
+      const { container } = renderSwitch({ name: 'u', isActive: true, ...user }, isSelf)
+      expect(container.querySelector('input')?.disabled).toBe(true)
+      fireEvent.mouseOver(container.querySelector('span')!)
+      expect(await screen.findByText(reason)).toBeDefined()
+    })
+
+    it('stays editable for an ordinary user', () => {
+      const { container } = renderSwitch({ name: 'u', isActive: true, isService: false })
+      expect(container.querySelector('input')?.disabled).toBe(false)
+    })
+  })
+})

--- a/catalog/app/containers/Admin/UsersAndRoles/Users.spec.tsx
+++ b/catalog/app/containers/Admin/UsersAndRoles/Users.spec.tsx
@@ -11,8 +11,6 @@ describe('containers/Admin/UsersAndRoles/Users', () => {
     afterEach(cleanup)
 
     it('explains why it is disabled', async () => {
-      // A dead control with no cause is indistinguishable from a rendering
-      // bug -- and two causes (self, service user) share this column.
       const { container } = render(
         <EditableSwitch
           hint="Deactivated users can't sign in"
@@ -30,8 +28,6 @@ describe('containers/Admin/UsersAndRoles/Users', () => {
     })
 
     it('carries the reason to keyboard and screen-reader users', async () => {
-      // The switch is disabled, so it is out of the tab order and fires no
-      // events: without a focusable, named wrapper the reason is mouse-only.
       render(
         <EditableSwitch
           hint="Deactivated users can't sign in"

--- a/catalog/app/containers/Admin/UsersAndRoles/Users.spec.tsx
+++ b/catalog/app/containers/Admin/UsersAndRoles/Users.spec.tsx
@@ -50,6 +50,34 @@ describe('containers/Admin/UsersAndRoles/Users', () => {
       ).toBeDefined()
     })
 
+    it('draws a focus ring on the reason carrier', () => {
+      // The carrier is focusable but is not a `ButtonBase`, and
+      // `constants/style` implements the Focus Ring Rule for `MuiButtonBase`
+      // only — so without a rule of its own it would take keyboard focus with
+      // nothing drawn on it, on an element added by an accessibility fix.
+      render(
+        <EditableSwitch
+          hint="Deactivated users can't sign in"
+          disabled
+          disabledReason="This service user is managed by the stack"
+          checked
+          onChange={vi.fn()}
+        />,
+      )
+      const wrapper = screen.getByLabelText('This service user is managed by the stack')
+      const sheets = [...document.querySelectorAll('style')].map(
+        (el) => el.textContent ?? '',
+      )
+      const rules = sheets
+        .join('\n')
+        .split('}')
+        .filter((r) =>
+          [...wrapper.classList].some((c) => r.includes(`.${c}:focus-visible`)),
+        )
+      expect(rules.length).toBeGreaterThan(0)
+      expect(rules.join('\n')).toMatch(/outline:\s*2px solid/)
+    })
+
     it('keeps the hint on the enabled control', async () => {
       const { container } = render(
         <EditableSwitch

--- a/catalog/app/containers/Admin/UsersAndRoles/Users.spec.tsx
+++ b/catalog/app/containers/Admin/UsersAndRoles/Users.spec.tsx
@@ -43,18 +43,21 @@ describe('containers/Admin/UsersAndRoles/Users', () => {
       )
       const wrapper = screen.getByLabelText('This service user is managed by the stack')
       expect(wrapper.getAttribute('tabindex')).toBe('0')
+      // ARIA gives a bare span no name; the role is what makes `aria-label` count.
+      expect(wrapper.getAttribute('role')).toBe('group')
+      expect(wrapper.getAttribute('title')).toBeNull()
 
-      fireEvent.focus(wrapper)
+      // Real focus, not a synthetic focus event: MUI opens on focus only when it
+      // reads the focus as keyboard-driven, and a dispatched event moves nothing.
+      fireEvent.keyDown(document.body, { key: 'Tab' })
+      wrapper.focus()
+      expect(document.activeElement).toBe(wrapper)
       expect(
         await screen.findByText('This service user is managed by the stack'),
       ).toBeDefined()
     })
 
     it('draws a focus ring on the reason carrier', () => {
-      // The carrier is focusable but is not a `ButtonBase`, and
-      // `constants/style` implements the Focus Ring Rule for `MuiButtonBase`
-      // only — so without a rule of its own it would take keyboard focus with
-      // nothing drawn on it, on an element added by an accessibility fix.
       render(
         <EditableSwitch
           hint="Deactivated users can't sign in"

--- a/catalog/app/containers/Admin/UsersAndRoles/Users.tsx
+++ b/catalog/app/containers/Admin/UsersAndRoles/Users.tsx
@@ -771,6 +771,19 @@ const useEditableStyles = M.makeStyles((t) => ({
   root: {
     marginLeft: t.spacing(0.5),
   },
+  // The reason carrier below is focusable but is not a `ButtonBase`, and
+  // `constants/style` implements the Focus Ring Rule (DESIGN.md §2) for
+  // `MuiButtonBase` only — so this element would take keyboard focus with
+  // nothing drawn on it. Same 2px ring in the ground's counter-color, offset the
+  // same way, so a keyboard admin can see where they are.
+  reason: {
+    borderRadius: t.shape.borderRadius,
+    display: 'inline-flex',
+    '&:focus-visible': {
+      outline: `2px solid ${t.palette.primary.main}`,
+      outlineOffset: 2,
+    },
+  },
 }))
 
 interface EditableSwitchProps {
@@ -806,8 +819,8 @@ export function EditableSwitch({
         {/* A disabled switch fires no events and is out of the tab order, so the
             reason needs a live wrapper that is focusable and named — otherwise it
             is mouse-only. */}
-        {/* oxlint-disable-next-line jsx-a11y/no-noninteractive-tabindex -- the span is the only reachable carrier of the reason */}
-        <span tabIndex={0} aria-label={disabledReason}>
+        {/* eslint-disable-next-line jsx-a11y/no-noninteractive-tabindex -- the span is the only reachable carrier of the reason */}
+        <span className={classes.reason} tabIndex={0} aria-label={disabledReason}>
           {sw}
         </span>
       </M.Tooltip>

--- a/catalog/app/containers/Admin/UsersAndRoles/Users.tsx
+++ b/catalog/app/containers/Admin/UsersAndRoles/Users.tsx
@@ -775,21 +775,45 @@ const useEditableStyles = M.makeStyles((t) => ({
 
 interface EditableSwitchProps {
   disabled?: boolean
+  /** Why the control is disabled — a disabled switch with no cause is
+   * indistinguishable from a rendering bug, and two different causes (self,
+   * service user) sit in the same column. A string, not a node: it is also the
+   * wrapper's accessible name, which is the only way a keyboard or
+   * screen-reader admin reaches the reason at all. */
+  disabledReason?: string
   checked: boolean
   onChange: (v: boolean) => void
   hint: NonNullable<React.ReactNode>
 }
 
-function EditableSwitch({
+// Exported for testing: the disabled branch must keep explaining itself, and
+// only a render proves the tooltip survives the disabled element's dead events.
+export function EditableSwitch({
   disabled = false,
+  disabledReason,
   checked,
   onChange,
   hint,
 }: EditableSwitchProps) {
   const classes = useEditableStyles()
-  return disabled ? (
-    <M.Switch className={classes.root} checked={checked} disabled color="default" />
-  ) : (
+  if (disabled) {
+    const sw = (
+      <M.Switch className={classes.root} checked={checked} disabled color="default" />
+    )
+    if (!disabledReason) return sw
+    return (
+      <M.Tooltip title={disabledReason}>
+        {/* A disabled switch fires no events and is out of the tab order, so the
+            reason needs a live wrapper that is focusable and named — otherwise it
+            is mouse-only. */}
+        {/* oxlint-disable-next-line jsx-a11y/no-noninteractive-tabindex -- the span is the only reachable carrier of the reason */}
+        <span tabIndex={0} aria-label={disabledReason}>
+          {sw}
+        </span>
+      </M.Tooltip>
+    )
+  }
+  return (
     <Editable value={checked} onChange={onChange}>
       {({ change, busy, value }) => (
         <M.Tooltip title={hint}>
@@ -870,19 +894,45 @@ interface ColumnDisplayProps {
   isSelf: boolean
 }
 
-const columns: Table.Column<User>[] = [
+const MANAGED_BY_STACK = 'This service user is managed by the stack'
+
+// One resolver per switch column, so the guard and its explanation cannot drift:
+// `disabled` is derived from whether there is a reason, never stated separately.
+function whyEnabledDisabled(user: User, isSelf: boolean): string | undefined {
+  if (isSelf) return 'You cannot deactivate your own account'
+  if (user.isService) return MANAGED_BY_STACK
+  return undefined
+}
+
+function whyAdminDisabled(user: User, isSelf: boolean): string | undefined {
+  if (isSelf) return 'You cannot change your own admin status'
+  // `isService` before the SSO flag: the registry couples them, but the guard
+  // must not depend on that, and "managed by the stack" is the truer reason.
+  if (user.isService) return MANAGED_BY_STACK
+  if (user.isAdminAssignmentDisabled)
+    return 'Admin capabilities for this user are managed by the SSO configuration'
+  return undefined
+}
+
+// Exported for testing: a disabled control's explanation lives in the column that
+// renders it, so only the call site proves it is there.
+export const columns: Table.Column<User>[] = [
   {
     id: 'isActive',
     label: 'Enabled',
     getValue: (u) => u.isActive,
-    getDisplay: (_v, u, { setActive, isSelf }: ColumnDisplayProps) => (
-      <EditableSwitch
-        hint="Deactivated users can't sign in and use the Catalog"
-        disabled={isSelf || u.isService}
-        checked={u.isActive}
-        onChange={(active) => setActive(u.name, active)}
-      />
-    ),
+    getDisplay: (_v, u, { setActive, isSelf }: ColumnDisplayProps) => {
+      const reason = whyEnabledDisabled(u, isSelf)
+      return (
+        <EditableSwitch
+          hint="Deactivated users can't sign in and use the Catalog"
+          disabled={reason !== undefined}
+          disabledReason={reason}
+          checked={u.isActive}
+          onChange={(active) => setActive(u.name, active)}
+        />
+      )
+    },
     props: { padding: 'none' },
   },
   {
@@ -931,21 +981,25 @@ const columns: Table.Column<User>[] = [
     id: 'isAdmin',
     label: 'Admin',
     getValue: (u) => u.isAdmin,
-    getDisplay: (_v, u, { openDialog, isSelf }: ColumnDisplayProps) => (
-      <EditableSwitch
-        hint="Admins can see this page, add/remove users, and make/remove admins"
-        disabled={isSelf || u.isAdminAssignmentDisabled}
-        checked={u.isAdmin}
-        onChange={(admin) =>
-          openDialog<boolean>(
-            ({ close }) => <ConfirmAdminRights {...{ close, admin, name: u.name }} />,
-            DIALOG_PROPS,
-          ).then((res) => {
-            if (!res) throw new Error('cancel')
-          })
-        }
-      />
-    ),
+    getDisplay: (_v, u, { openDialog, isSelf }: ColumnDisplayProps) => {
+      const reason = whyAdminDisabled(u, isSelf)
+      return (
+        <EditableSwitch
+          hint="Admins can see this page, add/remove users, and make/remove admins"
+          disabled={reason !== undefined}
+          disabledReason={reason}
+          checked={u.isAdmin}
+          onChange={(admin) =>
+            openDialog<boolean>(
+              ({ close }) => <ConfirmAdminRights {...{ close, admin, name: u.name }} />,
+              DIALOG_PROPS,
+            ).then((res) => {
+              if (!res) throw new Error('cancel')
+            })
+          }
+        />
+      )
+    },
     props: { padding: 'none' },
   },
 ]

--- a/catalog/app/containers/Admin/UsersAndRoles/Users.tsx
+++ b/catalog/app/containers/Admin/UsersAndRoles/Users.tsx
@@ -817,10 +817,17 @@ export function EditableSwitch({
     return (
       <M.Tooltip title={disabledReason}>
         {/* A disabled switch fires no events and is out of the tab order, so the
-            reason needs a live wrapper that is focusable and named — otherwise it
-            is mouse-only. */}
-        {/* eslint-disable-next-line jsx-a11y/no-noninteractive-tabindex -- the span is the only reachable carrier of the reason */}
-        <span className={classes.reason} tabIndex={0} aria-label={disabledReason}>
+            reason needs a focusable wrapper of its own. `role` because ARIA
+            forbids `aria-label` on a bare span; `title` off because MUI seeds it
+            with the same string, repeating the name as the description. */}
+        <span
+          className={classes.reason}
+          // eslint-disable-next-line jsx-a11y/no-noninteractive-tabindex -- the span is the only reachable carrier of the reason
+          tabIndex={0}
+          role="group"
+          aria-label={disabledReason}
+          title={undefined}
+        >
           {sw}
         </span>
       </M.Tooltip>

--- a/catalog/app/containers/Admin/UsersAndRoles/Users.tsx
+++ b/catalog/app/containers/Admin/UsersAndRoles/Users.tsx
@@ -771,11 +771,8 @@ const useEditableStyles = M.makeStyles((t) => ({
   root: {
     marginLeft: t.spacing(0.5),
   },
-  // The reason carrier below is focusable but is not a `ButtonBase`, and
-  // `constants/style` implements the Focus Ring Rule (DESIGN.md §2) for
-  // `MuiButtonBase` only — so this element would take keyboard focus with
-  // nothing drawn on it. Same 2px ring in the ground's counter-color, offset the
-  // same way, so a keyboard admin can see where they are.
+  // Not a `ButtonBase`, and `constants/style` applies the Focus Ring Rule
+  // (DESIGN.md §2) to `MuiButtonBase` only: without this it takes focus unmarked.
   reason: {
     borderRadius: t.shape.borderRadius,
     display: 'inline-flex',
@@ -788,19 +785,14 @@ const useEditableStyles = M.makeStyles((t) => ({
 
 interface EditableSwitchProps {
   disabled?: boolean
-  /** Why the control is disabled — a disabled switch with no cause is
-   * indistinguishable from a rendering bug, and two different causes (self,
-   * service user) sit in the same column. A string, not a node: it is also the
-   * wrapper's accessible name, which is the only way a keyboard or
-   * screen-reader admin reaches the reason at all. */
+  /** A string, not a node: it is also the wrapper's accessible name. */
   disabledReason?: string
   checked: boolean
   onChange: (v: boolean) => void
   hint: NonNullable<React.ReactNode>
 }
 
-// Exported for testing: the disabled branch must keep explaining itself, and
-// only a render proves the tooltip survives the disabled element's dead events.
+// Exported for testing.
 export function EditableSwitch({
   disabled = false,
   disabledReason,
@@ -916,8 +908,8 @@ interface ColumnDisplayProps {
 
 const MANAGED_BY_STACK = 'This service user is managed by the stack'
 
-// One resolver per switch column, so the guard and its explanation cannot drift:
-// `disabled` is derived from whether there is a reason, never stated separately.
+// One resolver per switch column: each call site derives `disabled` from the
+// reason, so the guard and the explanation cannot drift apart.
 function whyEnabledDisabled(user: User, isSelf: boolean): string | undefined {
   if (isSelf) return 'You cannot deactivate your own account'
   if (user.isService) return MANAGED_BY_STACK
@@ -927,15 +919,14 @@ function whyEnabledDisabled(user: User, isSelf: boolean): string | undefined {
 function whyAdminDisabled(user: User, isSelf: boolean): string | undefined {
   if (isSelf) return 'You cannot change your own admin status'
   // `isService` before the SSO flag: the registry couples them, but the guard
-  // must not depend on that, and "managed by the stack" is the truer reason.
+  // must not depend on that.
   if (user.isService) return MANAGED_BY_STACK
   if (user.isAdminAssignmentDisabled)
     return 'Admin capabilities for this user are managed by the SSO configuration'
   return undefined
 }
 
-// Exported for testing: a disabled control's explanation lives in the column that
-// renders it, so only the call site proves it is there.
+// Exported for testing.
 export const columns: Table.Column<User>[] = [
   {
     id: 'isActive',


### PR DESCRIPTION
# Description

In Admin → Users, a disabled **Enabled** or **Admin** switch said nothing about
why. Two different causes — "that row is you" and "that is a service user managed
by the stack" — rendered as the same mute, dead control in the same column, and a
dead control with no stated cause is indistinguishable from a rendering bug.

Each switch column now resolves a reason and derives `disabled` from whether
there is one, so the guard and its explanation cannot drift apart. The reason
reaches keyboard and screen-reader admins as well as mouse users: a disabled
switch fires no events and is out of the tab order, so the tooltip hangs on a
focusable, named wrapper rather than on the switch.

## Review findings addressed

- **f29** — the wrapper that carries the reason is a `<span tabIndex={0})`:
  focusable, and not a `ButtonBase`. `constants/style` implements the Focus Ring
  Rule (`catalog/DESIGN.md` §2, bound onto UI changes by `catalog/CLAUDE.md`) for
  `MuiButtonBase` only, so the new element took keyboard focus with nothing drawn
  on it — an invisible-focus defect on an element added by an accessibility fix.
  It now carries the same 2px ring, at the same offset, from the theme palette.
  The review called this the strongest citation in its set; it was parked on rank,
  not on merit.
- **f38** — this unit introduced `oxlint-disable-next-line` while 111 files in
  `app/` use `eslint-disable-next-line` and two use the oxlint form. oxlint honors
  the eslint comments, so the majority form ships here. **Worth a ruling:** if the
  intent is to migrate the other 111 rather than keep them, say so and this flips.

## Deliberate assumptions and recorded observations

- **f32 — stated as an assumption, because this repository cannot settle it.**
  The Admin switch now refuses **every** `isService` user, and puts `isService`
  ahead of the SSO flag when choosing which reason to show. The GraphQL contract
  this consumes does not declare that coupling; the registry that computes
  `isService` and `isAdminAssignmentDisabled` is outside this repository, so
  nothing in the checkout proves the two always travel together. The guard is
  written not to depend on it — refusing a service user is correct on its own
  terms, and "managed by the stack" is the truer reason where both hold — but a
  reviewer with registry access should confirm there is no service user for whom
  admin assignment is legitimately allowed. The review graded this PLAUSIBLE
  rather than CONFIRMED for exactly this reason.
- **f8** — "what may an admin do to this user" is still re-derived at each render
  site rather than resolved once beside the flags. The
  `whyEnabledDisabled` / `whyAdminDisabled` split answers part of it. Out of scope
  here.
- **f35** — checked and refuted: the reason is not attached where ARIA forbids an
  accessible name.

For reference, the hardening review this stack comes from compared master
([`6167dd82`](https://github.com/quiltdata/quilt/commit/6167dd82)) against the
26.7.4 pin ([`eda3016f`](https://github.com/quiltdata/quilt/commit/eda3016f)) —
linked rather than named, so the comparison is checkable.

# Verification

```
cd catalog && npx vitest run app/containers/Admin/UsersAndRoles
```

12 tests. The focus-ring assertion reads the generated stylesheet for a
`:focus-visible` outline rule on the wrapper's own class, and was checked against
a version with the class removed.

# Position in the stack

**PR 5 of 9**, based on
[`stack/5217-4-search-ordering-visibility`](https://github.com/quiltdata/quilt/pull/5262).

Part of the split of #5217 asked for in
[f27](https://github.com/quiltdata/quilt/pull/5217#discussion_r3889140880). PR 6
edits the same file and stacks directly above; the two sets of hunks are disjoint
and share no symbol, so either order is correct. This one is first because its
fold-in is a present-tense accessibility defect on an element the diff adds.

# TODO

- [x] Unit tests
- [x] Security: Confirm that this change meets security best practices and does not violate the security model
- [x] Open: Confirm that this change doesn't break the Open variant
- [x] Changelog entry

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR explains why Enabled and Admin switches are disabled for self-managed and stack-managed users.
- Adds a focusable, accessibly named tooltip carrier around disabled switches.
- Derives switch disabled state from the corresponding explanatory reason.
- Adds focused unit coverage for mouse, keyboard, focus-ring, and column-level behavior.
- Documents the user-facing fix in the Catalog changelog.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge, with no concrete blocking or independently actionable non-blocking issue identified.

The existing self and service-user restrictions remain enforced, while disabled controls gain mouse and keyboard-accessible explanations with focused test coverage.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| catalog/app/containers/Admin/UsersAndRoles/Users.tsx | Adds reason resolvers and an accessible tooltip wrapper while preserving the existing switch restrictions. |
| catalog/app/containers/Admin/UsersAndRoles/Users.spec.tsx | Covers disabled reasons, keyboard focus, focus-ring styling, enabled hints, and ordinary editable users. |
| catalog/CHANGELOG.md | Adds an accurate entry describing the disabled-switch explanation improvement. |

<sub>Reviews (1): Last reviewed commit: ["docs(changelog): entry for the disabled-..."](https://github.com/quiltdata/quilt/commit/733be4558a8ea25a0ed89721b5043b21ee22fafa) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=58629620)</sub>

<!-- /greptile_comment -->