### PR TITLE
Catalog: honor a bucket's Athena preferences in the workspace console (5217 stack 9/9)

### DIFF
--- a/catalog/CHANGELOG.md
+++ b/catalog/CHANGELOG.md
@@ -21,6 +21,7 @@ complete sentence without it.
 
 ## Changes
 
+- [Fixed] Athena Queries: a console scoped to a bucket honors that bucket's `ui.athena.defaultWorkgroup` again — for readers who have not already picked a workgroup themselves, whose choice is still remembered and still wins — and the scope survives following an execution, a breadcrumb or the Queries tabs; the workspace re-home had silently dropped the preference, landing readers on the alphabetically-first workgroup ([#5267](https://github.com/quiltdata/quilt/pull/5267))
 - [Fixed] Athena Queries: a legacy per-bucket Athena link now lands in the workspace console still scoped to that bucket (`?bucket=`) instead of unscoped, and a `?bucket=` already on the link no longer overrides the bucket the link is for ([#5266](https://github.com/quiltdata/quilt/pull/5266))
 - [Fixed] Athena Queries: a workgroup named in the URL is honored whatever its capitalisation, instead of matching a workgroup you can see and then having every AWS call rejected ([#5265](https://github.com/quiltdata/quilt/pull/5265))
 - [Fixed] Admin Users: the roles dialog and the Role column are read-only for service users, rather than offering a Save the registry refuses ([#5264](https://github.com/quiltdata/quilt/pull/5264))

--- a/catalog/app/containers/Bucket/PackageDialog/Inputs/Files/S3FilePicker.spec.tsx
+++ b/catalog/app/containers/Bucket/PackageDialog/Inputs/Files/S3FilePicker.spec.tsx
@@ -1,0 +1,45 @@
+import * as React from 'react'
+import { MemoryRouter } from 'react-router-dom'
+import { render, screen } from '@testing-library/react'
+import { describe, expect, it, vi } from 'vitest'
+
+import { BucketSelect } from './S3FilePicker'
+
+vi.mock('constants/config', () => ({ default: {} }))
+
+vi.mock('utils/NamedRoutes', async () => ({
+  ...(await vi.importActual('utils/NamedRoutes')),
+  use: () => ({ urls: { bucketFile: (b: string, k: string) => `/b/${b}/tree/${k}` } }),
+}))
+
+const handle = vi.fn<() => { bucket: string; key: string } | null>(() => null)
+vi.mock('utils/BucketPreferences', () => ({ use: () => ({ handle: handle() }) }))
+
+/**
+ * The dialog this control lives in is opened from the Athena console, whose route
+ * is `/queries/athena/:workgroup` — no `:bucket` segment. The control used to
+ * assert that segment unconditionally, and the nearest error boundary is the app
+ * root, so the throw replaced the whole catalog screen rather than failing the
+ * panel.
+ */
+describe('containers/Bucket/PackageDialog/Inputs/Files/S3FilePicker', () => {
+  function renderAt(path: string) {
+    return render(
+      <MemoryRouter initialEntries={[path]}>
+        <BucketSelect bucket="picked" buckets={['picked']} selectBucket={vi.fn()} />
+      </MemoryRouter>,
+    )
+  }
+
+  it('renders on a route with no bucket segment', () => {
+    renderAt('/queries/athena/primary?bucket=scoped')
+    expect(screen.getByText('picked')).toBeDefined()
+  })
+
+  it('prefers the preferences handle when there is one', () => {
+    handle.mockImplementation(() => ({ bucket: 'from-handle', key: 'cfg' }))
+    renderAt('/queries/athena/primary?bucket=scoped')
+    expect(screen.getByText('picked')).toBeDefined()
+    handle.mockImplementation(() => null)
+  })
+})

--- a/catalog/app/containers/Bucket/PackageDialog/Inputs/Files/S3FilePicker.tsx
+++ b/catalog/app/containers/Bucket/PackageDialog/Inputs/Files/S3FilePicker.tsx
@@ -115,15 +115,27 @@ interface BucketSelectProps {
   selectBucket: (bucket: string) => void
 }
 
-function BucketSelect({ bucket, buckets, selectBucket }: BucketSelectProps) {
+// Exported for testing: this is the only node in the dialog that read a
+// `:bucket` route segment, and the route it is opened from does not always have
+// one.
+export function BucketSelect({ bucket, buckets, selectBucket }: BucketSelectProps) {
   const classes = useBucketSelectStyles()
 
   const { handle } = BucketPreferences.use()
-  const { bucket: currentBucket } = RRDom.useParams<{ bucket: string }>()
-  invariant(currentBucket, '`currentBucket` must be defined')
+  // The route param is a *fallback* for `handle`, and nothing more. Asserting it
+  // unconditionally crashed every mount from a route without a `:bucket`
+  // segment: the Athena console reaches this dialog from
+  // `/queries/athena/:workgroup`, which has no such segment, and the only error
+  // boundary above it is the app root -- so the throw replaced the whole catalog
+  // screen rather than failing the panel. `bucket` (the picker's own selection)
+  // is always defined, so there is a last resort that cannot be absent.
+  const { bucket: routeBucket } = RRDom.useParams<{ bucket?: string }>()
 
   const toConfig = FileEditorRoutes.useEditBucketFile(
-    handle || { bucket: currentBucket, key: quiltConfigs.bucketPreferences[0] },
+    handle || {
+      bucket: routeBucket ?? bucket,
+      key: quiltConfigs.bucketPreferences[0],
+    },
   )
 
   const handleChange = React.useCallback(

--- a/catalog/app/containers/Queries/Athena/Athena.spec.tsx
+++ b/catalog/app/containers/Queries/Athena/Athena.spec.tsx
@@ -1,9 +1,10 @@
 import * as React from 'react'
-import { MemoryRouter } from 'react-router-dom'
-import { render, cleanup, screen } from '@testing-library/react'
-import { describe, it, expect, vi, afterEach } from 'vitest'
+import { createMemoryHistory } from 'history'
+import { MemoryRouter, Router } from 'react-router-dom'
+import { act, render, cleanup, screen } from '@testing-library/react'
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
 
-import { extendDefaults } from 'utils/BucketPreferences/BucketPreferences'
+import { Result, extendDefaults } from 'utils/BucketPreferences/BucketPreferences'
 
 import Athena from './Athena'
 
@@ -13,12 +14,18 @@ vi.mock('constants/config', () => ({ default: {} }))
 // below the Provider is irrelevant here, so the probe renders a marker instead
 // of children — AthenaContainer and its AWS-backed hooks never mount.
 const providerProps = vi.fn()
+const providerMounts = vi.fn()
 vi.mock('./model', async () => {
   const utils = await vi.importActual<object>('./model/utils')
   return {
     ...utils,
     Provider: (props: { preferences?: unknown }) => {
       providerProps(props)
+      // Counts mounts, not renders: the point of a single `Model.Provider`
+      // element is that a change of scope re-renders it instead of replacing it.
+      React.useEffect(() => {
+        providerMounts()
+      }, [])
       return <div data-testid="model-provider" />
     },
     use: () => {
@@ -32,7 +39,13 @@ vi.mock('utils/BucketPreferences', async () => {
   const actual = await vi.importActual<object>('utils/BucketPreferences')
   return {
     ...actual,
-    Provider: ({ bucket, children }: { bucket: string; children: React.ReactNode }) => (
+    Provider: ({
+      bucket,
+      children,
+    }: {
+      bucket: string | null
+      children: React.ReactNode
+    }) => (
       <div data-testid="prefs-provider" data-bucket={bucket}>
         {children}
       </div>
@@ -40,6 +53,8 @@ vi.mock('utils/BucketPreferences', async () => {
     use: () => ({ prefs: prefsResult() }),
   }
 })
+
+const athenaPrefs = (athena: object) => Result.Ok(extendDefaults({ ui: { athena } }))
 
 function renderAthena(entry: string) {
   return render(
@@ -50,6 +65,12 @@ function renderAthena(entry: string) {
 }
 
 describe('containers/Queries/Athena/Athena', () => {
+  beforeEach(() => {
+    // What the provider serves with no bucket in scope: no document, and
+    // nothing pending on one either.
+    prefsResult.mockReturnValue(Result.Init())
+  })
+
   afterEach(() => {
     cleanup()
     vi.clearAllMocks()
@@ -59,39 +80,59 @@ describe('containers/Queries/Athena/Athena', () => {
     it('passes no preferences without a bucket in scope', () => {
       // The bare global console has no preference document to consult.
       renderAthena('/queries/athena')
-      expect(screen.queryByTestId('prefs-provider')).toBeNull()
+      expect(screen.getByTestId('prefs-provider').dataset.bucket).toBeUndefined()
       expect(providerProps).toHaveBeenCalledTimes(1)
       expect(providerProps.mock.calls[0][0].preferences).toBeUndefined()
     })
 
-    it('threads ui.athena from the ?bucket= scope into the model', async () => {
+    it('threads ui.athena from the ?bucket= scope into the model', () => {
       // The regression this pins: a legacy /b/:bucket/queries URL redirects here
       // with ?bucket= set, and ui.athena.defaultWorkgroup must keep applying for
       // those — it silently stopped when the console went global.
-      const { Result } = await vi.importActual<typeof import('utils/BucketPreferences')>(
-        'utils/BucketPreferences',
-      )
       const athena = { defaultWorkgroup: 'analytics-prod' }
       // Through the real parse pipeline, so a change to how `ui.athena` is
       // parsed shows up here rather than being mocked away.
-      prefsResult.mockReturnValue(Result.Ok(extendDefaults({ ui: { athena } })))
+      prefsResult.mockReturnValue(athenaPrefs(athena))
       renderAthena('/queries/athena?bucket=my-bucket')
       expect(screen.getByTestId('prefs-provider').dataset.bucket).toBe('my-bucket')
       expect(providerProps).toHaveBeenCalledTimes(1)
       expect(providerProps.mock.calls[0][0].preferences).toEqual(athena)
     })
 
-    it('holds rendering until the scoped preferences resolve', async () => {
+    it('holds rendering until the scoped preferences resolve', () => {
       // Rendering the console before prefs settle would seed the workgroup from
       // localStorage/first-in-list and then not correct it — Init must not
       // reach the model at all.
-      const { Result } = await vi.importActual<typeof import('utils/BucketPreferences')>(
-        'utils/BucketPreferences',
-      )
-      prefsResult.mockReturnValue(Result.Init())
       renderAthena('/queries/athena?bucket=my-bucket')
       expect(providerProps).not.toHaveBeenCalled()
       expect(screen.queryByTestId('model-provider')).toBeNull()
+    })
+  })
+
+  describe('a change of scope', () => {
+    // `Model.Provider` owns the query being typed and the selected catalog and
+    // database. React reconciles by position, so if the scoped and unscoped
+    // consoles were different trees, losing the scope — clicking the "Athena"
+    // tab, say — would remount the console and discard all of it.
+    it('re-renders the console rather than remounting it', () => {
+      prefsResult.mockReturnValue(athenaPrefs({ defaultWorkgroup: 'analytics-prod' }))
+      const history = createMemoryHistory({
+        initialEntries: ['/queries/athena/primary?bucket=my-bucket'],
+      })
+      render(
+        <Router history={history}>
+          <Athena />
+        </Router>,
+      )
+      expect(providerMounts).toHaveBeenCalledTimes(1)
+
+      prefsResult.mockReturnValue(Result.Init())
+      act(() => {
+        history.push('/queries/athena/primary')
+      })
+
+      expect(providerMounts).toHaveBeenCalledTimes(1)
+      expect(providerProps.mock.calls.at(-1)?.[0].preferences).toBeUndefined()
     })
   })
 })

--- a/catalog/app/containers/Queries/Athena/Athena.spec.tsx
+++ b/catalog/app/containers/Queries/Athena/Athena.spec.tsx
@@ -1,0 +1,97 @@
+import * as React from 'react'
+import { MemoryRouter } from 'react-router-dom'
+import { render, cleanup, screen } from '@testing-library/react'
+import { describe, it, expect, vi, afterEach } from 'vitest'
+
+import { extendDefaults } from 'utils/BucketPreferences/BucketPreferences'
+
+import Athena from './Athena'
+
+vi.mock('constants/config', () => ({ default: {} }))
+
+// The wiring under test is Wrapper → Model.Provider(preferences). Everything
+// below the Provider is irrelevant here, so the probe renders a marker instead
+// of children — AthenaContainer and its AWS-backed hooks never mount.
+const providerProps = vi.fn()
+vi.mock('./model', async () => {
+  const utils = await vi.importActual<object>('./model/utils')
+  return {
+    ...utils,
+    Provider: (props: { preferences?: unknown }) => {
+      providerProps(props)
+      return <div data-testid="model-provider" />
+    },
+    use: () => {
+      throw new Error('not reachable: the Provider probe renders no children')
+    },
+  }
+})
+
+const prefsResult = vi.fn<() => unknown>()
+vi.mock('utils/BucketPreferences', async () => {
+  const actual = await vi.importActual<object>('utils/BucketPreferences')
+  return {
+    ...actual,
+    Provider: ({ bucket, children }: { bucket: string; children: React.ReactNode }) => (
+      <div data-testid="prefs-provider" data-bucket={bucket}>
+        {children}
+      </div>
+    ),
+    use: () => ({ prefs: prefsResult() }),
+  }
+})
+
+function renderAthena(entry: string) {
+  return render(
+    <MemoryRouter initialEntries={[entry]}>
+      <Athena />
+    </MemoryRouter>,
+  )
+}
+
+describe('containers/Queries/Athena/Athena', () => {
+  afterEach(() => {
+    cleanup()
+    vi.clearAllMocks()
+  })
+
+  describe('Wrapper preferences wiring', () => {
+    it('passes no preferences without a bucket in scope', () => {
+      // The bare global console has no preference document to consult.
+      renderAthena('/queries/athena')
+      expect(screen.queryByTestId('prefs-provider')).toBeNull()
+      expect(providerProps).toHaveBeenCalledTimes(1)
+      expect(providerProps.mock.calls[0][0].preferences).toBeUndefined()
+    })
+
+    it('threads ui.athena from the ?bucket= scope into the model', async () => {
+      // The regression this pins: a legacy /b/:bucket/queries URL redirects here
+      // with ?bucket= set, and ui.athena.defaultWorkgroup must keep applying for
+      // those — it silently stopped when the console went global.
+      const { Result } = await vi.importActual<typeof import('utils/BucketPreferences')>(
+        'utils/BucketPreferences',
+      )
+      const athena = { defaultWorkgroup: 'analytics-prod' }
+      // Through the real parse pipeline, so a change to how `ui.athena` is
+      // parsed shows up here rather than being mocked away.
+      prefsResult.mockReturnValue(Result.Ok(extendDefaults({ ui: { athena } })))
+      renderAthena('/queries/athena?bucket=my-bucket')
+      expect(screen.getByTestId('prefs-provider').dataset.bucket).toBe('my-bucket')
+      expect(providerProps).toHaveBeenCalledTimes(1)
+      expect(providerProps.mock.calls[0][0].preferences).toEqual(athena)
+    })
+
+    it('holds rendering until the scoped preferences resolve', async () => {
+      // Rendering the console before prefs settle would seed the workgroup from
+      // localStorage/first-in-list and then not correct it — Init must not
+      // reach the model at all.
+      const { Result } = await vi.importActual<typeof import('utils/BucketPreferences')>(
+        'utils/BucketPreferences',
+      )
+      prefsResult.mockReturnValue(Result.Init())
+      renderAthena('/queries/athena?bucket=my-bucket')
+      expect(providerProps).not.toHaveBeenCalled()
+      expect(screen.queryByTestId('model-provider')).toBeNull()
+    })
+  })
+})

--- a/catalog/app/containers/Queries/Athena/Athena.tsx
+++ b/catalog/app/containers/Queries/Athena/Athena.tsx
@@ -21,6 +21,7 @@ import Workgroups from './Workgroups'
 import TabulatorTables from './TabulatorTables'
 import * as Model from './model'
 import { doQueryResultsContainManifestEntries } from './model/createPackage'
+import { useBucketScope } from './scope'
 
 const CreatePackage = React.lazy(() => import('./CreatePackage'))
 
@@ -443,11 +444,7 @@ function ScopedWrapper() {
 }
 
 export default function Wrapper() {
-  const location = RRDom.useLocation()
-  const bucket = React.useMemo(
-    () => new URLSearchParams(location.search).get('bucket'),
-    [location.search],
-  )
+  const bucket = useBucketScope()
   if (!bucket)
     return (
       <Model.Provider>

--- a/catalog/app/containers/Queries/Athena/Athena.tsx
+++ b/catalog/app/containers/Queries/Athena/Athena.tsx
@@ -5,7 +5,9 @@ import * as RRDom from 'react-router-dom'
 import * as M from '@material-ui/core'
 
 import Code from 'components/Code'
+import Placeholder from 'components/Placeholder'
 import Skeleton from 'components/Skeleton'
+import * as BucketPreferences from 'utils/BucketPreferences'
 import * as CatalogSettings from 'utils/CatalogSettings'
 import * as NamedRoutes from 'utils/NamedRoutes'
 
@@ -310,12 +312,19 @@ function ResultsBreadcrumbs({ children, className }: ResultsBreadcrumbsProps) {
   const classes = useResultsBreadcrumbsStyles()
   const overrideClasses = useOverrideStyles()
   const { urls } = NamedRoutes.use()
+  const location = RRDom.useLocation()
   return (
     <div className={cx(classes.root, className)}>
       <M.Breadcrumbs classes={overrideClasses}>
         <RRDom.Link
           className={classes.breadcrumb}
-          to={urls.queriesAthenaWorkgroup(workgroup.data)}
+          // Keep the query string (e.g. the ?bucket= preference scope): the
+          // console branches on it, so dropping it here remounts the whole
+          // screen unscoped.
+          to={{
+            pathname: urls.queriesAthenaWorkgroup(workgroup.data),
+            search: location.search,
+          }}
         >
           Query Executions
         </RRDom.Link>
@@ -414,10 +423,40 @@ function AthenaContainer() {
   )
 }
 
+// `ui.athena.defaultWorkgroup` is a per-bucket preference, and the console is
+// workspace-global — so it applies exactly when a bucket is in scope via
+// `?bucket=` (every legacy `/b/:bucket/queries/...` URL redirects here with it
+// set). Without a bucket there is no preference document to consult.
+function ScopedWrapper() {
+  const { prefs } = BucketPreferences.use()
+  return BucketPreferences.Result.match(
+    {
+      Ok: ({ ui }) => (
+        <Model.Provider preferences={ui.athena}>
+          <AthenaContainer />
+        </Model.Provider>
+      ),
+      _: () => <Placeholder color="inherit" />,
+    },
+    prefs,
+  )
+}
+
 export default function Wrapper() {
+  const location = RRDom.useLocation()
+  const bucket = React.useMemo(
+    () => new URLSearchParams(location.search).get('bucket'),
+    [location.search],
+  )
+  if (!bucket)
+    return (
+      <Model.Provider>
+        <AthenaContainer />
+      </Model.Provider>
+    )
   return (
-    <Model.Provider>
-      <AthenaContainer />
-    </Model.Provider>
+    <BucketPreferences.Provider bucket={bucket}>
+      <ScopedWrapper />
+    </BucketPreferences.Provider>
   )
 }

--- a/catalog/app/containers/Queries/Athena/Athena.tsx
+++ b/catalog/app/containers/Queries/Athena/Athena.tsx
@@ -428,32 +428,35 @@ function AthenaContainer() {
 // workspace-global — so it applies exactly when a bucket is in scope via
 // `?bucket=` (every legacy `/b/:bucket/queries/...` URL redirects here with it
 // set). Without a bucket there is no preference document to consult.
-function ScopedWrapper() {
+function ScopedConsole({ scoped }: { scoped: boolean }) {
   const { prefs } = BucketPreferences.use()
-  return BucketPreferences.Result.match(
-    {
-      Ok: ({ ui }) => (
-        <Model.Provider preferences={ui.athena}>
-          <AthenaContainer />
-        </Model.Provider>
-      ),
-      _: () => <Placeholder color="inherit" />,
-    },
+  const preferences = BucketPreferences.Result.match(
+    { Ok: ({ ui }) => ui.athena, _: () => undefined },
     prefs,
+  )
+  // A scoped console must not mount the model before the document resolves: the
+  // workgroup is seeded once — from storage, or the first workgroup Athena lists
+  // — and a default arriving afterwards would not displace it.
+  if (scoped && preferences === undefined) return <Placeholder color="inherit" />
+  // One `Model.Provider` element, at one position, for both cases. React
+  // reconciles by position, so returning it from two different branches of the
+  // tree would remount the console whenever `?bucket=` came or went, taking the
+  // query being typed and the selected catalog and database with it.
+  return (
+    <Model.Provider preferences={preferences}>
+      <AthenaContainer />
+    </Model.Provider>
   )
 }
 
 export default function Wrapper() {
   const bucket = useBucketScope()
-  if (!bucket)
-    return (
-      <Model.Provider>
-        <AthenaContainer />
-      </Model.Provider>
-    )
+  // Mounted unscoped as well as scoped: with `bucket` null the provider serves
+  // the same state as no provider at all, and the console below it keeps its
+  // mount across a change of scope.
   return (
     <BucketPreferences.Provider bucket={bucket}>
-      <ScopedWrapper />
+      <ScopedConsole scoped={!!bucket} />
     </BucketPreferences.Provider>
   )
 }

--- a/catalog/app/containers/Queries/Athena/History.spec.tsx
+++ b/catalog/app/containers/Queries/Athena/History.spec.tsx
@@ -1,0 +1,59 @@
+import * as React from 'react'
+import { MemoryRouter } from 'react-router-dom'
+import { render, cleanup } from '@testing-library/react'
+import { describe, it, expect, vi, afterEach } from 'vitest'
+
+import * as NamedRoutes from 'utils/NamedRoutes'
+import { queriesAthenaExecution } from 'constants/routes'
+
+import History from './History'
+
+vi.mock('constants/config', () => ({ default: {} }))
+
+vi.mock('containers/Notifications', () => ({ use: () => ({ push: vi.fn() }) }))
+
+// Keep the real Model helpers (hasValue, etc.); stub only `use`.
+vi.mock('./model', async () => {
+  const utils = await vi.importActual<object>('./model/utils')
+  return { ...utils, use: () => ({ workgroup: { data: 'primary' }, queryBody: {} }) }
+})
+
+const succeeded = {
+  id: 'exec-1',
+  status: 'SUCCEEDED',
+  query: 'SELECT 1',
+  created: new Date(0),
+  completed: new Date(0),
+}
+
+function renderHistory(entry: string) {
+  return render(
+    <MemoryRouter initialEntries={[entry]}>
+      <NamedRoutes.Provider routes={{ queriesAthenaExecution }}>
+        <History executions={[succeeded] as never} />
+      </NamedRoutes.Provider>
+    </MemoryRouter>,
+  )
+}
+
+describe('containers/Queries/Athena/History', () => {
+  afterEach(() => {
+    cleanup()
+    vi.clearAllMocks()
+  })
+
+  it('keeps the ?bucket= scope on an execution row link', () => {
+    // The console branches on ?bucket=, so a bare pathname here remounts the
+    // whole screen and drops the bucket's preferences.
+    const { container } = renderHistory('/queries/athena/primary?bucket=my-bucket')
+    const href = container.querySelector('a')?.getAttribute('href')
+    expect(href).toBe('/queries/athena/primary/exec-1?bucket=my-bucket')
+  })
+
+  it('adds no query string when the console has no scope', () => {
+    const { container } = renderHistory('/queries/athena/primary')
+    expect(container.querySelector('a')?.getAttribute('href')).toBe(
+      '/queries/athena/primary/exec-1',
+    )
+  })
+})

--- a/catalog/app/containers/Queries/Athena/History.tsx
+++ b/catalog/app/containers/Queries/Athena/History.tsx
@@ -150,7 +150,7 @@ function Row({ className, children }: RowProps) {
 interface LinkCellProps {
   children: React.ReactNode
   className: string
-  to?: string
+  to?: RRDom.LinkProps['to']
 }
 
 function LinkCell({ children, className, to }: LinkCellProps) {
@@ -181,7 +181,7 @@ const useExecutionStyles = M.makeStyles((t) => ({
 }))
 
 interface ExecutionProps {
-  to?: string
+  to?: RRDom.LinkProps['to']
   queryExecution: Model.QueryExecution
 }
 
@@ -251,6 +251,7 @@ interface HistoryProps {
 
 export default function History({ executions, onLoadMore }: HistoryProps) {
   const { urls } = NamedRoutes.use()
+  const location = RRDom.useLocation()
   const classes = useStyles()
 
   const pageSize = 10
@@ -308,7 +309,16 @@ export default function History({ executions, onLoadMore }: HistoryProps) {
               key={queryExecution.id}
               to={
                 queryExecution.status === 'SUCCEEDED'
-                  ? urls.queriesAthenaExecution(workgroup.data, queryExecution.id)
+                  ? {
+                      // Keep the query string (e.g. the ?bucket= preference
+                      // scope): the console branches on it, so dropping it here
+                      // remounts the whole screen unscoped.
+                      pathname: urls.queriesAthenaExecution(
+                        workgroup.data,
+                        queryExecution.id,
+                      ),
+                      search: location.search,
+                    }
                   : undefined
               }
             />

--- a/catalog/app/containers/Queries/Athena/TabulatorTables.tsx
+++ b/catalog/app/containers/Queries/Athena/TabulatorTables.tsx
@@ -11,6 +11,7 @@ import {
 } from 'containers/Bucket/Tabulator/requests'
 
 import * as Model from './model'
+import { useBucketScope } from './scope'
 
 const useStyles = M.makeStyles((t) => ({
   root: {
@@ -126,11 +127,7 @@ function BucketTabulatorTables({ bucket }: BucketTabulatorTablesProps) {
 // arrives as a `?bucket=` search param (set by the bucket-page deep links and
 // the legacy-route redirect). Without it there is nothing to list.
 export default function TabulatorTables() {
-  const location = RRDom.useLocation()
-  const bucket = React.useMemo(
-    () => new URLSearchParams(location.search).get('bucket'),
-    [location.search],
-  )
+  const bucket = useBucketScope()
   if (!bucket) return null
   return <BucketTabulatorTables bucket={bucket} />
 }

--- a/catalog/app/containers/Queries/Athena/scope.ts
+++ b/catalog/app/containers/Queries/Athena/scope.ts
@@ -1,0 +1,20 @@
+import * as React from 'react'
+import * as RRDom from 'react-router-dom'
+
+/**
+ * The bucket the Athena console is scoped to, or `null` when it is scoped to no
+ * bucket.
+ *
+ * The console is workspace-global, while `ui.athena` and tabulator tables are
+ * per-bucket — so a bucket reaches the console as a `?bucket=` search param, set
+ * by the bucket-page deep links and by the legacy `/b/:bucket/queries/...`
+ * redirects. Read it here rather than at each consumer: the console branches on
+ * the scope in more than one place, and the two must not disagree.
+ */
+export function useBucketScope(): string | null {
+  const location = RRDom.useLocation()
+  return React.useMemo(
+    () => new URLSearchParams(location.search).get('bucket'),
+    [location.search],
+  )
+}

--- a/catalog/app/containers/Queries/Athena/spec.md
+++ b/catalog/app/containers/Queries/Athena/spec.md
@@ -25,11 +25,30 @@ interface ValueController<T> {
 **DataController** - Manages loading operations, handles `Loading`/`Error` states.
 **ValueController** - Manages user selections, cannot set `Loading`/`Error` directly.
 
+## Bucket scope
+
+The console is workspace-wide, and the state above is workspace-wide with it. A
+bucket reaches the console only as a `?bucket=` search param, set by the bucket
+header's tables link, by a Tabulator table deep link, and by the legacy
+`/b/:bucket/queries/athena...` redirects. It is a precondition, not part of the
+state:
+
+- with a bucket in scope the console reads that bucket's preference document and
+  `ui.athena.defaultWorkgroup` becomes a `workgroup` candidate, and
+  `TabulatorTables` has a bucket to list;
+- with no bucket in scope neither applies, and the console behaves as it does
+  below.
+
+Every in-console link therefore carries the query string forward, and the
+console keeps one mount across a change of scope -- `queryBody`, `catalogName`
+and `database` do not survive being remounted. The `?bucket=` in the URLs below
+is optional throughout.
+
 ## XML User Stories
 
 ### Story 1: View Execution Results
 
-**URL:** `/queries/athena/{workgroupId}/{executionId}`
+**URL:** `/queries/athena/{workgroupId}/{executionId}[?bucket={bucket}]`
 
 ```xml
 <Athena :workgroupId :executionId>
@@ -57,7 +76,7 @@ interface ValueController<T> {
 
 ### Story 2: Main Query Interface
 
-**URL:** `/queries/athena/{workgroupId}`
+**URL:** `/queries/athena/{workgroupId}[?bucket={bucket}]`
 
 ```xml
 <Athena :workgroupId>
@@ -84,7 +103,7 @@ interface ValueController<T> {
 
 ### Story 3: Landing Page (No Workgroup Selected)
 
-**URL:** `/queries/athena`
+**URL:** `/queries/athena[?bucket={bucket}]`
 
 ```xml
 <Athena>

--- a/catalog/app/containers/Queries/Queries.spec.tsx
+++ b/catalog/app/containers/Queries/Queries.spec.tsx
@@ -107,5 +107,25 @@ describe('containers/Queries', () => {
       const { queryByTestId } = at('/queries/es')
       expect(queryByTestId('es')).not.toBeNull()
     })
+
+    // The Athena console is scoped by `?bucket=`. A bare pathname on these tabs
+    // drops the scope, so switching consoles and coming back would land the
+    // reader in a different console from the one they left.
+    it('keeps the scope on both tabs', () => {
+      const { getByText } = at('/queries/athena?bucket=my-bucket')
+      expect(getByText('Athena').closest('a')?.getAttribute('href')).toBe(
+        '/queries/athena?bucket=my-bucket',
+      )
+      expect(getByText('ElasticSearch').closest('a')?.getAttribute('href')).toBe(
+        '/queries/es?bucket=my-bucket',
+      )
+    })
+
+    it('adds no query string to the tabs when there is no scope', () => {
+      const { getByText } = at('/queries/athena')
+      expect(getByText('Athena').closest('a')?.getAttribute('href')).toBe(
+        '/queries/athena',
+      )
+    })
   })
 })

--- a/catalog/app/containers/Queries/Queries.tsx
+++ b/catalog/app/containers/Queries/Queries.tsx
@@ -56,6 +56,7 @@ function useSection(): 'athena' | 'es' {
 export function QueriesScreen() {
   const classes = useStyles()
   const { paths, urls } = NamedRoutes.use()
+  const { search } = useLocation()
   const section = useSection()
   // Suspending read (CatalogSettings.use()) — safe here because the whole app
   // tree sits inside the root Suspense boundary in app.tsx.
@@ -77,8 +78,20 @@ export function QueriesScreen() {
             <M.Divider />
             <div className={classes.tabsRow}>
               <M.Tabs value={section} variant="scrollable" scrollButtons="auto">
-                <NavTab label="Athena" value="athena" to={urls.queriesAthena()} />
-                <NavTab label="ElasticSearch" value="es" to={urls.queriesEs()} />
+                {/* Both tabs keep the query string. The Athena console is
+                    scoped by `?bucket=`, so a bare pathname here would drop the
+                    scope — and switching consoles and back would silently land
+                    the reader in a different one. */}
+                <NavTab
+                  label="Athena"
+                  value="athena"
+                  to={{ pathname: urls.queriesAthena(), search }}
+                />
+                <NavTab
+                  label="ElasticSearch"
+                  value="es"
+                  to={{ pathname: urls.queriesEs(), search }}
+                />
               </M.Tabs>
             </div>
           </>

--- a/catalog/app/utils/BucketPreferences/Provider.spec.tsx
+++ b/catalog/app/utils/BucketPreferences/Provider.spec.tsx
@@ -1,0 +1,71 @@
+import * as React from 'react'
+import { render, cleanup } from '@testing-library/react'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+vi.mock('constants/config', () => ({ default: { mode: 'PRODUCT' } }))
+
+vi.mock('utils/AWS', () => ({ S3: { use: () => ({}) } }))
+
+const { fetchFileInCollection } = vi.hoisted(() => ({
+  fetchFileInCollection: vi.fn(async (args: { handles: { bucket: string }[] }) => ({
+    handle: null,
+    body: '',
+    requested: args.handles,
+  })),
+}))
+vi.mock('containers/Bucket/requests', () => ({ fetchFileInCollection }))
+
+import { Result } from './BucketPreferences'
+import { Provider, use } from './Provider'
+
+function Probe() {
+  const { prefs, handle } = use()
+  return (
+    <div
+      data-testid="probe"
+      data-prefs={Result.match(
+        { Ok: () => 'ok', Pending: () => 'pending', Init: () => 'init' },
+        prefs,
+      )}
+      data-handle={handle ? 'yes' : 'no'}
+    />
+  )
+}
+
+describe('utils/BucketPreferences/Provider', () => {
+  afterEach(() => {
+    cleanup()
+    vi.clearAllMocks()
+  })
+
+  // Consumers whose scope comes and goes — the workspace Athena console, scoped
+  // by `?bucket=` — mount the provider either way, so that losing the scope
+  // re-renders their subtree instead of replacing it. With no bucket there is no
+  // document, and the state must say so rather than pend on a fetch that will
+  // never happen.
+  describe('with no bucket in scope', () => {
+    it('reads as an uninitialized context and fetches nothing', () => {
+      const { getByTestId } = render(
+        <Provider bucket={null}>
+          <Probe />
+        </Provider>,
+      )
+      expect(getByTestId('probe').dataset.prefs).toBe('init')
+      expect(getByTestId('probe').dataset.handle).toBe('no')
+      expect(fetchFileInCollection).not.toHaveBeenCalled()
+    })
+  })
+
+  describe('with a bucket in scope', () => {
+    it('fetches that bucket document', () => {
+      render(
+        <Provider bucket="my-bucket">
+          <Probe />
+        </Provider>,
+      )
+      expect(fetchFileInCollection).toHaveBeenCalledTimes(1)
+      const { handles } = fetchFileInCollection.mock.calls[0][0]
+      expect(handles[0].bucket).toBe('my-bucket')
+    })
+  })
+})

--- a/catalog/app/utils/BucketPreferences/Provider.tsx
+++ b/catalog/app/utils/BucketPreferences/Provider.tsx
@@ -1,4 +1,5 @@
 import type { S3 } from 'aws-sdk'
+import invariant from 'invariant'
 import * as React from 'react'
 
 import type * as Model from 'model'
@@ -21,7 +22,8 @@ import LocalProvider from './LocalProvider'
 
 interface FetchBucketPreferencesArgs {
   s3: S3
-  bucket: string
+  // Widened for the provider's unscoped mode, where the fetch does not run.
+  bucket: string | null
   counter: number
 }
 
@@ -34,6 +36,7 @@ async function fetchBucketPreferences({
   s3,
   bucket,
 }: FetchBucketPreferencesArgs): Promise<FetchBucketPreferencesOutput> {
+  invariant(bucket, 'Cannot fetch bucket preferences with no bucket in scope')
   try {
     const { handle, body } = await requests.fetchFileInCollection({
       s3,
@@ -90,41 +93,63 @@ const Ctx = React.createContext<State>({
   update: () => Promise.reject(new Error('Bucket preferences context not initialized')),
 })
 
-type ProviderProps = React.PropsWithChildren<{ bucket: string }>
+type ProviderProps = React.PropsWithChildren<{
+  /**
+   * The bucket whose preference document to read, or `null` for no bucket at all.
+   *
+   * `null` provides the state a consumer sees *outside* any provider -- no
+   * document, no handle, no update -- rather than the subtree being unmounted.
+   * That is what a consumer whose scope comes and goes at runtime needs: the
+   * workspace Athena console is scoped by a `?bucket=` search param, and
+   * branching the tree on that param instead would remount the console (and
+   * discard the query being typed) every time the scope changed.
+   */
+  bucket: string | null
+}>
 
 function CatalogProvider({ bucket, children }: ProviderProps) {
   const s3 = AWS.S3.use()
   const [counter, setCounter] = React.useState(0)
-  const data = useData(fetchBucketPreferences, { s3, bucket, counter })
+  // `const`, so the narrowing below reaches the `data.case` arms.
+  const scope = bucket
+  const data = useData(
+    fetchBucketPreferences,
+    { s3, bucket: scope, counter },
+    { noAutoFetch: !scope },
+  )
 
   const update = React.useCallback(
     async (upd: BucketPreferencesInput) => {
-      const preferences = await uploadBucketPreferences(s3, bucket, upd)
+      invariant(scope, 'Cannot update bucket preferences with no bucket in scope')
+      const preferences = await uploadBucketPreferences(s3, scope, upd)
       setCounter((prev) => prev + 1)
       return preferences
     },
-    [s3, bucket],
+    [s3, scope],
   )
 
-  const prefs = data.case({
-    Ok: ({ body }: FetchBucketPreferencesOutput) => {
-      try {
-        // You can adjust input here to add beta features if `settings?.beta`
-        // For example,
-        // const input = CatalogSettings.use()?.beta ? merge(body, {ui: { some: true }}) : body
-        return Result.Ok(parse(body, bucket))
-      } catch (e) {
-        // eslint-disable-next-line no-console
-        console.log('Unable to parse bucket preferences')
-        // eslint-disable-next-line no-console
-        console.error(e)
-        return Result.Ok(parse('', bucket))
-      }
-    },
-    Err: () => Result.Ok(parse('', bucket)),
-    Pending: Result.Pending,
-    Init: Result.Init,
-  })
+  const prefs: Result = scope
+    ? data.case({
+        Ok: ({ body }: FetchBucketPreferencesOutput) => {
+          try {
+            // You can adjust input here to add beta features if `settings?.beta`
+            // For example,
+            // const input = CatalogSettings.use()?.beta ? merge(body, {ui: { some: true }}) : body
+            return Result.Ok(parse(body, scope))
+          } catch (e) {
+            // eslint-disable-next-line no-console
+            console.log('Unable to parse bucket preferences')
+            // eslint-disable-next-line no-console
+            console.error(e)
+            return Result.Ok(parse('', scope))
+          }
+        },
+        Err: () => Result.Ok(parse('', scope)),
+        Pending: Result.Pending,
+        Init: Result.Init,
+      })
+    : // No bucket, so there is no document to be pending on either.
+      Result.Init()
   const handle = data.case({
     Ok: (r: FetchBucketPreferencesOutput) => r.handle,
     _: () => null,

--- a/docs/Catalog/Preferences.md
+++ b/docs/Catalog/Preferences.md
@@ -94,7 +94,13 @@ that maps package handle regular expressions
 to JSONPath expressions of fields to show from package metadata
 in the package list view.
 * `ui.package_description_multiline: True` - expands package metadata's root key/values
-* `ui.athena.defaultWorkgroup` - default workgroup to select on the Athena page
+* `ui.athena.defaultWorkgroup` - default workgroup to select on the Athena page,
+when that page is scoped to this bucket. The Athena page is workspace-wide, so it
+reads a bucket's preferences only when a bucket is in scope - which is the case
+when you arrive from this bucket's tables link, from a Tabulator table deep link,
+or from a `/b/<bucket>/queries/athena` link, and shows in the address bar as
+`?bucket=<bucket>`. Opening Queries from the sidebar scopes it to no bucket, and
+no bucket's `defaultWorkgroup` applies
 
 ![Alongside text editor users can use visual form to modify the config](../imgs/bucket-preferences-editor.png)
 
@@ -146,6 +152,10 @@ ui:
   athena:
     defaultWorkgroup: primary
 ```
+
+This applies on the Athena page while it is scoped to this bucket
+(`/queries/athena?bucket=<bucket>`). A workgroup you select on the page is
+remembered and takes precedence over this default on your next visit.
 
 #### `ui.blocks.meta`
 


### PR DESCRIPTION
# Description

`ui.athena.defaultWorkgroup` is a per-bucket preference, and the Athena console
is workspace-global — so since the re-home the console had no bucket whose
preferences to read, and the setting silently stopped working. This is the
consumer half of the pair: PR 8 makes every legacy `/b/:bucket/queries/athena...`
URL carry the bucket as `?bucket=`, and this PR makes the console read it, mount
that bucket's preferences, and hand `ui.athena` to the model.

**The scope has to survive navigation, or it is worse than nothing.** A reader
who lands scoped and then clicks anything in-console would drop the scope and
land in a different console than the one they left. Three link sites now carry
the query string forward: the breadcrumb back to Query Executions, each execution
row in History, and the Queries tab strip.

**Two defects the scoped mount introduced, fixed here rather than shipped:**

- **It crashed the catalog.** The unconditional `<Model.Provider>` this replaces
  kept the console outside any `BucketPreferences.Provider`, and that absence is
  what made the create-package Files panel inert there. Scoping re-establishes
  the provider; nothing re-established the inertness. So on
  `/queries/athena/<wg>?bucket=<b>`, Create package → "Add files from bucket"
  mounted `BucketSelect`, which read a `:bucket` route segment that route does
  not have and asserted it — and the nearest error boundary is the app root, so
  the throw **replaced the whole catalog screen** rather than failing the panel.
- **It threw away the query you were typing.** Branching the tree on `?bucket=`
  made the console's mount identity depend on the param, so losing the scope
  remounted `Model.Provider` and discarded `queryBody`, the selected catalog and
  the selected database with it.

# ⚠️ A direction decision this PR does not take

**Re-scoping a workspace-level console with `?bucket=` is a direction call, and
no artifact in this repository makes it.** Both readings are live and neither is
refutable from the checkout: this PR's (a per-bucket preference needs a bucket in
scope), and the alternative the original description never weighs (a
workspace-level default, leaving the console bucket-free). `queryRedirects.jsx`
states the re-home's premise in a comment, not a decision record; the console's
own state spec modelled no `?bucket=` state before this PR; there are no linked
issues. **A maintainer should rule before this merges.** Everything below it in
the stack stands on its own either way — which is why it is last.

# Review findings addressed

- **f30** ([thread](https://github.com/quiltdata/quilt/pull/5217#discussion_r3889140885))
  — the crash, above. The route param was only ever a fallback for
  `BucketPreferences`' own handle; it is treated as one now, with the picker's
  current selection as a last resort that cannot be absent. `BucketSelect` is
  exported so the mount can be driven from a route without the segment, and the
  test fails with the original assertion in place.
- **f31** ([thread](https://github.com/quiltdata/quilt/pull/5217#discussion_r3889140889))
  — the remount, above. `BucketPreferences.Provider` takes
  `bucket: string | null` and with no bucket serves the state a consumer sees
  outside any provider — no document, no handle, no update, no fetch — instead of
  the subtree being unmounted. The console mounts it either way, so there is one
  `Model.Provider` element at one position for both cases. A scoped console still
  waits for its document before mounting the model (the workgroup is seeded once,
  and a default arriving later would not displace it), so *acquiring* a scope is
  a mount, as it has to be; *losing* one is a re-render. The test counts mounts
  rather than renders.
- **f2** — the same class as f31's scenario, at the navigation site the
  scope-carrying fix stopped short of: the tab strip linked to bare pathnames.
- **f21** — the breadcrumb half of the scope fix had no test. Both in-console
  link sites are pinned now, in both directions.
- **f17** — the new precondition was absent from *both* documents that describe
  the behaviour. The preferences reference now says when a bucket is in scope and
  when it is not; the console's state spec gets a section on the scope as a
  precondition rather than as state, and the optional param on each URL.
- **f41** — the `?bucket=` parse was duplicated byte-for-byte in the console
  wrapper and the tabulator table list, and a repo-wide search for
  `get('bucket')` found exactly those two. The earlier dismissal said "extract a
  `useBucketScope()` when a third appears"; this PR needed the scope in a second
  place in the wrapper, which is the third.

Recorded, not acted on:

- **f15** — checked and refuted: the `_: () => <Placeholder/>` arm is not a
  terminal-error trap. The pre-existing wrapper matched `_ → Placeholder`
  identically.
- The review recorded its own depth limit, and one of the areas it did not read
  is **the `?bucket=` × `?table=` tabulator deep-link interaction**. Both params
  ride the same query string and both are now load-bearing; that interaction is
  worth a reviewer's attention here specifically.

# Dependencies

Hardening review of master
([`6167dd82`](https://github.com/quiltdata/quilt/commit/6167dd82)) against the
26.7.4 pin ([`eda3016f`](https://github.com/quiltdata/quilt/commit/eda3016f)) —
linked rather than named, so the cross-version seam can actually be read.

# Beyond the original diff

Three files here are not in #5217 and arrive with the fold-ins:
`Queries.tsx`/`Queries.spec.tsx` (f2), `utils/BucketPreferences/Provider.tsx`
plus a spec (f31), `PackageDialog/Inputs/Files/S3FilePicker.tsx` plus a spec
(f30), and `Athena/scope.ts` (f41).

# Verification

```
cd catalog && npx vitest run app/containers/Queries app/utils/BucketPreferences app/containers/Bucket/PackageDialog/Inputs/Files/S3FilePicker.spec.tsx
```

12 files, 141 tests. The whole catalog suite (183 files, 1720 tests) is green,
`tsc --noEmit` is clean, and `oxlint app` reports nothing.

# Position in the stack

**PR 9 of 9**, based on
[`stack/5217-8-queries-legacy-redirect-scope`](https://github.com/quiltdata/quilt/pull/5266).

Part of the split of #5217 asked for in
[f27](https://github.com/quiltdata/quilt/pull/5217#discussion_r3889140880).
Last, for two reasons: it is the consumer of PR 8's producer, and it is the only
unit blocked on the direction ruling above. It also carries the crash, so it is
the one unit that should not be waved through.

# TODO

- [x] Unit tests
- [x] Security: Confirm that this change meets security best practices and does not violate the security model
- [x] Open: Confirm that this change doesn't break the Open variant
- [x] Documentation
    - [x] Markdown somewhere in docs/**/*.md that explains the feature to end users
    - [x] Markdown docs for developers
- [x] Changelog entry

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR restores bucket-scoped Athena preferences in the workspace query console while preserving console state when scope changes.
- Reads the optional `bucket` query parameter through a shared scope hook and mounts bucket preferences around the Athena model.
- Preserves query parameters across Athena history, breadcrumbs, and query-console tabs.
- Makes the S3 file picker safe on routes without a bucket path segment.
- Adds focused tests, user documentation, developer documentation, and a changelog entry.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge, with no concrete changed-code failure remaining after reviewing scoped loading, navigation, and provider transitions.

The scoped provider avoids unscoped fetches, navigation retains the required bucket parameter, and the file picker now has a valid fallback when no bucket route segment exists.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| catalog/app/containers/Queries/Athena/Athena.tsx | Adds stable bucket-preference scoping around the Athena model and delays scoped model initialization until preferences resolve. |
| catalog/app/utils/BucketPreferences/Provider.tsx | Supports an explicit unscoped mode without fetching or exposing an update target while retaining existing scoped behavior. |
| catalog/app/containers/Queries/Queries.tsx | Preserves the current query string across query-console tab navigation. |
| catalog/app/containers/Queries/Athena/History.tsx | Retains bucket scope when opening successful query executions. |
| catalog/app/containers/Bucket/PackageDialog/Inputs/Files/S3FilePicker.tsx | Removes the route-bucket assertion and safely falls back to the picker’s current bucket. |


<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
  participant U as User
  participant R as Queries Router
  participant B as BucketPreferences Provider
  participant A as Athena Model
  U->>R: "Open /queries/athena?bucket=my-bucket"
  R->>B: Mount with bucket scope
  B->>B: Load bucket preferences
  B->>A: Pass ui.athena preferences
  A-->>U: Render scoped Athena console
  U->>R: Follow execution, breadcrumb, or tab
  R->>R: Preserve query string and bucket scope
```

<sub>Reviews (1): Last reviewed commit: ["docs(changelog): entry for the bucket-sc..."](https://github.com/quiltdata/quilt/commit/ad6f7aedd4e0e0beeccf463e6c92da81de489a77) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=58629644)</sub>

<!-- /greptile_comment -->