### PR TITLE
Catalog: stop offering a refused Save for service users (5217 stack 6/9)

### DIFF
--- a/catalog/CHANGELOG.md
+++ b/catalog/CHANGELOG.md
@@ -21,6 +21,7 @@ complete sentence without it.
 
 ## Changes
 
+- [Fixed] Admin Users: the roles dialog and the Role column read as read-only end to end for service users, rather than offering a Save the registry refuses ([#5264](https://github.com/quiltdata/quilt/pull/5264))
 - [Fixed] Admin Users: a disabled Enabled or Admin switch says why on hover and on keyboard focus — your own account, a service user managed by the stack, or admin capabilities managed by the SSO configuration — instead of rendering as the same unexplained dead control; the Admin switch now also refuses service users ([#5263](https://github.com/quiltdata/quilt/pull/5263))
 - [Fixed] Search sidebar: the facet "Sort by" control no longer disappears while you type in "Find metadata" on stacks with truncated facet lists, and it is withheld when the query matches nothing rather than offering to sort an empty list ([#5262](https://github.com/quiltdata/quilt/pull/5262))
 - [Fixed] Search sidebar: the facet "Sort by" control announces what it is — its label used to land on a hidden input, leaving assistive tech to read the control as its current ordering and nothing more ([#5261](https://github.com/quiltdata/quilt/pull/5261))

--- a/catalog/CHANGELOG.md
+++ b/catalog/CHANGELOG.md
@@ -21,7 +21,7 @@ complete sentence without it.
 
 ## Changes
 
-- [Fixed] Admin Users: the roles dialog and the Role column read as read-only end to end for service users, rather than offering a Save the registry refuses ([#5264](https://github.com/quiltdata/quilt/pull/5264))
+- [Fixed] Admin Users: the roles dialog and the Role column are read-only for service users, rather than offering a Save the registry refuses ([#5264](https://github.com/quiltdata/quilt/pull/5264))
 - [Fixed] Admin Users: a disabled Enabled or Admin switch says why on hover and on keyboard focus — your own account, a service user managed by the stack, or admin capabilities managed by the SSO configuration — instead of rendering as the same unexplained dead control; the Admin switch now also refuses service users ([#5263](https://github.com/quiltdata/quilt/pull/5263))
 - [Fixed] Search sidebar: the facet "Sort by" control no longer disappears while you type in "Find metadata" on stacks with truncated facet lists, and it is withheld when the query matches nothing rather than offering to sort an empty list ([#5262](https://github.com/quiltdata/quilt/pull/5262))
 - [Fixed] Search sidebar: the facet "Sort by" control announces what it is — its label used to land on a hidden input, leaving assistive tech to read the control as its current ordering and nothing more ([#5261](https://github.com/quiltdata/quilt/pull/5261))

--- a/catalog/app/containers/Admin/UsersAndRoles/Users.spec.tsx
+++ b/catalog/app/containers/Admin/UsersAndRoles/Users.spec.tsx
@@ -196,4 +196,47 @@ describe('containers/Admin/UsersAndRoles/Users', () => {
       expect(container.querySelector('input')?.disabled).toBe(false)
     })
   })
+  describe('the Role column', () => {
+    afterEach(cleanup)
+
+    const column = columns.find((c) => c.id === 'role')!
+
+    function renderRole(user: object) {
+      return render(
+        <>
+          {column.getDisplay!(
+            undefined,
+            { extraRoles: [], ...user } as never,
+            {
+              roles: [],
+              defaultRole: null,
+              openDialog: vi.fn(),
+            } as never,
+          )}
+        </>,
+      )
+    }
+
+    // The dialog this opens is read-only for both flags, so the invitation to
+    // edit must be gated on the same pair.
+    it.each([
+      ['an SSO-managed user', { isRoleAssignmentDisabled: true, isService: false }],
+      ['a service user', { isRoleAssignmentDisabled: false, isService: true }],
+    ])('offers only viewing for %s', (_label, user) => {
+      const { container } = renderRole(user)
+      expect(container.querySelector('[title]')?.getAttribute('title')).toBe(
+        'Click to view',
+      )
+    })
+
+    it('offers editing for an ordinary user', () => {
+      const { container } = renderRole({
+        isRoleAssignmentDisabled: false,
+        isService: false,
+      })
+      expect(container.querySelector('[title]')?.getAttribute('title')).toBe(
+        'Click to edit',
+      )
+    })
+  })
 })

--- a/catalog/app/containers/Admin/UsersAndRoles/Users.spec.tsx
+++ b/catalog/app/containers/Admin/UsersAndRoles/Users.spec.tsx
@@ -7,9 +7,15 @@ import { EditRoles, EditableSwitch, columns } from './Users'
 vi.mock('constants/config', () => ({ default: {} }))
 
 // The dialog reaches for a notification channel and a GraphQL mutation on mount;
-// neither is what these tests are about.
-vi.mock('containers/Notifications', () => ({ use: () => ({ push: vi.fn() }) }))
-vi.mock('utils/GraphQL', () => ({ useMutation: () => vi.fn() }))
+// stub only those, so the rest of each module still resolves for later tests.
+vi.mock('containers/Notifications', async () => ({
+  ...(await vi.importActual('containers/Notifications')),
+  use: () => ({ push: vi.fn() }),
+}))
+vi.mock('utils/GraphQL', async () => ({
+  ...(await vi.importActual('utils/GraphQL')),
+  useMutation: () => vi.fn(),
+}))
 
 describe('containers/Admin/UsersAndRoles/Users', () => {
   describe('EditableSwitch', () => {
@@ -222,8 +228,7 @@ describe('containers/Admin/UsersAndRoles/Users', () => {
       )
     }
 
-    // The dialog this opens is read-only for both flags, so the invitation to
-    // edit must be gated on the same pair.
+    // Gated on the same reason as the dialog it opens, so both flags matter here.
     it.each([
       ['an SSO-managed user', { isRoleAssignmentDisabled: true, isService: false }],
       ['a service user', { isRoleAssignmentDisabled: false, isService: true }],
@@ -259,18 +264,23 @@ describe('containers/Admin/UsersAndRoles/Users', () => {
       )
     }
 
-    // Before this pair was used, the title, the select and the Save action all
-    // gated on `isRoleAssignmentDisabled` alone -- so a service user without
-    // that flag was offered a Save the registry refuses, which submits the
-    // unchanged values and reports success.
     it.each([
-      ['an SSO-managed user', { isRoleAssignmentDisabled: true, isService: false }],
-      ['a service user', { isRoleAssignmentDisabled: false, isService: true }],
-    ])('offers no way to save for %s', (_label, user) => {
+      [
+        'an SSO-managed user',
+        { isRoleAssignmentDisabled: true, isService: false },
+        'Roles are assigned via role mapping and may be changed in config.',
+      ],
+      [
+        'a service user',
+        { isRoleAssignmentDisabled: false, isService: true },
+        'Roles for this service user are managed by the stack.',
+      ],
+    ])('offers no way to save for %s, and says why', (_label, user, why) => {
       renderDialog(user)
       expect(screen.getByText('Roles assigned to "u"')).toBeDefined()
       expect(screen.queryByText('Save')).toBeNull()
       expect(screen.getByText('Close')).toBeDefined()
+      expect(screen.getByText(why)).toBeDefined()
     })
 
     it('offers a save for an ordinary user', () => {

--- a/catalog/app/containers/Admin/UsersAndRoles/Users.spec.tsx
+++ b/catalog/app/containers/Admin/UsersAndRoles/Users.spec.tsx
@@ -2,9 +2,14 @@ import * as React from 'react'
 import { render, cleanup, fireEvent, screen } from '@testing-library/react'
 import { describe, it, expect, vi, afterEach } from 'vitest'
 
-import { EditableSwitch, columns } from './Users'
+import { EditRoles, EditableSwitch, columns } from './Users'
 
 vi.mock('constants/config', () => ({ default: {} }))
+
+// The dialog reaches for a notification channel and a GraphQL mutation on mount;
+// neither is what these tests are about.
+vi.mock('containers/Notifications', () => ({ use: () => ({ push: vi.fn() }) }))
+vi.mock('utils/GraphQL', () => ({ useMutation: () => vi.fn() }))
 
 describe('containers/Admin/UsersAndRoles/Users', () => {
   describe('EditableSwitch', () => {
@@ -237,6 +242,41 @@ describe('containers/Admin/UsersAndRoles/Users', () => {
       expect(container.querySelector('[title]')?.getAttribute('title')).toBe(
         'Click to edit',
       )
+    })
+  })
+
+  describe('EditRoles', () => {
+    afterEach(cleanup)
+
+    function renderDialog(user: object) {
+      return render(
+        <EditRoles
+          close={vi.fn()}
+          roles={[]}
+          defaultRole={null}
+          user={{ name: 'u', extraRoles: [], role: null, ...user } as never}
+        />,
+      )
+    }
+
+    // Before this pair was used, the title, the select and the Save action all
+    // gated on `isRoleAssignmentDisabled` alone -- so a service user without
+    // that flag was offered a Save the registry refuses, which submits the
+    // unchanged values and reports success.
+    it.each([
+      ['an SSO-managed user', { isRoleAssignmentDisabled: true, isService: false }],
+      ['a service user', { isRoleAssignmentDisabled: false, isService: true }],
+    ])('offers no way to save for %s', (_label, user) => {
+      renderDialog(user)
+      expect(screen.getByText('Roles assigned to "u"')).toBeDefined()
+      expect(screen.queryByText('Save')).toBeNull()
+      expect(screen.getByText('Close')).toBeDefined()
+    })
+
+    it('offers a save for an ordinary user', () => {
+      renderDialog({ isRoleAssignmentDisabled: false, isService: false })
+      expect(screen.getByText('Assign roles to "u"')).toBeDefined()
+      expect(screen.getByText('Save')).toBeDefined()
     })
   })
 })

--- a/catalog/app/containers/Admin/UsersAndRoles/Users.tsx
+++ b/catalog/app/containers/Admin/UsersAndRoles/Users.tsx
@@ -594,9 +594,17 @@ interface EditRolesProps {
   user: User
 }
 
-// Exported for testing: the read-only branch decides whether a Save is offered
-// at all, and only a render of the dialog proves which branch a given pair of
-// flags lands on.
+// One resolver for the dialog and the Role column that opens it: each derives
+// `readOnly` from the reason, so the guard and the copy cannot drift apart.
+function whyRoleReadOnly(user: User): 'service' | 'sso' | undefined {
+  // `isService` before the SSO flag: the registry couples them, but the guard
+  // must not depend on that.
+  if (user.isService) return 'service'
+  if (user.isRoleAssignmentDisabled) return 'sso'
+  return undefined
+}
+
+// Exported for testing.
 export function EditRoles({ close, roles, defaultRole, user }: EditRolesProps) {
   const { push } = Notifications.use()
   const setRole = GQL.useMutation(USER_SET_ROLE_MUTATION)
@@ -657,10 +665,8 @@ export function EditRoles({ close, roles, defaultRole, user }: EditRolesProps) {
     [user.extraRoles, user.role],
   )
 
-  // One expression for the whole dialog. The registry couples these (isService
-  // implies isRoleAssignmentDisabled), but nothing here may depend on that: a
-  // live Save the registry refuses submits unchanged values and reports success.
-  const readOnly = user.isRoleAssignmentDisabled || user.isService
+  const nonAssignableReason = whyRoleReadOnly(user)
+  const readOnly = nonAssignableReason !== undefined
 
   return (
     <RF.Form<FormValues>
@@ -692,7 +698,7 @@ export function EditRoles({ close, roles, defaultRole, user }: EditRolesProps) {
                     roles={roles}
                     defaultRole={defaultRole}
                     nonAssignable={readOnly}
-                    nonAssignableReason={user.isService ? 'service' : 'sso'}
+                    nonAssignableReason={nonAssignableReason}
                     {...props}
                   />
                 )}
@@ -886,9 +892,7 @@ function RoleDisplay({ user, roles, defaultRole, openDialog }: RoleDisplayProps)
       fullWidth: true,
     })
 
-  // Same pair as the dialog this opens and the switch columns: the registry
-  // couples the flags, but nothing here may depend on that holding.
-  const readOnly = user.isRoleAssignmentDisabled || user.isService
+  const readOnly = whyRoleReadOnly(user) !== undefined
 
   return (
     <M.Tooltip title={readOnly ? 'Click to view' : 'Click to edit'}>

--- a/catalog/app/containers/Admin/UsersAndRoles/Users.tsx
+++ b/catalog/app/containers/Admin/UsersAndRoles/Users.tsx
@@ -594,7 +594,10 @@ interface EditRolesProps {
   user: User
 }
 
-function EditRoles({ close, roles, defaultRole, user }: EditRolesProps) {
+// Exported for testing: the read-only branch decides whether a Save is offered
+// at all, and only a render of the dialog proves which branch a given pair of
+// flags lands on.
+export function EditRoles({ close, roles, defaultRole, user }: EditRolesProps) {
   const { push } = Notifications.use()
   const setRole = GQL.useMutation(USER_SET_ROLE_MUTATION)
 

--- a/catalog/app/containers/Admin/UsersAndRoles/Users.tsx
+++ b/catalog/app/containers/Admin/UsersAndRoles/Users.tsx
@@ -654,6 +654,11 @@ function EditRoles({ close, roles, defaultRole, user }: EditRolesProps) {
     [user.extraRoles, user.role],
   )
 
+  // One expression for the whole dialog. The registry couples these (isService
+  // implies isRoleAssignmentDisabled), but nothing here may depend on that: a
+  // live Save the registry refuses submits unchanged values and reports success.
+  const readOnly = user.isRoleAssignmentDisabled || user.isService
+
   return (
     <RF.Form<FormValues>
       onSubmit={onSubmit}
@@ -672,7 +677,7 @@ function EditRoles({ close, roles, defaultRole, user }: EditRolesProps) {
       }) => (
         <>
           <M.DialogTitle>
-            {user.isRoleAssignmentDisabled
+            {readOnly
               ? `Roles assigned to "${user.name}"`
               : `Assign roles to "${user.name}"`}
           </M.DialogTitle>
@@ -683,7 +688,7 @@ function EditRoles({ close, roles, defaultRole, user }: EditRolesProps) {
                   <RoleSelect.RoleSelect
                     roles={roles}
                     defaultRole={defaultRole}
-                    nonAssignable={user.isRoleAssignmentDisabled}
+                    nonAssignable={readOnly}
                     nonAssignableReason={user.isService ? 'service' : 'sso'}
                     {...props}
                   />
@@ -694,7 +699,7 @@ function EditRoles({ close, roles, defaultRole, user }: EditRolesProps) {
               </Form.FormErrorAuto>
             </DialogForm>
           </M.DialogContent>
-          {user.isRoleAssignmentDisabled ? (
+          {readOnly ? (
             <M.DialogActions>
               <M.Button color="primary" onClick={close} variant="contained">
                 Close
@@ -878,8 +883,12 @@ function RoleDisplay({ user, roles, defaultRole, openDialog }: RoleDisplayProps)
       fullWidth: true,
     })
 
+  // Same pair as the dialog this opens and the switch columns: the registry
+  // couples the flags, but nothing here may depend on that holding.
+  const readOnly = user.isRoleAssignmentDisabled || user.isService
+
   return (
-    <M.Tooltip title={user.isRoleAssignmentDisabled ? 'Click to view' : 'Click to edit'}>
+    <M.Tooltip title={readOnly ? 'Click to view' : 'Click to edit'}>
       <Clickable onClick={edit}>
         {user.role?.name ?? emptyRole}
         {user.extraRoles.length > 0 && <Hint> +{user.extraRoles.length}</Hint>}


### PR DESCRIPTION
# Description

In Admin → Users, the roles dialog and the Role column offered an edit that
cannot happen. Both gated on `isRoleAssignmentDisabled` alone, so a **service
user with that flag unset** got a dialog headed "Assign roles to …", an assignable
`RoleSelect`, and a live **Save** — a Save the registry refuses. The Role column's
tooltip invited the click on the same basis.

Both now derive one `readOnly` from the pair. The registry couples these flags,
but nothing here depends on that holding: refusing a service user is correct on
its own terms.

**Why this is a real fix and not a claim about an unreachable state.** It is worth
stating explicitly, because it was challenged and survived: before this change,
the dialog title, `RoleSelect.nonAssignable` and the Save action all gated on
`isRoleAssignmentDisabled` *alone*. A Save therefore **was** offered for any user
with `isService && !isRoleAssignmentDisabled`. That combination is what the fix
closes, and the failure it produces is the worst kind — the Save submits unchanged
values and reports success, so the admin is told a change landed that did not.

## Review findings addressed

- **f49** — the Role column's half of the change was covered by a test; the
  dialog's was not, and the dialog is where the refused Save lived. `EditRoles`
  was unexported and never rendered by a test. It is exported for testing now, and
  both flags are driven through it.

Recorded:

- **f43** — checked and refuted. The disclosure names two sites and the Role
  column did change too; both are in this PR.
- **f53** — checked and refuted, and the refutation's reasoning is the paragraph
  above.

# Verification

```
cd catalog && npx vitest run app/containers/Admin/UsersAndRoles
```

18 tests. The three new ones render `EditRoles` directly; they were checked
against a version gated on `isRoleAssignmentDisabled` alone, which fails the
service-user case.

# Position in the stack

**PR 6 of 9**, based on
[`stack/5217-5-admin-disabled-switch-reason`](https://github.com/quiltdata/quilt/pull/5263).

Part of the split of #5217 asked for in
[f27](https://github.com/quiltdata/quilt/pull/5217#discussion_r3889140880). PR 5
edits the same file; the two sets of hunks are disjoint and share no symbol, so
either order is correct and neither depends on the other's behaviour. They are
stacked rather than combined so that the accessibility fix and the permission fix
can be reviewed, and reverted, separately.

# TODO

- [x] Unit tests
- [x] Security: Confirm that this change meets security best practices and does not violate the security model
- [x] Open: Confirm that this change doesn't break the Open variant
- [x] Changelog entry

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR makes service-user role management consistently read-only across the Admin Users role column and dialog.

- Uses one read-only predicate for dialog copy, role selection, actions, and the Role-column tooltip.
- Adds direct coverage for service, SSO-managed, and ordinary users.
- Documents the corrected behavior in the Catalog changelog.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge with no actionable regressions identified.

The role column and dialog now share the same read-only condition, and the affected service-user, SSO-managed-user, and ordinary-user branches have focused render coverage.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| catalog/app/containers/Admin/UsersAndRoles/Users.tsx | Consistently applies the combined service-user and role-assignment-disabled predicate to every affected role-editing affordance. |
| catalog/app/containers/Admin/UsersAndRoles/Users.spec.tsx | Adds focused coverage proving both read-only cases suppress Save while ordinary users retain role editing. |
| catalog/CHANGELOG.md | Accurately records the service-user role-management UI fix. |

<sub>Reviews (1): Last reviewed commit: ["docs(changelog): entry for the service-u..."](https://github.com/quiltdata/quilt/commit/6600455e098b41a45ce3fc48c5bb1f83b4b5ab97) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=58629624)</sub>

<!-- /greptile_comment -->