### PR TITLE
Add gitbook-docs.yaml for GitBook Site Git Sync

### DIFF
--- a/gitbook-docs.yaml
+++ b/gitbook-docs.yaml
@@ -1,0 +1,11 @@
+$schema: https://api.gitbook.com/gitbook-docs.yaml
+site:
+  title: Quilt
+  structure:
+    - type: space
+      key: space-docs
+      title: Documentation
+      path: docs
+      default: true
+      content:
+        directory: ./docs


### PR DESCRIPTION
Prepares the repository for GitBook Site Git Sync per the schema at https://api.gitbook.com/gitbook-docs.yaml.

Structure: a single default space **Documentation** at path `docs`, reading `./docs` — the existing SUMMARY.md-driven book. No sections were created: `docs/` is the only documentation content directory at the repository root, and its subdirectories (`Catalog/`, `advanced-features/`, `api-reference/`, `examples/`, `walkthrough/`, `imgs/`) are internal to that one book (SUMMARY.md interleaves pages across them), so splitting them into separate spaces would fracture the book.

Verified: `content.directory ./docs` exists; YAML parses; no other files touched.

Made with [Cursor](https://cursor.com)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds `gitbook-docs.yaml` to configure GitBook Site Git Sync.
- Defines one default site space named Documentation.
- Sources the existing SUMMARY-driven book from `./docs`.
- Introduces no application, API, dependency, or security behavior changes.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge; the configuration is consistent with the existing documentation layout and no actionable issues were identified.

The declared content directory exists and contains the expected GitBook entry and navigation files, while the sole default space introduces no established routing or compatibility failure.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| gitbook-docs.yaml | Adds a valid single-space GitBook site configuration targeting the existing documentation directory. |

<sub>Reviews (1): Last reviewed commit: ["Add gitbook-docs.yaml for GitBook Site G..."](https://github.com/quiltdata/quilt/commit/8a76e2ae9b11d1c71fde5dff56eecb4ced485e5d) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=60139399)</sub>

<!-- /greptile_comment -->