### PR TITLE
docs: correct the Connect OAuth issuer to bare origin

### DIFF
--- a/docs/Catalog/Connect.md
+++ b/docs/Catalog/Connect.md
@@ -95,19 +95,18 @@ CloudFormation output.
 Connect Server publishes OAuth authorization server metadata at
 `/.well-known/oauth-authorization-server` and OpenID metadata at
 `/.well-known/openid-configuration`. The `issuer` value is the Connect
-Server origin with the explicit HTTPS default port
-(`https://<connect-host>:443`), and all advertised endpoints
+Server origin (`https://<connect-host>`), and all advertised endpoints
 (`/auth/token`, `/auth/register`, `/auth/revoke`,
 `/auth/.well-known/jwks.json`, and the cross-served
-`/connect/authorize`) include the same explicit `:443`.
+`/connect/authorize`) are derived from it.
 
-> **Compatibility note.** Per RFC 3986, `https://host` and `https://host:443`
-> identify the same origin and are equivalent. However, some strict OAuth
-> clients — notably Databricks Apps — perform string-sensitive origin
-> comparisons against the issuer and reject DCR when the issuer omits the
-> default port. Quilt Connect emits `https://<connect-host>:443` to remain
-> compatible with these clients; well-behaved clients that normalize per
-> RFC 3986 are unaffected.
+> **Compatibility note.** The issuer omits the HTTPS default port, per
+> RFC 3986 §3.2.3 ("URI producers and normalizers should omit the port
+> component ... if its value would be the same as that of the scheme's
+> default"). Clients that normalize the AS origin before the RFC 8414 §3.3
+> issuer comparison — the OpenAI Codex CLI among them — drop `:443`, so an
+> issuer carrying it can never compare equal and OAuth aborts at discovery.
+> A non-default port in `CONNECT_DOMAIN` is preserved.
 
 ### Protected Resource Identifier
 

--- a/docs/Catalog/MCP-Server.md
+++ b/docs/Catalog/MCP-Server.md
@@ -156,9 +156,10 @@ redirect URI (the workspace region determines the exact host).
 
 `.cloud.databricks.com` must be in `ConnectAllowedHosts` so DCR accepts
 that redirect URI (see
-[Connect.md](Connect.md#connectallowedhosts-entry-formats)). Quilt Connect
-already emits the `:443`-explicit metadata Databricks requires — see
-[Connect.md OAuth Metadata](Connect.md#oauth-metadata) for why.
+[Connect.md](Connect.md#connectallowedhosts-entry-formats)). Note the
+redirect host is regional (`oregon.cloud.databricks.com`), not the
+workspace host, so the leading-dot suffix form is required — a bare
+workspace hostname is an exact-match entry and will not match it.
 
 > **Serverless egress caveat.** Databricks Apps and serving endpoints run
 > on a serverless network plane that blocks outbound traffic by default.

--- a/docs/Catalog/MCP-Server.md
+++ b/docs/Catalog/MCP-Server.md
@@ -3,9 +3,9 @@
 The **Quilt Platform MCP Server** lets AI assistants interact with your
 organization's data through natural language. Built on the open
 [Model Context Protocol](https://modelcontextprotocol.io/), it connects
-Claude, Cursor, and other MCP-compatible clients directly to your Quilt
-environment — so users can search, browse, read, create, and query data
-without leaving their AI workflow.
+Claude, Cursor, OpenAI Codex, and other MCP-compatible clients directly to
+your Quilt environment — so users can search, browse, read, create, and query
+data without leaving their AI workflow.
 
 All actions respect your existing Quilt roles and permissions. Data never
 leaves your AWS environment.


### PR DESCRIPTION
# Description

The Connect OAuth docs claimed Quilt emits an explicit `:443` in the issuer because Databricks Apps require it. That claim is unsupported, and the registry no longer does it.

Code companion: quiltdata/enterprise#1142

No Databricks documentation mentions the issuer field or a port requirement. The claim traces to a single PR description (enterprise#1056), where `:443` was appended *after* the commit that actually fixed Databricks — the one removing the `/auth` path component (RFC 8414 §3 forbids a path). Verified on dev: Databricks completes OAuth DCR against a bare-origin issuer, while the `:443` broke the Codex CLI, which normalizes the origin per RFC 3986 §6.2.3 before comparing.

## Changes

- **`Connect.md`** — issuer documented as the bare Connect origin; the compatibility note now gives the real constraint (RFC 3986 §3.2.3) instead of the Databricks claim.
- **`MCP-Server.md`** — drops the `:443` cross-reference; names OpenAI Codex in the intro alongside Claude and Cursor; notes the Databricks redirect host is regional (`oregon.cloud.databricks.com`), so `ConnectAllowedHosts` needs the leading-dot suffix form.

Docs only — no changelog entry, per convention for docs-only changes here.
