### PR TITLE
docs: Checksums & Hashing — customer-facing page + CRC64/NVME enablement

### DIFF
--- a/docs/CHUNKED_CHECKSUMS.md
+++ b/docs/CHUNKED_CHECKSUMS.md
@@ -72,17 +72,56 @@ stack's packaging lambdas.
 For files already in S3, packaging can be up to 10x faster by using S3's
 native CRC64/NVME checksums instead of computing SHA-256 hashes.
 
-Since AWS enabled default data-integrity protections (early 2025), S3
-automatically computes and stores a full-object `CRC64NVME` checksum for
-objects uploaded with current AWS SDKs, the AWS CLI, or the S3 console.
-When CRC64/NVME support is enabled on your Quilt stack, the packaging
-lambdas read that precomputed checksum with a metadata request instead of
-downloading and re-hashing the object.
+S3 stores a full-object `CRC64NVME` checksum in an object's metadata when
+the object was uploaded with the `CRC64NVME` algorithm, or — since S3's
+[default data integrity protections](https://aws.amazon.com/blogs/aws/introducing-default-data-integrity-protections-for-new-objects-in-amazon-s3/)
+rolled out (January 2025) — when it was uploaded without any client-side
+checksum, including multipart uploads. When CRC64/NVME support is enabled
+on your Quilt stack, the packaging lambdas read that precomputed checksum
+with a single metadata request (`HeadObject`) instead of reading and
+re-hashing the object's data. That is where the speedup comes from.
 
-Objects that do not have a precomputed `CRC64NVME` checksum (for example,
-objects uploaded before the AWS integrity changes or with older tooling)
-automatically fall back to `sha2-256-chunked` hashing, so a single package
-may contain entries with both hash types.
+### Do I need to change my objects or buckets?
+
+No. Enabling CRC64/NVME is a stack-level setting only:
+
+* **Quilt never modifies your source objects.** Checksums are stored in
+  the package manifest, not written back to the objects.
+* **No bucket configuration is required.**
+* **Objects without a precomputed checksum still work.** For those, the
+  packaging lambdas compute the checksum using server-side S3 copies into
+  the stack's internal scratch bucket, so your data never leaves S3 and
+  the source object is untouched — this path is simply slower than the
+  metadata-only read. If a compliant precomputed SHA-256 checksum exists
+  on the object, it is reused instead. As a result, a single package may
+  contain entries with both `CRC64NVME` and `sha2-256-chunked` hash
+  types; that is expected and fully supported.
+* **Existing packages are unaffected.** The hash type is recorded per
+  entry, so packages created before enabling (or after disabling) the
+  feature remain valid and verifiable.
+
+To check whether a given object already has a precomputed checksum:
+
+<!--pytest.mark.skip-->
+```sh
+aws s3api head-object --bucket your-bucket --key your/key \
+  --checksum-mode ENABLED
+```
+
+Look for `ChecksumCRC64NVME` in the response. Two common reasons it is
+absent:
+
+* The object was uploaded before January 2025 and no checksum was
+  requested at upload time.
+* The uploading AWS SDK sent a different default checksum (recent SDKs
+  may send `CRC32` or `CRC32C`); S3 only adds `CRC64NVME` automatically
+  when the client sends no checksum at all.
+
+Optionally, you can backfill a `CRC64NVME` checksum onto existing objects
+with an in-place copy, e.g.
+`aws s3 cp s3://bucket/key s3://bucket/key --checksum-algorithm CRC64NVME`.
+This is not required — it only pre-populates the fast path. Note that in
+versioned buckets this creates a new object version.
 
 ### How to enable
 
@@ -108,8 +147,7 @@ Notes:
   Engine, `pkgpush`). The `quilt3` client continues to compute
   `sha2-256-chunked` checksums on `push`.
 * The feature is experimental. To revert, set `CRC64Checksums` back to
-  `Disabled`; existing packages remain valid because the hash type is
-  recorded per entry.
+  `Disabled`; packages created while it was enabled remain valid.
 
 ## Verifying package integrity
 

--- a/docs/CHUNKED_CHECKSUMS.md
+++ b/docs/CHUNKED_CHECKSUMS.md
@@ -1,27 +1,135 @@
-# Chunked Checksums
+# Checksums and Hashing
 
-This variant of sha2-256 is designed to enable large files
-to be efficiently uploaded and hashed in parallel using uniform size chunks
-(8 MiB to start with), with the final result being a "top hash"
-that doesn't depend on the upload order.
+Every entry in a Quilt package records a checksum (hash) of the object's
+contents in the package manifest. Quilt uses these checksums to:
 
-The algorithm has an upper limit of 10,000 chunks.
-If the file is larger than 80,000 MiB,
-it will double the chunk size until the number of chunks
-is under that limit.
+* Verify data integrity when a package is installed or verified
+  (`Package.verify()`).
+* Detect whether an object has changed since it was packaged.
+* Produce the package *top hash*, which uniquely identifies each package
+  revision by its contents.
 
-If the file is zero bytes, the top hash is the sha2-256 hash of the empty string.
+Each manifest entry stores both the hash **type** and the hash **value**, so
+packages created with different hash types remain valid and verifiable side
+by side.
 
-## CRC64/NVME Checksums (Experimental)
+## Hash types
 
-For files already in S3, packaging can be up to 10x faster by using
-S3's native CRC64/NVME checksums instead of computing SHA-256 hashes
-manually. This is opt-in: set the `CRC64Checksums` CloudFormation stack
-parameter to enable it.
+Quilt supports three hash types:
+
+| Type | Encoding | Status |
+| ------------------ | -------- | ------------------------------------- |
+| `SHA256` | hex | Legacy (packages from `quilt3` < 6) |
+| `sha2-256-chunked` | base64 | Default since `quilt3` v6 (Feb 2024) |
+| `CRC64NVME` | base64 | Opt-in, stack-side only (see below) |
+
+All three remain fully supported for verification: `quilt3` verifies
+whichever hash type is recorded in the manifest. Verification of
+`CRC64NVME` hashes requires `quilt3` 7.2.0 or later.
+
+## The chunked hashing algorithm (`sha2-256-chunked`)
+
+This variant of SHA2-256 is designed so that large files can be uploaded
+and hashed efficiently in parallel using uniform-size chunks, with a final
+result that does not depend on upload order:
+
+1. Split the file into 8 MiB chunks.
+1. Compute the SHA2-256 digest of each chunk (in parallel).
+1. Concatenate the per-chunk digests and compute the SHA2-256 hash of the
+   result. This is the recorded checksum, encoded as base64.
+
+Edge cases:
+
+* The algorithm has an upper limit of 10,000 chunks (matching the S3
+  multipart part limit). For files larger than 80,000 MiB (~78 GiB), the
+  chunk size is doubled until the chunk count is under that limit.
+* Files smaller than 8 MiB are treated as a single chunk. The result is
+  still wrapped, i.e. `sha256(sha256(data))`.
+* A zero-byte file is treated as an empty list of chunks; its checksum is
+  the SHA2-256 hash of the empty string.
+
+Because the chunk boundaries match the multipart part sizes used for S3
+uploads, Quilt can reuse the `ChecksumSHA256` values that S3 computes
+during upload (or that are already stored on compliant multipart objects)
+instead of re-reading the object — both in the `quilt3` client and in the
+stack's packaging lambdas.
+
+### Where hashing happens
+
+* **`quilt3` SDK (`push`):** checksums are computed on the client, in
+  parallel across chunks, and S3-provided checksums from the upload
+  response are reused where possible. See the
+  [FAQ](FAQ.md#hashing-during-push-takes-a-long-time-can-i-speed-it-up)
+  for performance tuning.
+* **Catalog and Packaging Engine:** packages created through the Catalog
+  UI, the [Packaging Engine](Catalog/Packaging.md), or the `pkgpush` API
+  are hashed server-side by dedicated lambdas that scale out
+  automatically and reuse existing S3 checksums when the object's part
+  layout is compliant.
+
+## CRC64/NVME checksums (experimental)
+
+For files already in S3, packaging can be up to 10x faster by using S3's
+native CRC64/NVME checksums instead of computing SHA-256 hashes.
+
+Since AWS enabled default data-integrity protections (early 2025), S3
+automatically computes and stores a full-object `CRC64NVME` checksum for
+objects uploaded with current AWS SDKs, the AWS CLI, or the S3 console.
+When CRC64/NVME support is enabled on your Quilt stack, the packaging
+lambdas read that precomputed checksum with a metadata request instead of
+downloading and re-hashing the object.
+
+Objects that do not have a precomputed `CRC64NVME` checksum (for example,
+objects uploaded before the AWS integrity changes or with older tooling)
+automatically fall back to `sha2-256-chunked` hashing, so a single package
+may contain entries with both hash types.
+
+### How to enable
+
+CRC64/NVME checksums are **opt-in**, controlled by a CloudFormation stack
+parameter:
+
+1. In the AWS Console, go to CloudFormation > Stacks > *YourQuiltStack* >
+   Update.
+1. Choose **Use current template**.
+1. Under **Beta features**, set `CRC64Checksums` to `Enabled`.
+1. Complete the stack update.
+
+Requirements:
+
+* Quilt Platform release 1.65.0 (December 2025) or later.
+* `quilt3` 7.2.0 or later on any client that needs to *verify* packages
+  containing `CRC64NVME` hashes (older clients can still install and read
+  such packages).
+
+Notes:
+
+* This setting affects server-side packaging (Catalog UI, Packaging
+  Engine, `pkgpush`). The `quilt3` client continues to compute
+  `sha2-256-chunked` checksums on `push`.
+* The feature is experimental. To revert, set `CRC64Checksums` back to
+  `Disabled`; existing packages remain valid because the hash type is
+  recorded per entry.
+
+## Verifying package integrity
+
+`Package.verify()` recomputes the checksum of each local file against the
+hash type and value recorded in the manifest and reports any mismatches:
+
+<!--pytest.mark.skip-->
+```python
+import quilt3
+
+p = quilt3.Package.browse(
+    "user/package",
+    registry="s3://your-bucket",
+)
+p.verify("path/to/local/copy")
+```
 
 ## Inspiration
 
-This algorithm is inspired by Amazon's
+The chunked algorithm is inspired by Amazon's
 [S3 Checksums](https://aws.amazon.com/blogs/aws/new-additional-checksum-algorithms-for-amazon-s3/)
 implementation.
 

--- a/docs/Catalog/Packaging.md
+++ b/docs/Catalog/Packaging.md
@@ -78,9 +78,11 @@ name inferred from the S3 key. For example, if the key is
 
 The Quilt Packaging Engine is built on top of the existing packaging lambdas
 used by the Quilt Platform, including the ability to parallelize creation of S3
-Checksums for existing objects. We have exposed this functionality to customers
-via an SQS queue, which is invoked by the EventBridge rules created by the Admin
-Settings GUI.
+Checksums for existing objects (see
+[Checksums and Hashing](../CHUNKED_CHECKSUMS.md) for the algorithm and how to
+enable faster CRC64/NVME checksums). We have exposed this functionality to
+customers via an SQS queue, which is invoked by the EventBridge rules created
+by the Admin Settings GUI.
 
 ### SQS Parameters
 

--- a/docs/FAQ.md
+++ b/docs/FAQ.md
@@ -78,11 +78,16 @@ a local machine or foreign region)—I/O is much faster.
 [`QUILT_TRANSFER_MAX_CONCURRENCY`](api-reference/cli.md#quilt_transfer_max_concurrency)
 above its default to match your available vCPUs.
 
-1. If you are using Quilt Catalog 1.51 (released Feb 2024), you can enable the
-   `ChunkedChecksums` CloudFormation parameter so it will calculate the
-   checksums in parallel, or reuse them if already existing in S3. Parallel
-   checksums are also available by default in `quilt3` v6 or later (pre-released
-   Feb 2024).
+1. Use `quilt3` v6 or later, which calculates
+   [chunked checksums](CHUNKED_CHECKSUMS.md) in parallel and reuses
+   checksums already computed by S3 where possible.
+
+1. For packages created server-side (Catalog UI or Packaging Engine), on
+   Quilt Platform 1.65.0 or later you can enable the `CRC64Checksums`
+   CloudFormation parameter so the stack reuses S3's precomputed
+   CRC64/NVME checksums instead of re-hashing objects — up to 10x faster
+   for data already in S3. See
+   [Checksums and Hashing](CHUNKED_CHECKSUMS.md) for details.
 
 ## Does Quilt work with R?
 

--- a/docs/SUMMARY.md
+++ b/docs/SUMMARY.md
@@ -34,6 +34,7 @@
 * [Enterprise Installs](technical-reference.md)
 * [quilt3.admin Python API](api-reference/Admin.md)
 * **Advanced**
+  * [Checksums & Hashing](CHUNKED_CHECKSUMS.md)
   * [Package Events](advanced-features/package-events.md)
   * [Private Endpoints](advanced-features/private-endpoint-access.md)
   * [Restrict Access by Bucket Prefix](advanced-features/s3-prefix-permissions.md)


### PR DESCRIPTION
## Motivation

A customer asked us to better document the hashing algorithm and how to enable CRC64/NVME checksums on objects and packages. Reviewing the current docs surfaced three gaps:

1. `docs/CHUNKED_CHECKSUMS.md` existed but was **not listed in `SUMMARY.md`**, so it never appeared in the published docs navigation.
2. The FAQ still told users to enable the `ChunkedChecksums` CloudFormation parameter, which was **removed** in quiltdata/deployment#2194 (Platform 1.65.0) and replaced by `CRC64Checksums`.
3. There were no customer-facing enablement steps for CRC64/NVME checksums anywhere in the docs.

## Changes

- **`docs/CHUNKED_CHECKSUMS.md`** — rewritten as a customer-facing *Checksums and Hashing* page: the three hash types (`SHA256` legacy / `sha2-256-chunked` default / `CRC64NVME` opt-in), the chunked algorithm (8 MiB chunks, 10,000-part limit, small/empty-file edge cases), where hashing happens (client vs stack lambdas), step-by-step `CRC64Checksums` enablement with version requirements (Platform ≥ 1.65.0, `quilt3` ≥ 7.2.0 for verification), and `Package.verify()`. The multiformats registration and inspiration sections are preserved.
- **`docs/SUMMARY.md`** — added the page under *Quilt Platform Administrator → Advanced*.
- **`docs/FAQ.md`** — replaced the stale `ChunkedChecksums` step in the hashing-performance answer with current guidance (`quilt3` v6+ default behavior + `CRC64Checksums` for server-side packaging).
- **`docs/Catalog/Packaging.md`** — cross-link to the new page from the architecture section.

## Verification

Claims were checked against the source:
- Hash types and defaults: `api/python/quilt3/checksums.py` (`DEFAULT_HASH = sha2-256-chunked`, chunk sizing, empty-file case).
- Stack-side algorithm selection: `lambdas/pkgpush` `CHECKSUM_ALGORITHMS` (`["CRC64NVME", "SHA256_CHUNKED"]` when enabled, precomputed checksum via `HeadObject` with `ChecksumMode=ENABLED`, fallback to chunked SHA-256).
- Parameter definition: deployment `t4/template/parameters.py` (`CRC64Checksums`, Enabled/Disabled, default Disabled, Beta features group).
- Versions: deployment CHANGELOG 1.65.0 (2025-12-18) for the parameter; quilt3 7.2.0 (#4696) for CRC64NVME verification.

`markdownlint` clean on all four files; the new Python snippet carries `<!--pytest.mark.skip-->` so `testdocs` won't execute it.

Made with [Cursor](https://cursor.com)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR turns the existing chunked-checksum notes into a customer-facing guide, documents CRC64/NVME enablement, updates outdated FAQ guidance, and exposes the page through documentation navigation and Packaging Engine links.

- Describes Quilt’s supported hash types and chunked SHA-256 algorithm.
- Documents server-side CRC64/NVME selection and fallback behavior.
- Adds CloudFormation enablement and client-version guidance.
- Adds package-integrity verification guidance, although its compatibility statement and verification example need correction.
- Integrates the guide into `SUMMARY.md`, the FAQ, and Packaging Engine documentation.

<h3>Confidence Score: 3/5</h3>

The documentation should not merge until its old-client compatibility guidance and silent verification example are corrected.

The new guide tells users that older clients can read CRC64NVME-backed entries even though content-reading helpers reject unsupported hashes, and its integrity-check example ignores the only signal that verification failed.

**Files Needing Attention:** docs/CHUNKED_CHECKSUMS.md

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| docs/CHUNKED_CHECKSUMS.md | Rewrites the checksum guide and adds CRC64/NVME enablement, but overstates old-client read compatibility and provides a verification example that silently ignores failures. |
| docs/Catalog/Packaging.md | Adds a valid cross-link from the Packaging Engine architecture section to the checksum guide. |
| docs/FAQ.md | Replaces obsolete ChunkedChecksums guidance with current client and server-side checksum recommendations. |
| docs/SUMMARY.md | Adds the checksum guide to the administrator navigation using the existing summary structure. |


<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
  Push[quilt3 push] --> ClientHash[Client computes sha2-256-chunked]
  Server[Catalog UI / Packaging Engine / pkgpush] --> CRCEnabled{CRC64 enabled?}
  CRCEnabled -- No --> ServerSHA[Compute or reuse sha2-256-chunked]
  CRCEnabled -- Yes --> CRCStored{Object has CRC64NVME?}
  CRCStored -- Yes --> ReuseCRC[Reuse CRC64NVME metadata]
  CRCStored -- No --> ServerSHA
  ClientHash --> Manifest[Package manifest records hash type and value]
  ServerSHA --> Manifest
  ReuseCRC --> Manifest
  Manifest --> Verify[Client verification or entry reading]
```

<sub>Reviews (1): Last reviewed commit: ["docs: expand checksums/hashing docs and ..."](https://github.com/quiltdata/quilt/commit/8a48134c1da2199188559b5e1f0cc359c0bf07a3) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=60119837)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->