### PR TITLE
Catalog: keep the bucket scope on legacy Athena redirects (5217 stack 8/9)

### DIFF
--- a/catalog/CHANGELOG.md
+++ b/catalog/CHANGELOG.md
@@ -21,7 +21,7 @@ complete sentence without it.
 
 ## Changes
 
-- [Changed] Athena Queries: a legacy per-bucket queries link now lands in the workspace console scoped to that bucket (`?bucket=`) instead of unscoped, so the bucket's `ui.athena` preferences still apply; a `?bucket=` already on the link no longer overrides the bucket the link is for ([#5266](https://github.com/quiltdata/quilt/pull/5266))
+- [Fixed] Athena Queries: a legacy per-bucket Athena link now lands in the workspace console still scoped to that bucket (`?bucket=`) instead of unscoped, and a `?bucket=` already on the link no longer overrides the bucket the link is for ([#5266](https://github.com/quiltdata/quilt/pull/5266))
 - [Fixed] Athena Queries: a workgroup named in the URL is honored whatever its capitalisation, instead of matching a workgroup you can see and then having every AWS call rejected ([#5265](https://github.com/quiltdata/quilt/pull/5265))
 - [Fixed] Admin Users: the roles dialog and the Role column are read-only for service users, rather than offering a Save the registry refuses ([#5264](https://github.com/quiltdata/quilt/pull/5264))
 - [Fixed] Admin Users: a disabled Enabled or Admin switch says why on hover and on keyboard focus — your own account, a service user managed by the stack, or admin capabilities managed by the SSO configuration — instead of rendering as the same unexplained dead control; the Admin switch now also refuses service users ([#5263](https://github.com/quiltdata/quilt/pull/5263))

--- a/catalog/CHANGELOG.md
+++ b/catalog/CHANGELOG.md
@@ -21,6 +21,7 @@ complete sentence without it.
 
 ## Changes
 
+- [Changed] Athena Queries: a legacy per-bucket queries link now lands in the workspace console scoped to that bucket (`?bucket=`) instead of unscoped, so the bucket's `ui.athena` preferences still apply; a `?bucket=` already on the link no longer overrides the bucket the link is for ([#5266](https://github.com/quiltdata/quilt/pull/5266))
 - [Fixed] Athena Queries: a workgroup named in the URL is honored whatever its capitalisation, instead of matching a workgroup you can see and then having every AWS call rejected ([#5265](https://github.com/quiltdata/quilt/pull/5265))
 - [Fixed] Admin Users: the roles dialog and the Role column are read-only for service users, rather than offering a Save the registry refuses ([#5264](https://github.com/quiltdata/quilt/pull/5264))
 - [Fixed] Admin Users: a disabled Enabled or Admin switch says why on hover and on keyboard focus — your own account, a service user managed by the stack, or admin capabilities managed by the SSO configuration — instead of rendering as the same unexplained dead control; the Admin switch now also refuses service users ([#5263](https://github.com/quiltdata/quilt/pull/5263))

--- a/catalog/app/containers/App/queryRedirects.jsx
+++ b/catalog/app/containers/App/queryRedirects.jsx
@@ -7,23 +7,18 @@ import parseSearch from 'utils/parseSearch'
 
 // Legacy bucket-scoped query console routes redirect to the workspace-global
 // /queries screens (the bucket is not a home for the consoles anymore). These
-// components are extracted from App.jsx unchanged so their redirect targets are
-// unit-testable; App.jsx wires them at `paths.bucketQueries` exactly as before.
+// components live outside App.jsx so their redirect targets are unit-testable;
+// App.jsx wires them at `paths.bucketQueries`.
 
-// The bucket segment becomes the console's `?bucket=` scope param on every shape
-// below, because that param is what makes the bucket's `ui.athena` preferences
-// apply — a workgroup or execution link that dropped it would land the reader in
-// the same console, unscoped.
+// The bucket segment becomes the console's `?bucket=` scope param: the console
+// is workspace-global, so that param is what keeps it pointed at the bucket the
+// legacy link named.
 function useScopeSearch() {
   const { bucket } = useParams()
-  const { search } = useLocation()
-  // `bucket` last, so the route wins. The bucket is in the path being redirected
-  // from and is therefore authoritative; a `?bucket=` already on the incoming
-  // URL is a query param on a per-bucket route, which cannot outrank it. With
-  // the spread the other way round,
-  // `/b/source/queries/athena/primary?bucket=other` loaded `other`'s
-  // preferences.
-  return mkSearch({ ...parseSearch(search, true), bucket })
+  // The scope and nothing else. These two routes declare no other search param,
+  // and carrying a `?table=` onto an execution would fire the Tabulator autofill
+  // over the SQL of the execution being viewed.
+  return mkSearch({ bucket })
 }
 
 export function AthenaWorkgroupRedirect() {
@@ -51,10 +46,9 @@ export function AthenaRootRedirect() {
   const { bucket } = useParams()
   const { search } = useLocation()
   const { urls } = NamedRoutes.use()
-  // Through the route builder rather than `useScopeSearch`, so `?table=`
-  // tabulator deep links keep their declared shape.
-  // `bucket` last for the same reason as `useScopeSearch`: the route's bucket
-  // outranks one arriving in the query string.
+  // The builder keeps `{ bucket, table }`, so the `?table=` tabulator deep links
+  // this shape carries survive. `bucket` last: the path being redirected from
+  // outranks a `?bucket=` arriving in the query string.
   const params = parseSearch(search, true)
   return <Redirect to={urls.queriesAthena({ ...params, bucket })} />
 }

--- a/catalog/app/containers/App/queryRedirects.jsx
+++ b/catalog/app/containers/App/queryRedirects.jsx
@@ -17,7 +17,13 @@ import parseSearch from 'utils/parseSearch'
 function useScopeSearch() {
   const { bucket } = useParams()
   const { search } = useLocation()
-  return mkSearch({ bucket, ...parseSearch(search, true) })
+  // `bucket` last, so the route wins. The bucket is in the path being redirected
+  // from and is therefore authoritative; a `?bucket=` already on the incoming
+  // URL is a query param on a per-bucket route, which cannot outrank it. With
+  // the spread the other way round,
+  // `/b/source/queries/athena/primary?bucket=other` loaded `other`'s
+  // preferences.
+  return mkSearch({ ...parseSearch(search, true), bucket })
 }
 
 export function AthenaWorkgroupRedirect() {
@@ -47,8 +53,10 @@ export function AthenaRootRedirect() {
   const { urls } = NamedRoutes.use()
   // Through the route builder rather than `useScopeSearch`, so `?table=`
   // tabulator deep links keep their declared shape.
+  // `bucket` last for the same reason as `useScopeSearch`: the route's bucket
+  // outranks one arriving in the query string.
   const params = parseSearch(search, true)
-  return <Redirect to={urls.queriesAthena({ bucket, ...params })} />
+  return <Redirect to={urls.queriesAthena({ ...params, bucket })} />
 }
 
 export function BucketQueriesRedirect() {

--- a/catalog/app/containers/App/queryRedirects.jsx
+++ b/catalog/app/containers/App/queryRedirects.jsx
@@ -1,6 +1,7 @@
 import * as React from 'react'
 import { Switch, Route, Redirect, useLocation, useParams } from 'react-router-dom'
 
+import mkSearch from 'utils/mkSearch'
 import * as NamedRoutes from 'utils/NamedRoutes'
 import parseSearch from 'utils/parseSearch'
 
@@ -9,24 +10,43 @@ import parseSearch from 'utils/parseSearch'
 // components are extracted from App.jsx unchanged so their redirect targets are
 // unit-testable; App.jsx wires them at `paths.bucketQueries` exactly as before.
 
+// The bucket segment becomes the console's `?bucket=` scope param on every shape
+// below, because that param is what makes the bucket's `ui.athena` preferences
+// apply — a workgroup or execution link that dropped it would land the reader in
+// the same console, unscoped.
+function useScopeSearch() {
+  const { bucket } = useParams()
+  const { search } = useLocation()
+  return mkSearch({ bucket, ...parseSearch(search, true) })
+}
+
 export function AthenaWorkgroupRedirect() {
   const { workgroup } = useParams()
   const { urls } = NamedRoutes.use()
-  return <Redirect to={urls.queriesAthenaWorkgroup(workgroup)} />
+  const search = useScopeSearch()
+  return <Redirect to={{ pathname: urls.queriesAthenaWorkgroup(workgroup), search }} />
 }
 
 export function AthenaExecutionRedirect() {
   const { workgroup, queryExecutionId } = useParams()
   const { urls } = NamedRoutes.use()
-  return <Redirect to={urls.queriesAthenaExecution(workgroup, queryExecutionId)} />
+  const search = useScopeSearch()
+  return (
+    <Redirect
+      to={{
+        pathname: urls.queriesAthenaExecution(workgroup, queryExecutionId),
+        search,
+      }}
+    />
+  )
 }
 
 export function AthenaRootRedirect() {
   const { bucket } = useParams()
   const { search } = useLocation()
   const { urls } = NamedRoutes.use()
-  // The bucket segment becomes the console's `?bucket=` scope param (keeping
-  // `?table=` tabulator deep links alive); the rest of the search is preserved.
+  // Through the route builder rather than `useScopeSearch`, so `?table=`
+  // tabulator deep links keep their declared shape.
   const params = parseSearch(search, true)
   return <Redirect to={urls.queriesAthena({ bucket, ...params })} />
 }

--- a/catalog/app/containers/App/queryRedirects.spec.tsx
+++ b/catalog/app/containers/App/queryRedirects.spec.tsx
@@ -72,15 +72,23 @@ describe('containers/App/queryRedirects', () => {
     expect(landingAt('/b/my-bucket/queries/es')).toBe('/queries/es')
   })
 
-  it('redirects an athena workgroup, dropping the bucket', () => {
+  // Every athena shape carries the bucket, because `?bucket=` is what makes that
+  // bucket's `ui.athena` preferences apply to the console.
+  it('redirects an athena workgroup, carrying the bucket', () => {
     expect(landingAt('/b/my-bucket/queries/athena/primary')).toBe(
-      '/queries/athena/primary',
+      '/queries/athena/primary?bucket=my-bucket',
     )
   })
 
-  it('redirects an athena query execution', () => {
+  it('redirects an athena query execution, carrying the bucket', () => {
     expect(landingAt('/b/my-bucket/queries/athena/primary/exec-1')).toBe(
-      '/queries/athena/primary/exec-1',
+      '/queries/athena/primary/exec-1?bucket=my-bucket',
+    )
+  })
+
+  it('preserves other query params alongside the bucket on a workgroup URL', () => {
+    expect(landingAt('/b/my-bucket/queries/athena/primary?table=drugs')).toBe(
+      '/queries/athena/primary?bucket=my-bucket&table=drugs',
     )
   })
 })

--- a/catalog/app/containers/App/queryRedirects.spec.tsx
+++ b/catalog/app/containers/App/queryRedirects.spec.tsx
@@ -72,8 +72,8 @@ describe('containers/App/queryRedirects', () => {
     expect(landingAt('/b/my-bucket/queries/es')).toBe('/queries/es')
   })
 
-  // Every athena shape carries the bucket, because `?bucket=` is what makes that
-  // bucket's `ui.athena` preferences apply to the console.
+  // Every athena shape carries the bucket: the console is workspace-global, so
+  // `?bucket=` is what keeps it scoped to the bucket the legacy link named.
   it('redirects an athena workgroup, carrying the bucket', () => {
     expect(landingAt('/b/my-bucket/queries/athena/primary')).toBe(
       '/queries/athena/primary?bucket=my-bucket',
@@ -87,9 +87,9 @@ describe('containers/App/queryRedirects', () => {
   })
 
   // The bucket in the path is the authoritative one: it is the route being
-  // redirected from. A `?bucket=` riding along on the incoming URL used to win,
-  // so `/b/source/queries/athena/primary?bucket=other` loaded `other`'s
-  // preferences instead of `source`'s.
+  // redirected from, so it outranks a `?bucket=` riding along in the query
+  // string. Only the athena root ever honoured that param before; the other two
+  // shapes dropped the search entirely and landed unscoped.
   it.each([
     [
       'a workgroup URL',
@@ -113,12 +113,21 @@ describe('containers/App/queryRedirects', () => {
     },
   )
 
-  it('preserves other query params alongside the bucket on a workgroup URL', () => {
-    // `bucket` comes last in the string because the route's value is applied
-    // last, so it outranks one arriving in the query. Order carries no meaning
-    // to any reader of these params.
-    expect(landingAt('/b/my-bucket/queries/athena/primary?table=drugs')).toBe(
-      '/queries/athena/primary?table=drugs&bucket=my-bucket',
-    )
+  // Only the athena root takes a `?table=` deep link. Carrying one onto an
+  // execution would fire the Tabulator autofill over the SQL of the execution
+  // being viewed, so these two shapes take the scope and nothing else.
+  it.each([
+    [
+      'a workgroup URL',
+      '/b/my-bucket/queries/athena/primary?table=drugs',
+      '/queries/athena/primary?bucket=my-bucket',
+    ],
+    [
+      'an execution URL',
+      '/b/my-bucket/queries/athena/primary/exec-1?table=drugs',
+      '/queries/athena/primary/exec-1?bucket=my-bucket',
+    ],
+  ])('drops ?table= on %s, keeping the bucket scope', (_label, from, to) => {
+    expect(landingAt(from)).toBe(to)
   })
 })

--- a/catalog/app/containers/App/queryRedirects.spec.tsx
+++ b/catalog/app/containers/App/queryRedirects.spec.tsx
@@ -86,9 +86,39 @@ describe('containers/App/queryRedirects', () => {
     )
   })
 
+  // The bucket in the path is the authoritative one: it is the route being
+  // redirected from. A `?bucket=` riding along on the incoming URL used to win,
+  // so `/b/source/queries/athena/primary?bucket=other` loaded `other`'s
+  // preferences instead of `source`'s.
+  it.each([
+    [
+      'a workgroup URL',
+      '/b/source/queries/athena/primary?bucket=other',
+      '/queries/athena/primary?bucket=source',
+    ],
+    [
+      'an execution URL',
+      '/b/source/queries/athena/primary/exec-1?bucket=other',
+      '/queries/athena/primary/exec-1?bucket=source',
+    ],
+    [
+      'the athena root',
+      '/b/source/queries/athena?bucket=other',
+      '/queries/athena?bucket=source',
+    ],
+  ])(
+    'keeps the route bucket ahead of one in the query string on %s',
+    (_label, from, to) => {
+      expect(landingAt(from)).toBe(to)
+    },
+  )
+
   it('preserves other query params alongside the bucket on a workgroup URL', () => {
+    // `bucket` comes last in the string because the route's value is applied
+    // last, so it outranks one arriving in the query. Order carries no meaning
+    // to any reader of these params.
     expect(landingAt('/b/my-bucket/queries/athena/primary?table=drugs')).toBe(
-      '/queries/athena/primary?bucket=my-bucket&table=drugs',
+      '/queries/athena/primary?table=drugs&bucket=my-bucket',
     )
   })
 })


### PR DESCRIPTION
# Description

A legacy `/b/:bucket/queries/athena/...` URL redirects into the workspace-level
console. It dropped the bucket segment on the way, so the bucket's `ui.athena`
preferences stopped applying — the reader landed in the same console, unscoped.
The bucket segment now becomes the console's `?bucket=` scope param on every
athena shape, with the rest of the search preserved alongside it.

**This is a behaviour change to legacy deep links, and it deserves saying out
loud:** a bookmarked `/b/:bucket/queries/athena/:workgroup` now lands somewhere
different from before — same path, but with `?bucket=` set. Nothing in the
previous description or changelog said so, which is why this unit carries its own
entry.

**Safe on its own.** The param is carried and, until PR 9, ignored. That makes
this the producer half of a producer/consumer pair, and it is deliberately first:
PR 9 alone would leave the preference dead for exactly the legacy-URL readers the
fix is for.

## Review findings addressed

- **f12** ([thread](https://github.com/quiltdata/quilt/pull/5217#discussion_r3889140875))
  — the incoming query string was spread *after* the route's bucket, so a
  `?bucket=` riding along on the legacy URL **overrode the bucket the URL was
  about**. `/b/source/queries/athena/primary?bucket=other` redirected into the
  console scoped to `other` and loaded `other`'s preferences. Both sites had the
  same spread order — the workgroup/execution helper and the root redirect — and
  both are reversed. Three cases are pinned.
- **f13** — the undisclosed relocation of legacy deep links, above and in the
  changelog. Splitting the change is what made this statable: it is this PR's
  whole subject rather than one line in a six-subsystem diff.

Recorded:

- **f14** — checked and refuted: the in-file "unchanged" claim is not inside the
  hunk that changes it.

# Verification

```
cd catalog && npx vitest run app/containers/App/queryRedirects.spec.tsx
```

9 tests. The three added for f12 fail against the original spread order, as does
the param-preservation test whose expected string this PR updates — the query
string's param *order* reverses, which carries no meaning to any reader of these
params.

# Position in the stack

**PR 8 of 9**, based on
[`stack/5217-7-athena-workgroup-seam`](https://github.com/quiltdata/quilt/pull/5265).

Part of the split of #5217 asked for in
[f27](https://github.com/quiltdata/quilt/pull/5217#discussion_r3889140880).
Producer before consumer: this PR makes legacy URLs carry `?bucket=`, and PR 9
makes the console read it. The user-visible changelog claim about honoring
`ui.athena.defaultWorkgroup` lands with PR 9, because that is when it becomes
true.

# TODO

- [x] Unit tests
- [x] Security: Confirm that this change meets security best practices and does not violate the security model
- [x] Open: Confirm that this change doesn't break the Open variant
- [x] Changelog entry

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR preserves the bucket scope when legacy per-bucket Athena links redirect into the workspace query console.

- Adds the route-derived bucket as an authoritative `?bucket=` parameter for root, workgroup, and execution links.
- Preserves other incoming search parameters on workgroup and execution redirects.
- Adds focused redirect tests and documents the user-visible behavior in the changelog.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge, with the changed redirect behavior consistently applied and covered by focused tests.

The route-derived bucket is available on every affected legacy route, is applied after incoming parameters so it remains authoritative, and is serialized through the existing URL utility without an identified contract break.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| catalog/app/containers/App/queryRedirects.jsx | Adds bucket-scoped search construction to legacy Athena workgroup and execution redirects and gives the route bucket precedence on every Athena redirect shape. |
| catalog/app/containers/App/queryRedirects.spec.tsx | Covers bucket propagation, conflicting query-string bucket precedence, and preservation of another query parameter. |
| catalog/CHANGELOG.md | Documents the changed destination scope and authoritative route-bucket behavior for legacy Athena links. |


<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart LR
  Legacy[Legacy /b/:bucket/queries/athena link] --> Parse[Parse incoming search parameters]
  Parse --> Override[Apply route bucket as authoritative scope]
  Override --> Console[Workspace Athena console with ?bucket=:bucket]
  Console --> Preferences[Bucket ui.athena preferences]
```

<sub>Reviews (1): Last reviewed commit: ["docs(changelog): entry for the legacy re..."](https://github.com/quiltdata/quilt/commit/bdd41539ecf33a3d7614f52922f08e1de6c3b7a2) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=58629638)</sub>

<!-- /greptile_comment -->