### PR TITLE
Catalog: honor a mis-cased Athena workgroup and stop masking the bucket default (5217 stack 7/9)

### DIFF
--- a/catalog/CHANGELOG.md
+++ b/catalog/CHANGELOG.md
@@ -21,7 +21,7 @@ complete sentence without it.
 
 ## Changes
 
-- [Fixed] Athena Queries: a workgroup named in `ui.athena.defaultWorkgroup` or in the URL is honored whatever its capitalisation — a mis-cased name used to match and then have every AWS call rejected — and a stored workgroup that has been deleted or lost access no longer hides a valid bucket default ([#5265](https://github.com/quiltdata/quilt/pull/5265))
+- [Fixed] Athena Queries: a workgroup named in the URL is honored whatever its capitalisation, instead of matching a workgroup you can see and then having every AWS call rejected ([#5265](https://github.com/quiltdata/quilt/pull/5265))
 - [Fixed] Admin Users: the roles dialog and the Role column are read-only for service users, rather than offering a Save the registry refuses ([#5264](https://github.com/quiltdata/quilt/pull/5264))
 - [Fixed] Admin Users: a disabled Enabled or Admin switch says why on hover and on keyboard focus — your own account, a service user managed by the stack, or admin capabilities managed by the SSO configuration — instead of rendering as the same unexplained dead control; the Admin switch now also refuses service users ([#5263](https://github.com/quiltdata/quilt/pull/5263))
 - [Fixed] Search sidebar: the facet "Sort by" control no longer disappears while you type in "Find metadata" on stacks with truncated facet lists, and it is withheld when the query matches nothing rather than offering to sort an empty list ([#5262](https://github.com/quiltdata/quilt/pull/5262))

--- a/catalog/CHANGELOG.md
+++ b/catalog/CHANGELOG.md
@@ -21,6 +21,7 @@ complete sentence without it.
 
 ## Changes
 
+- [Fixed] Athena Queries: a workgroup named in `ui.athena.defaultWorkgroup` or in the URL is honored whatever its capitalisation — a mis-cased name used to match and then have every AWS call rejected — and a stored workgroup that has been deleted or lost access no longer hides a valid bucket default ([#5265](https://github.com/quiltdata/quilt/pull/5265))
 - [Fixed] Admin Users: the roles dialog and the Role column are read-only for service users, rather than offering a Save the registry refuses ([#5264](https://github.com/quiltdata/quilt/pull/5264))
 - [Fixed] Admin Users: a disabled Enabled or Admin switch says why on hover and on keyboard focus — your own account, a service user managed by the stack, or admin capabilities managed by the SSO configuration — instead of rendering as the same unexplained dead control; the Admin switch now also refuses service users ([#5263](https://github.com/quiltdata/quilt/pull/5263))
 - [Fixed] Search sidebar: the facet "Sort by" control no longer disappears while you type in "Find metadata" on stacks with truncated facet lists, and it is withheld when the query matches nothing rather than offering to sort an empty list ([#5262](https://github.com/quiltdata/quilt/pull/5262))

--- a/catalog/app/containers/Queries/Athena/model/requests.spec.ts
+++ b/catalog/app/containers/Queries/Athena/model/requests.spec.ts
@@ -1300,6 +1300,46 @@ describe('containers/Queries/Athena/model/requests', () => {
       unmount()
     })
 
+    it('prefers an exact match over a differently-cased sibling', async () => {
+      // Workgroup names are case-sensitive, so both can exist. `fetchWorkgroups`
+      // sorts, which puts 'Alpha' first -- a case-insensitive match alone would
+      // hand the user the workgroup they did not ask for.
+      const workgroups = {
+        data: { list: ['Alpha', 'alpha'] },
+        loadMore: noop,
+      }
+
+      const { result, waitFor, unmount } = renderHook(() =>
+        useWrapper([workgroups, 'alpha', undefined]),
+      )
+
+      await act(async () => {
+        await waitFor(() => typeof result.current.data === 'string')
+        expect(result.current.data).toBe('alpha')
+      })
+      unmount()
+    })
+
+    it('falls back rather than throwing when the default is not a string', async () => {
+      // `ui.athena` is unconstrained by the bucket-config schema, so an all-digit
+      // workgroup name in the YAML arrives as a number. Reaching `toLowerCase`
+      // with it threw out of the effect and took the console down.
+      const workgroups = {
+        data: { list: ['foo', '2024'] },
+        loadMore: noop,
+      }
+
+      const { result, waitFor, unmount } = renderHook(() =>
+        useWrapper([workgroups, undefined, 2024 as unknown as string]),
+      )
+
+      await act(async () => {
+        await waitFor(() => typeof result.current.data === 'string')
+        expect(result.current.data).toBe('foo')
+      })
+      unmount()
+    })
+
     it('canonicalises a mis-cased workgroup from the URL too', async () => {
       const workgroups = {
         data: { list: ['foo', 'analytics-prod'] },

--- a/catalog/app/containers/Queries/Athena/model/requests.spec.ts
+++ b/catalog/app/containers/Queries/Athena/model/requests.spec.ts
@@ -1266,10 +1266,9 @@ describe('containers/Queries/Athena/model/requests', () => {
         data: { list: ['foo', 'bar'] },
         loadMore: noop,
       }
-      const preferences = { defaultWorkgroup: 'bar' }
 
       const { result, waitFor, unmount } = renderHook(() =>
-        useWrapper([workgroups, undefined, preferences]),
+        useWrapper([workgroups, undefined, 'bar']),
       )
 
       await act(async () => {

--- a/catalog/app/containers/Queries/Athena/model/requests.spec.ts
+++ b/catalog/app/containers/Queries/Athena/model/requests.spec.ts
@@ -1279,11 +1279,6 @@ describe('containers/Queries/Athena/model/requests', () => {
     })
 
     it('stores the workgroup as AWS spells it, not as the caller did', async () => {
-      // The match is case-insensitive, but `listNamedQueries` and
-      // `startQueryExecution` send this value verbatim: an admin writing
-      // `ui.athena.defaultWorkgroup: Analytics-Prod` against a workgroup named
-      // `analytics-prod` used to match here and then have AWS reject every call,
-      // so the console errored instead of honoring the default.
       const workgroups = {
         data: { list: ['foo', 'analytics-prod'] },
         loadMore: noop,
@@ -1358,10 +1353,6 @@ describe('containers/Queries/Athena/model/requests', () => {
     })
 
     it('falls through to the bucket default when the stored workgroup is gone', async () => {
-      // A stored workgroup that has been deleted, or whose access was revoked,
-      // used to be picked by `stored || default`, fail the availability check,
-      // and drop through to the first workgroup in the list -- masking a bucket
-      // default that was perfectly valid.
       const storageMock = getStorageKey.getMockImplementation()
       getStorageKey.mockImplementation(() => 'deleted')
       const workgroups = {
@@ -1369,23 +1360,24 @@ describe('containers/Queries/Athena/model/requests', () => {
         loadMore: noop,
       }
 
-      const { result, waitFor, unmount } = renderHook(() =>
-        useWrapper([workgroups, undefined, 'team']),
-      )
+      try {
+        const { result, waitFor, unmount } = renderHook(() =>
+          useWrapper([workgroups, undefined, 'team']),
+        )
 
-      await act(async () => {
-        await waitFor(() => typeof result.current.data === 'string')
-        expect(result.current.data).toBe('team')
-      })
-      getStorageKey.mockImplementation(storageMock!)
-      unmount()
+        await act(async () => {
+          await waitFor(() => typeof result.current.data === 'string')
+          expect(result.current.data).toBe('team')
+        })
+        unmount()
+      } finally {
+        getStorageKey.mockImplementation(storageMock!)
+      }
     })
 
     it('keeps the stored workgroup ahead of the bucket default', async () => {
-      // Pinned in whichever direction it is set: nothing tested this precedence
-      // either way, and the two candidates are read in one expression. Storage
-      // first predates this code path, and reordering it is a product decision
-      // rather than a bug fix -- so it is asserted here rather than changed.
+      // Precedence pinned, not chosen here: storage-before-default predates this
+      // code path, so changing it is a product decision.
       const storageMock = getStorageKey.getMockImplementation()
       getStorageKey.mockImplementation(() => 'alpha')
       const workgroups = {
@@ -1393,16 +1385,19 @@ describe('containers/Queries/Athena/model/requests', () => {
         loadMore: noop,
       }
 
-      const { result, waitFor, unmount } = renderHook(() =>
-        useWrapper([workgroups, undefined, 'team']),
-      )
+      try {
+        const { result, waitFor, unmount } = renderHook(() =>
+          useWrapper([workgroups, undefined, 'team']),
+        )
 
-      await act(async () => {
-        await waitFor(() => typeof result.current.data === 'string')
-        expect(result.current.data).toBe('alpha')
-      })
-      getStorageKey.mockImplementation(storageMock!)
-      unmount()
+        await act(async () => {
+          await waitFor(() => typeof result.current.data === 'string')
+          expect(result.current.data).toBe('alpha')
+        })
+        unmount()
+      } finally {
+        getStorageKey.mockImplementation(storageMock!)
+      }
     })
 
     it('select the first available workgroup if no requested or default', async () => {

--- a/catalog/app/containers/Queries/Athena/model/requests.spec.ts
+++ b/catalog/app/containers/Queries/Athena/model/requests.spec.ts
@@ -1278,6 +1278,93 @@ describe('containers/Queries/Athena/model/requests', () => {
       unmount()
     })
 
+    it('stores the workgroup as AWS spells it, not as the caller did', async () => {
+      // The match is case-insensitive, but `listNamedQueries` and
+      // `startQueryExecution` send this value verbatim: an admin writing
+      // `ui.athena.defaultWorkgroup: Analytics-Prod` against a workgroup named
+      // `analytics-prod` used to match here and then have AWS reject every call,
+      // so the console errored instead of honoring the default.
+      const workgroups = {
+        data: { list: ['foo', 'analytics-prod'] },
+        loadMore: noop,
+      }
+
+      const { result, waitFor, unmount } = renderHook(() =>
+        useWrapper([workgroups, undefined, 'Analytics-Prod']),
+      )
+
+      await act(async () => {
+        await waitFor(() => typeof result.current.data === 'string')
+        expect(result.current.data).toBe('analytics-prod')
+      })
+      unmount()
+    })
+
+    it('canonicalises a mis-cased workgroup from the URL too', async () => {
+      const workgroups = {
+        data: { list: ['foo', 'analytics-prod'] },
+        loadMore: noop,
+      }
+
+      const { result, waitFor, unmount } = renderHook(() =>
+        useWrapper([workgroups, 'ANALYTICS-PROD', undefined]),
+      )
+
+      await act(async () => {
+        await waitFor(() => typeof result.current.data === 'string')
+        expect(result.current.data).toBe('analytics-prod')
+      })
+      unmount()
+    })
+
+    it('falls through to the bucket default when the stored workgroup is gone', async () => {
+      // A stored workgroup that has been deleted, or whose access was revoked,
+      // used to be picked by `stored || default`, fail the availability check,
+      // and drop through to the first workgroup in the list -- masking a bucket
+      // default that was perfectly valid.
+      const storageMock = getStorageKey.getMockImplementation()
+      getStorageKey.mockImplementation(() => 'deleted')
+      const workgroups = {
+        data: { list: ['alpha', 'team'] },
+        loadMore: noop,
+      }
+
+      const { result, waitFor, unmount } = renderHook(() =>
+        useWrapper([workgroups, undefined, 'team']),
+      )
+
+      await act(async () => {
+        await waitFor(() => typeof result.current.data === 'string')
+        expect(result.current.data).toBe('team')
+      })
+      getStorageKey.mockImplementation(storageMock!)
+      unmount()
+    })
+
+    it('keeps the stored workgroup ahead of the bucket default', async () => {
+      // Pinned in whichever direction it is set: nothing tested this precedence
+      // either way, and the two candidates are read in one expression. Storage
+      // first predates this code path, and reordering it is a product decision
+      // rather than a bug fix -- so it is asserted here rather than changed.
+      const storageMock = getStorageKey.getMockImplementation()
+      getStorageKey.mockImplementation(() => 'alpha')
+      const workgroups = {
+        data: { list: ['alpha', 'team'] },
+        loadMore: noop,
+      }
+
+      const { result, waitFor, unmount } = renderHook(() =>
+        useWrapper([workgroups, undefined, 'team']),
+      )
+
+      await act(async () => {
+        await waitFor(() => typeof result.current.data === 'string')
+        expect(result.current.data).toBe('alpha')
+      })
+      getStorageKey.mockImplementation(storageMock!)
+      unmount()
+    })
+
     it('select the first available workgroup if no requested or default', async () => {
       await act(async () => {
         const workgroups = {

--- a/catalog/app/containers/Queries/Athena/model/requests.ts
+++ b/catalog/app/containers/Queries/Athena/model/requests.ts
@@ -35,9 +35,16 @@ function parseNamedQuery(query: Athena.NamedQuery): Query {
  * the *canonical* name: the match ignores case, but every AWS call downstream
  * sends the workgroup name verbatim and rejects a mis-cased one with
  * `InvalidRequestException`.
+ *
+ * Names are case-sensitive, so `alpha` and `Alpha` can both exist -- an exact
+ * hit has to win over the case-insensitive one, which the sorted list would
+ * otherwise resolve to whichever sorts first.
  */
 function canonical(list: string[], value: string): string | undefined {
-  return list.find((x) => x.toLowerCase() === value.toLowerCase())
+  return (
+    list.find((x) => x === value) ??
+    list.find((x) => x.toLowerCase() === value.toLowerCase())
+  )
 }
 
 function listIncludes(list: string[], value: string): boolean {
@@ -223,8 +230,10 @@ export function useWorkgroup(
     //
     // Storage still outranks the bucket default. That precedence predates this
     // code path and reordering it is a product decision, not a bug fix.
-    const pick = (candidate?: string | null): boolean => {
-      if (!candidate) return false
+    // `unknown`, not `string`: `defaultWorkgroup` comes from a user-authored YAML
+    // document, and the bucket-config schema does not constrain `ui.athena`.
+    const pick = (candidate: unknown): boolean => {
+      if (typeof candidate !== 'string' || !candidate) return false
       const found = canonical(list, candidate)
       if (!found) return false
       setData(found)

--- a/catalog/app/containers/Queries/Athena/model/requests.ts
+++ b/catalog/app/containers/Queries/Athena/model/requests.ts
@@ -4,7 +4,6 @@ import * as React from 'react'
 import * as Sentry from '@sentry/react'
 
 import * as AWS from 'utils/AWS'
-import * as BucketPreferences from 'utils/BucketPreferences'
 import Log from 'utils/Logging'
 import noop from 'utils/noop'
 
@@ -190,7 +189,10 @@ export function useWorkgroups(): Model.DataController<Model.List<Workgroup>> {
 export function useWorkgroup(
   workgroups: Model.DataController<Model.List<Workgroup>>,
   requestedWorkgroup?: Workgroup,
-  preferences?: BucketPreferences.AthenaPreferences,
+  // The one preference this needs, as a string rather than the `ui.athena`
+  // object: the parsed preferences are rebuilt on every provider render, so an
+  // object here would re-fire this effect throughout the workgroup probe.
+  defaultWorkgroup?: string,
 ): Model.DataController<Workgroup> {
   const [data, setData] = React.useState<Model.Data<Workgroup>>()
   React.useEffect(() => {
@@ -203,7 +205,7 @@ export function useWorkgroup(
     }
 
     // Stored or default workgroup
-    const initialWorkgroup = storage.getWorkgroup() || preferences?.defaultWorkgroup
+    const initialWorkgroup = storage.getWorkgroup() || defaultWorkgroup
     if (initialWorkgroup && listIncludes(workgroups.data.list, initialWorkgroup)) {
       setData(initialWorkgroup)
       return
@@ -212,7 +214,7 @@ export function useWorkgroup(
     // First available workgroup or error. Producer drains to exhaustion, so
     // an accessible workgroup that exists is in this list.
     setData(workgroups.data.list[0] || new Error('Workgroup not found'))
-  }, [preferences, requestedWorkgroup, workgroups])
+  }, [defaultWorkgroup, requestedWorkgroup, workgroups])
   return React.useMemo(() => ({ data, loadMore: noop }), [data])
 }
 

--- a/catalog/app/containers/Queries/Athena/model/requests.ts
+++ b/catalog/app/containers/Queries/Athena/model/requests.ts
@@ -28,8 +28,20 @@ function parseNamedQuery(query: Athena.NamedQuery): Query {
   }
 }
 
+/**
+ * The list's own spelling of `value`, matched case-insensitively.
+ *
+ * Returns the entry rather than a boolean, because the caller must go on to use
+ * the *canonical* name: the match ignores case, but every AWS call downstream
+ * sends the workgroup name verbatim and rejects a mis-cased one with
+ * `InvalidRequestException`.
+ */
+function canonical(list: string[], value: string): string | undefined {
+  return list.find((x) => x.toLowerCase() === value.toLowerCase())
+}
+
 function listIncludes(list: string[], value: string): boolean {
-  return list.map((x) => x.toLowerCase()).includes(value.toLowerCase())
+  return canonical(list, value) !== undefined
 }
 
 export type Workgroup = string
@@ -197,23 +209,38 @@ export function useWorkgroup(
   const [data, setData] = React.useState<Model.Data<Workgroup>>()
   React.useEffect(() => {
     if (!Model.hasData(workgroups.data)) return
+    const { list } = workgroups.data
 
-    // URL parameter workgroup (user navigation)
-    if (requestedWorkgroup && listIncludes(workgroups.data.list, requestedWorkgroup)) {
-      setData(requestedWorkgroup)
-      return
+    // Each candidate is resolved to the list's own spelling before it is stored:
+    // the match is case-insensitive, but `listNamedQueries` and
+    // `startQueryExecution` send this value verbatim and AWS rejects a mis-cased
+    // workgroup outright.
+    //
+    // Tried in turn rather than `stored || default`: an unavailable stored
+    // workgroup -- deleted, or access revoked -- used to be picked by the `||`,
+    // fail the availability check, and drop through to the first workgroup in the
+    // list, masking a bucket default that was perfectly valid.
+    //
+    // Storage still outranks the bucket default. That precedence predates this
+    // code path and reordering it is a product decision, not a bug fix.
+    const pick = (candidate?: string | null): boolean => {
+      if (!candidate) return false
+      const found = canonical(list, candidate)
+      if (!found) return false
+      setData(found)
+      return true
     }
 
-    // Stored or default workgroup
-    const initialWorkgroup = storage.getWorkgroup() || defaultWorkgroup
-    if (initialWorkgroup && listIncludes(workgroups.data.list, initialWorkgroup)) {
-      setData(initialWorkgroup)
-      return
-    }
+    // URL parameter workgroup (user navigation), then the stored one, then the
+    // bucket default. Read in that order and only as far as needed, so a URL
+    // that names a workgroup never touches storage.
+    if (pick(requestedWorkgroup)) return
+    if (pick(storage.getWorkgroup())) return
+    if (pick(defaultWorkgroup)) return
 
     // First available workgroup or error. Producer drains to exhaustion, so
     // an accessible workgroup that exists is in this list.
-    setData(workgroups.data.list[0] || new Error('Workgroup not found'))
+    setData(list[0] || new Error('Workgroup not found'))
   }, [defaultWorkgroup, requestedWorkgroup, workgroups])
   return React.useMemo(() => ({ data, loadMore: noop }), [data])
 }

--- a/catalog/app/containers/Queries/Athena/model/requests.ts
+++ b/catalog/app/containers/Queries/Athena/model/requests.ts
@@ -29,16 +29,13 @@ function parseNamedQuery(query: Athena.NamedQuery): Query {
 }
 
 /**
- * The list's own spelling of `value`, matched case-insensitively.
+ * The list's own spelling of `value`, preferring an exact match.
  *
- * Returns the entry rather than a boolean, because the caller must go on to use
- * the *canonical* name: the match ignores case, but every AWS call downstream
- * sends the workgroup name verbatim and rejects a mis-cased one with
- * `InvalidRequestException`.
- *
- * Names are case-sensitive, so `alpha` and `Alpha` can both exist -- an exact
- * hit has to win over the case-insensitive one, which the sorted list would
- * otherwise resolve to whichever sorts first.
+ * Callers must use the spelling this returns: AWS calls send the workgroup name
+ * verbatim and reject a mis-cased one with `InvalidRequestException`. Names are
+ * case-sensitive, so `alpha` and `Alpha` can both exist -- an exact hit has to
+ * win over the case-insensitive one, which the sorted list would otherwise
+ * resolve to whichever sorts first.
  */
 function canonical(list: string[], value: string): string | undefined {
   return (
@@ -208,9 +205,9 @@ export function useWorkgroups(): Model.DataController<Model.List<Workgroup>> {
 export function useWorkgroup(
   workgroups: Model.DataController<Model.List<Workgroup>>,
   requestedWorkgroup?: Workgroup,
-  // The one preference this needs, as a string rather than the `ui.athena`
-  // object: the parsed preferences are rebuilt on every provider render, so an
-  // object here would re-fire this effect throughout the workgroup probe.
+  // A string rather than the `ui.athena` object: the parsed preferences are
+  // rebuilt on every provider render, so an object would re-fire this effect
+  // throughout the workgroup probe.
   defaultWorkgroup?: string,
 ): Model.DataController<Workgroup> {
   const [data, setData] = React.useState<Model.Data<Workgroup>>()
@@ -218,18 +215,6 @@ export function useWorkgroup(
     if (!Model.hasData(workgroups.data)) return
     const { list } = workgroups.data
 
-    // Each candidate is resolved to the list's own spelling before it is stored:
-    // the match is case-insensitive, but `listNamedQueries` and
-    // `startQueryExecution` send this value verbatim and AWS rejects a mis-cased
-    // workgroup outright.
-    //
-    // Tried in turn rather than `stored || default`: an unavailable stored
-    // workgroup -- deleted, or access revoked -- used to be picked by the `||`,
-    // fail the availability check, and drop through to the first workgroup in the
-    // list, masking a bucket default that was perfectly valid.
-    //
-    // Storage still outranks the bucket default. That precedence predates this
-    // code path and reordering it is a product decision, not a bug fix.
     // `unknown`, not `string`: `defaultWorkgroup` comes from a user-authored YAML
     // document, and the bucket-config schema does not constrain `ui.athena`.
     const pick = (candidate: unknown): boolean => {
@@ -240,9 +225,6 @@ export function useWorkgroup(
       return true
     }
 
-    // URL parameter workgroup (user navigation), then the stored one, then the
-    // bucket default. Read in that order and only as far as needed, so a URL
-    // that names a workgroup never touches storage.
     if (pick(requestedWorkgroup)) return
     if (pick(storage.getWorkgroup())) return
     if (pick(defaultWorkgroup)) return

--- a/catalog/app/containers/Queries/Athena/model/state.spec.tsx
+++ b/catalog/app/containers/Queries/Athena/model/state.spec.tsx
@@ -102,4 +102,58 @@ describe('app/containers/Queries/Athena/model/state', () => {
     expect(result.current.workgroup.data).toBe('w')
     unmount()
   })
+
+  it('threads the bucket default workgroup through to the model', async () => {
+    // The seam this branch exists to restore: `Provider` takes `ui.athena` from
+    // the `?bucket=` scope's preferences and hands the default workgroup to
+    // `useWorkgroup`. Nothing crossed it, so the prop could have been dropped on
+    // the floor and every test here would still have passed.
+    // A workgroup *is* named, but it is one this user cannot reach — a bookmark
+    // from before access changed. Without a named workgroup the provider
+    // redirects instead of rendering, so this is also the shape that lets the
+    // default be observed at all.
+    useParams.mockImplementation(() => ({ workgroup: 'gone' }) as Record<string, string>)
+    listWorkGroups.mockImplementation(() => ({
+      promise: () =>
+        Promise.resolve({
+          WorkGroups: [{ Name: 'alpha' }, { Name: 'team' }],
+        }),
+    }))
+    getWorkGroup.mockImplementation(({ WorkGroup: Name }: { WorkGroup: string }) => ({
+      promise: () =>
+        Promise.resolve({
+          WorkGroup: {
+            Configuration: { ResultConfiguration: { OutputLocation: 'any' } },
+            State: 'ENABLED',
+            Name,
+          },
+        }),
+    }))
+    listNamedQueries.mockImplementation((_x, cb) => {
+      cb(undefined, { NamedQueryIds: [] })
+      return { abort: noop }
+    })
+    listQueryExecutions.mockImplementation((_x, cb) => {
+      cb(undefined, { QueryExecutionIds: [] })
+      return { abort: noop }
+    })
+    listDataCatalogs.mockImplementation(() => ({
+      promise: () => Promise.resolve({ DataCatalogsSummary: [] }),
+    }))
+
+    const wrapper = ({ children }: { children: React.ReactNode }) => (
+      <Model.Provider preferences={{ defaultWorkgroup: 'team' }}>
+        {children}
+      </Model.Provider>
+    )
+    const { result, waitFor, unmount } = renderHook(() => Model.useState(), { wrapper })
+    await act(async () => {
+      await waitFor(() => typeof result.current.workgroup.data === 'string')
+    })
+    // 'alpha' is first in the list, so this is the default being honored rather
+    // than the fallback happening to agree.
+    expect(result.current.workgroup.data).toBe('team')
+    unmount()
+    useParams.mockImplementation(() => ({ workgroup: 'w' }) as Record<string, string>)
+  })
 })

--- a/catalog/app/containers/Queries/Athena/model/state.spec.tsx
+++ b/catalog/app/containers/Queries/Athena/model/state.spec.tsx
@@ -104,14 +104,9 @@ describe('app/containers/Queries/Athena/model/state', () => {
   })
 
   it('threads the bucket default workgroup through to the model', async () => {
-    // The seam this branch exists to restore: `Provider` takes `ui.athena` from
-    // the `?bucket=` scope's preferences and hands the default workgroup to
-    // `useWorkgroup`. Nothing crossed it, so the prop could have been dropped on
-    // the floor and every test here would still have passed.
-    // A workgroup *is* named, but it is one this user cannot reach — a bookmark
-    // from before access changed. Without a named workgroup the provider
-    // redirects instead of rendering, so this is also the shape that lets the
-    // default be observed at all.
+    // The workgroup named in the URL is deliberately one this user cannot reach:
+    // without a named workgroup the provider redirects instead of rendering, so
+    // this is the only shape in which the default can be observed.
     useParams.mockImplementation(() => ({ workgroup: 'gone' }) as Record<string, string>)
     listWorkGroups.mockImplementation(() => ({
       promise: () =>
@@ -146,14 +141,17 @@ describe('app/containers/Queries/Athena/model/state', () => {
         {children}
       </Model.Provider>
     )
-    const { result, waitFor, unmount } = renderHook(() => Model.useState(), { wrapper })
-    await act(async () => {
-      await waitFor(() => typeof result.current.workgroup.data === 'string')
-    })
-    // 'alpha' is first in the list, so this is the default being honored rather
-    // than the fallback happening to agree.
-    expect(result.current.workgroup.data).toBe('team')
-    unmount()
-    useParams.mockImplementation(() => ({ workgroup: 'w' }) as Record<string, string>)
+    try {
+      const { result, waitFor, unmount } = renderHook(() => Model.useState(), { wrapper })
+      await act(async () => {
+        await waitFor(() => typeof result.current.workgroup.data === 'string')
+      })
+      // 'alpha' is first in the list, so this is the default being honored rather
+      // than the fallback happening to agree.
+      expect(result.current.workgroup.data).toBe('team')
+      unmount()
+    } finally {
+      useParams.mockImplementation(() => ({ workgroup: 'w' }) as Record<string, string>)
+    }
   })
 })

--- a/catalog/app/containers/Queries/Athena/model/state.tsx
+++ b/catalog/app/containers/Queries/Athena/model/state.tsx
@@ -2,6 +2,7 @@ import invariant from 'invariant'
 import * as React from 'react'
 import * as RRDom from 'react-router-dom'
 
+import type * as BucketPreferences from 'utils/BucketPreferences'
 import * as NamedRoutes from 'utils/NamedRoutes'
 
 import * as requests from './requests'
@@ -62,10 +63,15 @@ export interface State {
 export const Ctx = React.createContext<State | null>(null)
 
 interface ProviderProps {
+  /**
+   * `ui.athena` from the `?bucket=` scope's preferences. The console is
+   * workspace-global, so this only arrives when a bucket is in scope.
+   */
+  preferences?: BucketPreferences.AthenaPreferences
   children: React.ReactNode
 }
 
-export function Provider({ children }: ProviderProps) {
+export function Provider({ preferences, children }: ProviderProps) {
   const { urls } = NamedRoutes.use()
   const location = RRDom.useLocation()
 
@@ -77,7 +83,11 @@ export function Provider({ children }: ProviderProps) {
   const execution = requests.useWaitForQueryExecution(queryExecutionId)
 
   const workgroups = requests.useWorkgroups()
-  const workgroup = requests.useWorkgroup(workgroups, workgroupId)
+  const workgroup = requests.useWorkgroup(
+    workgroups,
+    workgroupId,
+    preferences?.defaultWorkgroup,
+  )
   const queries = requests.useQueries(workgroup.data)
   const query = requests.useQuery(queries.data, execution)
   const queryBody = requests.useQueryBody(query.value, query.setValue, execution)


### PR DESCRIPTION
# Description

Two bugs in how the Athena console chooses a workgroup, plus the seam that lets a
bucket's `ui.athena.defaultWorkgroup` reach that choice at all.

**The console errors instead of honoring the default.** The workgroup was matched
case-insensitively and then stored and used verbatim. An admin writing
`ui.athena.defaultWorkgroup: Analytics-Prod` against a workgroup named
`analytics-prod` matched here — and then `listNamedQueries` and
`startQueryExecution` sent the admin's casing, and AWS rejected it with
`InvalidRequestException`. The same hole swallowed a mis-cased `:workgroup` URL
segment. Candidates now resolve to the list's own spelling before being stored.

**An unavailable stored workgroup masked a valid default.** With
`storage.getWorkgroup() || defaultWorkgroup`, a stored workgroup that had been
deleted or lost access was picked by the `||`, failed the availability check, and
dropped through to the alphabetically-first workgroup — never trying a bucket
default that was perfectly good. Candidates are tried in turn instead.

**The seam.** `Model.Provider` takes an optional `preferences` prop and hands
`ui.athena.defaultWorkgroup` to `useWorkgroup` as a string rather than the whole
object — the parsed preferences are rebuilt on every provider render, so an object
would re-fire the workgroup effect throughout the probe.

**Safe on its own.** Nothing passes the new prop yet, so the seam is a no-op in
isolation and this PR stands as a refactor plus two real bug fixes. The consumer
that supplies the prop is PR 9.

## Review findings addressed

- **f34** — the case-insensitive match with verbatim use, above.
- **f16** — the masked bucket default, above. **Strictly a bug fix:** storage
  still outranks the bucket default; only the fall-through changed.
- **f46** — the `Provider` → `useWorkgroup` seam was crossed by no test, so the
  prop could have been dropped on the floor unnoticed. Now driven through the
  provider.
- **f33 (i)** — nothing pinned the stored-vs-preference precedence in either
  direction. It is pinned now.
- **f51** — recorded as the change's own benefit rather than left implicit:
  narrowing the third parameter to `defaultWorkgroup?: string` removes
  `utils/BucketPreferences` from the AWS-call layer entirely.

## ⚠️ f33 (ii) — a decision this PR deliberately does not take

`storage.getWorkgroup()` still outranks `ui.athena.defaultWorkgroup`. That means
**any user who has ever switched workgroup never sees the bucket default** — which
is narrower than "honors that bucket's `defaultWorkgroup` again" implies.

This precedence is not new: it exists verbatim in the 26.7.4 pin
([`eda3016f`](https://github.com/quiltdata/quilt/commit/eda3016f),
`Bucket/Queries/Athena/model/requests.ts:127`), which is the baseline the
hardening review compared master
([`6167dd82`](https://github.com/quiltdata/quilt/commit/6167dd82)) against.
Reordering it changes behaviour for returning users, which is a product decision
rather than hardening — so it is **not** silently reordered here.

**A maintainer should rule on one of two things:** either the precedence is
reordered deliberately in its own change, or the changelog wording narrows to
match what the code does. The test added here pins the current order, so a
deliberate reversal will show up as a test to change rather than a silent drift.

f16's fall-through fix is independent of this and lands either way.

## Recorded, not fixed here

- **f19** — `preferences?.defaultWorkgroup` flattens a preference object to a
  primitive at the consumer to dodge an unmemoized shared provider. Real; the
  proper fix is to memoize `BucketPreferences`, which is wider than this branch.
- The same case-canonicalisation shape exists for **databases and catalog names**
  (`listIncludes` at five other call sites in this file). Untouched here: f34 named
  the workgroup, and those paths have their own storage-restore behaviour that
  deserves its own reading rather than a blanket change.

# Verification

```
cd catalog && npx vitest run app/containers/Queries/Athena
```

102 tests. The four new ones in `requests.spec.ts` and the one in `state.spec.tsx`
were each checked against the pre-fix code and fail there.

# Position in the stack

**PR 7 of 9**, based on
[`stack/5217-6-admin-service-read-only`](https://github.com/quiltdata/quilt/pull/5264).

Part of the split of #5217 asked for in
[f27](https://github.com/quiltdata/quilt/pull/5217#discussion_r3889140880). This
is the one hard mechanical dependency in that set, and the reason the Athena work
splits in two: the seam is a no-op in isolation, so it can land on its own merits
while the mount change that activates it (PR 9) waits on a direction call. **Do
not squash this into PR 9** — that destroys the property that makes it
independently mergeable.

# TODO

- [x] Unit tests
- [x] Security: Confirm that this change meets security best practices and does not violate the security model
- [x] Open: Confirm that this change doesn't break the Open variant
- [x] Changelog entry

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR corrects Athena workgroup selection by canonicalizing case-insensitive matches to AWS-provided names and trying stored and bucket-default candidates independently. It also adds an optional provider seam for forwarding the bucket’s default workgroup and expands focused test coverage.

- Canonicalizes URL, stored, and configured workgroup names before downstream AWS calls.
- Falls through from an unavailable stored workgroup to a valid bucket default.
- Threads `preferences.defaultWorkgroup` through the Athena model provider.
- Adds regression tests for casing, precedence, fallback, and provider propagation.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge, with the changed selection paths constrained to available Athena workgroups and covered by targeted regression tests.

The implementation resolves candidate names against Athena’s returned list, preserves the documented precedence, falls through unavailable candidates correctly, and introduces no active incompatibility because the new provider prop is optional.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| catalog/app/containers/Queries/Athena/model/requests.ts | Refactors workgroup matching and precedence to use canonical available names and correctly fall through among candidates. |
| catalog/app/containers/Queries/Athena/model/requests.spec.ts | Adds focused regression coverage for case canonicalization, unavailable stored selections, and stored/default precedence. |
| catalog/app/containers/Queries/Athena/model/state.tsx | Adds a type-safe optional Athena preference prop and forwards only the stable default-workgroup string. |
| catalog/app/containers/Queries/Athena/model/state.spec.tsx | Verifies that the provider seam forwards the configured default through the integrated Athena model. |
| catalog/CHANGELOG.md | Documents the corrected casing and fallback behavior accurately. |

<sub>Reviews (1): Last reviewed commit: ["docs(changelog): entry for the workgroup..."](https://github.com/quiltdata/quilt/commit/fc62d139ea8c51af83b02b9b5cf79978145a1092) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=58629632)</sub>

<!-- /greptile_comment -->